### PR TITLE
#2636, Remove takeover tag from template

### DIFF
--- a/dns/can-i-take-over-dns.yaml
+++ b/dns/can-i-take-over-dns.yaml
@@ -4,7 +4,7 @@ info:
   name: Can I Take Over DNS - Fingerprint
   author: pdteam
   severity: info
-  tags: dns,ns,takeover
+  tags: dns,ns
   reference: https://github.com/indianajson/can-i-take-over-dns
 
 dns:


### PR DESCRIPTION
### Template / PR Information

The template does not indicate an actual takeover and only provides fingerprinting capabilities, therefore it shouldn't have the takeover tag.

### Template Validation

I've validated this template locally?
- [x] YES
