### PR TITLE
Create Directory-listing.yaml

### DIFF
--- a/Directory-listing.yaml
+++ b/Directory-listing.yaml
@@ -1,0 +1,29 @@
+id: Directory-listing
+
+info:
+  name: Directory listing
+  author: huowuzhao
+  severity: medium
+  reference: https://portswigger.net/kb/issues/00600100_directory-listing
+  tags: Directory listing
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - "<title>/</title>"
+          - "<title>Index of /</title>"
+          - "<title>Directory listing for /</title>"
+        part: body
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "<small>([a-z0-9.]+)</small>"


### PR DESCRIPTION
Web servers can be configured to automatically list the contents of directories that do not have an index page present. This can aid an attacker by enabling them to quickly identify the resources at a given path, and proceed directly to analyzing and attacking those resources. It particularly increases the exposure of sensitive files within the directory that are not intended to be accessible to users, such as temporary files and crash dumps.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)