### PR TITLE
Add support for detecting a Home Assistant instance

### DIFF
--- a/technologies/home-assistant.yaml
+++ b/technologies/home-assistant.yaml
@@ -13,4 +13,4 @@ requests:
     matchers:
       - type: word
         words:
-          - "Home Assistant"
+          - "<title>Home Assistant</title>"

--- a/technologies/home-assistant.yaml
+++ b/technologies/home-assistant.yaml
@@ -1,0 +1,16 @@
+id: home-assistant
+
+info:
+  name: Detect Home Assistant
+  author: fabaff
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}:8123/"
+      - "{{BaseURL}}/"
+    matchers:
+      - type: word
+        words:
+          - "Home Assistant"


### PR DESCRIPTION
This is a template to detect [Home Assistant](https://www.home-assistant.io/) instances which are usually serving their web frontend on TCP port 8123.

Sorry, not sure about the naming of the file. The `-detect` suffix looks often a bit "double stitched". I would be happy to follow the common agreement about the naming of the files.