### PR TITLE
Add support for detecting web server daemons

### DIFF
--- a/technologies/web-server.yaml
+++ b/technologies/web-server.yaml
@@ -1,0 +1,43 @@
+id: web-server
+
+info:
+  name: Detect web server daemon
+  author: fabaff
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: or
+    matchers:
+      - type: word
+        name: apache
+        words:
+         - "Apache"
+        part: header
+      - type: word
+        name: lighttpd
+        words:
+          - "lighttpd"
+        part: header
+      - type: word
+        name: lighttpd
+        words:
+         - "lighttpd"
+        part: header
+      - type: word
+        name: wsgiserver
+        words:
+         - "WSGIServer"
+        part: header
+      - type: word
+        name: simplehttp
+        words:
+         - "SimpleHTTP"
+        part: header
+      - type: word
+        name: twistedweb
+        words:
+         - "TwistedWeb"
+        part: header


### PR DESCRIPTION
Detection of the used web server daemon. I added some examples for now of web servers which can be run locally as one-liners to verify that the detection works beside the both most popular ones.

There is currently an overlap with `reverse-proxy-detect.yaml`. Any input how to avoid duplicate results in a smart way when the whole content of the directory is used?