### PR TITLE
cve-2019-15858 reversed check

### DIFF
--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -27,3 +27,5 @@ requests:
         words:
           - "2.2.5"
         part: body
+        negative: true
+

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -28,4 +28,3 @@ requests:
           - "2.2.5"
         part: body
         negative: true
-


### PR DESCRIPTION
2.2.5 is the fixed version and should therefore be absent.