### PR TITLE
Update grails-database-admin-console.yaml

### DIFF
--- a/exposed-panels/grails-database-admin-console.yaml
+++ b/exposed-panels/grails-database-admin-console.yaml
@@ -18,6 +18,7 @@ requests:
       - type: word
         words:
           - "<title>H2 Console</title>"
+
       - type: word
         words:
           - "Sorry, remote connections ('webAllowOthers') are disabled on this server"

--- a/exposed-panels/grails-database-admin-console.yaml
+++ b/exposed-panels/grails-database-admin-console.yaml
@@ -13,7 +13,12 @@ requests:
       - '{{BaseURL}}/dbconsole/'
       - '{{BaseURL}}/h2-console/'
 
+    matchers-condition: and
     matchers:
       - type: word
         words:
           - "<title>H2 Console</title>"
+      - type: word
+        words:
+          - "Sorry, remote connections ('webAllowOthers') are disabled on this server"
+        negative: true


### PR DESCRIPTION
Solves the case where the response is "Sorry, remote connections ('webAllowOthers') are disabled on this server"

Example: 

nuclei  -t nuclei-templates/exposed-panels/grails-database-admin-console.yaml -u https://uptime-service.ford.com

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)