### PR TITLE
Create jira-unauthenticated-user-picker.yaml

### DIFF
--- a/security-misconfiguration/jira-unauthenticated-user-picker.yaml
+++ b/security-misconfiguration/jira-unauthenticated-user-picker.yaml
@@ -1,0 +1,15 @@
+id: jira-unauthenticated-user-picker
+
+info:
+  name: Jira Unauthenticated User Picker
+  author: TechbrunchFR
+  severity: High
+  
+requests: 
+  - method: GET
+    path:
+      - "{{BaseURL}}/secure/popups/UserPickerBrowser.jspa"
+    matchers:
+      - type: word
+        words:
+          - 'user-picker'

--- a/security-misconfiguration/jira-unauthenticated-user-picker.yaml
+++ b/security-misconfiguration/jira-unauthenticated-user-picker.yaml
@@ -4,8 +4,8 @@ info:
   name: Jira Unauthenticated User Picker
   author: TechbrunchFR
   severity: High
-  
-requests: 
+
+requests:
   - method: GET
     path:
       - "{{BaseURL}}/secure/popups/UserPickerBrowser.jspa"


### PR DESCRIPTION
Through the user picker functionality within Jira your user base information could be available to anonymous users. The Browse User Global Permission allows a user to view a list of all Jira user names and group names, share issues, and @mention people on issues. This is used for selecting users/groups in popup screens and also enables auto-completion of usernames in most 'User Picker' menus and popups.

If you grant this permission to the Anyone group, you will be allowing anonymous users access to the endpoints that provide a list of users.

Remediation: Ensure that this permission is restricted to specific groups that require it. You can restrict it in Administration > System > Global Permissions.