### PR TITLE
Update CVE-2021-36260.yaml

### DIFF
--- a/cves/2021/CVE-2021-36260.yaml
+++ b/cves/2021/CVE-2021-36260.yaml
@@ -37,7 +37,7 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - "contains(body_2,'uid=') && contains(body_2,'gid=')"
+          - "contains(body_2,'uid=') && contains(body_2,'gid=') && contains(body_2,'groups=')"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information
original template showing false positive results as this is only checking for ```uid``` and ```gid```. I have included ```groups``` for additional checking

example false positive result : ```uid="" data-orgid="" data-email=""></div>```
- Fixed CVE-2021-36260

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)