### PR TITLE
Add oidc-detect

### DIFF
--- a/technologies/oidc-detect.yaml
+++ b/technologies/oidc-detect.yaml
@@ -1,0 +1,19 @@
+id: oidc-detect
+info:
+  name: Detect OpenID Connect provider
+  author: jarijaas
+  severity: info
+  description: Detects OpenID Connect providers. See https://en.wikipedia.org/wiki/OpenID_Connect
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/openid-configuration"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - issuer

--- a/technologies/oidc-detect.yaml
+++ b/technologies/oidc-detect.yaml
@@ -17,3 +17,5 @@ requests:
       - type: word
         words:
           - issuer
+          - authorization_endpoint
+        condition: and


### PR DESCRIPTION
This template detects OpenID Connect providers that support "/.well-known/openid-configuration" endpoint.