### PR TITLE
Add top-level directory check for security.txt

### DIFF
--- a/files/security.txt.yaml
+++ b/files/security.txt.yaml
@@ -9,6 +9,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/.well-known/security.txt"
+      - "{{BaseURL}}/security.txt"
     matchers:
       - type: status
         status:


### PR DESCRIPTION
security.txt files can be placed under the top-level directory too. This commit adds a check for:

    https://example.com/security.txt