### PR TITLE
Add Another Redirect Payload and Extend the Regex to Recognize it

### DIFF
--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -41,7 +41,7 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com\/?(\/|[^.].*)?$'
         part: header
 
       - type: status

--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -28,6 +28,7 @@ requests:
       - '{{BaseURL}}/%0d/example.com/'
       - '{{BaseURL}}////example.com/%2f%2e%2e'
       - '{{BaseURL}}/%5cexample.com/%2f%2e%2e'
+      - '{{BaseURL}}/%5C%5Cexample.com/%252e%252e%252f'
       - '{{BaseURL}}/{{BaseURL}}example.com'
       - '{{BaseURL}}//{{BaseURL}}example.com/'
       - '{{BaseURL}}////{{BaseURL}}example.com/%2f%2e%2e'
@@ -40,10 +41,11 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
         part: header
 
       - type: status
         status:
           - 302
           - 301
+          - 308

--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -40,12 +40,13 @@ requests:
     matchers-condition: and
     matchers:
       - type: regex
+        part: header
         regex:
           - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com\/?(\/|[^.].*)?$'
-        part: header
 
       - type: status
         status:
-          - 302
           - 301
+          - 302
+          - 307
           - 308

--- a/vulnerabilities/generic/open-redirect.yaml
+++ b/vulnerabilities/generic/open-redirect.yaml
@@ -40,7 +40,7 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/)?(?:[a-zA-Z0-9\-_\.@]*)example\.com.*$'
         part: header
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

Another vulnerability scanner uses this payload too.

Here's an example:
```
❯ http https://redacted.io/%5C%5Cexample.com/%252e%252e%252f
HTTP/1.1 308 Permanent Redirect
[...]
Location: /\\example.com/%2e%2e%2f/
[...]

<a href="/\\example.com/%2e%2e%2f/">Permanent Redirect</a>.
```

I tested the `Location` header in Chrome and Firefox and both follow the redirect. I also tested the Nuclei template against a vulnerable site.


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
There will be a CVE too soon(tm)