### PR TITLE
Swapped put-method-enabled to DSL for multi-req

### DIFF
--- a/security-misconfiguration/put-method-enabled.yaml
+++ b/security-misconfiguration/put-method-enabled.yaml
@@ -19,12 +19,8 @@ requests:
         GET /testing-put.txt HTTP/1.1
         Content-Type: text/plain
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        words:
-          - testing-payload
+      - type: dsl
+        name: multi-req
+        dsl:
+          - 'contains(body_2, "testing-payload") == true'


### PR DESCRIPTION
Addresses concerns for https://github.com/projectdiscovery/nuclei/issues/407

This change stops reporting on false positives where the first request will reflect back the testing-payload string, but the content is not actually uploaded.