### PR TITLE
Add cve-2020-26214 detection

### DIFF
--- a/cves/CVE-2020-26214.yaml
+++ b/cves/CVE-2020-26214.yaml
@@ -1,0 +1,34 @@
+id: cve-2020-26214
+info:
+
+  name: Alerta Authentication Bypass (CVE-2020-26214)
+  author: CasperGN
+  severity: critical
+  description: Alerta prior to version 8.1.0 is prone to Authentication Bypass when using LDAP as authorization provider and the LDAP server accepts Unauthenticated Bind reqests.
+
+  # Reference: https://github.com/advisories/GHSA-5hmm-x8q8-w5jh
+  # Reference: https://tools.ietf.org/html/rfc4513#section-5.1.2
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/api/config'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - 'name":"Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'
+          - 'name": "Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'
+        condition: or
+    extractors:
+      - type: regex
+        part: body
+        name: alerta-version
+        group: 1
+        regex:
+          - 'name":"Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'
+          - 'name": "Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'


### PR DESCRIPTION
Referencing https://github.com/advisories/GHSA-5hmm-x8q8-w5jh

Note however, that as stated in the advisory, to be vulnerable apart from the version, the LDAP config must be in place as noted. Not sure how to reference the required pre-reqs other than the comments attached. 

Criticality given by the referenced CVSS at https://nvd.nist.gov/vuln/detail/CVE-2020-26214 registered by Github.

Cheers,
Casper