### PR TITLE
Reintroduce CVE-2019-15858.yaml check

### DIFF
--- a/.nuclei-ignore
+++ b/.nuclei-ignore
@@ -16,7 +16,6 @@ cves/CVE-2017-7529.yaml
 cves/CVE-2020-13379.yaml
 cves/CVE-2013-2251.yaml
 cves/CVE-2020-16139.yaml
-cves/CVE-2019-15858.yaml
 vulnerabilities/x-forwarded-host-injection.yaml
 
 # Fuzzing is excluded to avoid running bruteforce on every server as default.

--- a/cves/CVE-2019-15858.yaml
+++ b/cves/CVE-2019-15858.yaml
@@ -1,0 +1,42 @@
+id: cve-2019-15858
+
+info:
+  name: Unauthenticated Woody Ad Snippets WordPress Plugin RCE
+  author: dwisiswant0 & fmunozs & patralos
+  severity: high
+  description: |
+    This template supports the detection part only. See references.
+
+    admin/includes/class.import.snippet.php in the "Woody ad snippets" plugin
+    before 2.2.5 for WordPress allows unauthenticated options import,
+    as demonstrated by storing an XSS payload for remote code execution.
+
+    Source/References:
+    - https://github.com/GeneralEG/CVE-2019-15858
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/insert-php/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "2.2.5"
+        part: body
+        negative: true
+
+      - type: word
+        words:
+          - "Changelog"
+        part: body
+
+      - type: word
+        words:
+          - "Woody ad snippets"
+        part: body

--- a/workflows/wordpress-workflow.yaml
+++ b/workflows/wordpress-workflow.yaml
@@ -13,6 +13,7 @@ workflows:
     matchers:
       - name: wordpress
         subtemplates:
+          - template: cves/CVE-2019-15858.yaml
           - template: cves/CVE-2019-6715.yaml
           - template: cves/CVE-2019-9978.yaml
           - template: files/wordpress-db-backup.yaml


### PR DESCRIPTION
Old version had a lot of FP as it did not check if the returned page was
acutally the correct readme. So I added a check for the name of the
plugin and another one to ensure there is a changelog. This shoud remove
almost all false positives.

Hopefully, this is good enough to get this check back in.

Cheers,