### PR TITLE
Fix false-negative in open-redirect.yaml

### DIFF
--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -45,5 +45,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com(?:\s*?)$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com(?:\s*?).*$'
         part: header

--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -45,5 +45,5 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com(?:\s*?).*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
         part: header


### PR DESCRIPTION
This was giving a false-negative because the Location header had extra path data after the example.com name. This change resolves the false-negatives.