### PR TITLE
Fixing OOB based templates to eliminate few edge cases

### DIFF
--- a/cves/2015/CVE-2015-8813.yaml
+++ b/cves/2015/CVE-2015-8813.yaml
@@ -17,6 +17,6 @@ requests:
 
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/cves/2017/CVE-2017-3506.yaml
+++ b/cves/2017/CVE-2017-3506.yaml
@@ -39,6 +39,6 @@ requests:
 
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/cves/2017/CVE-2017-9506.yaml
+++ b/cves/2017/CVE-2017-9506.yaml
@@ -26,4 +26,4 @@ requests:
       - type: word
         part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/cves/2019/CVE-2019-2616.yaml
+++ b/cves/2019/CVE-2019-2616.yaml
@@ -23,6 +23,6 @@ requests:
 
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/cves/2019/CVE-2019-2767.yaml
+++ b/cves/2019/CVE-2019-2767.yaml
@@ -18,6 +18,6 @@ requests:
 
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/vulnerabilities/confluence/confluence-ssrf-sharelinks.yaml
+++ b/vulnerabilities/confluence/confluence-ssrf-sharelinks.yaml
@@ -16,6 +16,6 @@ requests:
       - '{{BaseURL}}/rest/sharelinks/1.0/link?url=https://{{interactsh-url}}/'
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"


### PR DESCRIPTION
- Only looking for DNS interaction is not reliable.
- Either use DNS Interaction + Additional check or look for HTTP if valid POC contains HTTP request.
- Few web servers try to make DNS requests for hosts included in the path or in the query parameter producing unexpected results.