### PR TITLE
Content type checking for graphql detection

### DIFF
--- a/technologies/graphql-detect.yaml
+++ b/technologies/graphql-detect.yaml
@@ -145,6 +145,11 @@ requests:
         status:
           - 200
 
+      - type: word
+        words:
+          - "Content-Type: application/json"
+        part: header
+      
       - type: regex
         regex:
           - "__schema"

--- a/technologies/graphql-detect.yaml
+++ b/technologies/graphql-detect.yaml
@@ -146,9 +146,9 @@ requests:
           - 200
 
       - type: word
-        words:
-          - "Content-Type: application/json"
         part: header
+        words:
+          - "application/json"
 
       - type: regex
         regex:

--- a/technologies/graphql-detect.yaml
+++ b/technologies/graphql-detect.yaml
@@ -149,7 +149,7 @@ requests:
         words:
           - "Content-Type: application/json"
         part: header
-      
+
       - type: regex
         regex:
           - "__schema"


### PR DESCRIPTION
### Template / PR Information
Added content type checking to avoid false positives as sometimes error pages contains _schema in the error which is a False positive.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)