### PR TITLE
Added conditional word in body

### DIFF
--- a/misconfiguration/springboot/springboot-env.yaml
+++ b/misconfiguration/springboot/springboot-env.yaml
@@ -18,6 +18,8 @@ requests:
         part: body
         words:
           - "applicationConfig"
+          - "activeProfiles"
+        condition: or
 
       - type: word
         part: body


### PR DESCRIPTION
I found this be a valid finding /actuator/env on a production host but was missing additional words to check which was causing a false negative. 'activeProfiles' allows this test to pass on the instance that I came across.