### PR TITLE
Create wptouch-plugin-open-redirect.yaml

### DIFF
--- a/wptouch-plugin-open-redirect.yaml
+++ b/wptouch-plugin-open-redirect.yaml
@@ -1,0 +1,19 @@
+id: wptouch-plugin-open-redirect
+
+info:
+  name: WPTouch Switch Desktop 3.x Open Redirection
+  author: 0x_Akoko
+  reference: https://cxsecurity.com/issue/WLB-2020030114
+  severity: medium
+  tags: wp,redirect,wordpress
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?wptouch_switch=desktop&redirect=https://example.com/"
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
+        part: header


### PR DESCRIPTION
### Template / PR Information

WordPress WPTouch Switch Desktop 3.x Open Redirection
Date : 22/03/2020
Vendor Homepage : wptouch.com
Software Link : wordpress.org/plugins/wptouch
WordPress CMS Affected Version : 5.0.3 - 5.x
Software Affected Version : 3.x 
References: https://cxsecurity.com/issue/WLB-2020030114

### Template Validation

I've validated this template locally?
-  YES
