### PR TITLE
Update CVE-2017-5487.yaml

### DIFF
--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -15,7 +15,8 @@ requests:
     path:
       - "{{BaseURL}}/wp-json/wp/v2/users/"
       - "{{BaseURL}}/?rest_route=/wp/v2/users/"
-
+      
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word

--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}/wp-json/wp/v2/users/"
       - "{{BaseURL}}/?rest_route=/wp/v2/users/"
-      
+
     stop-at-first-match: true
     matchers-condition: and
     matchers:
@@ -34,6 +34,7 @@ requests:
           - '"name":'
           - '"avatar_urls":'
         condition: and
+
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
Using `stop-at-first-match: true` because the second endpoint `?rest_route=/wp/v2/users/` is only alternative path if `/wp-json/wp/v2/users/` is blocked