### PR TITLE
Fix false-positives for WordPress debug log

### DIFF
--- a/files/wordpress-debug-log.yaml
+++ b/files/wordpress-debug-log.yaml
@@ -2,14 +2,13 @@ id: wp-debug-log
 
 info:
   name: WordPress debug log
-  author: geraldino2
+  author: geraldino2 & @dwisiswant0
   severity: info
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/debug.log"
-
     matchers-condition: and
     matchers:
       - type: word
@@ -18,7 +17,10 @@ requests:
           - text/plain
         part: header
         condition: or
-
+      - type: regex
+        regex:
+          - "[[0-9]{2}-[a-zA-Z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3}] PHP"
+        part: body
       - type: status
         status:
           - 200


### PR DESCRIPTION
- Add regex matcher for `time_local` at body