### PR TITLE
Spring Boot Gateway Actuator

### DIFF
--- a/misconfiguration/springboot/springboot-gateway.yaml
+++ b/misconfiguration/springboot/springboot-gateway.yaml
@@ -1,0 +1,30 @@
+id: springboot-gateway
+
+info:
+  name: Detect Spring Gateway Actuator
+  author: wdahlenb
+  severity: medium
+  description: Sensitive environment variables may not be masked
+  tags: springboot,exposure
+  reference: https://wya.pl/2021/12/20/bring-your-own-ssrf-the-gateway-actuator/
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/gateway/routes"
+      - "{{BaseURL}}/actuator/gateway/routes"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "predicate"
+          - "route_id"
+        condition: and
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "application/json"
+        part: header

--- a/misconfiguration/springboot/springboot-gateway.yaml
+++ b/misconfiguration/springboot/springboot-gateway.yaml
@@ -13,6 +13,8 @@ requests:
     path:
       - "{{BaseURL}}/gateway/routes"
       - "{{BaseURL}}/actuator/gateway/routes"
+
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
@@ -21,10 +23,12 @@ requests:
           - "predicate"
           - "route_id"
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
       - type: status
         status:
           - 200
-      - type: word
-        words:
-          - "application/json"
-        part: header


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Adding Springboot Gateway Actuator template
- References: https://wya.pl/2021/12/20/bring-your-own-ssrf-the-gateway-actuator/

This template will return valid when the gateway actuator is enabled and there is at least one configured route. An application without configured routes will return an empty JSON array, a 200 status code, and the content-type set to "application/json", so this scenario is skipped due to a higher likelihood of false positives.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
This can result in a SSRF attack, open redirect, session stealing, denial of service, and more. The severity is set to medium on the template as a default case, but in most cases it could be leveraged as high or critical severity.

### Additional References: