### PR TITLE
update(workflow): Missing templates directory

### DIFF
--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -32,5 +32,6 @@ jobs:
 
       - name: Template Validation
         run: |
+          cp -r ${{ github.workspace }} $HOME
           nuclei -validate -t .
           nuclei -validate -w ./workflows


### PR DESCRIPTION
With `-t .`, it still points to `$HOME/nuclei-templates`, not the current directory. So we had to copy recursively. Bug?