### PR TITLE
Update CVE-2020-7473.yaml

### DIFF
--- a/cves/CVE-2020-7473.yaml
+++ b/cves/CVE-2020-7473.yaml
@@ -11,6 +11,9 @@ requests:
     path:
       - "{{BaseURL}}/UploadTest.aspx"
     matchers:
+      - type: status
+        status:
+            - 200
       - type: size
         size:
            - 0


### PR DESCRIPTION
This is to avoid false positives. I think it would be better to only match 2xx and 3xx status code (don't know if nuclei supports this terminology)