### PR TITLE
New tomcat manager path

### DIFF
--- a/exposed-panels/public-tomcat-manager.yaml
+++ b/exposed-panels/public-tomcat-manager.yaml
@@ -9,6 +9,7 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/manager/html'
+      - '{{BaseURL}}/host-manager/html'
 
     matchers-condition: and
     matchers:

--- a/exposed-panels/tomcat-manager-pathnormalization.yaml
+++ b/exposed-panels/tomcat-manager-pathnormalization.yaml
@@ -8,6 +8,7 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/..;/manager/html'
+      - '{{BaseURL}}/..;/host-manager/html'
     headers:
       User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:55.0) Gecko/20100101 Firefox/55
     matchers:


### PR DESCRIPTION
Hi, 

I found the manager html on another path last time so it could be useful to add it to nuclei. 

I didn't add it in "default-logins/apache/tomcat-manager-default.yaml". 
However, concerning default passwords, if you are interested, you could take a look to this project where I worked some times ago: https://github.com/ztgrace/changeme 

For example, tomcat default passwords here (https://github.com/projectdiscovery/nuclei-templates/blob/master/default-logins/apache/tomcat-manager-default.yaml) are not the good one, here it's a better list (https://github.com/ztgrace/changeme/blob/master/creds/http/general/apache_tomcat_host_manager.yml). You could find it, on some metasploit modules as well. 

Have a nice day.