### PR TITLE
update(workflow): Reduce wasting time installing via binary instead for template-validate

### DIFF
--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -7,21 +7,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-go@v2
-        with: 
-          go-version: 1.17
 
-      - name: Cache Go
-        id: cache-go
-        uses: actions/cache@v2
+      - name: Get latest Nuclei release version
+        id: nuclei-latest
+        uses: actions/github-script@v5
         with:
-          path: /home/runner/go
-          key: ${{ runner.os }}-go
+          result-encoding: string
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: 'projectdiscovery',
+              repo: 'nuclei',
+            });
 
-      - name: Installing Nuclei
-#        if: steps.cache-go.outputs.cache-hit != 'true'
+            return release.data.name
+
+      - name: Setup Nuclei
+        if: steps.nuclei-latest.outputs.result != ''
+        env:
+          VERSION: ${{ steps.nuclei-latest.outputs.result }}
         run: |
-          go install github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
+          wget -q https://github.com/projectdiscovery/nuclei/releases/download/${VERSION}/nuclei_${VERSION:1}_linux_amd64.zip
+          sudo unzip nuclei*.zip -d /usr/local/bin
+        working-directory: /tmp
 
       - name: Template Validation
         run: |


### PR DESCRIPTION
As we have seen on [actions runner history for template validate](https://github.com/projectdiscovery/nuclei-templates/actions/workflows/template-validate.yml) it takes approx ~45-60s to `go install`. But with the latest release binary, we can reduce the wasted time by as much as 99.5% coz it only takes at least ~0.2-1s (to get latest release version & setting up).

**Proof:** see [template-validate check](https://github.com/projectdiscovery/nuclei-templates/runs/4629195217?check_suite_focus=true) for this PR.

**Additional suggestions**

I think we can achieve for both [templates-stats](https://github.com/projectdiscovery/nuclei-templates/actions/workflows/templates-stats.yml) & [cve-annotate](https://github.com/projectdiscovery/nuclei-templates/actions/workflows/cve-annotate.yml) too; if you guys archive those binaries to release tag along with the nuclei engine by configuring in Goreleaser action.