### PR TITLE
Add Drupal  Install

### DIFF
--- a/subdomain-takeover/drupal.yaml
+++ b/subdomain-takeover/drupal.yaml
@@ -1,0 +1,18 @@
+id: drupal
+
+info:
+  name: Drupal Install
+  author: NkxxkN
+  severity: medium
+
+requests:
+  - method: GET
+    path: 
+      - "{{BaseURL}}/core/install.php"
+      - "{{BaseURL}}/install.php"
+    matchers:
+      - type: word
+        words:
+          - 'Choose language'
+          - 'Verify requirements'
+        condition: and


### PR DESCRIPTION
## Drupal Install

In some cases, it is possible to takeover a Drupal instance if the administrator left it open in the wild. 


Depending on the Drupal version, there are two urls possible:
![Drupal_1](https://user-images.githubusercontent.com/5072452/79864557-f03ea280-83d9-11ea-92d6-439524220b2a.png)
![Drupal_2](https://user-images.githubusercontent.com/5072452/79864563-f16fcf80-83d9-11ea-85ee-4c2a6ad0a7c5.png)

## Note

Thanks Wh11teW0lf https://twitter.com/Wh11teW0lf/status/1226862698085875718 for inspiration.