### PR TITLE
 Wordpress_directory_listing.yaml

### DIFF
--- a/files/Wordpress_directory_listing.yaml
+++ b/files/Wordpress_directory_listing.yaml
@@ -1,0 +1,18 @@
+id: wordpress-directory-listing
+
+info:
+  name: Wordpress Directory Listing
+  author: Manas_Harsh
+  severity: informative
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/uploads"
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - avatar_urls


### PR DESCRIPTION
It will show the internal files on a WordPress website if those are enabled.