### PR TITLE
Changed the severity

### DIFF
--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -3,7 +3,7 @@ id: CVE-2017-5487
 info:
   name: WordPress Core < 4.7.1 - Username Enumeration
   author: Manas_Harsh,daffainfo
-  severity: medium
+  severity: low
   description: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php in the REST API implementation in WordPress 4.7 before 4.7.1 does not properly restrict listings of post authors, which allows remote attackers to obtain sensitive information via a wp-json/wp/v2/users request.
   tags: cve,cve2017,wordpress
   reference: |


### PR DESCRIPTION
https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-disclosures-of-usernames-or-user-ids-not-a-security-issue