### PR TITLE
Update springboot-httptrace.yaml

### DIFF
--- a/misconfiguration/springboot/springboot-httptrace.yaml
+++ b/misconfiguration/springboot/springboot-httptrace.yaml
@@ -10,6 +10,7 @@ info:
 requests:
   - method: GET
     path:
+      - "{{BaseURL}}/httptrace"
       - "{{BaseURL}}/actuator/httptrace"
     matchers-condition: and
     matchers:


### PR DESCRIPTION
It can be accessed via a path like /httptrace also.