### PR TITLE
Add tpl to detect credentials

### DIFF
--- a/default-logins/ibm/ibm-mqseries-default-login.yaml
+++ b/default-logins/ibm/ibm-mqseries-default-login.yaml
@@ -1,11 +1,14 @@
-id: ibm-mqseries-web-console-default-login
+id: ibm-mqseries-default-login
 
 info:
   name: IBM MQSeries web console default login
   author: righettod
-  severity: critical
+  severity: high
+  description: The remote host is running IBM MQ and REST API and is using default credentials. An unauthenticated, remote attacker can exploit this gain privileged or administrator access to the system.
   tags: ibm,default-login
-  reference: https://github.com/ibm-messaging/mq-container/blob/master/etc/mqm/mq.htpasswd
+  reference:
+    - https://github.com/ibm-messaging/mq-container/blob/master/etc/mqm/mq.htpasswd
+    - https://vulners.com/nessus/IBM_MQ_DEFAULT_CREDENTIALS.NASL
 
 requests:
   - raw:
@@ -18,21 +21,23 @@ requests:
 
         j_username={{username}}&j_password={{password}}
 
+    attack: pitchfork
     payloads:
       username:
         - admin
         - app
-        - donotexists # To detect false-positives
+        - mqadmin
       password:
         - passw0rd
-    attack: clusterbomb
+        - passw0rd
+        - mqadmin
+
     matchers-condition: and
     matchers:
       - type: word
+        part: header
         words:
           - "LtpaToken2_"
-        part: header
-        condition: and
 
       - type: status
         status:

--- a/default-logins/ibm/ibm-mqseries-default-login.yaml
+++ b/default-logins/ibm/ibm-mqseries-default-login.yaml
@@ -15,9 +15,9 @@ requests:
       - |
         POST /ibmmq/console/j_security_check HTTP/1.1
         Host: {{Hostname}}
-        Origin: {{BaseURL}}
+        Origin: {{RootURL}}
         Content-Type: application/x-www-form-urlencoded
-        Referer: {{BaseURL}}/ibmmq/console/login.html
+        Referer: {{RootURL}}/ibmmq/console/login.html
 
         j_username={{username}}&j_password={{password}}
 

--- a/default-logins/ibm/ibm-mqseries-web-console-default-login.yaml
+++ b/default-logins/ibm/ibm-mqseries-web-console-default-login.yaml
@@ -1,0 +1,39 @@
+id: ibm-mqseries-web-console-default-login
+
+info:
+  name: IBM MQSeries web console default login
+  author: righettod
+  severity: critical
+  tags: ibm,default-login
+  reference: https://github.com/ibm-messaging/mq-container/blob/master/etc/mqm/mq.htpasswd
+
+requests:
+  - raw:
+      - |
+        POST /ibmmq/console/j_security_check HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+        Content-Type: application/x-www-form-urlencoded
+        Referer: {{BaseURL}}/ibmmq/console/login.html
+
+        j_username={{username}}&j_password={{password}}
+
+    payloads:
+      username:
+        - admin
+        - app
+        - donotexists # To detect false-positives
+      password:
+        - passw0rd
+    attack: clusterbomb
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "LtpaToken2_"
+        part: header
+        condition: and
+
+      - type: status
+        status:
+          - 302


### PR DESCRIPTION
# Template / PR Information

This PR propose a template to detect the presence of default credentials for the following users for the [IBM MQSeries web console](https://www.ibm.com/docs/en/ibm-mq/9.0?topic=console-getting-started-mq):
- admin
- app

# References:
  - [Default credentials](https://github.com/ibm-messaging/mq-container/blob/master/etc/mqm/mq.htpasswd).
  - Credentials recovered via hashcat:

![image](https://user-images.githubusercontent.com/1573775/143679851-e61d7cf9-3759-4c53-95f7-c7dcef8d16d0.png)

# Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof of local test using developer instance of the software:

![image](https://user-images.githubusercontent.com/1573775/143679856-50a06dd6-cc91-41cc-8740-b89fdc182b70.png)

# Additional Details (leave it blank if not applicable)

# Additional References

Thank a lot in advance 😃 


