### PR TITLE
add tomcat manager disclosure (authenticated)

### DIFF
--- a/files/tomcat.yaml
+++ b/files/tomcat.yaml
@@ -1,0 +1,19 @@
+id: tomcat instance
+
+info:
+  name: tomcat manager disclosure
+  author: Ahmed Sherif
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/manager/html'
+      - '{{BaseURL}}:8080/manager/html'
+    matchers:
+      - type: word
+        words:
+          - '"Unauthorized":'
+      - type: status
+        status:
+          - 401


### PR DESCRIPTION
Sometimes bug hunters tend to discover tomcat manager instances even if authenticated for reconnaissance purposes and in case new vulnerabilities affecting tomcat instance. 