### PR TITLE
Detect T3s protocol for Weblogic

### DIFF
--- a/network/weblogic-t3-detect.yaml
+++ b/network/weblogic-t3-detect.yaml
@@ -2,7 +2,7 @@ id: weblogic-t3-detect
 
 info:
   name: Detect Weblogic T3 Protocol
-  author: F1tz,milo2012
+  author: F1tz,milo2012,wdahlenb
   severity: info
   description: Check T3 protocol status.
   tags: network,weblogic
@@ -10,16 +10,29 @@ info:
 network:
   - inputs:
       - data: "t3 12.2.1\nAS:255\nHL:19\nMS:10000000\nPU:t3://us-l-breens:7001\n\n"
-
     host:
       - "{{Hostname}}"
     read-size: 1024
-
     matchers:
       - type: word
         words:
           - "HELO"
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "HELO:(.*).false"
 
+  - inputs:
+      - data: "t3s 12.2.1\nAS:255\nHL:19\nMS:10000000\nPU:t3://us-l-breens:7001\n\n"
+    host:
+      - "tls://{{Hostname}}"
+    read-size: 1024
+    matchers:
+      - type: word
+        words:
+          - "HELO"
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
This PR is based on the discussion from https://github.com/projectdiscovery/nuclei/issues/786.

The T3 handshake over TLS has a modified syntax that uses `t3s` instead of just `t3`. The response is the same in both handshakes.

This modification allows scripts such as https://github.com/Y4er/CVE-2020-2555/blob/master/weblogic_t3.py to work when wrapped in an SSL/TLS socket. 