### PR TITLE
Update shell-history.yaml

### DIFF
--- a/misconfiguration/shell-history.yaml
+++ b/misconfiguration/shell-history.yaml
@@ -10,7 +10,7 @@ info:
 requests:
   - method: GET
     redirects: true
-    max-redirects: 5
+    max-redirects: 1
     path:
       - "{{BaseURL}}/.bash_history"
       - "{{BaseURL}}/.ksh_history"
@@ -32,12 +32,13 @@ requests:
           - "cd "
           - "ps aux "
         condition: or
-        
+
       - type: status
         status:
           - 200
+
       - type: word
         words:
-          - "<html "
+          - "<html"
         part: body
         negative: true

--- a/misconfiguration/shell-history.yaml
+++ b/misconfiguration/shell-history.yaml
@@ -22,6 +22,22 @@ requests:
       - type: word
         words:
           - "chmod "
+          - "exit"
+          - "kill "
+          - "nano "
+          - "vim "
+          - "pico "
+          - "sudo "
+          - "rm "
+          - "cd "
+          - "ps aux "
+        condition: or
+        
       - type: status
         status:
           - 200
+      - type: word
+        words:
+          - "<html "
+        part: body
+        negative: true


### PR DESCRIPTION
There are two problems with this template, it only checks for chmod commands but most importantly doesn't check for html tags. A real history file the response doesn't include html tags at all. 

So, I'm adding two rules: Check for another possible commands (from real example) and adding a negative rule to discard false positives like this one:

nuclei -debug -t /home/kali/nuclei-templates/misconfiguration/shell-history.yaml -u http://777.urbanup.com