### PR TITLE
Create jira-unauthenticated-projects.yaml

### DIFF
--- a/security-misconfiguration/jira-unauthenticated-projects.yaml
+++ b/security-misconfiguration/jira-unauthenticated-projects.yaml
@@ -1,0 +1,18 @@
+id: jira-unauthenticated-projects
+
+info:
+  name: Jira Unauthenticated Projects
+  author: TechbrunchFR
+  severity: Info
+  
+requests: 
+  - method: GET
+    path:
+      - "{{BaseURL}}/rest/api/2/project?maxResults=100"
+    matchers:
+      - type: word
+        words:
+          - 'projects'
+          - 'startAt'
+          - 'maxResults'
+        condition: and

--- a/security-misconfiguration/jira-unauthenticated-projects.yaml
+++ b/security-misconfiguration/jira-unauthenticated-projects.yaml
@@ -4,8 +4,8 @@ info:
   name: Jira Unauthenticated Projects
   author: TechbrunchFR
   severity: Info
-  
-requests: 
+
+requests:
   - method: GET
     path:
       - "{{BaseURL}}/rest/api/2/project?maxResults=100"


### PR DESCRIPTION
If public sharing is ON it allows users to share projects with all users including those that are not logged in. Those projects could reveal potentially sensitive information.