### PR TITLE
Create CVE-2015-7823

### DIFF
--- a/cves/2015/CVE-2015-7823.yaml
+++ b/cves/2015/CVE-2015-7823.yaml
@@ -1,12 +1,14 @@
-id: kentico-open-redirect
+id: CVE-2015-7823
 
 info:
-  name: Web application Kentico CMS 8.2 Open Redirection
+  name: Kentico CMS 8.2 Open Redirection
   author: 0x_Akoko
   description: The GetDocLink.ashx  with link variable is vulnerable to open redirect vulnerability
-  reference: https://packetstormsecurity.com/files/133981/Kentico-CMS-8.2-Cross-Site-Scripting-Open-Redirect.html
+  reference: |
+      - https://packetstormsecurity.com/files/133981/Kentico-CMS-8.2-Cross-Site-Scripting-Open-Redirect.html
+      - https://nvd.nist.gov/vuln/detail/CVE-2015-7823
   severity: low
-  tags: kentico,redirect
+  tags: cve,cve2015,kentico,redirect
 
 requests:
   - method: GET

--- a/kentico-open-redirect.yaml
+++ b/kentico-open-redirect.yaml
@@ -1,0 +1,20 @@
+id: kentico-open-redirect
+
+info:
+  name: Web application Kentico CMS 8.2 Open Redirection
+  author: 0x_Akoko
+  description: The GetDocLink.ashx  with link variable is vulnerable to open redirect vulnerability
+  reference: https://packetstormsecurity.com/files/133981/Kentico-CMS-8.2-Cross-Site-Scripting-Open-Redirect.html
+  severity: low
+  tags: kentico,redirect
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/CMSPages/GetDocLink.ashx?link=https://example.com/"
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
+        part: header


### PR DESCRIPTION
### Template / PR Information

The GetDocLink.ashx  with link variable is vulnerable to open redirect vulnerability

- References:  https://packetstormsecurity.com/files/133981/Kentico-CMS-8.2-Cross-Site-Scripting-Open-Redirect.html

### Template Validation

I've validated this template locally?
-  YES



#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)