### PR TITLE
Improve cisco-asa-panel-detect matcher

### DIFF
--- a/exposed-panels/cisco-asa-panel.yaml
+++ b/exposed-panels/cisco-asa-panel.yaml
@@ -16,5 +16,5 @@ requests:
     matchers:
       - type: word
         words:
-          - "<title>SSL VPN Service</title>"
+          - "/+CSCOU+/portal.css"
         part: body

--- a/exposed-panels/cisco-asa-panel.yaml
+++ b/exposed-panels/cisco-asa-panel.yaml
@@ -15,6 +15,8 @@ requests:
     max-redirects: 2
     matchers:
       - type: word
+        part: body
         words:
           - "/+CSCOU+/portal.css"
-        part: body
+          - "SSL VPN Service"
+        condition: or


### PR DESCRIPTION
Update exposed-panels/cisco-asa-panel.yaml for a better matcher.
The present matcher is "<title>SSL VPN Service</title>", but this makes some false negatives.
For example, "https://bg-vpn.acronis.com/" and "https://vpn-gdl.att.com.mx/" are cisco ssl vpn service, but they have "<title></title>". I change the matcher to "/+CSCOU+/portal.css" to improve the accuracy.
