### PR TITLE
updates to the phpmyadmin panel detection script

### DIFF
--- a/exposed-panels/phpmyadmin-panel.yaml
+++ b/exposed-panels/phpmyadmin-panel.yaml
@@ -20,13 +20,12 @@ requests:
       - "{{BaseURL}}/typo3/phpmyadmin/"
       - "{{BaseURL}}/web/phpmyadmin/"
       - "{{BaseURL}}/xampp/phpmyadmin/"
-      - "{{BaseURL}}/phpMyAdmin/" #add another possible path for phpmyadmin panel detection
-    matchers-condition: or #add matching condition
+      - "{{BaseURL}}/phpMyAdmin/"
+
     matchers:
       - type: word
         words:
-          - "<title>phpMyAdmin</title>"
-          - "<title>phpMyAdmin </title>" #result pattern with a trailing whitespace.
+          - "<title>phpMyAdmin"
 
     extractors:
       - type: regex

--- a/exposed-panels/phpmyadmin-panel.yaml
+++ b/exposed-panels/phpmyadmin-panel.yaml
@@ -20,10 +20,13 @@ requests:
       - "{{BaseURL}}/typo3/phpmyadmin/"
       - "{{BaseURL}}/web/phpmyadmin/"
       - "{{BaseURL}}/xampp/phpmyadmin/"
+      - "{{BaseURL}}/phpMyAdmin/" #add another possible path for phpmyadmin panel detection
+    matchers-condition: or #add matching condition
     matchers:
       - type: word
         words:
           - "<title>phpMyAdmin</title>"
+          - "<title>phpMyAdmin </title>" #result pattern with a trailing whitespace.
 
     extractors:
       - type: regex


### PR DESCRIPTION
Added another possible path URL for detection phpmyadmin panel and matching condition along with possile title to be detected for confirmation of the exposed phpmyadmin panel.

### Template / PR Information

- Found one more possbile path that can be checked for while detecting an exposed phpmyadmin panel.
- Also, the response for the same is added with very minor change in the matchers and added an OR condition for confirmation of the detection.

### Template Validation

I've validated this template locally?
- [Y ] YES

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)