### PR TITLE
Create CVE-2021-20031.yaml

### DIFF
--- a/cves/2021/CVE-2021-20031.yaml
+++ b/cves/2021/CVE-2021-20031.yaml
@@ -9,8 +9,7 @@ info:
     - https://www.exploit-db.com/exploits/50414
     - https://nvd.nist.gov/vuln/detail/CVE-2021-20031
   metadata:
-    google-dork: inurl:"auth.html" intitle:"SonicWall" 
-    google-dork: intitle:"SonicWall Analyzer Login"
+    google-dork: inurl:"auth.html" intitle:"SonicWall"
   tags: cve,cve2021,sonicwall,redirect
 
 requests:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-20031

```
A Host Header Injection vulnerability may allow an attacker to spoof a particular Host header, allowing the attacker to render arbitrary links that point to a malicious website with poisoned Host header webpages. An issue was discovered in Sonicwall NAS, SonicWall Analyzer version 8.5.0 (may be affected on other versions too). The values of the 'Host' headers are implicitly set as trusted while this should be forbidden, leading to potential host header injection attack and also the affected hosts can be used for domain fronting. This means affected hosts can be used by attackers to hide behind during various other attack
```

- References: https://www.exploit-db.com/exploits/50414

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
