### PR TITLE
Add jetbrains datasource exposure check

### DIFF
--- a/exposures/configs/jetbrains-datasources.yaml
+++ b/exposures/configs/jetbrains-datasources.yaml
@@ -1,4 +1,4 @@
-id: package-json
+id: jetbrains-datasource
 
 info:
   name: Jetbrains IDE DataSources exposure
@@ -16,7 +16,7 @@ requests:
     matchers:
       - type: word
         words:
-          - "uuid"
+          - "DataSourceManagerImpl"
         part: body
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

Check for exposed dataSources.xml generated by Jetbrains IDEs.
dataSources.xml can be used to retrieve uuid of dataSource that can be accessed via .idea/dataSources/{uuid}.xml
to get information about database structure.

- References: https://blog.jetbrains.com/datagrip/2018/05/21/copy-and-share-data-sources-in-datagrip/

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

### Additional References: