### PR TITLE
Add GLPI default credentials check template

### DIFF
--- a/default-logins/glpi/glpi-default-credential.yaml
+++ b/default-logins/glpi/glpi-default-credential.yaml
@@ -4,7 +4,7 @@ info:
   author: andysvints
   severity: high
   tags: glpi,default-login
-  description: GLPI is an incredible ITSM software tool that helps you plan and manage IT changes in an easy way, solve problems efficiently when they emerge and allow you to gain legitimate control over your company’s IT budget, and expenses. 
+  description: GLPI is an ITSM software tool that helps you plan and manage IT changes. Checking is default super admin account(glpi/glpi) is enabled. 
   reference: https://glpi-project.org/
 
 requests:

--- a/default-logins/glpi/glpi-default-credential.yaml
+++ b/default-logins/glpi/glpi-default-credential.yaml
@@ -4,37 +4,37 @@ info:
   author: andysvints
   severity: high
   tags: glpi,default-login
-  description: GLPI is an ITSM software tool that helps you plan and manage IT changes. Checking is default super admin account(glpi/glpi) is enabled. 
+  description: GLPI is an ITSM software tool that helps you plan and manage IT changes. Checking is default super admin account(glpi/glpi) is enabled.
   reference: https://glpi-project.org/
 
 requests:
   - raw:
-    - |
-      GET / HTTP/1.1
-      Host: {{Hostname}}
-      Upgrade-Insecure-Requests: 1
-      Connection: keep-alive
-      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
-      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-      Accept-Encoding: gzip, deflate
-      Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
-    
-    - |
-      POST /front/login.php HTTP/1.1
-      Host: {{Hostname}}
-      Connection: keep-alive
-      Content-Length: 179
-      Cache-Control: max-age=0
-      Upgrade-Insecure-Requests: 1
-      Origin: {{BaseURL}}
-      Content-Type: application/x-www-form-urlencoded
-      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
-      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-      Referer: {{BaseURL}}
-      Accept-Encoding: gzip, deflate
-      Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Upgrade-Insecure-Requests: 1
+        Connection: keep-alive
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
 
-      {{name}}=glpi&{{password}}=glpi&auth=local&submit=Submit&_glpi_csrf_token={{token}}
+      - |
+        POST /front/login.php HTTP/1.1
+        Host: {{Hostname}}
+        Connection: keep-alive
+        Content-Length: 179
+        Cache-Control: max-age=0
+        Upgrade-Insecure-Requests: 1
+        Origin: {{BaseURL}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: {{BaseURL}}
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
+
+        {{name}}=glpi&{{password}}=glpi&auth=local&submit=Submit&_glpi_csrf_token={{token}}
 
     cookie-reuse: true
     redirects: true
@@ -55,7 +55,7 @@ requests:
         group: 1
         regex:
           - "type=\"text\" name=\"([0-9a-z]+)\" id=\"login_name\" required=\"required\""
-      
+
       - type: regex
         name: password
         part: body

--- a/default-logins/glpi/glpi-default-credential.yaml
+++ b/default-logins/glpi/glpi-default-credential.yaml
@@ -68,8 +68,7 @@ requests:
     matchers:
       - type: word
         words:
-          - 'GLPI - Standard Interface'
+          - '<title>GLPI - Standard Interface</title>'
       - type: status
         status:
-          - 302
-          - 200 
+          - 200

--- a/default-logins/glpi/glpi-default-credential.yaml
+++ b/default-logins/glpi/glpi-default-credential.yaml
@@ -1,0 +1,75 @@
+id: glpi-default-credentials
+info:
+  name: GLPI Default Credentials Check
+  author: andysvints
+  severity: high
+  tags: glpi,default-login
+  description: GLPI is an incredible ITSM software tool that helps you plan and manage IT changes in an easy way, solve problems efficiently when they emerge and allow you to gain legitimate control over your company’s IT budget, and expenses. 
+  reference: https://glpi-project.org/
+
+requests:
+  - raw:
+    - |
+      GET / HTTP/1.1
+      Host: {{Hostname}}
+      Upgrade-Insecure-Requests: 1
+      Connection: keep-alive
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
+      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+      Accept-Encoding: gzip, deflate
+      Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
+    
+    - |
+      POST /front/login.php HTTP/1.1
+      Host: {{Hostname}}
+      Connection: keep-alive
+      Content-Length: 179
+      Cache-Control: max-age=0
+      Upgrade-Insecure-Requests: 1
+      Origin: {{BaseURL}}
+      Content-Type: application/x-www-form-urlencoded
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.70
+      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+      Referer: {{BaseURL}}
+      Accept-Encoding: gzip, deflate
+      Accept-Language: en-US,en;q=0.9,ru;q=0.8,uk;q=0.7
+
+      {{name}}=glpi&{{password}}=glpi&auth=local&submit=Submit&_glpi_csrf_token={{token}}
+
+    cookie-reuse: true
+    redirects: true
+
+    extractors:
+      - type: regex
+        name: token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - "hidden\" name=\"_glpi_csrf_token\" value=\"([0-9a-z]+)\""
+
+      - type: regex
+        name: name
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - "type=\"text\" name=\"([0-9a-z]+)\" id=\"login_name\" required=\"required\""
+      
+      - type: regex
+        name: password
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - "type=\"password\" name=\"([0-9a-z]+)\" id=\"login_password\" required=\"required\""
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'GLPI - Standard Interface'
+      - type: status
+        status:
+          - 302
+          - 200 


### PR DESCRIPTION
### Template / PR Information
GLPI is an ITSM software tool that helps you plan and manage IT changes. It open-source and widely used and adopted in organizations of different sizes. 
Default user accounts are:
    - glpi/glpi admin account,
    - tech/tech technical account,
    - normal/normal “normal” account,
    - post-only/postonly post-only account.

- References:
https://glpi-project.org/
https://glpi-install.readthedocs.io/en/latest/install/wizard.html

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)