### PR TITLE
Using regex to detect when a hash is used

### DIFF
--- a/panels/pulse-secure-panel.yaml
+++ b/panels/pulse-secure-panel.yaml
@@ -16,7 +16,7 @@ requests:
           - "/dana-na/auth/welcome.cgi"
         part: header
 
-      - type: word
-        words:
+      - type: regex
+        regex:
           - "(?i)/dana-na/css/ds(_[a-f0-9]{64})?.css"
         part: body

--- a/panels/pulse-secure-panel.yaml
+++ b/panels/pulse-secure-panel.yaml
@@ -18,5 +18,5 @@ requests:
 
       - type: word
         words:
-          - "/dana-na/css/ds.css"
+          - "(?i)/dana-na/css/ds(_[a-f0-9]{64})?.css"
         part: body


### PR DESCRIPTION
There is some case where the like to the css file contains the hash of the file and looks like:
`/dana-na/css/ds_<hash>.css`

With this modification the case above will be detected