### PR TITLE
Fix false-positive for wordpress-tmm-db-migrate

### DIFF
--- a/files/wordpress-tmm-db-migrate.yaml
+++ b/files/wordpress-tmm-db-migrate.yaml
@@ -15,6 +15,10 @@ requests:
         words:
           - "application/zip"
         part: header
+      - type: regex
+        regex:
+          - "[a-z0-9_]+.dat"
+        part: body
       - type: status
         status:
           - 200


### PR DESCRIPTION
- Adding matcher to body