### PR TITLE
Github Enterprise Detect

### DIFF
--- a/technologies/github-enterprise-detect.yaml
+++ b/technologies/github-enterprise-detect.yaml
@@ -1,0 +1,15 @@
+id: Github-Enterprise-Detect
+
+info:
+  name: Detect Github Enterprise
+  author: ehsahil
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+    matchers:
+      - type: word
+        words:
+          - "GitHub · Enterprise"


### PR DESCRIPTION
Detecting the Github Enterprise can help the hacker in multiple ways to understand the structure of the internal services for a target.