### PR TITLE
Update exposed-bitkeeper.yaml

### DIFF
--- a/exposures/configs/exposed-bitkeeper.yaml
+++ b/exposures/configs/exposed-bitkeeper.yaml
@@ -15,6 +15,7 @@ requests:
     matchers:
       - type: word
         words:
+          - "BitKeeper configuration"
           - "logging"
           - "email"
           - "description"


### PR DESCRIPTION
Looking at multiple sources, it seems as though adding `Bitkeeper configuration` would help lower the false positive rate.