### PR TITLE
Add detection of WSO2 API Manager instance

### DIFF
--- a/technologies/wso2-apimanager-detect.yaml
+++ b/technologies/wso2-apimanager-detect.yaml
@@ -4,7 +4,7 @@ info:
   name: WSO2 API Manager detect
   author: righettod
   severity: info
-  description: Try to detect the presence of a WSO2 API Manager instance via the version endpoint  
+  description: Try to detect the presence of a WSO2 API Manager instance via the version endpoint
   tags: tech,wso2,api-manager
 
 requests:

--- a/technologies/wso2-apimanager-detect.yaml
+++ b/technologies/wso2-apimanager-detect.yaml
@@ -1,0 +1,23 @@
+id: wso2-apimanager-detect
+
+info:
+  name: WSO2 API Manager detect
+  author: righettod
+  severity: info
+  description: Try to detect the presence of a WSO2 API Manager instance via the version endpoint  
+  tags: tech,wso2,api-manager
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/services/Version"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "version.services.core.carbon.wso2.org"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

This PR add a new template to detect the presence of a [WSO2 API Manager](https://apim.docs.wso2.com/en/latest/) instance via the version endpoint.

This [template](https://github.com/projectdiscovery/nuclei-templates/blob/master/exposed-panels/wso2-management-console.yaml) exists but it was detecting the presence of the management console. This PR is dedicated to detect the presence of the API Manager product so I think that there are complementary, in the way in which, API Manager can be in use without that the management console was accessible for security reason.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Below is the result of the local test of the proposed template against the last version of NUCLEI and [WSO2 API Manager](https://hub.docker.com/r/wso2/wso2am):

![sample](https://user-images.githubusercontent.com/1573775/127764633-7dfe06d5-8cd6-4f68-b7c5-1104fe4bc6c8.png)

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [WSO2 API Manager](https://apim.docs.wso2.com/en/latest/)
- [WSO2 API Manager docker image](https://hub.docker.com/r/wso2/wso2am)
- [Source of the request used for the detection](https://stackoverflow.com/a/64145820)