### PR TITLE
Fix not found error in the CVE annotation action

### DIFF
--- a/.github/workflows/cve-annotate.yml
+++ b/.github/workflows/cve-annotate.yml
@@ -27,7 +27,7 @@ jobs:
             echo -e "Command cve-annotate not found! Installing\c"
             go install github.com/projectdiscovery/nuclei/v2/cmd/cve-annotate@dev
           fi
-          cve-annotate -i ./cves/ -d .
+          ~/go/bin/cve-annotate -i ./cves/ -d .
           echo "::set-output name=changes::$(git status -s | wc -l)"
 
       - name: Commit files


### PR DESCRIPTION
by default installed packages through go get are being installed in Go bin folder, using path to the direct file in the bin folder will run the tool
