### PR TITLE
Adding Unencrypted F5 Cookie disclosure

### DIFF
--- a/tokens/unecrypted-bigip-ltm-cookie.yaml
+++ b/tokens/unecrypted-bigip-ltm-cookie.yaml
@@ -1,0 +1,18 @@
+id: unecrypted-bigip-ltm-cookie
+
+info:
+  name: F5 BIGIP Unecrypted Cookie
+  author: PR3R00T
+  severity: low
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    matchers:
+      - type: regex
+        regex:
+          - '(BIGipServer[a-z\_\.\-\~0-9A-Z]*)=([0-9a-zA-Z\.]*;)'
+          - '=[0-9]*\.[0-9]{3,5}\.[0-9]{4};'
+        part: header

--- a/tokens/unencrypted-bigip-ltm-cookie.yaml
+++ b/tokens/unencrypted-bigip-ltm-cookie.yaml
@@ -3,12 +3,15 @@ id: unencrypted-bigip-ltm-cookie
 info:
   name: F5 BIGIP Unencrypted Cookie
   author: PR3R00T
-  severity: low
+  severity: info
+  reference: https://www.intelisecure.com/how-to-decode-big-ip-f5-persistence-cookie-values
+  mitigation: https://support.f5.com/csp/article/K23254150
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     redirects: true
     matchers:
       - type: regex

--- a/tokens/unencrypted-bigip-ltm-cookie.yaml
+++ b/tokens/unencrypted-bigip-ltm-cookie.yaml
@@ -1,7 +1,7 @@
-id: unecrypted-bigip-ltm-cookie
+id: unencrypted-bigip-ltm-cookie
 
 info:
-  name: F5 BIGIP Unecrypted Cookie
+  name: F5 BIGIP Unencrypted Cookie
   author: PR3R00T
   severity: low
 


### PR DESCRIPTION
Locate F5 Load balancer Persistence cookies, use other tools to decode these cookies to disclose internal IP address and port number of the service.