### PR TITLE
Add a tpl for IBM MQSeries web console detection

### DIFF
--- a/exposed-panels/ibm/ibm-mqseries-web-console.yaml
+++ b/exposed-panels/ibm/ibm-mqseries-web-console.yaml
@@ -1,0 +1,22 @@
+id: ibm-mqseries-web-console
+
+info:
+  name: IBM MQSeries web console
+  author: righettod
+  severity: info
+  reference: https://www.ibm.com/docs/en/ibm-mq/9.0?topic=console-getting-started-mq
+  tags: panel,ibm
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/ibmmq/console/login.html'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>MQ Console</title>'
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

This PR add a new template to detect the presence of the web console of the product [IBM MQSeries](https://developer.ibm.com/tutorials/mq-connect-app-queue-manager-containers/).

- References: [IBM Documentation](https://www.ibm.com/docs/en/ibm-mq/9.0?topic=console-determining-mq-url).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO 

Proof of validation using the [developer version of the product](https://developer.ibm.com/tutorials/mq-connect-app-queue-manager-containers/#step-3-run-the-container-from-the-image):

![image](https://user-images.githubusercontent.com/1573775/141785889-e680a622-0f4e-445f-b548-79ee58bd3cd0.png)
