### PR TITLE
Add Frontify subdomain takeover detection

### DIFF
--- a/subdomain-takeover/detect-all-takeovers.yaml
+++ b/subdomain-takeover/detect-all-takeovers.yaml
@@ -350,3 +350,9 @@ requests:
         name: zendesk
         words:
           - this help center no longer exists
+
+      - type: word
+        name: frontify
+        words:
+          - 404 - Page Not Found
+          - Oops… looks like you got lost

--- a/subdomain-takeover/detect-all-takeovers.yaml
+++ b/subdomain-takeover/detect-all-takeovers.yaml
@@ -356,3 +356,5 @@ requests:
         words:
           - 404 - Page Not Found
           - Oops… looks like you got lost
+        condition: and
+        part: body


### PR DESCRIPTION
Please keep in mind, Frontify subdomain takeovers require a premium account.

![image](https://user-images.githubusercontent.com/18099289/87246556-70f7c280-c44e-11ea-931f-df283f319851.png)
