### PR TITLE
Create azure-trafficmanager-takeover-detection.yaml

### DIFF
--- a/dns/azure-trafficmanager-takeover-detection.yaml
+++ b/dns/azure-trafficmanager-takeover-detection.yaml
@@ -1,0 +1,30 @@
+id: azure-trafficmanager-takeover-detection
+
+info:
+  name: Azure Trafficmanager takeover detection
+  author: pdteam,philippedelteil
+  severity: info
+  tags: dns,takeover
+  reference:
+    - https://godiego.tech/posts/STO/ # kudos to @secfaults for sharing process details.
+
+dns:
+  - name: "{{FQDN}}"
+    type: A
+    class: inet
+    recursion: true
+    retries: 3
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "trafficmanager.net"
+      - type: word
+        words:
+          - "NXDOMAIN"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "IN\tCNAME\t(.+)"


### PR DESCRIPTION
This is a split from the azure-takeover-detection template. TrafficManager is not longer possible to takeover.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)