### PR TITLE
guacamole-default-login

### DIFF
--- a/default-logins/guacamole/guacamole-default-login.yaml
+++ b/default-logins/guacamole/guacamole-default-login.yaml
@@ -1,0 +1,32 @@
+id: guacamole-default-admin
+
+info:
+  name: Guacamole Default Credentials
+  author: r3dg33k
+  severity: high
+  tags: guacamole,default-login
+
+  # References:
+  # - https://wiki.debian.org/Guacamole#:~:text=You%20can%20now%20access%20the,password%20are%20both%20%22guacadmin%22.
+
+requests:
+  - raw:
+      - |
+        POST /api/tokens HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{Hostname}}
+        Referer: {{Hostname}}
+
+        username=guacadmin&password=guacadmin
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"username":"guacadmin",'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

- Added guacamole-default-login
- References: https://wiki.debian.org/Guacamole#:~:text=You%20can%20now%20access%20the,password%20are%20both%20%22guacadmin%22.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO