### PR TITLE
Detect wordpress xmlrpc (sometimes leads to ssrf)

### DIFF
--- a/security-misconfiguration/wp-xmlrpc.yaml
+++ b/security-misconfiguration/wp-xmlrpc.yaml
@@ -1,0 +1,15 @@
+id: xmlrpc
+
+info:
+  name: WordPress xmlrpc
+  author: udit_thakkur
+  severity: medium
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/xmlrpc.php"
+    matchers:
+      - type: status
+        status:
+          - 405


### PR DESCRIPTION
Provides a way to detect the wordpress xmlrpc endpoint that can help and leads to possible ssrf sometimes.
I am not sure if it is worth to add. But I have got a few good findings using this.

Let me know if I'm doing it right, You guys are doing great work, Love this project. Kudos..! 
Trying to contribute a little.