### PR TITLE
Added template for IIS Internal IP Disclosure

### DIFF
--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -1,0 +1,32 @@
+id: iis-internal-ip-disclosure
+
+info:
+  name: IIS Internal IP Disclosure Template
+  author: WillD96
+  severity: none
+  description: Checks for disclosure of IIS Internal IP Address as per: https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
+  tags: iis, config, disclosure
+
+requests:
+  - raw:
+      - |+
+        GET / HTTP/1.0
+        User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0 
+        Accept: */*
+
+
+    unsafe: true #Unsafe HTTP Lib for 'malformed' requests.
+    matchers:
+      - type: regex
+        regex:
+          - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'
+        condition: and
+      - type: status
+        status:
+          - 302
+     
+    extractors:
+       - type: regex
+         part: header
+         regex:
+           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'


### PR DESCRIPTION
By sending a HTTP 1.0 request to the root of the webserver, sometimes an internal IP address is disclosed in the Location header of the 302 response.