### PR TITLE
rack-mini-profiler environment information discloure detection template

### DIFF
--- a/security-misconfiguration/rack-mini-profiler.yaml
+++ b/security-misconfiguration/rack-mini-profiler.yaml
@@ -1,4 +1,4 @@
-id: rack-miniprofiler
+id: rack-mini-profiler
 
 info:
   name: rack-mini-profiler environmnet information discloure

--- a/security-misconfiguration/rack-miniprofiler.yaml
+++ b/security-misconfiguration/rack-miniprofiler.yaml
@@ -1,0 +1,18 @@
+id: rack-miniprofiler
+
+info:
+  name: rack-mini-profiler environmnet information discloure
+  author: vzamanillo
+  severity: high
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?pp=env"
+    matchers:
+      - type: word
+        words:
+          - "Rack Environment"
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Ruby Rack based web applications using `rack-mini-profiler` without access control can show application’s environment details via `?pp=env` param.

```
Rack Environment
---------------
rack.version: [1, 3]
rack.errors: #<IO:0x000056388804c8d0>
rack.multithread: true
rack.multiprocess: false
rack.run_once: false
SCRIPT_NAME:
QUERY_STRING: pp=env
SERVER_PROTOCOL: HTTP/1.1
SERVER_SOFTWARE: puma 3.12.1 Llamas in Pajamas
GATEWAY_INTERFACE: CGI/1.2
REQUEST_METHOD: GET
REQUEST_PATH: /path
REQUEST_URI: /path?pp=env
HTTP_VERSION: HTTP/1.0
HTTP_X_REAL_IP: x.x.x.x
HTTP_X_FORWARDED_FOR: x.x.x.x, x.x.x.x
HTTP_X_FORWARDED_PROTO: http
HTTP_HOST: example.com
HTTP_X_NGINX_PROXY: true
HTTP_CONNECTION: close
HTTP_X_FORWARDED_PORT: 443
_FIGARO_URL_REDIS: redis.example.com
_FIGARO_S3_ACCESS_KEY: AKIAxxxxxxx
_FIGARO_S3_SECRET_KEY: iXkcGxxxxxx
_FIGARO_S3_REGION: us-west-2
_FIGARO_S3_BUCKET: bucketexample
...
```
https://github.com/MiniProfiler/rack-mini-profiler#memory-profiling