### PR TITLE
Updated CVE-2021-44228.yaml regex to match interact.sh server

### DIFF
--- a/cves/2021/CVE-2021-44228.yaml
+++ b/cves/2021/CVE-2021-44228.yaml
@@ -31,11 +31,11 @@ requests:
       - type: regex
         part: interactsh_request
         regex:
-          - '([a-z0-9\.\-]+)\.([a-z0-9]+)\.interactsh\.com'
+          - '([a-z0-9\.\-]+)\.([a-z0-9]+)\.interact(\.sh|sh\.com)'
 
     extractors:
       - type: regex
         part: interactsh_request
         group: 1
         regex:
-          - '([a-z0-9\.\-]+)\.([a-z0-9]+)\.interactsh\.com'   # Extract ${hostName}
+          - '([a-z0-9\.\-]+)\.([a-z0-9]+)\.interact(\.sh|sh\.com)'   # Extract ${hostName}


### PR DESCRIPTION
### Template / PR Information

This template won't match anything anymore with the new version of nuclei 2.5.5 as it will now use `https://interact.sh` as its default interactsh server.

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated CVE-2021-44228
- References: https://github.com/projectdiscovery/nuclei/releases/tag/v2.5.5

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)