### PR TITLE
Fix for false-positive CVE-2018-16341 results

### DIFF
--- a/cves/CVE-2018-16341.yaml
+++ b/cves/CVE-2018-16341.yaml
@@ -8,9 +8,9 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/nuxeo/login.jsp/pwn${1330+7}.xhtml"
+      - "{{BaseURL}}/nuxeo/login.jsp/pwn${31333333330+7}.xhtml"
     matchers:
       - type: word
         words:
-          - "1337"
+          - "31333333337"
         part: body


### PR DESCRIPTION
Sometimes, the previous `matchers` conditions are considered suitable for the response body that contains the Javascript CDN file name in other words giving a false-positive result.