### PR TITLE
Add semicolon to path

### DIFF
--- a/cves/CVE-2018-11759.yaml
+++ b/cves/CVE-2018-11759.yaml
@@ -10,7 +10,7 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}/jkstatus'
+      - '{{BaseURL}}/jkstatus;'
 
     matchers-condition: and
     matchers:

--- a/cves/CVE-2018-11759.yaml
+++ b/cves/CVE-2018-11759.yaml
@@ -3,13 +3,14 @@ id: CVE-2018-11759
 info:
   name: Apache Tomcat JK Status Manager Access
   author: Harsh Bothra
-  severity: Medium
+  severity: medium
 
-# source:- https://github.com/immunIT/CVE-2018-11759
+# Source:- https://github.com/immunIT/CVE-2018-11759
 
 requests:
   - method: GET
     path:
+      - '{{BaseURL}}/jkstatus'
       - '{{BaseURL}}/jkstatus;'
 
     matchers-condition: and


### PR DESCRIPTION
The vulnerability is that access restriction can be circumvented by adding a semicolon to the path (as pointed out in https://github.com/immunIT/CVE-2018-11759).
Without semicolon, jkstatus would be public anyway and would not be related to the CVE.