### PR TITLE
Handle some more edge cases in crlf-injection and open-redirect tests

### DIFF
--- a/vulnerabilities/crlf-injection.yaml
+++ b/vulnerabilities/crlf-injection.yaml
@@ -13,5 +13,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?:Set-Cookie:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
+          - '(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
         part: header

--- a/vulnerabilities/crlf-injection.yaml
+++ b/vulnerabilities/crlf-injection.yaml
@@ -13,5 +13,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
+          - '(?m)^(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)(?:\s*?)(?:$|;)'
         part: header

--- a/vulnerabilities/crlf-injection.yaml
+++ b/vulnerabilities/crlf-injection.yaml
@@ -13,5 +13,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
+          - '(?m)^(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
         part: header

--- a/vulnerabilities/crlf-injection.yaml
+++ b/vulnerabilities/crlf-injection.yaml
@@ -13,5 +13,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - "^(?:Set-Cookie\\s?:|;)\\s?crlfinjection=crlfinjection(?:$|;)"
+          - '(?:Set-Cookie:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)'
         part: header

--- a/vulnerabilities/open-redirect.yaml
+++ b/vulnerabilities/open-redirect.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '^Location:\s?(?:(?:http|https)://|//|[a-zA-Z0-9\-_]+\.|(?:http|https)://[a-zA-Z0-9\-_]+\.)?evil\.com'
+          - '(?:Location:\s*?)(?:https?://)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
         part: header

--- a/vulnerabilities/open-redirect.yaml
+++ b/vulnerabilities/open-redirect.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?:Location:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
+          - '(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
         part: header

--- a/vulnerabilities/open-redirect.yaml
+++ b/vulnerabilities/open-redirect.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?:Location:\s*?)(?:https?://)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
+          - '(?:Location:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
         part: header

--- a/vulnerabilities/open-redirect.yaml
+++ b/vulnerabilities/open-redirect.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
         part: header

--- a/vulnerabilities/open-redirect.yaml
+++ b/vulnerabilities/open-redirect.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com(?:\s*?)$'
         part: header


### PR DESCRIPTION
I noticed some hit-or-miss behavior during testing with a `^` (start of line/text) prefix on the regex, not sure why this is happening.

Options where to prepend a `(?m)` for explicit multiline matching or to avoid matching the start of line/text entirely: since it doesn't look like the former isn't used anywhere i decided to stick with the latter, feel free to modify that.

Also, I've yet to go through the code and see if header names are Normalized-Like-This: if this doesn't happen i would have prefixed the regex with `(?i)` as well.