### PR TITLE
Improvement of the regex in open redirection template

### DIFF
--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -20,7 +20,6 @@ requests:
       - '{{BaseURL}}//example.com/..;/css'
       - '{{BaseURL}}/example%E3%80%82com'
       - '{{BaseURL}}/%5Cexample.com'
-      - '{{BaseURL}}example.com'
       - '{{BaseURL}}/example.com'
       - '{{BaseURL}}\example.com'
       - '{{BaseURL}}//example.com/'

--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -46,5 +46,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?example\.com(?:\s*?)$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com(?:\s*?)$'
         part: header


### PR DESCRIPTION
The original regex does not detect the open redirect, when the crafted URL contains several subdomains or username (`@`).