### PR TITLE
Create recruitee-takeover.yaml

### DIFF
--- a/takeovers/recruitee-takeover.yaml
+++ b/takeovers/recruitee-takeover.yaml
@@ -1,0 +1,20 @@
+id: recruitee-takeover
+
+info:
+  name: Recruitee Takeover Detection
+  author: geeknik
+  severity: info
+  tags: takeover
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+    matchers:
+      - type: word
+        words:
+          - "<title>Careers site is no longer hosted here</title>"
+          - "Sorry, this careers site is no longer hosted here."
+        condition: and


### PR DESCRIPTION
My research here is incomplete, I'm not sure if these endpoints can be taken over. If the endpoint is not configured or setup correctly, it will either load or redirect to `https://recruitee.com/careers_not_hosted`. 👍🏻 