### PR TITLE
CVE-2016-6210 - Fix typo in the regex

### DIFF
--- a/cves/2016/CVE-2016-6210.yaml
+++ b/cves/2016/CVE-2016-6210.yaml
@@ -24,9 +24,9 @@ network:
     matchers:
       - type: regex
         regex:
-          - '(?i)SSH-2.0-OpenSSH_(?:[1-6][^\d][^\r]+|7\.[0-2][^\d][^\r]+)'
+          - '(?i)SSH-2.0-OpenSSH_(?:[1-6][^\d][^\r\n]+|7\.[0-2][^\d][\n^\r]+)'
 
     extractors:
       - type: regex
         regex:
-          - '(?i)SSH-2.0-OpenSSH_[^\r]+'
+          - '(?i)SSH-2.0-OpenSSH_[^\r\n]+'

--- a/cves/2016/CVE-2016-6210.yaml
+++ b/cves/2016/CVE-2016-6210.yaml
@@ -19,8 +19,9 @@ info:
 
 network:
   - host:
+      - "{{Host}}:22"
       - "{{Hostname}}"
-      - "{{Hostname}}:22"
+
     matchers:
       - type: regex
         regex:


### PR DESCRIPTION
### Related issue
#3364
### Template / PR Information
Issue description:
The regex used in the current implementation of this template does not correctly end lines.

![image](https://user-images.githubusercontent.com/2551605/146519730-415dcee3-1538-4e3c-84e8-a438de318224.png)

For that reason, the output is printed on two lines in case of SSH-2.0-OpenSSH_4.3 which contains \n character.

![image](https://user-images.githubusercontent.com/2551605/146520458-88ef51e0-b83e-42df-bfbd-49e3170596bc.png)

This causes troubles, when results are parsed by the script.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

The issue was in the missing _\n_ character inside the regex.
![image](https://user-images.githubusercontent.com/2551605/146520970-95f9d3f0-4c92-4f25-8171-35559c8eda96.png)
