### PR TITLE
Create jira-unauthenticated-popular-filters.yaml

### DIFF
--- a/security-misconfiguration/jira-unauthenticated-popular-filters.yaml
+++ b/security-misconfiguration/jira-unauthenticated-popular-filters.yaml
@@ -1,0 +1,23 @@
+id: jira-unauthenticated-popular-filters
+
+info:
+  name: Jira Unauthenticated Popular Filters
+  author: TechbrunchFR
+  severity: Info
+  
+requests: 
+  - method: GET
+    path:
+      - "{{BaseURL}}/secure/ManageFilters.jspa?filter=popular&filterView=popular"
+    matchers:
+      - type: word
+        words:
+          - 'filterlink_'
+
+# Remediation:
+# Ensure that this permission is restricted to specific groups that require it.
+# You can restrict it in Administration > System > Global Permissions.
+# Turning the feature off will not affect existing filters and dashboards.
+# If you change this setting, you will still need to update the existing filters and dashboards if they have already been
+# shared publicly.
+# Since Jira 7.2.10, a dark feature to disable site-wide anonymous access was introduced.

--- a/security-misconfiguration/jira-unauthenticated-popular-filters.yaml
+++ b/security-misconfiguration/jira-unauthenticated-popular-filters.yaml
@@ -4,8 +4,8 @@ info:
   name: Jira Unauthenticated Popular Filters
   author: TechbrunchFR
   severity: Info
-  
-requests: 
+
+requests:
   - method: GET
     path:
       - "{{BaseURL}}/secure/ManageFilters.jspa?filter=popular&filterView=popular"


### PR DESCRIPTION
If public sharing is ON it allows users to share dashboards and filters with all users including those that are not logged in. Those dashboard and filters could reveal potentially sensitive information.