### PR TITLE
Updates wordpress-login.yaml

### DIFF
--- a/exposed-panels/wordpress-login.yaml
+++ b/exposed-panels/wordpress-login.yaml
@@ -1,4 +1,4 @@
-id: wordpress-panel
+id: wordpress-login
 
 info:
   name: WordPress Panel

--- a/exposed-panels/wordpress-login.yaml
+++ b/exposed-panels/wordpress-login.yaml
@@ -1,8 +1,8 @@
 id: wordpress-login
 
 info:
-  name: WordPress Panel
-  author: github.com/its0x08
+  name: WordPress login
+  author: its0x08
   severity: info
   tags: panel
 


### PR DESCRIPTION
### Template / PR Information

The ID used in the ``wordpress-panel`` template was incorrect and didn't match the title of the template, making it hard to find if you're wanting to exclude it.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details

Wasn't sure whether the ID should change or the filename - I figured it would cause more interference if the filename were to change, so altered the ID instead.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)