### PR TITLE
header matcher update

### DIFF
--- a/security-misconfiguration/springboot-detect.yaml
+++ b/security-misconfiguration/springboot-detect.yaml
@@ -95,6 +95,7 @@ requests:
         words:
           - "X-Application-Context"
           - "application/json"
+          - "application/vnd.spring-boot.actuator.v2+json;charset=UTF-8"
           - "hprof"
         condition: or
         part: header

--- a/security-misconfiguration/springboot-detect.yaml
+++ b/security-misconfiguration/springboot-detect.yaml
@@ -95,7 +95,7 @@ requests:
         words:
           - "X-Application-Context"
           - "application/json"
-          - "application/vnd.spring-boot.actuator.v2+json;charset=UTF-8"
+          - "application/vnd.spring-boot.actuator.v2+json"
           - "hprof"
         condition: or
         part: header


### PR DESCRIPTION
Came across a condition where this template wasn't matching because the application was sending "application/vnd.spring-boot.actuator.v2+json;charset=UTF-8" instead of "application/json" in content-type header of response.