### PR TITLE
Add support for detecting Jolokia instance

### DIFF
--- a/files/jolokia.yaml
+++ b/files/jolokia.yaml
@@ -1,18 +1,18 @@
 id: jolokia instance
 
 info:
-  name: Jolokia Version Disclosure 
+  name: Jolokia Version Disclosure
   author: mavericknerd
   severity: low
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/jolokia/version"
+      - '{{BaseURL}}/jolokia/version'
     matchers:
       - type: word
         words:
-          - "\"agent\":"
+          - '"agent":'
       - type: status
         status:
           - 200

--- a/files/jolokia.yaml
+++ b/files/jolokia.yaml
@@ -1,0 +1,18 @@
+id: jolokia instance
+
+info:
+  name: Jolokia Version Disclosure 
+  author: mavericknerd
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/jolokia/version"
+    matchers:
+      - type: word
+        words:
+          - "\"agent\":"
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adding support for checking if Jolokia endpoint is available and its version.

Got this idea from: https://blog.it-securityguard.com/how-i-made-more-than-30k-with-jolokia-cves/

CVE detection with version check is also possible, but all the current CVE's in the cve/ directory has the exploit, but exploit for this is not possible with nuclei, but still we can detect it, let me know if I can make a change for that too.