### PR TITLE
Exposed Docker API added

### DIFF
--- a/panels/docker-api.yaml
+++ b/panels/docker-api.yaml
@@ -1,0 +1,17 @@
+id: Exposed Docker API
+
+info:
+  name: Exposed Docker API
+  author: furkansenan
+  severity: medium
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}:2376/version'
+    matchers:
+      - type: word
+        words:
+          - "Version"
+          - "Docker"
+        part: body


### PR DESCRIPTION
Detection for internet exposed Docker API configuration is added to the "panel" folder. It is tested by using shodan public dataset and no fault has found so far.