### PR TITLE
Fix [false-positive] front-page-misconfig

### DIFF
--- a/misconfiguration/front-page-misconfig.yaml
+++ b/misconfiguration/front-page-misconfig.yaml
@@ -2,7 +2,7 @@ id: front-page-misconfig
 
 info:
   name: FrontPage configuration information discloure
-  author: JTeles
+  author: JTeles & pikpikcu
   severity: info
 
   # Reference: https://docs.microsoft.com/en-us/archive/blogs/fabdulwahab/security-protecting-sharepoint-server-applications
@@ -11,7 +11,16 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/_vti_inf.html"
+      - "{{BaseURL}}/_vti_pvt/service.cnf"
+
+    matchers-condition: and
     matchers:
-      - type: size
-        size:
-          - 247
+      - type: word
+        words:
+          - "vti_extenderversion:"
+          - "FPVersion="
+        part: body
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Fix [false-positive] front-page-misconfig [https://github.com/projectdiscovery/nuclei-templates/issues/823](https://github.com/projectdiscovery/nuclei-templates/issues/823)
```

                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.2.0

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Loading templates...
[INF] [front-page-misconfig] FrontPage configuration information discloure (@JTeles & pikpikcu) [info]
[INF] Using 1 rules (1 templates, 0 workflows)
[front-page-misconfig] [http] [info] https://REDACTED/_vti_inf.html
[front-page-misconfig] [http] [info] https://REDACTED/_vti_inf.html
[front-page-misconfig] [http] [info] https://REDACTED/_vti_pvt/service.cnf

```