### PR TITLE
Update wordpress-db-repair.yaml

### DIFF
--- a/vulnerabilities/wordpress/wordpress-db-repair.yaml
+++ b/vulnerabilities/wordpress/wordpress-db-repair.yaml
@@ -24,5 +24,8 @@ requests:
 
       - type: word
         words:
-          - "define('WP_ALLOW_REPAIR', true);"
+          - "define"
+          - "WP_ALLOW_REPAIR"
+          - "true"
+        condition: and
         negative: true


### PR DESCRIPTION
Solves this false positive (different encoding) 

nuclei -debug -t   nuclei-templates/vulnerabilities/wordpress/wordpress-db-repair.yaml -u https://try.walmart.com

<p><code>define(&#39;WP_ALLOW_REPAIR&#39;, true);

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)