### PR TITLE
Add a template for finding Netlify CMS admin panel

### DIFF
--- a/exposed-panels/netlify_cms.yaml
+++ b/exposed-panels/netlify_cms.yaml
@@ -1,0 +1,19 @@
+info:
+  name: Netlify CMS Admin Panel
+  author: sullo
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin/index.html"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Netlify CMS"
+        part: body


### PR DESCRIPTION
A new template for finding Netlify CMS admin panel at ```/admin/index.html```