### PR TITLE
Add CVE-2020-11034 - GLPI v.9.4.6 - Open redirect 

### DIFF
--- a/cves/CVE-2020-11034.yaml
+++ b/cves/CVE-2020-11034.yaml
@@ -1,0 +1,23 @@
+id: CVE-2020-11034
+
+info:
+  name: GLPI v.9.4.6 - Open redirect Detection
+  author: pikpikcu
+  severity: low
+
+ # security-advisories:-https://github.com/glpi-project/glpi/security/advisories/GHSA-gxv6-xq9q-37hg
+ # https://github.com/glpi-project/glpi/archive/9.4.6.zip
+ # https://nvd.nist.gov/vuln/detail/CVE-2020-11034
+
+requests:
+  - method: GET
+
+    path:
+      - "{{BaseURL}}/index.php?redirect=/\/evil.com/"
+      - "{{BaseURL}}/index.php?redirect=//evil.com"
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?evil\.com(?:\s*?)$'
+        part: header

--- a/cves/CVE-2020-11034.yaml
+++ b/cves/CVE-2020-11034.yaml
@@ -1,7 +1,7 @@
 id: CVE-2020-11034
 
 info:
-  name: GLPI v.9.4.6 - Open redirect Detection
+  name: GLPI v.9.4.6 - Open redirect
   author: pikpikcu
   severity: low
 


### PR DESCRIPTION
### GLPI - Multiple Vulnerabilty

- https://offsec.almond.consulting/multiple-vulnerabilities-in-glpi.html
### issues:
- https://github.com/glpi-project/glpi/issues/506
### Refrences to Advisories:
- https://nvd.nist.gov/vuln/detail/CVE-2020-11034
- https://github.com/glpi-project/glpi/security/advisories/GHSA-gxv6-xq9q-37hg