### PR TITLE
Fix false-positive for CVE-2005-2428

### DIFF
--- a/cves/CVE-2005-2428.yaml
+++ b/cves/CVE-2005-2428.yaml
@@ -8,7 +8,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/names.nsf/People?OpenView"
-
+    matchers-condition: and
     matchers:
       - type: status
         status:


### PR DESCRIPTION
- Adding matcher condition to `and`.