### PR TITLE
Update CVE-2020-7473.yaml

### DIFF
--- a/cves/CVE-2020-7473.yaml
+++ b/cves/CVE-2020-7473.yaml
@@ -10,10 +10,12 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/UploadTest.aspx"
+    redirects: true
+    max-redirects: 3
     matchers:
-      - type: status
-        status:
-            - 200
+      - type: dsl
+        dsl:
+        - "status_code>=200 && status_code<400"
       - type: size
         size:
            - 0

--- a/cves/CVE-2020-7473.yaml
+++ b/cves/CVE-2020-7473.yaml
@@ -15,7 +15,4 @@ requests:
     matchers:
       - type: dsl
         dsl:
-        - "status_code>=200 && status_code<400"
-      - type: size
-        size:
-           - 0
+        - "len(body)==0 && status_code<=309"


### PR DESCRIPTION
Updated to support 2xx and 3xx status code, as well as accepting redirects just in case (continuation from #90 )