### PR TITLE
Fix small typo

### DIFF
--- a/files/telerik-fileupload-detect.yaml
+++ b/files/telerik-fileupload-detect.yaml
@@ -12,4 +12,4 @@ requests:
     matchers:
       - type: word
         words:
-          - "RadAsyncUpload handler is registered successfully"
+          - "RadAsyncUpload handler is registered succesfully"


### PR DESCRIPTION
The rule is looking for a wrong string.

I corrected the typos so that the rules work properly.

successfully -> succesfully

```
RadAsyncUpload handler is registered succesfully
```