### PR TITLE
Reduce false positives

### DIFF
--- a/misconfiguration/shell-history.yaml
+++ b/misconfiguration/shell-history.yaml
@@ -21,15 +21,16 @@ requests:
     matchers:
       - type: word
         words:
+          - "ls"
+          - "mkdir "
           - "chmod "
-          - "exit"
-          - "kill "
+          - "mv "
           - "nano "
           - "vim "
           - "pico "
           - "sudo "
-          - "rm "
           - "cd "
+          - "cp "
           - "ps aux "
         condition: or
 
@@ -40,6 +41,8 @@ requests:
       - type: word
         words:
           - "application/javascript"
+          - "application/json"
+          - "application/xml"
           - "html>"
           - "text/html"
         part: all


### PR DESCRIPTION
### Template / PR Information

Removed keywords that might cause false positives: **rm** (*farm*, *harm*, ...), **kill** and **exit** (might appears in 404 pages) as well as added some more common bash commands