### PR TITLE
Fix CVE-2021-3378

### DIFF
--- a/cves/2021/CVE-2021-3378.yaml
+++ b/cves/2021/CVE-2021-3378.yaml
@@ -4,17 +4,16 @@ info:
   name: FortiLogger Unauthenticated Arbitrary File Upload
   author: dwisiswant0
   severity: critical
-  reference: https://erberkan.github.io/2021/cve-2021-3378/
-  description: |
-    This template detects an unauthenticated arbitrary file upload
-    via insecure POST request. It has been tested on version 4.4.2.2 in
-    Windows 10 Enterprise.
-  tags: cve,cve2021,fortilogger,fortigate,fortinet
+  description: This template detects an unauthenticated arbitrary file upload via insecure POST request. It has been tested on version 4.4.2.2 in Windows 10 Enterprise.
+  reference:
+    - https://erberkan.github.io/2021/cve-2021-3378/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-3378
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.80
     cve-id: CVE-2021-3378
     cwe-id: CWE-434
+  tags: cve,cve2021,fortilogger,fortigate,fortinet,fileupload
 
 requests:
   - raw:
@@ -44,14 +43,15 @@ requests:
       - type: status
         status:
           - 200
-      - type: word
-        words:
-          - "POC_TEST"
-        part: body
 
       - type: word
+        part: body
+        words:
+          - "POC_TEST"
+
+      - type: word
+        part: header
         words:
           - "text/plain"
           - "ASP.NET"
         condition: and
-        part: header

--- a/cves/2021/CVE-2021-3378.yaml
+++ b/cves/2021/CVE-2021-3378.yaml
@@ -36,7 +36,7 @@ requests:
         ------WebKitFormBoundarySHHbUsfCoxlX1bpS
 
       - |
-        GET /Assets/temp/hotspot/img/logohotspot.txt HTTP/1.1
+        GET /Assets/temp/hotspot/img/logohotspot.asp HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and


### PR DESCRIPTION
Vulnerable endpoint is /Assets/temp/hotspot/img/logohotspot.asp
Not
/Assets/temp/hotspot/img/logohotspot.txt

### Template / PR Information

Vulnerable endpoint is /Assets/temp/hotspot/img/logohotspot.asp
Not /Assets/temp/hotspot/img/logohotspot.txt



- Fixed CVE-2021-3378
- References: https://www.exploit-db.com/exploits/49600
https://packetstormsecurity.com/files/161974/FortiLogger-Arbitrary-File-Upload.html

### Template Validation

I've validated this template locally?
- [ X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)



### Additional References:

