### PR TITLE
Added gitlab-public-repos

### DIFF
--- a/misconfiguration/gitlab-public-repos.yaml
+++ b/misconfiguration/gitlab-public-repos.yaml
@@ -1,0 +1,25 @@
+id: gitlab-snippets
+info:
+  name: GitLab public repositories
+  author: ldionmarcil
+  severity: info
+  reference: https://twitter.com/ldionmarcil/status/1370052344562470922
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v4/projects"
+    headers:
+      Cookie: _gitlab_session=
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Set-Cookie: _gitlab_session="
+
+      - type: word 
+        part: body
+        words:
+          - "name_with_namespace"

--- a/misconfiguration/gitlab-public-repos.yaml
+++ b/misconfiguration/gitlab-public-repos.yaml
@@ -3,7 +3,9 @@ info:
   name: GitLab public repositories
   author: ldionmarcil
   severity: info
-  reference: https://twitter.com/ldionmarcil/status/1370052344562470922
+  reference: |
+      - https://twitter.com/ldionmarcil/status/1370052344562470922
+      - https://github.com/ldionmarcil/gitlab-unauth-parser
 
 requests:
   - method: GET
@@ -19,7 +21,7 @@ requests:
         words:
           - "Set-Cookie: _gitlab_session="
 
-      - type: word 
+      - type: word
         part: body
         words:
           - "name_with_namespace"


### PR DESCRIPTION
Added detection for gitlab public repositories which can be leaked with an unauth v4 API. More info here https://twitter.com/ldionmarcil/status/1370052344562470922 and here https://github.com/ldionmarcil/gitlab-unauth-parser