### PR TITLE
Update kong-detect.yaml

### DIFF
--- a/technologies/kong-detect.yaml
+++ b/technologies/kong-detect.yaml
@@ -19,7 +19,7 @@ requests:
           - kong+
 
     extractors:
-      - type: kval
+      - type: regex
         part: header
-        kval:
-          - Server
+        regex:
+          - .*kong.*


### PR DESCRIPTION
Improved extractor will give less confusing results as sometimes the Server header will be nginx and the Via header will be kong. 👍🏻 

![2021-04-05_17-31](https://user-images.githubusercontent.com/466878/113634839-04b59280-965f-11eb-80be-b22a4538c9fc.png)

