### PR TITLE
Detect javascript environment configs.

### DIFF
--- a/exposures/configs/javascript-env.yaml
+++ b/exposures/configs/javascript-env.yaml
@@ -35,4 +35,10 @@ requests:
           - "module.exports"
           - "const audience"
           - "const domain"
+          - "NODE_ENV"
+          - "LOG_LEVEL"
+          - "TOKEN"
+          - "KEY"
+          - "PASSWORD"
+          - "VERSION"
         condition: or

--- a/exposures/configs/javascript-env.yaml
+++ b/exposures/configs/javascript-env.yaml
@@ -24,10 +24,10 @@ requests:
         status:
           - 200
 
-      - type: word
+      - type: dsl
         part: header
-        words:
-          - "application/javascript"
+        dsl:
+          - "contains(tolower(all_headers), 'content-type: application/javascript')"
 
       - type: word
         part: body

--- a/exposures/configs/javascript-env.yaml
+++ b/exposures/configs/javascript-env.yaml
@@ -1,0 +1,27 @@
+id: javascript-env
+
+info:
+  name: JavaScript Environment Detection 
+  author: pdp
+  severity: low
+  description: Detects common JavaScript environment configuration files. 
+  tags: javascript,config,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/env.js"
+      - "{{BaseURL}}/env.development.js"
+      - "{{BaseURL}}/env.production.js"
+      - "{{BaseURL}}/env.test.js"
+      - "{{BaseURL}}/env.dev.js"
+      - "{{BaseURL}}/env.prod.js"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: header
+        words:
+          - "application/javascript"

--- a/exposures/configs/javascript-env.yaml
+++ b/exposures/configs/javascript-env.yaml
@@ -1,7 +1,7 @@
 id: javascript-env
 
 info:
-  name: JavaScript Environment Detection
+  name: JavaScript Environment Config
   author: pdp
   severity: low
   description: Detects common JavaScript environment configuration files.
@@ -16,13 +16,23 @@ requests:
       - "{{BaseURL}}/env.test.js"
       - "{{BaseURL}}/env.dev.js"
       - "{{BaseURL}}/env.prod.js"
+
     matchers-condition: and
     matchers:
 
       - type: status
         status:
           - 200
+
       - type: word
         part: header
         words:
           - "application/javascript"
+
+      - type: word
+        part: body
+        words:
+          - "module.exports"
+          - "const audience"
+          - "const domain"
+        condition: or

--- a/exposures/configs/javascript-env.yaml
+++ b/exposures/configs/javascript-env.yaml
@@ -1,10 +1,10 @@
 id: javascript-env
 
 info:
-  name: JavaScript Environment Detection 
+  name: JavaScript Environment Detection
   author: pdp
   severity: low
-  description: Detects common JavaScript environment configuration files. 
+  description: Detects common JavaScript environment configuration files.
   tags: javascript,config,exposure
 
 requests:
@@ -18,6 +18,7 @@ requests:
       - "{{BaseURL}}/env.prod.js"
     matchers-condition: and
     matchers:
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
This is a simple template to detect JavaScript config files such as env.js. They are not too uncommon, and sometimes they contain pretty interesting information. The matcher checks the header. This is not a great way to detect these files, but the alternative is to create a regex for javascript, which is worse.