### PR TITLE
Create stem-audio-table-private-keys.yaml

### DIFF
--- a/iot/stem-audio-table-private-keys.yaml
+++ b/iot/stem-audio-table-private-keys.yaml
@@ -1,0 +1,30 @@
+id: stem-audio-table-private-keys
+
+info:
+  name: Detect Private Key on STEM Audio Table
+  author: gy741
+  severity: high
+  reference: https://blog.grimm-co.com/2021/06/the-walls-have-ears.html
+  tags: stem,config,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/privatekey.pem"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "BEGIN RSA PRIVATE KEY"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - '!contains(body_2, "<html")'
+          - '!contains(body_2, "<HTML")'
+        condition: and

--- a/iot/stem-audio-table-private-keys.yaml
+++ b/iot/stem-audio-table-private-keys.yaml
@@ -5,7 +5,7 @@ info:
   author: gy741
   severity: high
   reference: https://blog.grimm-co.com/2021/06/the-walls-have-ears.html
-  tags: stem,config,exposure
+  tags: stem,config,exposure,iot
 
 requests:
   - method: GET
@@ -17,7 +17,6 @@ requests:
       - type: word
         words:
           - "BEGIN RSA PRIVATE KEY"
-        condition: or
 
       - type: status
         status:
@@ -25,6 +24,4 @@ requests:
 
       - type: dsl
         dsl:
-          - '!contains(body_2, "<html")'
-          - '!contains(body_2, "<HTML")'
-        condition: and
+          - '!contains(tolower(body), "<html")'


### PR DESCRIPTION
Hello

Added private key exposure detection rule in STEM Audio Table.

This is similar to the existing rules.

If you want, you can add it there.

ref: https://github.com/projectdiscovery/nuclei-templates/blob/master/exposures/configs/server-private-keys.yaml

Thanks.