### PR TITLE
Add checks for public Wordpress debug.log

### DIFF
--- a/files/wordpress-debug-log.yaml
+++ b/files/wordpress-debug-log.yaml
@@ -9,6 +9,8 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/debug.log"
+
+    matchers-condition: and
     matchers:
       - type: word
         words:
@@ -16,7 +18,7 @@ requests:
           - text/plain
         part: header
         condition: or
-          
+
       - type: status
         status:
           - 200

--- a/files/wordpress-debug-log.yaml
+++ b/files/wordpress-debug-log.yaml
@@ -1,0 +1,22 @@
+id: wp-debug-log
+
+info:
+  name: WordPress debug log
+  author: geraldino2
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/debug.log"
+    matchers:
+      - type: word
+        words:
+          - octet-stream
+          - text/plain
+        part: header
+        condition: or
+          
+      - type: status
+        status:
+          - 200

--- a/workflows/wordpress-workflow.yaml
+++ b/workflows/wordpress-workflow.yaml
@@ -11,6 +11,7 @@ variables:
   wordpress_duplicator_path_traversal: vulnerabilities/wordpress-duplicator-path-traversal.yaml
   wordpress_wordfence_xss: vulnerabilities/wordpress-wordfence-xss.yaml
   wordpress_cve_1: cves/CVE-2019-9978.yaml
+  wordpress_debug_log: files/wordpress-debug-log.yaml
 
 logic: |
   wordpress_tech()
@@ -23,4 +24,5 @@ logic: |
     wordpress_duplicator_path_traversal()
     wordpress_wordfence_xss()
     wordpress_cve_1()
+    wordpress_debug_log()
   }


### PR DESCRIPTION
WordPress debug.log file may expose information, such as full path disclosures, IP and e-mail addresses, SQL queries, versions and errors.