### PR TITLE
Add H2 console template

### DIFF
--- a/cves/2021/CVE-2021-45232.yaml
+++ b/cves/2021/CVE-2021-45232.yaml
@@ -3,7 +3,7 @@ id: CVE-2021-45232
 info:
   name: Apache APISIX Dashboard api unauth access
   author: Mr-xn
-  severity: high
+  severity: critical
   description: In Apache APISIX Dashboard before 2.10.1, the Manager API uses two frameworks and introduces framework `droplet` on the basis of framework `gin`, all APIs and authentication middleware are developed based on framework `droplet`, but some API directly use the interface of framework `gin` thus bypassing the authentication.
   reference:
     - https://apisix.apache.org/zh/blog/2021/12/28/dashboard-cve-2021-45232/
@@ -12,6 +12,11 @@ info:
     - https://twitter.com/403Timeout/status/1475715079173976066
     - https://github.com/wuppp/cve-2021-45232-exp
   tags: cve,cve2021,apache,unauth,apisix
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2021-45232
+    cwe-id: CWE-306
 
 requests:
   - method: GET

--- a/exposed-panels/h2console-panel.yaml
+++ b/exposed-panels/h2console-panel.yaml
@@ -1,0 +1,24 @@
+id: h2console-panel
+
+info:
+  name: H2 console web panel
+  author: righettod
+  severity: info
+  reference:
+    - https://mp.weixin.qq.com/s/Yn5U8WHGJZbTJsxwUU3UiQ
+    - https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console
+    - https://www.shodan.io/search?query=http.title%3A%22H2+Console%22
+  tags: panel,h2,console
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/h2-console/login.jsp'
+
+    matchers:
+
+      - type: dsl
+        dsl:
+          - "status_code==200"
+          - "contains(tolower(body), '<title>h2 console</title>')"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

This PR propose a template dedicated to the detection of the presence of the web console of H2 DB.

This [template](https://github.com/projectdiscovery/nuclei-templates/blob/master/exposed-panels/grails-database-admin-console.yaml) already perform this detection. However, it is about grails technology and the H2 console can be located for example in a Spring boot app, so, I proposed a dedicated template to facilitate the evolution/tuning of the detection of this web console.

References:
- https://mp.weixin.qq.com/s/Yn5U8WHGJZbTJsxwUU3UiQ
- https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console
- https://www.shodan.io/search?query=http.title%3A%22H2+Console%22

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof of test against the last version of **nuclei**:

![image](https://user-images.githubusercontent.com/1573775/148644436-40366efe-b65c-4acd-969e-ef829051cb2e.png)

#### Additional Details (leave it blank if not applicable)

Thank you very much in advance 😃 
