### PR TITLE
New VMWare Vcenter File upload check.

### DIFF
--- a/cves/2021/CVE-2021-22005.yaml
+++ b/cves/2021/CVE-2021-22005.yaml
@@ -1,0 +1,23 @@
+id: cve-2021-22005
+info:
+  name: Vcenter Unauthenticated Remote Upload
+  author: PR3R00T
+  severity: Critical
+requests:
+  - raw:
+      - |
+        POST /analytics/telemetry/ph/api/hyper/send?_c&_i=test HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        test_data
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Server: Apache"
+        part: header
+      - type: status
+        status:
+          - 201

--- a/cves/2021/CVE-2021-22005.yaml
+++ b/cves/2021/CVE-2021-22005.yaml
@@ -1,10 +1,22 @@
-id: cve-2021-22005
+id: CVE-2021-22005
+
 info:
-  name: Vcenter Unauthenticated Remote Upload
+  name: VMware vCenter Server file upload vulnerability
   author: PR3R00T
-  severity: Critical
+  severity: critical
+  description: The vCenter Server contains an arbitrary file upload vulnerability in the Analytics service. VMware has evaluated the severity of this issue to be in the Critical severity range with a maximum CVSSv3 base score of 9.8.
+  reference:
+    - https://kb.vmware.com/s/article/85717
+    - https://www.vmware.com/security/advisories/VMSA-2021-0020.html
+    - https://core.vmware.com/vmsa-2021-0020-questions-answers-faq
+  tags: cve,cve2021,vmware,vcenter
+
 requests:
   - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
       - |
         POST /analytics/telemetry/ph/api/hyper/send?_c&_i=test HTTP/1.1
         Host: {{Hostname}}
@@ -12,12 +24,12 @@ requests:
 
         test_data
 
-    matchers-condition: and
+    req-condition: true
     matchers:
-      - type: word
-        words:
-          - "Server: Apache"
-        part: header
-      - type: status
-        status:
-          - 201
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "status_code_2 == 201"
+          - "contains(body_1, 'VMware vSphere')"
+          - "content_length_2 == 0"
+        condition: and


### PR DESCRIPTION

### Template / PR Information

New VMware VCenter exploit came out last night, looking into the details, this is due to a telemetry endpoint. The provided checker on the vmware site shows simple CURL requests to validate vulnerability exists. 

-  Added CVE-2021-22005
- References:
https://kb.vmware.com/s/article/85717 - taking the attached python script as validation.
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)