### PR TITLE
Add detection of WILDFLY

### DIFF
--- a/exposed-panels/wildfly-panel.yaml
+++ b/exposed-panels/wildfly-panel.yaml
@@ -10,8 +10,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/"
-    redirects: true
+      - "{{BaseURL}}"
 
     matchers-condition: and
     matchers:

--- a/exposed-panels/wildfly-panel.yaml
+++ b/exposed-panels/wildfly-panel.yaml
@@ -1,0 +1,24 @@
+id: wildfly-panel
+
+info:
+  name: WildFly Instance Detection Template
+  author: righettod
+  severity: info
+  description: Try to detect the presence of a WildFly (ex-JBoss) instance via the login panel
+  tags: panel,jboss,wildfly
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Welcome to WildFly"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Hello,

This PR add a template in the **exposed-panels** area in order to detect any instance of the [WildFly](https://www.wildfly.org/) application server (ex-JBoss).

Below is the test performed to validate that the template is functional:

![image](https://user-images.githubusercontent.com/1573775/123684073-4d8b7a80-d84d-11eb-99a2-5082cc1ad280.png)

Thanks a lot in advance 😃 