### PR TITLE
Add CVE-2020-2034

### DIFF
--- a/cves/CVE-2020-2034.yaml
+++ b/cves/CVE-2020-2034.yaml
@@ -27,12 +27,12 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/global-protect/login.esp"
-      - "{{BaseURL}}/php/login.php"
       - "{{BaseURL}}/global-protect/portal/css/login.css"
-      - "{{BaseURL}}/js/Pan.js"
       - "{{BaseURL}}/global-protect/portal/images/favicon.ico"
-      - "{{BaseURL}}/login/images/favicon.ico"
       - "{{BaseURL}}/global-protect/portal/images/logo-pan-48525a.svg"
+      - "{{BaseURL}}/js/Pan.js"
+      - "{{BaseURL}}/login/images/favicon.ico"
+      - "{{BaseURL}}/php/login.php"
     matchers-condition: and
     matchers:
       - type: word

--- a/cves/CVE-2020-2034.yaml
+++ b/cves/CVE-2020-2034.yaml
@@ -1,0 +1,45 @@
+id: cve-2020-2034
+
+info:
+  name: PAN-OS GlobalProtect OS Command Injection
+  author: dwisiswant0
+  severity: high
+  description: |
+    This template supports the detection part only. See references.
+
+    An OS Command Injection vulnerability in the PAN-OS GlobalProtect portal
+    allows an unauthenticated network based attacker to execute
+    arbitrary OS commands with root privileges.
+
+    An attacker requires some knowledge of the firewall to exploit this issue.
+    This issue can not be exploited if GlobalProtect portal feature is not enabled.
+    This issue impacts PAN-OS 9.1 versions earlier than PAN-OS 9.1.3;
+    PAN-OS 8.1 versions earlier than PAN-OS 8.1.15;
+    PAN-OS 9.0 versions earlier than PAN-OS 9.0.9;
+    all versions of PAN-OS 8.0 and PAN-OS 7.1.
+
+    Prisma Access services are not impacted by this vulnerability.
+
+    Source/References:
+    - https://github.com/blackhatethicalhacking/CVE-2020-2034-POC
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/global-protect/login.esp"
+      - "{{BaseURL}}/php/login.php"
+      - "{{BaseURL}}/global-protect/portal/css/login.css"
+      - "{{BaseURL}}/js/Pan.js"
+      - "{{BaseURL}}/global-protect/portal/images/favicon.ico"
+      - "{{BaseURL}}/login/images/favicon.ico"
+      - "{{BaseURL}}/global-protect/portal/images/logo-pan-48525a.svg"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "ETag"
+          - "Last-Modified"
+        part: header
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
**PAN-OS GlobalProtect OS Command Injection**
> This template supports the detection part only. See references.
>
> An OS Command Injection vulnerability in the PAN-OS GlobalProtect portal
> allows an unauthenticated network based attacker to execute
> arbitrary OS commands with root privileges.
>
> An attacker requires some knowledge of the firewall to exploit this issue.
> This issue can not be exploited if GlobalProtect portal feature is not enabled.
> This issue impacts PAN-OS 9.1 versions earlier than PAN-OS 9.1.3;
> PAN-OS 8.1 versions earlier than PAN-OS 8.1.15;
> PAN-OS 9.0 versions earlier than PAN-OS 9.0.9;
> all versions of PAN-OS 8.0 and PAN-OS 7.1.
>
> Prisma Access services are not impacted by this vulnerability.
>
> Source/References:
> - https://github.com/blackhatethicalhacking/CVE-2020-2034-POC