### PR TITLE
Create darkstat-detect.yaml

### DIFF
--- a/exposures/logs/darkstat-detect.yaml
+++ b/exposures/logs/darkstat-detect.yaml
@@ -6,7 +6,7 @@ info:
   description: Darkstat captures network traffic, calculates statistics about usage, and serves reports over HTTP
   reference: https://unix4lyfe.org/darkstat/
   severity: high
-  tags: darkstat,logs,exposure
+  tags: darkstat,log,exposure
 
 requests:
   - method: GET
@@ -28,6 +28,7 @@ requests:
           - "Measuring for"
           - "hosts</a>"
         condition: and
+
     extractors:
       - type: kval
         part: header

--- a/exposures/logs/darkstat-detect.yaml
+++ b/exposures/logs/darkstat-detect.yaml
@@ -6,6 +6,7 @@ info:
   description: Darkstat captures network traffic, calculates statistics about usage, and serves reports over HTTP
   reference: https://unix4lyfe.org/darkstat/
   severity: high
+  tags: darkstat,logs,exposure
 
 requests:
   - method: GET

--- a/exposures/logs/darkstat-detect.yaml
+++ b/exposures/logs/darkstat-detect.yaml
@@ -1,0 +1,34 @@
+id: darkstat-detect
+
+info:
+  name: Detect Darkstat Reports
+  author: geeknik
+  description: Darkstat captures network traffic, calculates statistics about usage, and serves reports over HTTP
+  reference: https://unix4lyfe.org/darkstat/
+  severity: high
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/darkstat/"
+    # FYI, the default port for darkstat is 666
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - "[Ss]erver: darkstat.*"
+      - type: word
+        part: body
+        words:
+          - "darkstat"
+          - "<title>Graphs"
+          - "Measuring for"
+          - "hosts</a>"
+        condition: and
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - server


### PR DESCRIPTION
Originally I was going to rank this as a medium severity, but due to the amount of internal network information that can be exposed, I believe this should be rated high instead. 99.99% of the ones I found out in the wild required zero authentication. 

![2021-05-06_14-41](https://user-images.githubusercontent.com/466878/117356493-4fffd280-aea3-11eb-8a9e-68fec8878320.png)
