### PR TITLE
Search for "provider":"ldap" to complete the match on the cve

### DIFF
--- a/cves/CVE-2020-26214.yaml
+++ b/cves/CVE-2020-26214.yaml
@@ -24,6 +24,11 @@ requests:
           - 'name":"Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'
           - 'name": "Alerta ([0-7]\.[0-9]\.[0-9]|8\.0.[0-9])"'
         condition: or
+      - type: regex
+        regex:
+          - 'provider":"ldap"'
+          - 'provider": "ldap"'
+        condition: or
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
Found a stable way to verify if the Authorization Provider is LDAP or not. 
Ref: #606 

Cheers,
Casper