### PR TITLE
Add template for CVE-2021-37704

### DIFF
--- a/cves/2021/CVE-2021-37704.yaml
+++ b/cves/2021/CVE-2021-37704.yaml
@@ -14,9 +14,22 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/vendor/phpfastcache/phpfastcache/docs/examples/phpinfo.php"
+
+    matchers-condition: and
     matchers:
       - type: word
         words:
           - "PHP Extension"
           - "PHP Version"
         condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '>PHP Version <\/td><td class="v">([0-9.]+)'

--- a/cves/2021/CVE-2021-37704.yaml
+++ b/cves/2021/CVE-2021-37704.yaml
@@ -14,6 +14,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/vendor/phpfastcache/phpfastcache/docs/examples/phpinfo.php"
+      - "{{BaseURL}}/vendor/phpfastcache/phpfastcache/examples/phpinfo.php"
 
     matchers-condition: and
     matchers:

--- a/cves/2021/CVE-2021-37704.yaml
+++ b/cves/2021/CVE-2021-37704.yaml
@@ -1,0 +1,18 @@
+id: CVE-2021-37704
+
+info:
+  name: phpinfo() exposure in unprotected composer vendor folder via phpfastcache/phpfastcache.
+  author: whoever
+  severity: low
+  tags: cve,composer,phpinfo
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vendor/phpfastcache/phpfastcache/docs/examples/phpinfo.php"
+    matchers:
+      - type: word
+        words:
+          - "PHP Extension"
+          - "PHP Version"
+        condition: and

--- a/cves/2021/CVE-2021-37704.yaml
+++ b/cves/2021/CVE-2021-37704.yaml
@@ -1,11 +1,11 @@
 id: CVE-2021-37704
 
 info:
-  name: phpinfo() exposure (CVE-2021-37704)
+  name: phpfastcache phpinfo exposure
   author: whoever
   severity: low
   description: phpinfo() exposure in unprotected composer vendor folder via phpfastcache/phpfastcache.
-  tags: cve,composer,phpinfo
+  tags: cve,cve2021,exposure,phpfastcache
   reference: |
     https://github.com/PHPSocialNetwork/phpfastcache/pull/813
     https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37704

--- a/cves/2021/CVE-2021-37704.yaml
+++ b/cves/2021/CVE-2021-37704.yaml
@@ -1,10 +1,14 @@
 id: CVE-2021-37704
 
 info:
-  name: phpinfo() exposure in unprotected composer vendor folder via phpfastcache/phpfastcache.
+  name: phpinfo() exposure (CVE-2021-37704)
   author: whoever
   severity: low
+  description: phpinfo() exposure in unprotected composer vendor folder via phpfastcache/phpfastcache.
   tags: cve,composer,phpinfo
+  reference: |
+    https://github.com/PHPSocialNetwork/phpfastcache/pull/813
+    https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37704
 
 requests:
   - method: GET


### PR DESCRIPTION
Hi team,

amazing project. Thanks a lot!
I wanted to dig into template creation so I got started with a trivial stupid one for CVE-2021-37704. I validated it and tried to make matchers consistent by copying it from `exposures/configs/phpinfo.yaml`. If there is anything wrong with my first template, I'm sorry in advance and glad to hear about it.

Vulnerability: Up until version 8.0.6 there is a phpinfo.php file in the composer package phpfastcache/phpfastcache (~ 1.5M installs) which causes a minor information disclosure in case of a publicly accessible vendor folder.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

Works fine.

### Additional References:

- [CVE-2021-37704](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37704)
- [Matcher source](https://github.com/projectdiscovery/nuclei-templates/blob/master/exposures/configs/phpinfo.yaml)
- [Vendor fix](https://github.com/PHPSocialNetwork/phpfastcache/pull/813)