### PR TITLE
Add template to detect open jenkins api.

### DIFF
--- a/exposed-panels/jenkins-api-panel.yaml
+++ b/exposed-panels/jenkins-api-panel.yaml
@@ -1,0 +1,23 @@
+id: jenkins-api-panel
+
+info:
+  name: Jenkins API Instance Detection Template
+  author: righettod
+  severity: info
+  description: Try to detect the presence of a Jenkins API instance via the API default XML endpoint
+  tags: panel,api,jenkins
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/xml"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "hudson.model.Hudson"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Hello,

First, thanks one time again a lot for this amazing tool ❤️

This PR add a template in the **exposed-panels** area in order to detect any open instance of the API for the [Jenkins](https://www.jenkins.io) tool.

Below is the test performed to validate that the template is functional:

![image](https://user-images.githubusercontent.com/1573775/123606039-c3b3c100-d7fc-11eb-890f-0fd861b06222.png)

Thanks in advance 😃