### PR TITLE
Add Redis Commander Panel Detection

### DIFF
--- a/exposed-panels/redis-commander-exposure.yaml
+++ b/exposed-panels/redis-commander-exposure.yaml
@@ -7,7 +7,7 @@ info:
   reference:
     - https://joeferner.github.io/redis-commander/
     - https://github.com/joeferner/redis-commander
-  tags: panel
+  tags: panel,redis
 
 requests:
   - method: GET
@@ -16,7 +16,7 @@ requests:
 
     matchers:
       - type: word
+        condition: and
         words:
           - "<title>Redis Commander"
           - "redisCommanderBearerToken"
-        condition: and


### PR DESCRIPTION
### Template / PR Information

Redis Commander is a common ui for redis. Access to Redis Commander can allow access to redis and expose sensible session or cache data.

References:
- https://joeferner.github.io/redis-commander/
- https://github.com/joeferner/redis-commander

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Match 1 (HTML title): https://github.com/joeferner/redis-commander/blob/10f4275df27ffb9fbce6db07991db2c5480138e6/web/views/layout.ejs#L4
Match 2 (Main Js): https://github.com/joeferner/redis-commander/blob/10f4275df27ffb9fbce6db07991db2c5480138e6/web/views/home/home.ejs#L147

Both matches are directly in the source code. 