### PR TITLE
Added check for spoofable SPF records

### DIFF
--- a/dns/mx-service-detector.yaml
+++ b/dns/mx-service-detector.yaml
@@ -38,7 +38,7 @@ dns:
           - "mx2.zoho.eu"
           - "mx3.zoho.eu"
       - type: word
-        name: "ProofPoint Email Security"
+        name: "ForcePoint Email Security"
         words:
           - "in.mailcontrol.com"
       - type: word

--- a/dns/mx-service-detector.yaml
+++ b/dns/mx-service-detector.yaml
@@ -1,0 +1,71 @@
+id: mx-service-detector
+
+info:
+  name: E-mail service detector
+  author: binaryfigments
+  severity: info
+  description: Check the email service or spamfilter that is used for a domain.
+
+dns:
+  - name: "{{FQDN}}"
+    type: MX
+    class: inet
+    recursion: true
+    retries: 5
+    matchers-condition: or
+    matchers:
+      - type: word
+        name: "Office 365"
+        words:
+          - "mail.protection.outlook.com"
+      - type: word
+        name: "Google Apps"
+        words:
+          - "aspmx2.googlemail.com"
+          - "aspmx3.googlemail.com"
+          - "alt1.aspmx.l.google.com"
+          - "alt2.aspmx.l.google.com"
+          - "aspmx.l.google.com"
+      - type: word
+        name: "ProtonMail"
+        words:
+          - "mail.protonmail.ch"
+          - "mailsec.protonmail.ch"
+      - type: word
+        name: "Zoho Mail"
+        words:
+          - "mx.zoho.eu"
+          - "mx2.zoho.eu"
+          - "mx3.zoho.eu"
+      - type: word
+        name: "ProofPoint Email Security"
+        words:
+          - "in.mailcontrol.com"
+      - type: word
+        name: "E-Zorg NL"
+        words:
+          - "spamfilter02.ezorg.nl"
+          - "spamfilter01.ezorg.nl"
+          - "spamfilter.ezorg.nl"
+          - "spamfilter03.ezorg.nl"
+      - type: word
+        name: "Kerio Cloud EU"
+        words:
+          - "mx1.eu1.kerio.cloud"
+          - "mx2.eu1.kerio.cloud"
+      - type: word
+        name: "Kerio Cloud US"
+        words:
+          - "mx1.us1.kerio.cloud"
+          - "mx2.us1.kerio.cloud"
+          - "mx3.us1.kerio.cloud"
+      - type: word
+        name: "Proofpoint EU"
+        words:
+          - "mx1-eu1.ppe-hosted.com"
+          - "mx2-eu1.ppe-hosted.com"
+      - type: word
+        name: "Proofpoint US"
+        words:
+          - "mx1-us1.ppe-hosted.com"
+          - "mx2-us1.ppe-hosted.com"

--- a/dns/spoofable-spf-records-ptr.yaml
+++ b/dns/spoofable-spf-records-ptr.yaml
@@ -1,0 +1,25 @@
+id: spoofable-spf-records-ptr
+
+info:
+  name: Find spoofable SPF records containing the PTR mechanism
+  author: binaryfigments
+  severity: info
+  description: Check if TXT records in DNS for SPF records that have the PTR mechanism that is spoofable.
+
+  # The PTR mechanism in an SPF records is spoofable. A bad actor can create a VPS with a mailserver and 
+  # give it any PTR record that it wants an most VPS providers.
+
+dns:
+  - name: "{{FQDN}}"
+    type: TXT
+    class: inet
+    recursion: true
+    retries: 3
+    matchers:
+      - type: word
+        words:
+          # Must contain SPF record
+          - "v=spf1"
+          # and must contain PTR option
+          - " ptr "
+        condition: and

--- a/dns/spoofable-spf-records-ptr.yaml
+++ b/dns/spoofable-spf-records-ptr.yaml
@@ -6,9 +6,6 @@ info:
   severity: info
   description: Check if TXT records in DNS for SPF records that have the PTR mechanism that is spoofable.
 
-  # The PTR mechanism in an SPF records is spoofable. A bad actor can create a VPS with a mailserver and 
-  # give it any PTR record that it wants an most VPS providers.
-
 dns:
   - name: "{{FQDN}}"
     type: TXT
@@ -18,8 +15,6 @@ dns:
     matchers:
       - type: word
         words:
-          # Must contain SPF record
           - "v=spf1"
-          # and must contain PTR option
           - " ptr "
         condition: and


### PR DESCRIPTION
Added DNS check for SPF. The PTR mechanism in an SPF records is spoofable. A bad actor can create a VPS with a mailserver and give it any PTR record that it wants an most VPS providers. Valid YAML, chacked by http://www.yamllint.com/