### PR TITLE
Gitlab Detect

### DIFF
--- a/technologies/gitlab-detect.yaml
+++ b/technologies/gitlab-detect.yaml
@@ -1,0 +1,19 @@
+id: Gitlab-Detect
+
+info:
+  name: Detect Gitlab
+  author: ehsahil
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/users/sign_in"
+      - "{{BaseURL}}/users/sign_up"
+      - "{{BaseURL}}/explore"
+    matchers:
+      - type: word
+        words:
+          - "GitLab"
+          - "Register for GitLab"
+          - "Explore GitLab"


### PR DESCRIPTION
Fingerprinting Gitlab can help the hacker in multiple ways, Sometimes hackers can find the signup or explore option open and using these he can escalate the access further.