### PR TITLE
OpenSSH version 7 detection

### DIFF
--- a/openssh7-detect.yaml
+++ b/openssh7-detect.yaml
@@ -1,0 +1,20 @@
+id: openssh7-detect
+
+info:
+  name: OpenSSH 7 Detection
+  author: iamthefrogy
+  severity: low
+  tags: network,openssh
+  description: OpenSSH < 7.3 is vulnerable to username enumeraiton and DoS vulnerabilities.
+  reference: |
+     - http://seclists.org/fulldisclosure/2016/Jul/51
+     - https://security-tracker.debian.org/tracker/CVE-2016-6210
+     - http://openwall.com/lists/oss-security/2016/08/01/2
+network:
+  - host:
+      - "{{Hostname}}"
+      - "{{Hostname}}:22"
+    matchers:
+      - type: word
+        words:
+          - "SSH-2.0-OpenSSH_7"


### PR DESCRIPTION
OpenSSH < 7.3 is vulnerable to User Enumeration