### PR TITLE
Update rce-shellshock-user-agent.yaml

### DIFF
--- a/vulnerabilities/rce-shellshock-user-agent.yaml
+++ b/vulnerabilities/rce-shellshock-user-agent.yaml
@@ -12,8 +12,7 @@ requests:
    path:
     - "{{BaseURL}}/cgi-bin/status"
    matchers:
-    - type: word
-      words:
-       - "/bin/sh"
-       - "/bin/bash"
+    - type: regex
+      regex:
+       - "root:[x*]:0:0"
       part: body


### PR DESCRIPTION
regex can be more precise to check for /etc/passwd