### PR TITLE
updated tags

### DIFF
--- a/vulnerabilities/oracle/oracle-ebs-bispgraph-file-access.yaml
+++ b/vulnerabilities/oracle/oracle-ebs-bispgraph-file-access.yaml
@@ -2,9 +2,9 @@ id: oracle-ebs-bispgrapgh-file-read
 
 info:
   name: Oracle EBS Bispgraph File Access
-  author: emenalf & tirtha_mandal
+  author: emenalf & tirtha_mandal & thomas_from_offensity
   severity: critical
-  tags: moodle,lfi
+  tags: oracle,lfi
   reference: |
     - https://www.blackhat.com/docs/us-16/materials/us-16-Litchfield-Hackproofing-Oracle-eBusiness-Suite-wp-4.pdf
     - https://www.blackhat.com/docs/us-16/materials/us-16-Litchfield-Hackproofing-Oracle-eBusiness-Suite.pdf


### PR DESCRIPTION
The given "moodle" tag can not be found in the referenced PDFs and seems to be an oracle vulnerability