### PR TITLE
Created IIS Internal IP Disclosure Template

### DIFF
--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -3,26 +3,29 @@ id: iis-internal-ip-disclosure
 info:
   name: IIS Internal IP Disclosure Template
   author: WillD96
-  severity: none
-  tags: iis, config, disclosure
+  severity: info
+  tags: iis,misconfig,disclosure
+  reference: https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
 
 requests:
   - raw:
       - |+
         GET / HTTP/1.0
+        Host:
         User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
         Accept: */*
 
-
-    unsafe: true
+    unsafe: true # Use Unsafe HTTP library for malformed HTTP requests.
+    matchers-condition: and
     matchers:
       - type: regex
         regex:
           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'
-        condition: and
+
       - type: status
         status:
           - 302
+
     extractors:
       - type: regex
         part: header

--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -4,7 +4,7 @@ info:
   name: IIS Internal IP Disclosure Template
   author: WillD96
   severity: none
-  description: Checks for disclosure of IIS Internal IP Address as per: https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
+  description: Checks for disclosure of IIS Internal IP Address as per https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
   tags: iis, config, disclosure
 
 requests:

--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -4,18 +4,17 @@ info:
   name: IIS Internal IP Disclosure Template
   author: WillD96
   severity: none
-  description: Checks for disclosure of IIS Internal IP Address as per https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
   tags: iis, config, disclosure
 
 requests:
   - raw:
       - |+
         GET / HTTP/1.0
-        User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0 
+        User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
         Accept: */*
 
 
-    unsafe: true #Unsafe HTTP Lib for 'malformed' requests.
+    unsafe: true
     matchers:
       - type: regex
         regex:
@@ -24,9 +23,8 @@ requests:
       - type: status
         status:
           - 302
-     
     extractors:
-       - type: regex
-         part: header
-         regex:
-           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'
+      - type: regex
+        part: header
+        regex:
+          - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'

--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -1,0 +1,32 @@
+id: iis-internal-ip-disclosure
+
+info:
+  name: IIS Internal IP Disclosure Template
+  author: WillD96
+  severity: none
+  description: Checks for disclosure of IIS Internal IP Address as per: https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
+  tags: iis, config, disclosure
+
+requests:
+  - raw:
+      - |+
+        GET / HTTP/1.0
+        User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0 
+        Accept: */*
+
+
+    unsafe: true #Unsafe HTTP Lib for 'malformed' requests.
+    matchers:
+      - type: regex
+        regex:
+          - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'
+        condition: and
+      - type: status
+        status:
+          - 302
+     
+    extractors:
+       - type: regex
+         part: header
+         regex:
+           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'


### PR DESCRIPTION
A template to check for Internal IP Disclosure on IIS Servers.

In some cases, the web server will respond to a HTTP/1.0 request with a 302 redirect containing an internal IP address in the location header. This template sends a raw HTTP request in order to trigger this response, and returns the internal IP address via a lazy regex extractor. 