### PR TITLE
Fix condition in S3 service detection template

### DIFF
--- a/technologies/aws/aws-bucket-service.yaml
+++ b/technologies/aws/aws-bucket-service.yaml
@@ -18,7 +18,7 @@ requests:
           - contains(tolower(all_headers), 'x-amz-bucket')
           - contains(tolower(all_headers), 'x-amz-request')
           - contains(tolower(all_headers), 'x-amz-id')
-          - contains(tolower(all_headers), 'AmazonS3')
+          - contains(tolower(all_headers), 'amazons3')
         part: header
         condition: or
 


### PR DESCRIPTION
### Template / PR Information

It seems this condition can never be true since the headers are lowercased whereas "AmazonS3" is not. Thanks and let me know if I'm misunderstanding something here.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO