### PR TITLE
Update CVE-2019-12616.yaml

### DIFF
--- a/cves/2019/CVE-2019-12616.yaml
+++ b/cves/2019/CVE-2019-12616.yaml
@@ -22,6 +22,7 @@ requests:
       - type: word
         words:
           - "phpmyadmin.net"
+          - "phpMyAdmin"
 
       - type: regex
         regex:
@@ -30,4 +31,4 @@ requests:
       - type: status
         status:
           - 200
-          - 401
+          - 401 #password protected 

--- a/cves/2019/CVE-2019-12616.yaml
+++ b/cves/2019/CVE-2019-12616.yaml
@@ -23,6 +23,7 @@ requests:
         words:
           - "phpmyadmin.net"
           - "phpMyAdmin"
+        condition: or
 
       - type: regex
         regex:

--- a/cves/2019/CVE-2019-12616.yaml
+++ b/cves/2019/CVE-2019-12616.yaml
@@ -31,4 +31,4 @@ requests:
       - type: status
         status:
           - 200
-          - 401 #password protected 
+          - 401 #password protected


### PR DESCRIPTION
I don't know why the matcher was changed. The matcher phpmyadmin.net doesn't work in my test cases.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)