### PR TITLE
Added status to CVE-2012-3153

### DIFF
--- a/cves/2012/CVE-2012-3153.yaml
+++ b/cves/2012/CVE-2012-3153.yaml
@@ -18,22 +18,26 @@ requests:
     path:
       - "{{BaseURL}}/reports/rwservlet/showenv"
       - "{{BaseURL}}/reports/rwservlet?report=test.rdf&desformat=html&destype=cache&JOBTYPE=rwurl&URLPARAMETER=file:///"
+
     req-condition: true
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - '!contains(body_2, "<html>")'
-          - '!contains(body_2, "<HTML>")'
-        condition: and
-      - type: dsl
-        dsl:
           - 'regex("\\\\.*\\\\showenv", body_1)'
           - 'regex("/.*/showenv", body_1)'
         condition: or
-      - type: status
-        status:
-          - 200
+
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+
+      - type: dsl
+        dsl:
+          - '!contains(body_2, "<html>")'
+          - '!contains(body_2, "<HTML>")'
+        condition: and
+
     extractors:
       - type: regex
         name: windows_working_path

--- a/cves/2012/CVE-2012-3153.yaml
+++ b/cves/2012/CVE-2012-3153.yaml
@@ -31,6 +31,9 @@ requests:
           - 'regex("\\\\.*\\\\showenv", body_1)'
           - 'regex("/.*/showenv", body_1)'
         condition: or
+      - type: status
+        status:
+          - 200
     extractors:
       - type: regex
         name: windows_working_path

--- a/cves/2012/CVE-2012-3153.yaml
+++ b/cves/2012/CVE-2012-3153.yaml
@@ -28,9 +28,9 @@ requests:
           - 'regex("/.*/showenv", body_1)'
         condition: or
 
-      - type: dsl
-        dsl:
-          - "status_code_1 == 200"
+      - type: status
+        status:
+          - 200
 
       - type: dsl
         dsl:


### PR DESCRIPTION
The [Metasploit module](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/oracle_reports_rce.rb) indicates that the status code should be 200 for these requests. 

I started getting a bunch of false positives for the linux_working_path if "showenv" is reflected in the response