### PR TITLE
add wordpress full path disclosure

### DIFF
--- a/misconfiguration/wordpress-full-path-disclosure.yaml
+++ b/misconfiguration/wordpress-full-path-disclosure.yaml
@@ -1,0 +1,19 @@
+id: wordpress-full-path-disclosure
+
+info:
+  name: Wordpress Full Path Disclosure
+  author: arcc
+  severity: info
+  reference: https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-there-path-disclosures-when-directly-loading-certain-files
+  tags: debug
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-includes/rss-functions.php"
+
+    matchers:
+      - type: word
+        words:
+          - 'undefined function'
+        part: body


### PR DESCRIPTION
simple template to detect full path disclosure in wordpress (error reporting has to be enabled on the web server)