### PR TITLE
Templates for detecting common Microsoft services

### DIFF
--- a/exposed-panels/microsoft-adfs-login.yaml
+++ b/exposed-panels/microsoft-adfs-login.yaml
@@ -1,0 +1,22 @@
+id: adfs-login
+
+info:
+  name: Microsoft ADFS login page
+  author: puzzlepeaches 
+  severity: info
+  tags: panel,adfs,microsoft
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/adfs/ls/?username=&wa=wsignin1.0&wtrealm=urn%3afederation%3aMicrosoftOnline&wctx=estsredirect%3d2%26estsrequest%3drQIIAY2Rv2_TQACFe3FqaAdAwFoJIRaQnNw5Pp9tqYOdhoZAkqbKj8pLiB07sWv7XOdMkjIjFSFE544VLJkQEhKCBQmmTJ37FwATQkJiJBELY9_w6Y1P37vHoRzS7sB_EYUlBei6SLCdZfsvyfX1ay--mkfPxd8PTt-8vfts9jJzAm7YNEhDKx0FnpX0kmmOJoMZuD1kLB5p-TxNWUDpfo66rmc7BRnnbBrm6biX_wDAGQCzDJELMlFlEcmqrKiqSCQxh1Uiwr4KBRtaqiC5CAuWS2RBJgWRuA5W7T4-z1yt6ykbikvQxDt0fmXWXJqE3ZiO2An3dMtmVpHqg1LJ2E3aHVg0hFqdVUeVKfSresOnrBBNSNBtj-lwEhIa1-HuUJcrpY65v1fxjJ26rxtl0z_AD2tJeeoMpAOzVSxh-mhcbgZpo2uiqtt2mr0oTIXaYeBvIxbJhFW3lBl3IaPvOH5hI6TRnONp7ERe_ywLfmQz8MqfLDhdXfgWP_e_vLr82Hj_ff5a-bSxMl_Nd9RyH1cbUsH248m2tZc2ilajFU_uD9VmbQe7bGTHSgnq5pPWJtHQMQ-Oef4bD37y4OjSyse1C1xzvn5ThEgR0GI9voWwJikaIuZf0"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Sign In</title>'
+          - '3aMicrosoftOnline'
+      - type: status
+        status:
+          - 200

--- a/miscellaneous/microsoft-certsrv.yaml
+++ b/miscellaneous/microsoft-certsrv.yaml
@@ -34,8 +34,3 @@ requests:
           - "WWW-Authenticate: NTLM"
           - "Www-Authenticate: NTLM"
         part: header
-        condition: and 
-
-      - type: status
-        status:
-          - 401

--- a/miscellaneous/microsoft-certsrv.yaml
+++ b/miscellaneous/microsoft-certsrv.yaml
@@ -1,0 +1,41 @@
+id: certsrv-directory
+
+info:
+  name: Discovering certsrv endpoint 
+  author: puzzlepeaches
+  severity: low 
+  description: Finding the certsrv directory to abuse new ADCS TTPs.
+  tags: msc,certsrv
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/certsrv/default.asp"
+      - "{{BaseURL}}/certsrv/certrqxt.asp"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - "Request a certificate"
+        part: body
+        condition: or
+
+      - type: word
+        words:
+          - "PKCS"
+        part: body
+        extractors:
+
+        condition: or
+
+      - type: word
+        words:
+          - "WWW-Authenticate: NTLM"
+          - "Www-Authenticate: NTLM"
+        part: header
+        condition: and 
+
+      - type: status
+        status:
+          - 401


### PR DESCRIPTION
### Template / PR Information

- Added detections for Microsoft self-hosted ADFS login portals
- Added detections for Microsoft ADCS web services portals

References:
ADCS: https://posts.specterops.io/certified-pre-owned-d95910965cd2
ADFS: https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services



### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional notes

I have had some issues building definitive detections for ADCS portals as they are commonly protected by NTLM authentication. If anyone has ideas on how to improve this please let me know. 


