### PR TITLE
Create CVE-2019-8451.yaml

### DIFF
--- a/cves/CVE-2019-8451.yaml
+++ b/cves/CVE-2019-8451.yaml
@@ -1,0 +1,31 @@
+id: CVE-2019-8451
+
+info:
+  name: JIRA SSRF in the /plugins/servlet/gadgets/makeRequest resource
+  author: "TechbrunchFR"
+  severity: medium
+
+# On September 9, Atlassian released version 8.4.0 for Jira Core and Jira Software, which included a fix for an important
+# security issue reported in August 2019.
+
+# CVE-2019-8451 is a pre-authentication server-side request forgery (SSRF) vulnerability found in 
+# the /plugins/servlet/gadgets/makeRequest resource. The vulnerability exists due to “a logic bug” in the JiraWhitelist class.
+# An unauthenticated attacker could exploit this vulnerability by sending a specially crafted web request to a vulnerable 
+# Jira server. Successful exploitation would result in unauthorized access to view and potentially modify internal 
+# network resources.
+# https://www.tenable.com/blog/cve-2019-8451-proof-of-concept-available-for-server-side-request-forgery-ssrf-vulnerability-in
+# https://twitter.com/benmontour/status/1177250393220239360
+# https://twitter.com/ojensen5115/status/1176569607357730817
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/plugins/servlet/gadgets/makeRequest?url=https://{{Hostname}}:1337@example.com'
+    headers:
+      X-Atlassian-token: no-check
+    matchers:
+      - type: word
+        name: ssrf-response-body
+        words:
+          - '<p>This domain is for use in illustrative examples in documents.'
+        part: body

--- a/cves/CVE-2019-8451.yaml
+++ b/cves/CVE-2019-8451.yaml
@@ -8,10 +8,10 @@ info:
 # On September 9, Atlassian released version 8.4.0 for Jira Core and Jira Software, which included a fix for an important
 # security issue reported in August 2019.
 
-# CVE-2019-8451 is a pre-authentication server-side request forgery (SSRF) vulnerability found in 
+# CVE-2019-8451 is a pre-authentication server-side request forgery (SSRF) vulnerability found in
 # the /plugins/servlet/gadgets/makeRequest resource. The vulnerability exists due to “a logic bug” in the JiraWhitelist class.
-# An unauthenticated attacker could exploit this vulnerability by sending a specially crafted web request to a vulnerable 
-# Jira server. Successful exploitation would result in unauthorized access to view and potentially modify internal 
+# An unauthenticated attacker could exploit this vulnerability by sending a specially crafted web request to a vulnerable
+# Jira server. Successful exploitation would result in unauthorized access to view and potentially modify internal
 # network resources.
 # https://www.tenable.com/blog/cve-2019-8451-proof-of-concept-available-for-server-side-request-forgery-ssrf-vulnerability-in
 # https://twitter.com/benmontour/status/1177250393220239360


### PR DESCRIPTION
On September 9, Atlassian released version 8.4.0 for Jira Core and Jira Software, which included a fix for an important
security issue reported in August 2019.

CVE-2019-8451 is a pre-authentication server-side request forgery (SSRF) vulnerability found in 
the /plugins/servlet/gadgets/makeRequest resource. The vulnerability exists due to “a logic bug” in the JiraWhitelist class.
An unauthenticated attacker could exploit this vulnerability by sending a specially crafted web request to a vulnerable 
Jira server. Successful exploitation would result in unauthorized access to view and potentially modify internal 
network resources.

- https://www.tenable.com/blog/cve-2019-8451-proof-of-concept-available-for-server-side-request-forgery-ssrf-vulnerability-in
- https://twitter.com/benmontour/status/1177250393220239360
- https://twitter.com/ojensen5115/status/1176569607357730817