### PR TITLE
Enhance Text Matching in Error Logs

### DIFF
--- a/exposures/logs/error-logs.yaml
+++ b/exposures/logs/error-logs.yaml
@@ -45,6 +45,8 @@ requests:
           - "script headers"
           - "Broken pipe"
           - "Array"
+          - "Exception"
+          - "Fatal"
         condition: or
 
       - type: word


### PR DESCRIPTION
### Template / PR Information

Some words are missing that normally indicate that this is an error log.

I'm thinking about php error words: Exception, Fatal Error, maybe even Warning (which I didn't add because it's too general)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
