### PR TITLE
Hotfix: Update operator

### DIFF
--- a/cves/2021/CVE-2021-29441.yaml
+++ b/cves/2021/CVE-2021-29441.yaml
@@ -40,7 +40,7 @@ requests:
       - type: dsl
         dsl:
           - "contains(body_1, 'Forbidden')"
-          - "contains(body_2, 'true')"
+          - "body_2 == 'true'"
         condition: and
 
       - type: word


### PR DESCRIPTION
Because using `contains` includes everything.