### PR TITLE
Update wordpress-takeover.yaml

### DIFF
--- a/takeovers/wordpress-takeover.yaml
+++ b/takeovers/wordpress-takeover.yaml
@@ -12,6 +12,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
+    redirects: true
     matchers-condition: and
     matchers:
       - type: word

--- a/takeovers/wordpress-takeover.yaml
+++ b/takeovers/wordpress-takeover.yaml
@@ -2,7 +2,7 @@ id: wordpress-takeover
 
 info:
   name: wordpress takeover detection
-  author: pdcommunity
+  author: pdcommunity & geeknik
   severity: high
   tags: takeover
   reference: https://github.com/EdOverflow/can-i-take-over-xyz

--- a/takeovers/wordpress-takeover.yaml
+++ b/takeovers/wordpress-takeover.yaml
@@ -1,10 +1,10 @@
 id: wordpress-takeover
 
 info:
-  name: wordpress takeover detection
+  name: WordPress takeover detection
   author: pdcommunity & geeknik
   severity: high
-  tags: takeover
+  tags: takeover,wordpress
   reference: https://github.com/EdOverflow/can-i-take-over-xyz
 
 requests:

--- a/takeovers/wordpress-takeover.yaml
+++ b/takeovers/wordpress-takeover.yaml
@@ -12,9 +12,12 @@ requests:
     path:
       - "{{BaseURL}}"
 
+    matchers-condition: and
     matchers:
       - type: word
         words:
           - 'Do you want to register'
-          - '*.wordpress.com'
-        condition: and
+
+      - type: regex
+        regex:
+          - "[a-zA-Z0-9][a-zA-Z0-9-_]*\.)*[a-zA-Z0-9]*[a-zA-Z0-9-_]*[[a-zA-Z0-9].wordpress.com"

--- a/takeovers/wordpress-takeover.yaml
+++ b/takeovers/wordpress-takeover.yaml
@@ -20,4 +20,4 @@ requests:
 
       - type: regex
         regex:
-          - "[a-zA-Z0-9][a-zA-Z0-9-_]*\.)*[a-zA-Z0-9]*[a-zA-Z0-9-_]*[[a-zA-Z0-9].wordpress.com"
+          - "[a-zA-Z0-9][a-zA-Z0-9-_]*\\.)*[a-zA-Z0-9]*[a-zA-Z0-9-_]*[[a-zA-Z0-9].wordpress.com"


### PR DESCRIPTION
Better matcher fix. \m/ Test here: 

`nuclei -t nuclei-templates/takeovers/wordpress-takeover.yaml -target https://wordpress.com/typo/?subdomain=ge92835723857` 
