### PR TITLE
Create jira-unauthenticated-dashboards.yaml

### DIFF
--- a/security-misconfiguration/jira-unauthenticated-dashboards.yaml
+++ b/security-misconfiguration/jira-unauthenticated-dashboards.yaml
@@ -1,0 +1,29 @@
+id: jira-unauthenticated-dashboards
+
+# If public sharing is ON it allows users to share dashboards and filters with all users including
+# those that are not logged in. Those dashboard and filters could reveal potentially sensitive information.
+
+info:
+  name: Jira Unauthenticated Dashboards
+  author: TechbrunchFR
+  severity: Info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/rest/api/2/dashboard?maxResults=100"
+    matchers:
+      - type: word
+        words:
+          - 'dashboards'
+          - 'startAt'
+          - 'maxResults'
+        condition: and
+
+# Remediation:
+# Ensure that this permission is restricted to specific groups that require it.
+# You can restrict it in Administration > System > Global Permissions.
+# Turning the feature off will not affect existing filters and dashboards.
+# If you change this setting, you will still need to update the existing filters and dashboards if they have already been
+# shared publicly.
+# Since Jira 7.2.10, a dark feature to disable site-wide anonymous access was introduced.


### PR DESCRIPTION
If public sharing is ON it allows users to share dashboards and filters with all users including those that are not logged in. Those dashboard and filters could reveal potentially sensitive information.