### PR TITLE
Create aspose-words-exporter-file-download.yaml

### DIFF
--- a/vulnerabilities/wordpress/aspose-words-file-download.yaml
+++ b/vulnerabilities/wordpress/aspose-words-file-download.yaml
@@ -1,11 +1,14 @@
-id: aspose-words-exporter-file-download
+id: aspose-words-file-download
 
 info:
   name: Aspose Words Exporter < 2.0 - Unauthenticated Arbitrary File Download
   author: 0x_Akoko
   severity: high
-  tags: wordpress,wp-plugin,lfi,wp
-  reference: https://wpscan.com/vulnerability/7869
+  description: The Aspose.Words Exporter WordPress plugin is affected by an Arbitrary File Download security vulnerability.
+  reference:
+    - https://wpscan.com/vulnerability/7869
+    - https://wordpress.org/plugins/aspose-doc-exporter
+  tags: wordpress,wp-plugin,lfi
 
 requests:
   - method: GET


### PR DESCRIPTION
### Template / PR Information
The Aspose.Words Exporter WordPress plugin was affected by an Arbitrary File Download security vulnerability.

The aspose_doc_exporter_download.php file of the plugin does not restrict access, check permission or validate the file parameter, allowing unauthenticated user to download any file from the blog (such as the wp-config.php), using a path traversal vector.

Vendor Homepage : https://wordpress.org/plugins/aspose-doc-exporter/developers
Download Link : https://downloads.wordpress.org/plugin/aspose-doc-exporter.zip
References: https://wpscan.com/vulnerability/7869

### Template Validation

I've validated this template locally?
- YES