### PR TITLE
Add postMessage outgoing tracker

### DIFF
--- a/headless/postmessage-outgoing-tracker.yaml
+++ b/headless/postmessage-outgoing-tracker.yaml
@@ -1,0 +1,65 @@
+id: postmessage-outgoing-tracker
+
+info:
+  name: Postmessage Outgoing Tracker
+  author: LogicalHunter
+  severity: info
+  reference: https://appcheck-ng.com/html5-cross-document-messaging-vulnerabilities/
+  tags: headless,postmessage
+
+headless:
+  - steps:
+      - action: setheader
+        args:
+          part: response
+          key: Content-Security-Policy
+          value: "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;"
+      - action: script
+        args:
+          hook: true
+          code: |
+            (function() {window.alerts = [];
+
+            function logger(found) {
+            	window.alerts.push(found);
+            }
+
+            function getStackTrace () {
+              var stack;
+              try {
+                throw new Error('');
+              }
+              catch (error) {
+                stack = error.stack || '';
+              }
+              stack = stack.split('\n').map(function (line) { return line.trim(); });
+              return stack.splice(stack[0] == 'Error' ? 2 : 1);
+            }
+
+            var oldSender = window.postMessage;
+
+            window.postMessage = function(data, origin) {
+            if(origin == '*'){
+                logger({stack: getStackTrace(), args: {data, origin}});
+                return oldSender.apply(this, arguments);
+                }
+              };
+            })();
+      - args:
+          url: "{{BaseURL}}"
+        action: navigate
+      - action: waitload
+      - action: script
+        name: alerts
+        args:
+          code: "window.alerts"
+    matchers:
+      - type: word
+        part: alerts
+        words:
+          - "at window.postMessage"
+    extractors:
+      - type: kval
+        part: alerts
+        kval:
+          - alerts


### PR DESCRIPTION
### Template / PR Information

There is already another template for tracking the postMessages. That template only covers the 'message' event handler. In some cases, a web page may use the wildcard (*) to send sensitive messages between different window objects. This template detects all of the postMessage interfaces and log the parameters. 

I've validated this template locally?
- [X] YES
- [ ] NO
