### PR TITLE
Add Template for Netbeans Configurations

### DIFF
--- a/exposures/configs/netbeans-config.yaml
+++ b/exposures/configs/netbeans-config.yaml
@@ -3,7 +3,7 @@ id: netbeans-config
 info:
   name: Exposed Netbeans configuration
   author: sbani
-  severity: low
+  severity: info
   description: Searches for a exposed Netbeans configuration
   tags: netbeans,config,exposure
 

--- a/exposures/configs/netbeans-config.yaml
+++ b/exposures/configs/netbeans-config.yaml
@@ -1,0 +1,26 @@
+id: netbeans-config
+
+info:
+  name: Exposed Netbeans configuration
+  author: sbani
+  severity: low
+  description: Searches for a exposed Netbeans configuration
+  tags: netbeans,config,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/nbproject/project.properties"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "(?mi)^src.dir="
+          - "(?mi)^build.[a-zA-Z]+="
+          - "(?mi)^jar.[a-zA-Z]+="
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Netbeans configs might be exposed via the path `nbproject/project.properties`.
That file can leak secrets.

I tried to add as many useful regex as possible. But environment variables might vary. Any additions are greatly appreciated.
The variable `src.dir=*` seems to be present all the time though I couldn't find any details in the Netbeans docs. So my vars are an assumption.

Examples:
- https://code.usgs.gov/prism/prism_engine/-/raw/master/nbproject/project.properties
- https://raw.githubusercontent.com/phylo42/RAPPAS/master/nbproject/project.properties
- https://git.ucr.ac.cr/JOSE.CAMACHOVARGAS/tareahilosprograii/-/raw/master/nbproject/project.properties

### Template Validation

You can check the template against the given examples.

Example:
```
nuclei -u https://code.usgs.gov/prism/prism_engine/-/raw/master/ -t ~/Code/nuclei-templates/exposures/configs/netbeans-config.yaml
```

I've validated this template locally?
- [X] YES
- [ ] NO