### PR TITLE
Add further path to composer-config.yaml

### DIFF
--- a/exposures/configs/composer-config.yaml
+++ b/exposures/configs/composer-config.yaml
@@ -11,6 +11,7 @@ requests:
       - "{{BaseURL}}/composer.json"
       - "{{BaseURL}}/composer.lock"
       - "{{BaseURL}}/.composer/composer.json"
+      - "{{BaseURL}}/vendor/composer/installed.json"
 
     matchers:
       - type: dsl


### PR DESCRIPTION
If the vendor directory is part of the web root you can also find the config in the provided path. 
Of course you've then also some more problems besides that ;)