### PR TITLE
Update rabbitmq-dashboard.yaml

### DIFF
--- a/panels/rabbitmq-dashboard.yaml
+++ b/panels/rabbitmq-dashboard.yaml
@@ -9,6 +9,7 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}'
+      - "{{BaseURL}}:15672"
     matchers:
       - type: word
         words:


### PR DESCRIPTION
15672 is default port of RabbitMQ Management