### PR TITLE
Create thinkific-redirect.yaml

### DIFF
--- a/vulnerabilities/thinkific-redirect.yaml
+++ b/vulnerabilities/thinkific-redirect.yaml
@@ -1,0 +1,24 @@
+id: thinkific-redirect
+
+info:
+  name: Open Redirect vulnerability on thinkific websites
+  author: Gal Nagli
+  severity: Medium
+
+
+requests:
+  - method: GET
+
+    path:
+      - "{{BaseURL}}/api/sso/v2/sso/jwt?error_url=http://evil.com"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        words:
+          - "<a href=\"http://evil.com?kind=jwt&amp;message=Nil+JSON+web+token\""
+        condition: or
+        part: body

--- a/vulnerabilities/thinkific-redirect.yaml
+++ b/vulnerabilities/thinkific-redirect.yaml
@@ -1,16 +1,15 @@
 id: thinkific-redirect
 
 info:
-  name: Open Redirect vulnerability on thinkific websites
+  name: Thinkific Open URL Redirect
   author: Gal Nagli
-  severity: Medium
-
+  severity: low
 
 requests:
   - method: GET
 
     path:
-      - "{{BaseURL}}/api/sso/v2/sso/jwt?error_url=http://evil.com"
+      - "{{BaseURL}}/api/sso/v2/sso/jwt?error_url=http://example.com"
 
     matchers-condition: and
     matchers:
@@ -19,6 +18,5 @@ requests:
           - 302
       - type: word
         words:
-          - "<a href=\"http://evil.com?kind=jwt&amp;message=Nil+JSON+web+token\""
-        condition: or
+          - "<a href=\"http://example.com?kind=jwt&amp;message=Nil+JSON+web+token\""
         part: body


### PR DESCRIPTION
Thinkific is a CMS for courses and learning platforms and it has about 50-75k costumers.
While exploring private program asset I have discovered a CMS wide Open Redirect for any website which had been created with thinkific.

I'm happy to contribute with a payload of my own for this great tool.

Best Regards,
nagli.