### PR TITLE
Improve WADL detection, remove WSDL check, add additional checks

### DIFF
--- a/files/wadl-files.yaml
+++ b/files/wadl-files.yaml
@@ -9,9 +9,27 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/application.wadl"
-      - "{{BaseURL}}/service?Wsdl"
+      - "{{BaseURL}}/application.wadl?detail=true"
+      - "{{BaseURL}}/api/application.wadl"
+      - "{{BaseURL}}/api/v1/application.wadl"
+      - "{{BaseURL}}/api/v2/application.wadl"
     matchers:
-      - type: word
+      - name: http-get
+        type: word
+        words:
+          - "This is simplified WADL with user and core resources only"
+          - "\"http://jersey.java.net/\""
+          - "http://wadl.dev.java.net/2009/02"
+        condition: or
+        part: body
+  - method: OPTIONS
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/api/v1"
+      - "{{BaseURL}}/api/v2"
+    matchers:
+      - name: http-options
+        type: word
         words:
           - "This is simplified WADL with user and core resources only"
           - "\"http://jersey.java.net/\""

--- a/files/wadl-files.yaml
+++ b/files/wadl-files.yaml
@@ -2,7 +2,7 @@ id: wadl-files
 
 info:
   name: wadl file disclosure
-  author: 0xrudra
+  author: 0xrudra & manuelbua
   severity: info
 
 requests:


### PR DESCRIPTION
Added a couple more checks for this one, removed a check for WSDL since this is a totally different DL. 
Not particularly happy of the duplicated matchers, am i missing something obvious @bauthard? Else i'm gonna think of way to re-use existing ones in nuclei.