### PR TITLE
Add detection for Manage Engine Key Manager Plus

### DIFF
--- a/exposed-panels/zoho/manageengine-keymanagerplus.yaml
+++ b/exposed-panels/zoho/manageengine-keymanagerplus.yaml
@@ -1,0 +1,23 @@
+id: manageengine-keymanagerplus
+
+info:
+  name: ZOHO ManageEngine KeyManagerPlus
+  author: righettod
+  severity: info
+  reference: https://www.manageengine.com/key-manager/
+  tags: panel,zoho,manageengine
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/apiclient/index.jsp'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Key Manager Plus</title>'
+
+      - type: status
+        status:
+          - 200

--- a/exposed-panels/zoho/manageengine-keymanagerplus.yaml
+++ b/exposed-panels/zoho/manageengine-keymanagerplus.yaml
@@ -11,13 +11,20 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/apiclient/index.jsp'
+      - '{{BaseURL}}/pki/images/keyManager_title.ico'
 
-    matchers-condition: and
+    stop-at-first-match: true
+    matchers-condition: or
     matchers:
-      - type: word
-        words:
-          - '<title>Key Manager Plus</title>'
 
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "status_code==200"
+          - "contains(tolower(body), '<title>key manager plus</title>')"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - "status_code==200"
+          - "('192917117' == mmh3(base64_py(body)))"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

This PR add a template to detect the presence of an instance of [Manage Engine Key Manager Plus](https://www.manageengine.com/key-manager/).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof of test against the last version of **nuclei**:

![image](https://user-images.githubusercontent.com/1573775/148640729-a3d481c7-fa70-45e0-aaab-e26627812a22.png)

#### Additional Details (leave it blank if not applicable)

Thank you very much in advance 😃 