### PR TITLE
HP 1820-8G Switch J9979A Default Credential

### DIFF
--- a/default-logins/hp/hp-switch-default-login.yaml
+++ b/default-logins/hp/hp-switch-default-login.yaml
@@ -1,4 +1,4 @@
-id: hp-1820-8G-switch-default-dredential
+id: hp-switch-default-login
 info:
   name: HP 1820-8G Switch J9979A Default Credential
   author: pussycat0x
@@ -6,25 +6,24 @@ info:
   reference: https://support.hpe.com/hpesc/public/docDisplay?docId=a00077779en_us&docLocale=en_US
   metadata:
     fofa-dork: 'HP 1820-8G Switch J9979A'
-  tags: default, hp
+  tags: default-login,hp
+
 requests:
   - raw:
       - |
           POST /htdocs/login/login.lua HTTP/1.1
           Host: {{Hostname}}
-          Accept: application/json, text/javascript, */*; q=0.01
-          Accept-Language: en-US,en;q=0.5
-          Accept-Encoding: gzip, deflate
-          Content-Type: application/x-www-form-urlencoded
-          X-Requested-With: XMLHttpRequest
 
           username=admin&password=
+
     matchers-condition: and
     matchers:
       - type: word
         words:
           - '"redirect": "/htdocs/pages/main/main.lsp"'
+          - '"error": ""'
         condition: and
+
       - type: status
         status:
           - 200

--- a/misconfiguration/hp-switch-default-creds.yaml
+++ b/misconfiguration/hp-switch-default-creds.yaml
@@ -1,0 +1,30 @@
+id: hp-1820-8G-switch-default-dredential
+info:
+  name: HP 1820-8G Switch J9979A Default Credential
+  author: pussycat0x
+  severity: high
+  reference: https://support.hpe.com/hpesc/public/docDisplay?docId=a00077779en_us&docLocale=en_US
+  metadata:
+    fofa-dork: 'HP 1820-8G Switch J9979A'
+  tags: default, hp
+requests:
+  - raw:
+      - |
+          POST /htdocs/login/login.lua HTTP/1.1
+          Host: {{Hostname}}
+          Accept: application/json, text/javascript, */*; q=0.01
+          Accept-Language: en-US,en;q=0.5
+          Accept-Encoding: gzip, deflate
+          Content-Type: application/x-www-form-urlencoded
+          X-Requested-With: XMLHttpRequest
+        
+          username=admin&password=
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"redirect": "/htdocs/pages/main/main.lsp"'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/misconfiguration/hp-switch-default-creds.yaml
+++ b/misconfiguration/hp-switch-default-creds.yaml
@@ -17,7 +17,7 @@ requests:
           Accept-Encoding: gzip, deflate
           Content-Type: application/x-www-form-urlencoded
           X-Requested-With: XMLHttpRequest
-        
+          
           username=admin&password=
     matchers-condition: and
     matchers:

--- a/misconfiguration/hp-switch-default-creds.yaml
+++ b/misconfiguration/hp-switch-default-creds.yaml
@@ -17,7 +17,7 @@ requests:
           Accept-Encoding: gzip, deflate
           Content-Type: application/x-www-form-urlencoded
           X-Requested-With: XMLHttpRequest
-          
+
           username=admin&password=
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:
    https://support.hpe.com/hpesc/public/docDisplay?docId=a00077779en_us&docLocale=en_US


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)