### PR TITLE
Create missing-hsts

### DIFF
--- a/security-misconfiguration/hsts.yaml
+++ b/security-misconfiguration/hsts.yaml
@@ -1,0 +1,17 @@
+id: missing-hsts
+info:
+  name: Strict Tranposrt Security Not Enforced
+  author: Dawid Czarnecki
+  severity: low
+  description: >-
+    Checks if the HSTS is enabled by looking for Strict Transport Security
+    response header.
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+    redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - '!contains(tolower(all_headers), ''strict-transport-security'')'

--- a/security-misconfiguration/missing-hsts.yaml
+++ b/security-misconfiguration/missing-hsts.yaml
@@ -2,9 +2,8 @@ id: missing-hsts
 info:
   name: Strict Tranposrt Security Not Enforced
   author: Dawid Czarnecki
-  severity: low
-  description: >-
-    Checks if the HSTS is enabled by looking for Strict Transport Security
+  severity: info
+  description: Checks if the HSTS is enabled by looking for Strict Transport Security
     response header.
 requests:
   - method: GET


### PR DESCRIPTION
Detects missing HSTS header
**Example:**
```
                       __     _ 
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ / 
   / / / / /_/ / /__/ /  __/ /  
  /_/ /_/\__,_/\___/_/\___/_/   v2.1									  

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[WRN] nuclei-templates are not installed, use update-templates flag.
[INF] [missing-hsts] Loaded template Strict Tranposrt Security Not Enforced (@Dawid Czarnecki) [low]
[missing-hsts] [http] https://zigrin.com
```