### PR TITLE
Update CVE-2019-15858.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An overview of the nuclei template directory including number of templates and H
 | dns | 6 | fuzzing | 6 |
 | generic-detections | 3 | default-credentials | 3 |
 | subdomain-takeover | 2 | payloads | 2 |
-| wordlists | 1 |
+| wordlists | 1 | misc | 12 |
 
 
 ### Nuclei templates `v7.2.9` tree overview

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Templates are the core of [nuclei scanner](https://github.com/projectdiscovery/n
 
 An overview of the nuclei template directory including number of templates and HTTP request associated with each directory. 
 
-### Nuclei templates `v4.0.0` overview
+### Nuclei templates `v7.3.0` overview
 
 | Templates | Counts | Templates | Counts |
 |----|----|----|----|
@@ -25,7 +25,7 @@ An overview of the nuclei template directory including number of templates and H
 | wordlists | 1 | misc | 12 |
 
 
-### Nuclei templates `v4.0.0` tree overview
+### Nuclei templates `v7.3.0` tree overview
 
 <details>
 <summary> Nuclei templates </summary>

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -2,7 +2,7 @@ id: cve-2019-15858
 
 info:
   name: Unauthenticated Woody Ad Snippets WordPress Plugin RCE
-  author: dwisiswant0 & fmunozs
+  author: dwisiswant0 & fmunozs & patralos
   severity: high
   description: |
     This template supports the detection part only. See references.
@@ -18,16 +18,19 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/insert-php/readme.txt"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: word
         words:
           - "2.2.5"
         part: body
         negative: true
+
       - type: word
         words:
           - "text/plain"

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -25,5 +25,10 @@ requests:
           - 200
       - type: word
         words:
+          - "2.2.5"
+        part: body
+        negative: true
+      - type: word
+        words:
           - "text/plain"
         part: header

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -8,7 +8,7 @@ info:
     This template supports the detection part only. See references.
 
     admin/includes/class.import.snippet.php in the "Woody ad snippets" plugin
-    before 2.2.4 for WordPress allows unauthenticated options import,
+    before 2.2.5 for WordPress allows unauthenticated options import,
     as demonstrated by storing an XSS payload for remote code execution.
 
     Source/References:

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -25,10 +25,5 @@ requests:
           - 200
       - type: word
         words:
-          - "2.2.5"
-        part: body
-        negative: true
-      - type: word
-        words:
           - "text/plain"
         part: header

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -2,13 +2,13 @@ id: cve-2019-15858
 
 info:
   name: Unauthenticated Woody Ad Snippets WordPress Plugin RCE
-  author: dwisiswant0
+  author: dwisiswant0 & fmunozs
   severity: high
   description: |
     This template supports the detection part only. See references.
 
     admin/includes/class.import.snippet.php in the "Woody ad snippets" plugin
-    before 2.2.5 for WordPress allows unauthenticated options import,
+    before 2.2.4 for WordPress allows unauthenticated options import,
     as demonstrated by storing an XSS payload for remote code execution.
 
     Source/References:
@@ -27,3 +27,8 @@ requests:
         words:
           - "2.2.5"
         part: body
+        negative: true
+      - type: word
+        words:
+          - "text/plain"
+        part: header


### PR DESCRIPTION
This got me a couple of false positive, so I went to review the original exploit

My changes:
- include the text/plain to make sure we are reading the readme file and not a redirect to /
- The check function on the template was  looking for 2.2.5 to report the finding, while the original exploit marks the site as NOT vulnerable if 2.2.5 string is found on the readme.txt file. [1] Changing that as negative check, so only versions lower to 2.2.5 should appear as vulnerable.

@dwisiswant0 could you please review that my changes are ok?

[1] https://github.com/GeneralEG/CVE-2019-15858/blob/master/exploit.py#L9 