### PR TITLE
Add support for detecting Compal CH7465LG devices

### DIFF
--- a/panels/compal.yaml
+++ b/panels/compal.yaml
@@ -1,0 +1,16 @@
+id: compal-panel-detect
+
+info:
+  name: Compal CH7465LG panel detect
+  author: fabaff
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/common_page/login.html"
+    matchers:
+      - type: word
+        words:
+          - "<!--for router status S-->"
+        part: body


### PR DESCRIPTION
The cable modem/router Compal CH7465LG which is provided under different names by various ISP in Europe.

- UPC Connect Box
- Irish Virgin Media Super Hub 3.0
- Ziggo Connectbox NL
- Unitymedia Connect Box (DE)