### PR TITLE
Create detect-dns-over-https.yaml

### DIFF
--- a/miscellaneous/detect-dns-over-https.yaml
+++ b/miscellaneous/detect-dns-over-https.yaml
@@ -1,0 +1,27 @@
+id: detect-dns-over-https
+
+info:
+  name: Detect DNS over HTTPS
+  author: geeknik
+  reference:
+    - https://developers.google.com/speed/public-dns/docs/doh/
+    - https://developers.cloudflare.com/1.1.1.1/dns-over-https/wireformat
+  severity: info
+  tags: dns,doh
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB"
+    headers:
+      Accept: application/dns-message
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "application/dns-message"
+        part: header

--- a/miscellaneous/detect-dns-over-https.yaml
+++ b/miscellaneous/detect-dns-over-https.yaml
@@ -25,3 +25,6 @@ requests:
         words:
           - "application/dns-message"
         part: header
+      - type: regex
+        regex:
+          - "(C|c)ontent-(L|l)ength: 49"

--- a/miscellaneous/detect-dns-over-https.yaml
+++ b/miscellaneous/detect-dns-over-https.yaml
@@ -28,3 +28,4 @@ requests:
       - type: regex
         regex:
           - "(C|c)ontent-(L|l)ength: 49"
+        part: header


### PR DESCRIPTION
Test validity against any known DoH host like Cloudflare or Google. Can be used to detect surreptitious DoH servers operating inside and outside of your network.

```
$ nuclei -t /opt/test/dns-over-https.yaml  -target https://cloudflare-dns.com
[2021-03-27 14:19:13] [detect-dns-over-https] [http] [info] https://cloudflare-dns.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB
```