### PR TITLE
AWS and Google API keys leak

### DIFF
--- a/tokens/aws-access-key-value.yaml
+++ b/tokens/aws-access-key-value.yaml
@@ -1,0 +1,21 @@
+id: aws-access-key-value
+
+info:
+  name: AWS Access Key ID Value
+  author: Swissky
+  severity: medium
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"

--- a/tokens/google-cloud-api-key.yaml
+++ b/tokens/google-cloud-api-key.yaml
@@ -1,0 +1,21 @@
+id: google-cloud-api-key
+
+info:
+  name: Google Cloud API Key
+  author: Swissky
+  severity: medium
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "AIza[0-9A-Za-z\\-_]{35}"
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "AIza[0-9A-Za-z\\-_]{35}"


### PR DESCRIPTION
Example of extractors for AWS and Google API keys.

Following the guide : https://github.com/projectdiscovery/nuclei-templates/blob/master/GUIDE.md#extractors

Reference to the issue: https://github.com/projectdiscovery/nuclei/issues/3