### PR TITLE
add redirects to support Drupal < 8.0.0

### DIFF
--- a/files/drupal-install.yaml
+++ b/files/drupal-install.yaml
@@ -8,10 +8,10 @@ info:
 requests:
   - method: GET
     path: 
-      - "{{BaseURL}}/core/install.php"
+      - "{{BaseURL}}/install.php?profile=default"
+    redirects: true
+    max-redirects: 1
     matchers:
       - type: word
         words:
-          - 'Choose language'
-          - 'Verify requirements'
-        condition: and
+          - '<title>Choose language | Drupal</title>'


### PR DESCRIPTION
Thanks for the good work implementing the redirect!

## Explanations for this PR

Drupal > 8.x.x
-`/core/install.php` => 200 => 0 redirect
- `/install.php` => 302 => `/core/install.php` => 200 => 1 redirect
- `/install.php?profile=default` => 302 => `/core/install.php` => 200 => 1 redirects

Drupal < 8.x.x
-`/core/install.php` => 302 => `/install.php` => 302 `/install.php?profile=default` => 200 => 2 redirects
- `/install.php` => 302 => `/install.php?profile=default` => 200 => 1 redirect
- `/install.php?profile=default` => 200 => 0 redirect

So in order to minimise the queries I'm privileging `/install.php?profile=default` with 1 redirect which seems to be the best compromise.

On a side note I think the `redirects:true` + `max-redirects:N` is a little bit redundant. I would have preffered `redirects:N` only with a default to 0 to achieve the same result.
