### PR TITLE
Fix from false-positive RabbitMQ default cred results

### DIFF
--- a/security-misconfiguration/rabbitmq-default-admin.yaml
+++ b/security-misconfiguration/rabbitmq-default-admin.yaml
@@ -2,16 +2,25 @@ id: rabbitmq-default-admin
 
 info:
   name: RabbitMQ Default Credentials
-  author: fyoorer
+  author: fyoorer & dwisiswant0
   severity: High
 
 requests:
   - method: GET
-    headers:
-      authorization: "Basic Z3Vlc3Q6Z3Vlc3Q="
     path:
-      - '{{BaseURL}}/api/whoami'
+      - "{{BaseURL}}/api/whoami"
+      - "{{BaseURL}}:15672/api/whoami"
+    headers:
+      Authorization: "Basic Z3Vlc3Q6Z3Vlc3Q="
+    matchers-condition: and
     matchers:
+      - type: word
+        words:
+          - "application/json"
+        part: header
+      - type:
+        words:
+          - "{\"name\":\"guest\""
       - type: status
         status:
           - 200

--- a/security-misconfiguration/rabbitmq-default-admin.yaml
+++ b/security-misconfiguration/rabbitmq-default-admin.yaml
@@ -21,6 +21,7 @@ requests:
       - type:
         words:
           - "{\"name\":\"guest\""
+        part: body
       - type: status
         status:
           - 200


### PR DESCRIPTION
Previously, this produced too many false-positives.

![Screenshot_2020-07-08_23-54-37](https://user-images.githubusercontent.com/25837540/86947924-aa8eac00-c176-11ea-9b11-13554b8461dc.png)