### PR TITLE
Update SSH user enum templates

### DIFF
--- a/cves/2016/CVE-2016-6210.yaml
+++ b/cves/2016/CVE-2016-6210.yaml
@@ -1,15 +1,16 @@
 id: CVE-2016-6210
 
 info:
-  name: OpenSSH 5.3 Detection
-  author: iamthefrogy
+  name: OpenSSH username enumeration < v7.3
+  author: iamthefrogy,forgedhallpass
   severity: medium
   tags: network,openssh
-  description: OpenSSH 5.3 is vulnerable to username enumeration and DoS vulnerabilities.
+  description: OpenSSH before 7.3 is vulnerable to username enumeration and DoS vulnerabilities.
   reference:
     - http://seclists.org/fulldisclosure/2016/Jul/51
     - https://security-tracker.debian.org/tracker/CVE-2016-6210
     - http://openwall.com/lists/oss-security/2016/08/01/2
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-6210
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 5.9
@@ -21,6 +22,11 @@ network:
       - "{{Hostname}}"
       - "{{Hostname}}:22"
     matchers:
-      - type: word
-        words:
-          - "SSH-2.0-OpenSSH_5.3"
+      - type: regex
+        regex:
+          - '(?i)SSH-2.0-OpenSSH_(?:[1-6][^\d][^\r]+|7\.[0-2][^\d][^\r]+)'
+
+    extractors:
+      - type: regex
+        regex:
+          - '(?i)SSH-2.0-OpenSSH_[^\r]+'

--- a/cves/2018/CVE-2018-15473.yaml
+++ b/cves/2018/CVE-2018-15473.yaml
@@ -1,8 +1,8 @@
 id: CVE-2018-15473
 
 info:
-  name: OpenSSH Username Enumeration
-  author: r3dg33k,daffainfo
+  name: OpenSSH Username Enumeration <= v7.7
+  author: r3dg33k,daffainfo,forgedhallpass
   severity: medium
   description: OpenSSH through 7.7 is prone to a user enumeration vulnerability due to not delaying bailout for an invalid authenticating user until after the packet containing the request has been fully parsed, related to auth2-gss.c, auth2-hostbased.c, and auth2-pubkey.c.
   reference: https://nvd.nist.gov/vuln/detail/CVE-2018-15473
@@ -21,9 +21,9 @@ network:
     matchers:
       - type: regex
         regex:
-          - 'SSH-2.0-OpenSSH_[1-7]'
+          - '(?i)SSH-2.0-OpenSSH_(?:[1-6][^\d][^\r]+|7\.[0-7][^\d][^\r]+)'
 
     extractors:
       - type: regex
         regex:
-          - 'SSH-2.0-OpenSSH_([0-9.]+)'
+          - '(?i)SSH-2.0-OpenSSH_[^\r]+'


### PR DESCRIPTION
SSH header structure:
`SSH-protoversion-softwareversion[SPcomments]CRLF`

see: https://datatracker.ietf.org/doc/html/rfc4253#section-4.2

The regex was created and tested based on the `OpenSSH` versions taken from the official change log:

```
SSH-2.0-OpenSSH_1.2.2p1
SSH-2.0-OpenSSH_1.2.3
SSH-2.0-OpenSSH_1.2.3p1
SSH-2.0-OpenSSH_2.1.0p1
SSH-2.0-OpenSSH_2.1.1p1
SSH-2.0-OpenSSH_2.1.1p2
SSH-2.0-OpenSSH_2.1.1p3
SSH-2.0-OpenSSH_2.1.1p4
SSH-2.0-OpenSSH_2.2.0p1
SSH-2.0-OpenSSH_2.3.0
SSH-2.0-OpenSSH_2.3.0p1
SSH-2.0-OpenSSH_2.5.0p1
SSH-2.0-OpenSSH_2.5.1p1
SSH-2.0-OpenSSH_2.5.1p2
SSH-2.0-OpenSSH_2.5.2p2
SSH-2.0-OpenSSH_2.9
SSH-2.0-OpenSSH_2.9.9
SSH-2.0-OpenSSH_2.9.9p1
SSH-2.0-OpenSSH_2.9p1
SSH-2.0-OpenSSH_2.9p2
SSH-2.0-OpenSSH_3.0
SSH-2.0-OpenSSH_3.0.1
SSH-2.0-OpenSSH_3.0.1p1
SSH-2.0-OpenSSH_3.0.2
SSH-2.0-OpenSSH_3.0.2p1
SSH-2.0-OpenSSH_3.0p1
SSH-2.0-OpenSSH_3.1
SSH-2.0-OpenSSH_3.1p1
SSH-2.0-OpenSSH_3.2
SSH-2.0-OpenSSH_3.2.2
SSH-2.0-OpenSSH_3.2.2p1
SSH-2.0-OpenSSH_3.2.3
SSH-2.0-OpenSSH_3.2.3p1
SSH-2.0-OpenSSH_3.3
SSH-2.0-OpenSSH_3.3p1
SSH-2.0-OpenSSH_3.4
SSH-2.0-OpenSSH_3.4p1
SSH-2.0-OpenSSH_3.5
SSH-2.0-OpenSSH_3.5p1
SSH-2.0-OpenSSH_3.6
SSH-2.0-OpenSSH_3.6.1
SSH-2.0-OpenSSH_3.6.1p1
SSH-2.0-OpenSSH_3.6.1p2
SSH-2.0-OpenSSH_3.6p1
SSH-2.0-OpenSSH_3.7
SSH-2.0-OpenSSH_3.7.1
SSH-2.0-OpenSSH_3.7.1p1
SSH-2.0-OpenSSH_3.7.1p2
SSH-2.0-OpenSSH_3.7p1
SSH-2.0-OpenSSH_3.8
SSH-2.0-OpenSSH_3.8.1p1
SSH-2.0-OpenSSH_3.8p1
SSH-2.0-OpenSSH_3.9
SSH-2.0-OpenSSH_3.9p1
SSH-2.0-OpenSSH_4.0
SSH-2.0-OpenSSH_4.0p1
SSH-2.0-OpenSSH_4.1
SSH-2.0-OpenSSH_4.1p1
SSH-2.0-OpenSSH_4.2
SSH-2.0-OpenSSH_4.2p1
SSH-2.0-OpenSSH_4.3
SSH-2.0-OpenSSH_4.3p1
SSH-2.0-OpenSSH_4.3p2
SSH-2.0-OpenSSH_4.4
SSH-2.0-OpenSSH_4.4p1
SSH-2.0-OpenSSH_4.5
SSH-2.0-OpenSSH_4.5p1
SSH-2.0-OpenSSH_4.6
SSH-2.0-OpenSSH_4.6p1
SSH-2.0-OpenSSH_4.7
SSH-2.0-OpenSSH_4.7p1
SSH-2.0-OpenSSH_4.8
SSH-2.0-OpenSSH_4.8p1
SSH-2.0-OpenSSH_4.9
SSH-2.0-OpenSSH_4.9p1
SSH-2.0-OpenSSH_5.0
SSH-2.0-OpenSSH_5.0p1
SSH-2.0-OpenSSH_5.1
SSH-2.0-OpenSSH_5.1p1
SSH-2.0-OpenSSH_5.2
SSH-2.0-OpenSSH_5.2p1
SSH-2.0-OpenSSH_5.3
SSH-2.0-OpenSSH_5.3p1
SSH-2.0-OpenSSH_5.4
SSH-2.0-OpenSSH_5.4p1
SSH-2.0-OpenSSH_5.5
SSH-2.0-OpenSSH_5.5p1
SSH-2.0-OpenSSH_5.6
SSH-2.0-OpenSSH_5.6p1
SSH-2.0-OpenSSH_5.7
SSH-2.0-OpenSSH_5.7p1
SSH-2.0-OpenSSH_5.8
SSH-2.0-OpenSSH_5.8p1
SSH-2.0-OpenSSH_5.8p2
SSH-2.0-OpenSSH_5.9
SSH-2.0-OpenSSH_5.9p1
SSH-2.0-OpenSSH_6.0
SSH-2.0-OpenSSH_6.0p1
SSH-2.0-OpenSSH_6.1
SSH-2.0-OpenSSH_6.1p1
SSH-2.0-OpenSSH_6.2
SSH-2.0-OpenSSH_6.2p1
SSH-2.0-OpenSSH_6.2p2
SSH-2.0-OpenSSH_6.3
SSH-2.0-OpenSSH_6.3p1
SSH-2.0-OpenSSH_6.4
SSH-2.0-OpenSSH_6.4p1
SSH-2.0-OpenSSH_6.5
SSH-2.0-OpenSSH_6.5p1
SSH-2.0-OpenSSH_6.6
SSH-2.0-OpenSSH_6.6p1
SSH-2.0-OpenSSH_6.7
SSH-2.0-OpenSSH_6.7p1
SSH-2.0-OpenSSH_6.8
SSH-2.0-OpenSSH_6.8
SSH-2.0-OpenSSH_6.8p1
SSH-2.0-OpenSSH_6.9
SSH-2.0-OpenSSH_6.9p1
SSH-2.0-OpenSSH_7.0
SSH-2.0-OpenSSH_7.0p1
SSH-2.0-OpenSSH_7.1
SSH-2.0-OpenSSH_7.1p1
SSH-2.0-OpenSSH_7.1p2
SSH-2.0-OpenSSH_7.2
SSH-2.0-OpenSSH_7.2p1
SSH-2.0-OpenSSH_7.2p2
SSH-2.0-OpenSSH_7.3
SSH-2.0-OpenSSH_7.3p1
SSH-2.0-OpenSSH_7.4
SSH-2.0-OpenSSH_7.4p1
SSH-2.0-OpenSSH_7.5
SSH-2.0-OpenSSH_7.5p1
SSH-2.0-OpenSSH_7.6
SSH-2.0-OpenSSH_7.6p1
SSH-2.0-OpenSSH_7.7
SSH-2.0-OpenSSH_7.7p1
SSH-2.0-OpenSSH_7.8
SSH-2.0-OpenSSH_7.8p1
SSH-2.0-OpenSSH_7.9
SSH-2.0-OpenSSH_7.9p1
SSH-2.0-OpenSSH_8.0
SSH-2.0-OpenSSH_8.0p1
SSH-2.0-OpenSSH_8.1
SSH-2.0-OpenSSH_8.1p1
SSH-2.0-OpenSSH_8.2
SSH-2.0-OpenSSH_8.2p1
SSH-2.0-OpenSSH_8.3
SSH-2.0-OpenSSH_8.3p1
SSH-2.0-OpenSSH_8.4
SSH-2.0-OpenSSH_8.4p1
SSH-2.0-OpenSSH_8.5
SSH-2.0-OpenSSH_8.5p1
SSH-2.0-OpenSSH_8.6
SSH-2.0-OpenSSH_8.6p1
SSH-2.0-OpenSSH_8.7
SSH-2.0-OpenSSH_8.7p1
SSH-2.0-OpenSSH_8.8
SSH-2.0-OpenSSH_8.8p1
```