### PR TITLE
Update aws-object-listing.yaml

### DIFF
--- a/misconfiguration/aws-object-listing.yaml
+++ b/misconfiguration/aws-object-listing.yaml
@@ -12,17 +12,19 @@ requests:
     path:
       - "{{BaseURL}}"
 
+    max-size: 1000
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+          - '<ListBucketResult xmlns='
         part: body
 
       - type: word
         words:
           - application/xml
         part: header
+
     extractors:
       - type: regex
         part: body

--- a/misconfiguration/aws-object-listing.yaml
+++ b/misconfiguration/aws-object-listing.yaml
@@ -23,3 +23,9 @@ requests:
         words:
           - application/xml
         part: header
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<Name>([a-z0-9-._]+)'


### PR DESCRIPTION
Added extractor that retrieves the name of the s3 bucket. 

Test
nuclei -t nuclei-templates/misconfiguration/aws-object-listing.yaml -u http://img.secnews.gr


[2021-06-06 01:19:10] [aws-object-listing] [http] [low] http://imgcdn.secnews.gr [img.secnews.gr]