### PR TITLE
Accuracy Fixes

### DIFF
--- a/cves/CVE-2019-14974.yaml
+++ b/cves/CVE-2019-14974.yaml
@@ -3,7 +3,7 @@ id: CVE-2019-14974
 info:
   name: SugarCRM Enterprise 9.0.0 - Cross-Site Scripting
   author: madrobot
-  severity: medium 
+  severity: low 
 
 requests:
   - method: GET
@@ -15,5 +15,5 @@ requests:
             - 200
       - type: word
         words:
-            - "1337"
+            - "url = window.location.search.split(\"?desktop_url=\")[1]"
         part: body

--- a/cves/CVE-2019-19368.yaml
+++ b/cves/CVE-2019-19368.yaml
@@ -15,5 +15,5 @@ requests:
             - 200
       - type: word
         words:
-            - "1337"
+            - "value=''><sVg/OnLoAD=alert`1337`//'>"
         part: body

--- a/vulnerabilities/moodle-filter-jmol-xss.yaml
+++ b/vulnerabilities/moodle-filter-jmol-xss.yaml
@@ -15,5 +15,5 @@ requests:
             - 200
       - type: word
         words:
-            - "alert(1337)"
+            - "\"};alert(1337);//"
         part: body


### PR DESCRIPTION
Some tests were causing a lot of false positives due to very simple checks (i.e. is `1337` present in the body). Another wouldn't have detected an XSS due to it being DOM based. I changed the check to look for the presence of the vulnerable JS code instead. 