### PR TITLE
Detect the version of a ZOHO ManageEngine ServiceDeskPlus instance

### DIFF
--- a/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
+++ b/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
@@ -10,8 +10,8 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/servlets/DCPluginServlet?action=getVersionDetails"
-      
-    matchers-condition: and      
+
+    matchers-condition: and
     matchers:
       - type: word
         words:

--- a/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
+++ b/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
@@ -5,7 +5,7 @@ info:
   severity: info
   description: Try to detect the version of an ZOHO  ManageEngine ServiceDesk Plus instance via a specific endpoint
   reference: https://www.shodan.io/search?query=http.title%3A%22ManageEngine+ServiceDesk+Plus%22
-  tags:  miscellaneous,msp,zoho
+  tags: miscellaneous,msp,zoho
 requests:
   - method: GET
     path:

--- a/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
+++ b/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
@@ -1,0 +1,23 @@
+id: zoho-manageengine-servicedeskplus-version
+info:
+  name: ZOHO ManageEngine ServiceDesk Plus Version Detection Template
+  author: righettod
+  severity: info
+  description: Try to detect the version of an ZOHO  ManageEngine ServiceDesk Plus instance via a specific endpoint
+  reference: https://www.shodan.io/search?query=http.title%3A%22ManageEngine+ServiceDesk+Plus%22
+  tags: panel,msp,zoho
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/servlets/DCPluginServlet?action=getVersionDetails"
+      
+    matchers-condition: and      
+    matchers:
+      - type: word
+        words:
+          - "<productName>ManageEngine ServiceDesk Plus - MSP</productName>"
+        part: body
+
+      - type: status
+        status:
+          - 200

--- a/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
+++ b/miscellaneous/zoho-manageengine-servicedeskplus-version.yaml
@@ -5,7 +5,7 @@ info:
   severity: info
   description: Try to detect the version of an ZOHO  ManageEngine ServiceDesk Plus instance via a specific endpoint
   reference: https://www.shodan.io/search?query=http.title%3A%22ManageEngine+ServiceDesk+Plus%22
-  tags: panel,msp,zoho
+  tags:  miscellaneous,msp,zoho
 requests:
   - method: GET
     path:


### PR DESCRIPTION
Hello,

This PR add a template in the **miscellaneous** area in order to detect the version of any instance of the [ZOHO  ManageEngine ServiceDesk Plus](https://www.manageengine.com/products/service-desk-msp/) tool.

Below is the test performed to validate that the template is functional:

![image](https://user-images.githubusercontent.com/1573775/124298329-6ac98d00-db5c-11eb-9e15-78792305076a.png)

I have added it into the **miscellaneous** area but feel free to reject the PR if the target area is not the right one 😃 

Thanks a lot in advance 😃 