### PR TITLE
Follow redirects on robots.txt

### DIFF
--- a/files/robots.txt.yaml
+++ b/files/robots.txt.yaml
@@ -9,6 +9,7 @@ requests:
     path:
       - "{{BaseURL}}/robots.txt"
     matchers-condition: and
+    redirects: true
     matchers:
       - type: word
         words:


### PR DESCRIPTION
Some sites redirects from http to https. As mostly the main goal is to get file itself, redirect should be followed.