### PR TITLE
create check for cve-2019-2578

### DIFF
--- a/cves/2019/CVE-2019-2578.yaml
+++ b/cves/2019/CVE-2019-2578.yaml
@@ -4,29 +4,24 @@ info:
   name: Broken Access Control Oracle WebCenter Sites
   author: leovalcante
   severity: high
-  description: Check cve-2019-2578 for Oracle WebCenter Sites.
+  description: Vulnerability in the Oracle WebCenter Sites component of Oracle Fusion Middleware. The supported version that is affected is 12.2.1.3.0. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle WebCenter Sites accessible data.
   reference: https://outpost24.com/blog/Vulnerabilities-discovered-in-Oracle-WebCenter-Sites
-  tags: oracle,webcenter sites,wcs,broken access control
+  tags: cve,cve2019,oracle,wcs,auth-bypass
 
 
 requests:
   - raw:
       - |
         GET /cs/Satellite?pagename=OpenMarket/Xcelerate/Admin/WebReferences HTTP/1.1
-        Host: {{BaseURL}}
-        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
-        Accept-Language: en-US,en;q=0.9
+        Host: {{Hostname}}
+
       - |
         GET /cs/Satellite?pagename=OpenMarket/Xcelerate/Admin/Slots HTTP/1.1
-        Host: {{BaseURL}}
-        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
-        Accept-Language: en-US,en;q=0.9
-    redirects: false
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
     matchers:
       - type: regex
+        part: body
         regex:
           - '<script[\d\D]*<throwexception/>'
-        part: body
-    stop-at-first-match: true

--- a/cves/2019/CVE-2019-2578.yaml
+++ b/cves/2019/CVE-2019-2578.yaml
@@ -1,0 +1,32 @@
+id: CVE-2019-2578
+
+info:
+  name: Broken Access Control Oracle WebCenter Sites
+  author: leovalcante
+  severity: high
+  description: Check cve-2019-2578 for Oracle WebCenter Sites.
+  reference: https://outpost24.com/blog/Vulnerabilities-discovered-in-Oracle-WebCenter-Sites
+  tags: oracle,webcenter sites,wcs,broken access control
+
+
+requests:
+  - raw:
+      - |
+        GET /cs/Satellite?pagename=OpenMarket/Xcelerate/Admin/WebReferences HTTP/1.1
+        Host: {{BaseURL}}
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+      - |
+        GET /cs/Satellite?pagename=OpenMarket/Xcelerate/Admin/Slots HTTP/1.1
+        Host: {{BaseURL}}
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+    redirects: false
+    matchers:
+      - type: regex
+        regex:
+          - '<script[\d\D]*<throwexception/>'
+        part: body
+    stop-at-first-match: true


### PR DESCRIPTION
### Template / PR Information

Create check for Oracle WebCenter Sites Broken Access Control vulnerability - cve-2019-2578

- Added cve-2019-2578 
- References:
  - https://outpost24.com/blog/Vulnerabilities-discovered-in-Oracle-WebCenter-Sites 

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
N.A.

### Additional References:
https://github.com/leovalcante/wcs_scanner
