### PR TITLE
Fix regex slack webhook

### DIFF
--- a/file/keys/slack-webhook.yaml
+++ b/file/keys/slack-webhook.yaml
@@ -13,4 +13,4 @@ file:
     extractors:
       - type: regex
         regex:
-          - "https://hooks.slack.com/services/T[0-9A-Za-z\\-_]{10}/B[0-9A-Za-z\\-_]{10}/[0-9A-Za-z\\-_]{23}"
+          - "https://hooks.slack.com/services/T[0-9A-Za-z\\-_]{8}/B[0-9A-Za-z\\-_]{8}/[0-9A-Za-z\\-_]{24}"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36522826/127863469-fb2a8b0d-1ccb-43f9-937a-d88907592592.png)

https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX

If using old regex, the templates can't detect the slack webhook