### PR TITLE
Add CPython

### DIFF
--- a/technologies/programming-language-detect.yaml
+++ b/technologies/programming-language-detect.yaml
@@ -29,5 +29,6 @@ requests:
         words:
           - "Python/2."
           - "Python/3."
+          - "CPython/3."
         condition: or
         part: header


### PR DESCRIPTION
The Django framework is using `CPython` when running locally (like during the development phase or if not deploy with a third-party service). E.g., 

```bash
$ nc 127.0.0.1 8000
GET / HTTP/1.1
host: localhost

HTTP/1.1 200 OK
Date: Sun, 24 May 2020 16:37:56 GMT
Server: WSGIServer/0.2 CPython/3.7.7
[...]
```