### PR TITLE
add gophish default credential template

### DIFF
--- a/default-logins/gophish/gophish-default-credentials.yaml
+++ b/default-logins/gophish/gophish-default-credentials.yaml
@@ -1,0 +1,46 @@
+id: gophish-default-credentials
+
+info:
+  name: Gophish < v0.10.1 default credentials
+  author: arcc
+  severity: high
+  tags: gophish,default-login
+
+requests:
+  - raw:
+      - |
+        GET /login HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
+
+        username=admin&password=gophish&csrf_token={{replace(url_encode(html_unescape(csrf_token)), "+", "%2B")}}
+    cookie-reuse: true
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'name="csrf_token" value="(.+?)"'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        words:
+          - "Location: /"
+        part: header


### PR DESCRIPTION
Gophish (https://getgophish.com/) before 0.10.1 uses default credentials. Reference:
https://docs.getgophish.com/user-guide/getting-started#logging-in

Some companies use gophish and set up on-demand instances on their internal or external network. Spotted some old instances with default creds in a few pentests last time. Number of gophish instances on shodan increases also. The template has been tested against several demo instances and a few non-gophish servers to check for false positives. The ugly replace helper function was neccessary because the url encode function does not encode the "+" symbol in the base64 csrf token which causes some problems if not encoded. Also the "=" symbol is not encoded but this causes no problems at all. Intercepting the original request from the browser shows that all key characters including the "/", "=" and the "+" are url encoded. Maybe this can be added to url_encode in the future or i am totally overlook something.

Cheers.