### PR TITLE
Update cvss/severity for CVE-2020-29453

### DIFF
--- a/cves/2020/CVE-2020-29453.yaml
+++ b/cves/2020/CVE-2020-29453.yaml
@@ -3,13 +3,13 @@ id: CVE-2020-29453
 info:
   name: Pre-Auth Limited Arbitrary File Read in Jira Server
   author: dwisiswant0
-  severity: medium
+  severity: high
   description: The CachingResourceDownloadRewriteRule class in Jira Server and Jira Data Center allowed unauthenticated remote attackers to read arbitrary files within WEB-INF and META-INF directories via an incorrect path access check.
   reference: https://jira.atlassian.com/browse/JRASERVER-72014
   tags: cve,cve2020,atlassian,jira,lfi
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-    cvss-score: 5.30
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2020-29453
     cwe-id: CWE-22
 


### PR DESCRIPTION
### Template / PR Information

CVSS calc had severity lower (medium) than it should have been (high).

- Updated CVE-2020-29453

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
