### PR TITLE
improve CVE-2017-7529 detection

### DIFF
--- a/cves/CVE-2017-7529.yaml
+++ b/cves/CVE-2017-7529.yaml
@@ -28,3 +28,7 @@ requests:
         words:
           - nginx
         part: header
+      - type: word
+        words:
+          - 'Content-Range'
+        part: body

--- a/cves/CVE-2017-7529.yaml
+++ b/cves/CVE-2017-7529.yaml
@@ -26,9 +26,5 @@ requests:
           - 206
       - type: word
         words:
-          - nginx
+          - Content-Range
         part: header
-      - type: word
-        words:
-          - 'Content-Range'
-        part: body


### PR DESCRIPTION
The python script for checking/exploiting the server (https://gist.github.com/BlackVirusScript/75fae10a037c376555b0ad3f3da1a966#file-cve-2017-7529-py-L27) also checks for the presence of "Content-Range" in response body.

Without it some false positives are produced.