### PR TITLE
Improvement of matching for robots.txt -> only match when there is potentially juicy content

### DIFF
--- a/files/robots.txt.yaml
+++ b/files/robots.txt.yaml
@@ -21,4 +21,4 @@ requests:
 
       - type: dsl
         dsl:
-          - "len(body)>=30 && status_code==200"
+          - "len(body)>=140 && status_code==200"

--- a/files/robots.txt.yaml
+++ b/files/robots.txt.yaml
@@ -19,6 +19,6 @@ requests:
           - text/plain
         part: header
 
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "len(body)>=30 && status_code==200"


### PR DESCRIPTION
Updated matcher to dsl to only match files that contains more than "Disallow: /"

/ Casper