### PR TITLE
SolarWinds Orion Login Panel

### DIFF
--- a/panels/solarwinds-orion.yaml
+++ b/panels/solarwinds-orion.yaml
@@ -1,8 +1,8 @@
-id: solarwinds-orion 
+id: solarwinds-orion
 
 info:
-  name: SolarWinds Orion 
-  author: puzzlepeaches 
+  name: SolarWinds Orion Panel
+  author: puzzlepeaches
   severity: info
 
 requests:

--- a/panels/solarwinds-orion.yaml
+++ b/panels/solarwinds-orion.yaml
@@ -1,0 +1,18 @@
+id: solarwinds-orion 
+
+info:
+  name: SolarWinds Orion 
+  author: puzzlepeaches 
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Orion/Login.aspx"
+    headers:
+      User-Agent: "Mozilla Firefox Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0"
+    matchers:
+      - type: word
+        words:
+          - "SolarWinds Orion"
+        part: body


### PR DESCRIPTION
This template contains a really simple detection for the SolarWinds Orion login panel. Ideally, we can also add the following:

* Extractor for the "Orion Platform" version (I suck at regex)
* A conditional OR for the header `Set-Cookie: Orion_IsSessionExp=TRUE;` for fringe cases and improved detection

This was tested with a list of hosts dumped from Shodan and is working well. Please let me know if you have any questions or concerns.