### PR TITLE
Add front-page-misconfig.yaml

### DIFF
--- a/cves/CVE-2020-7473.yaml
+++ b/cves/CVE-2020-7473.yaml
@@ -1,0 +1,16 @@
+id: CVE-2020-7473
+
+info:
+  name: Citrix ShareFile unauthenticated attacker to compromise the storage zones controller
+  author: JTeles
+  severity: High 
+  #CVE AUTHOR => DIMITRI
+  #GITHUB => https://github.com/DimitriNL/CTX-CVE-2020-7473
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/UploadTest.aspx"
+    matchers:
+      - type: status
+        status:
+            - 200

--- a/cves/CVE-2020-7473.yaml
+++ b/cves/CVE-2020-7473.yaml
@@ -11,6 +11,6 @@ requests:
     path:
       - "{{BaseURL}}/UploadTest.aspx"
     matchers:
-      - type: status
-        status:
-            - 200
+      - type: size
+        size:
+           - 0

--- a/security-misconfiguration/front-page-misconfig.yaml
+++ b/security-misconfiguration/front-page-misconfig.yaml
@@ -1,0 +1,15 @@
+id: front-page-misconfig
+
+info:
+  name: FrontPage configuration information discloure
+  author: JTeles
+  severity: low
+  #Reference => https://docs.microsoft.com/en-us/archive/blogs/fabdulwahab/security-protecting-sharepoint-server-applications
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/_vti_inf.html"
+    matchers:
+      - type: size
+        size:
+          - 247


### PR DESCRIPTION
This indicates an attack attempt against a file-disclosure vulnerability in Microsoft FrontPage.
The file _vti_inf.html contains Microsoft FrontPage configuration information such as version number and scripting paths. There exists a vulnerability in some versions of IIS that allows attackers to access this file on a target system by sending it a specially crafted URL request.

Reference: https://fortiguard.com/encyclopedia/ips/103284772 and https://docs.microsoft.com/en-us/archive/blogs/fabdulwahab/security-protecting-sharepoint-server-applications