### PR TITLE
[dead-host-with-cname] added extractor

### DIFF
--- a/dns/dead-host-with-cname.yaml
+++ b/dns/dead-host-with-cname.yaml
@@ -21,3 +21,9 @@ dns:
       - type: word
         words:
           - "IN\tCNAME"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "IN\tCNAME\t(.+)"

--- a/dns/dead-host-with-cname.yaml
+++ b/dns/dead-host-with-cname.yaml
@@ -1,8 +1,8 @@
 id: dead-host-with-cname
 
 info:
-  name: dead-host-with-cname
-  author: pdteam
+  name: Detect Dangling cnames
+  author: pdteam,nytr0gen
   severity: info
   tags: dns
 


### PR DESCRIPTION
### Template / PR Information

Improves the `dns/dead-host-with-cname.yaml` template by adding an extractor for clearer information.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="929" alt="Screenshot 2021-07-14 at 12 48 58" src="https://user-images.githubusercontent.com/6614470/125609957-4213b26a-4a28-497f-8692-cc7ad6497c1d.png">
