### PR TITLE
Add pre-commit and yamllint configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.17.0
+    hooks:
+      - id: yamllint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+extends: default
+
+rules:
+  document-start: disable

--- a/.yamllint
+++ b/.yamllint
@@ -3,3 +3,4 @@ extends: default
 
 rules:
   document-start: disable
+  line-length: disable


### PR DESCRIPTION
In #56 is a discussion in process about tests for PRs to ensure that there are no syntax errors.

[`pre-commit`](https://pre-commit.com/) allows one to run tests locally before changes are committed and avoid in the future that an additional commit has to be made to fix the syntax because the automatic check doesn't pass.

`pre-commit` is mainly about running `yamllint` at the moment. This is the reason that this PR also includes a configuration file for `yamllint`. While running `yamllint` manually or as part `pre-commit` this file contains the exceptions.  

I would be more than happy to add a little section to `GUIDE.md` at the end about the syntax linting.  
