### PR TITLE
Trillthic viewpoint default login

### DIFF
--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -8,19 +8,18 @@ info:
   tags: default-login,trilithic,viewpoint
 
 requests:
-  - raw:
-    - |
-      POST /ViewPoint/admin/Site/ViewPointLogin HTTP/1.1
-      Host: {{hostname}}
-      Content-Length: 65
-      Content-Type: application/json
-      Cookie: trilithic_win_auth=false
+    - raw:
+      - |
+        POST /ViewPoint/admin/Site/ViewPointLogin HTTP/1.1
+        Host: {{hostname}}
+        Content-Length: 65
+        Content-Type: application/json
+        Cookie: trilithic_win_auth=false
 
-      {u:"admin", t:"undefined", p:"trilithic", d:"", r:false, w:false}
- 
-    matchers:      
+        {u:"admin", t:"undefined", p:"trilithic", d:"", r:false, w:false}
+
+    matchers:
       - type: word
         words:
           - '"authorized":true'
         part: body
-

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -19,8 +19,15 @@ requests:
 
         {u:"admin", t:"undefined", p:"trilithic", d:"", r:false, w:false}
 
+    matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
+
       - type: word
         words:
           - '"authorized":true'
+          - 'redirectUrl'
         part: body
+        condition: and

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -8,7 +8,7 @@ info:
   tags: default-login,trilithic,viewpoint
 
 requests:
-    - raw:
+  - raw:
       - |
         POST /ViewPoint/admin/Site/ViewPointLogin HTTP/1.1
         Host: {{hostname}}

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -1,11 +1,11 @@
-id: Trillthic-Viewpoint-Default
+id: Trilithic-Viewpoint-Default
 info:
-  name: Trillthic Viewpoint Default Credentials
+  name: Trilithic Viewpoint Default Credentials
   author: davidmckennirey
   severity: high
   description: |
-    Searches for default admin credentials for the (discontinued) Trillthic Viewpoint application.
-  tags: default-login,trillthic,viewpoint
+    Searches for default admin credentials for the (discontinued) Trilithic Viewpoint application.
+  tags: default-login,trilithic,viewpoint
 
 requests:
   - raw:

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -1,0 +1,25 @@
+id: Trillthic-Viewpoint-Default
+info:
+  name: Trillthic Viewpoint Default Credentials
+  author: davidmckennirey
+  severity: high
+  description: |
+    Searches for default admin credentials for the (discontinued) Trillthic Viewpoint application.
+  tags: default-login,trillthic,viewpoint
+
+requests:
+  - raw:
+    - |
+      POST /ViewPoint/admin/Site/ViewPointLogin HTTP/1.1
+      Host: {{hostname}}
+      Content-Length: 65
+      Content-Type: application/json
+      Cookie: trilithic_win_auth=false
+
+      {u:"admin", t:"undefined", p:"trilithic", d:"", r:false, w:false}
+ 
+    matchers:      
+      - type: word
+        words:
+          - '"authorized":true'
+        part: body

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -23,3 +23,4 @@ requests:
         words:
           - '"authorized":true'
         part: body
+

--- a/default-logins/viewpoint/trilithic-viewpoint-default.yaml
+++ b/default-logins/viewpoint/trilithic-viewpoint-default.yaml
@@ -1,4 +1,5 @@
-id: Trilithic-Viewpoint-Default
+id: trilithic-viewpoint-default
+
 info:
   name: Trilithic Viewpoint Default Credentials
   author: davidmckennirey
@@ -11,7 +12,7 @@ requests:
   - raw:
       - |
         POST /ViewPoint/admin/Site/ViewPointLogin HTTP/1.1
-        Host: {{hostname}}
+        Host: {{Hostname}}
         Content-Length: 65
         Content-Type: application/json
         Cookie: trilithic_win_auth=false


### PR DESCRIPTION
Hello! Recently, I discovered a Thrilithic Viewpoint application in a target scope, and I found that the default credentials were "admin:trilithic"

This template requests the admin login endpoint with those credentials to check if the application is still using the defaults. This is my first pull request (more on the way) so let me know if you would like me to do anything different in the future. Thanks!