### PR TITLE
Update dir-listing.yaml

### DIFF
--- a/files/dir-listing.yaml
+++ b/files/dir-listing.yaml
@@ -13,3 +13,4 @@ requests:
       - type: word
         words: 
           - "Index of /"
+          - "[To Parent Directory]"


### PR DESCRIPTION
On IIS, there is no "Index of /" but the webpage contains "[To Parent Directory]" when directory listing is enabled.