### PR TITLE
Update phpmyadmin-panel.yaml

### DIFF
--- a/exposed-panels/phpmyadmin-panel.yaml
+++ b/exposed-panels/phpmyadmin-panel.yaml
@@ -21,12 +21,13 @@ requests:
       - "{{BaseURL}}/web/phpmyadmin/"
       - "{{BaseURL}}/xampp/phpmyadmin/"
       - "{{BaseURL}}/phpMyAdmin/"
-
+      
+    stop-at-first-match: true
     matchers:
       - type: word
         words:
           - "<title>phpMyAdmin"
-
+          - "pmahomme"
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
Stopping at first match (stop-at-first-match: true) 
With the id (html) "pmahomme" you will find hidden phpmyadmin instances (status 301) those instances do not show the title. The title can be easily change but id are not that simple to get rid of.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)