### PR TITLE
[false-positive] Unbounce SubDomain Takeover

### DIFF
--- a/subdomain-takeover/detect-all-takeovers.yaml
+++ b/subdomain-takeover/detect-all-takeovers.yaml
@@ -314,11 +314,6 @@ requests:
           - "Non-hub domain, The URL you've accessed does not provide a hub."
 
       - type: regex
-        name: unbounce
-        regex:
-          - "^The requested URL was not found on this server.$"
-
-      - type: regex
         name: uptimerobot
         regex:
           - "^page not found$"


### PR DESCRIPTION
Unbounce takeovers seems to be not possible these days because unbounce don't let yo claim  a dangling domain until you prove that you are the owner of that domain.

Ref: https://github.com/EdOverflow/can-i-take-over-xyz/issues/11