### PR TITLE
Sophos firewall detection

### DIFF
--- a/panels/sophos-fw-version-detect.yaml
+++ b/panels/sophos-fw-version-detect.yaml
@@ -1,0 +1,27 @@
+id: sophos-fw-version-detect
+
+info:
+  name: Sophos Firewall version detection
+  author: organiccrap
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/webconsole/webpages/login.jsp"
+      - "{{BaseURL}}/userportal/webpages/myaccount/login.jsp"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<title>Sophos</title>"
+      - type: regex
+        part: body
+        regex:
+          - "(\\d{2}.\\d{1,2}.\\d{1,2}.\\d{2,3})"
+    condition: and
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "(\\d{2}.\\d{1,2}.\\d{1,2}.\\d{2,3})"


### PR DESCRIPTION
Before CVE-2020-12271 exploit start popping up.