### PR TITLE
Add Zenphoto Installation Sensitive Information

### DIFF
--- a/generic-detections/zenphoto-installation-sensitive-info.yaml
+++ b/generic-detections/zenphoto-installation-sensitive-info.yaml
@@ -3,8 +3,7 @@ info:
   name: Zenphoto Installation Sensitive Information
   author: qlkwej
   severity: medium
-  description: >-
-    Misconfiguration on Zenphoto version < 1.5.X which lead to sensitive
+  description: Misconfiguration on Zenphoto version < 1.5.X which lead to sensitive
     information disclosure
 requests:
   - method: GET

--- a/generic-detections/zenphoto-installation-sensitive-info.yaml
+++ b/generic-detections/zenphoto-installation-sensitive-info.yaml
@@ -1,0 +1,28 @@
+id: zenphoto-installation-sensitive-info
+info:
+  name: Zenphoto Installation Sensitive Information
+  author: qlkwej
+  severity: medium
+  description: >-
+    Misconfiguration on Zenphoto version < 1.5.X which lead to sensitive
+    information disclosure
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/zenphoto/zp-core/setup/index.php'
+      - '{{BaseURL}}/zp/zp-core/setup/index.php'
+      - '{{BaseURL}}/gallery/zp-core/setup/index.php'
+      - '{{BaseURL}}/zp-core/setup/index.php'
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - Welcome to Zenphoto! This page will set up Zenphoto
+        part: body
+      - type: word
+        words:
+          - text/html
+        part: header
+      - type: status
+        status:
+          - 200

--- a/security-misconfiguration/zenphoto-installation-sensitive-info.yaml
+++ b/security-misconfiguration/zenphoto-installation-sensitive-info.yaml
@@ -1,10 +1,12 @@
 id: zenphoto-installation-sensitive-info
+
 info:
   name: Zenphoto Installation Sensitive Information
   author: qlkwej
   severity: medium
   description: Misconfiguration on Zenphoto version < 1.5.X which lead to sensitive
     information disclosure
+
 requests:
   - method: GET
     path:
@@ -12,16 +14,19 @@ requests:
       - '{{BaseURL}}/zp/zp-core/setup/index.php'
       - '{{BaseURL}}/gallery/zp-core/setup/index.php'
       - '{{BaseURL}}/zp-core/setup/index.php'
+
     matchers-condition: and
     matchers:
       - type: word
         words:
           - Welcome to Zenphoto! This page will set up Zenphoto
         part: body
+
       - type: word
         words:
           - text/html
         part: header
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
Zenphoto Installation Sensitive Information

Poc:
<img width="526" alt="Screen Shot 2020-09-12 at 23 36 01" src="https://user-images.githubusercontent.com/25258929/92999121-0ef03200-f551-11ea-8c3a-593ccfa6b9f1.png">


**Response nuclei-template**
```
qlkwej@🔥 generic-detections % nuclei -l test.txt -t zenphoto-installation-sensitive-info.yaml

                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.1.1

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[WRN] nuclei-templates are not installed, use update-templates flag.
[INF] Loading templates...
[INF] [zenphoto-installation-sensitive-info] Zenphoto Installation Sensitive Information (@qlkwej) [medium]
[INF] Using 1 rules (1 templates, 0 workflows)
[zenphoto-installation-sensitive-info] [http] http://XXXXXXXXXX/zenphoto/zp-core/setup/index.php
```