### PR TITLE
Add dir-listing.yaml

### DIFF
--- a/files/dir-listing.yaml
+++ b/files/dir-listing.yaml
@@ -1,0 +1,15 @@
+id: dir-listing
+
+info:
+  name: Directory listing enabled
+  author: _harleo
+  severity: medium
+
+requests:
+  - method: GET
+    path: 
+      - "{{BaseURL}}/"
+    matchers:
+      - type: word
+        words: 
+          - "Index of"


### PR DESCRIPTION
Checks whether basic directory listing is enabled at root