### PR TITLE
Update flir-ax8-default-credentials.yaml

### DIFF
--- a/default-logins/flir/flir-ax8-default-credentials.yaml
+++ b/default-logins/flir/flir-ax8-default-credentials.yaml
@@ -27,15 +27,13 @@ requests:
       - type: word
         words:
           - '"success"'
-      - type: word
-        words:
-          - "The requested page cannot be found"
-        negative: true
 
       - type: dsl
         dsl:
           - contains(tolower(all_headers), 'text/html')
           - contains(tolower(all_headers), 'phpsessid')
+          - contains(tolower(all_headers), 'showcameraid')
+
         condition: and
 
       - type: status

--- a/default-logins/flir/flir-ax8-default-credentials.yaml
+++ b/default-logins/flir/flir-ax8-default-credentials.yaml
@@ -27,6 +27,10 @@ requests:
       - type: word
         words:
           - '"success"'
+      - type: word
+        words:
+          - "The requested page cannot be found"
+        negative: true
 
       - type: dsl
         dsl:


### PR DESCRIPTION
The new condition solves this false positive:

``nuclei -t nuclei-templates/default-logins/flir/flir-ax8-default-credentials.yaml -u https://afreserve.com``