### PR TITLE
Update the detection of the pulse secure panel

### DIFF
--- a/panels/pulse-secure-panel.yaml
+++ b/panels/pulse-secure-panel.yaml
@@ -18,5 +18,5 @@ requests:
 
       - type: word
         words:
-          - "/dana-na/css/ds.css"
+          - "/dana-na/css/ds"
         part: body

--- a/panels/pulse-secure-panel.yaml
+++ b/panels/pulse-secure-panel.yaml
@@ -18,5 +18,5 @@ requests:
 
       - type: word
         words:
-          - "/dana-na/css/ds"
+          - "(?i)/dana-na/css/ds_[a-f0-9]{64}.css""
         part: body


### PR DESCRIPTION
There is some case where the like to the css file contains the hash of the file and looks like:
`/dana-na/css/ds_<hash>.css`

With this modification the case above will be detected