### PR TITLE
Create commax-cctv-rtsp-credentials-disclosure.yaml

### DIFF
--- a/vulnerabilities/other/commax-cctv-rtsp-credentials-disclosure.yaml
+++ b/vulnerabilities/other/commax-cctv-rtsp-credentials-disclosure.yaml
@@ -1,0 +1,23 @@
+id: commax-cctv-rtsp-credentials-disclosure
+
+info:
+  name: COMMAX Smart Home Ruvie CCTV Bridge DVR - RTSP Credentials Disclosure
+  author: gy741
+  severity: critical
+  description: The COMMAX CCTV Bridge for the DVR service allows an unauthenticated attacker to disclose RTSP credentials in plain-text
+  reference:
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5665.php
+  tags: commax,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/overview.asp"
+
+    matchers:
+      - type: word
+        words:
+          - "DVR Lists"
+          - "rtsp://"
+          - "login_check.js"
+        condition: and

--- a/vulnerabilities/other/commax-credentials-disclosure.yaml
+++ b/vulnerabilities/other/commax-credentials-disclosure.yaml
@@ -1,13 +1,12 @@
-id: commax-cctv-rtsp-credentials-disclosure
+id: commax-credentials-disclosure
 
 info:
   name: COMMAX Smart Home Ruvie CCTV Bridge DVR - RTSP Credentials Disclosure
   author: gy741
   severity: critical
   description: The COMMAX CCTV Bridge for the DVR service allows an unauthenticated attacker to disclose RTSP credentials in plain-text
-  reference:
-    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5665.php
-  tags: commax,exposure
+  reference: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5665.php
+  tags: commax,exposure,camera,iot
 
 requests:
   - method: GET
@@ -20,4 +19,11 @@ requests:
           - "DVR Lists"
           - "rtsp://"
           - "login_check.js"
+          - "MAX USER :"
         condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'rtsp:\/\/([a-z:0-9A-Z@$.]+)\/Streaming\/Chann'


### PR DESCRIPTION
### Template / PR Information

Hello,

Added Create commax-cctv-rtsp-credentials-disclosure issue

```
The COMMAX CCTV Bridge for the DVR service allows an unauthenticated attacker
to disclose RTSP credentials in plain-text.
```

- References: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5665.php

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO
