### PR TITLE
Fix "prometheus-exporter-detect" false positives

### DIFF
--- a/technologies/prometheus-exporter-detect.yaml
+++ b/technologies/prometheus-exporter-detect.yaml
@@ -1,5 +1,3 @@
-# See https://github.com/prometheus/prometheus/wiki/Default-port-allocations
-
 id: prometheus-exporter-detect
 info:
   name: Prometheus exporter detect
@@ -7,12 +5,15 @@ info:
   severity: info
   description: Prometheus exporter detector
 
+# See https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/"
     headers:
       User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:55.0) Gecko/20100101 Firefox/55
+    matchers-condition: and
     matchers:
       - type: word
         words:


### PR DESCRIPTION
I was running this template and noticed some false positives (this occurs against URLs that do not redirect e.g., https://example.org). "matchers-condition: and" fixes this. This behavior seems odd to me because there's only one matcher.