### PR TITLE
Create CVE-2021-20038.yaml

### DIFF
--- a/cves/2021/CVE-2021-20038.yaml
+++ b/cves/2021/CVE-2021-20038.yaml
@@ -1,0 +1,31 @@
+id: CVE-2021-20038
+
+info:
+  name: SonicWall SMA100 - Buffer overflow
+  author: gy741
+  severity: critical
+  description: A Stack-based buffer overflow vulnerability in SMA100 Apache httpd server's mod_cgi module environment variables allows a remote unauthenticated attacker to potentially execute code as a 'nobody' user in the appliance. This vulnerability affected SMA 200, 210, 400, 410 and 500v appliances firmware 10.2.0.8-37sv, 10.2.1.1-19sv, 10.2.1.2-24sv and earlier versions.
+  reference:
+    - https://attackerkb.com/topics/QyXRC1wbvC/cve-2021-20038/rapid7-analysis
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-20038
+    - https://github.com/jbaines-r7/badblood
+  tags: cve,cve2021,rce,sonicwall
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 9.80
+    cve-id: CVE-2021-20038
+    cwe-id: CWE-787
+
+requests:
+  - raw:
+      - |
+        GET /cgi-bin/welcome HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: regex
+        regex:
+          - 'swl_login.10.2.1([a-z0-9.]+)'
+          - 'swl_header.10.2.1([a-z0-9.]+)'
+          - 'sma_content_overrides.10.2.1([a-z0-9.]+)'
+        condition: or


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-20038

The template finds the vulnerable version. 

```
A Stack-based buffer overflow vulnerability in SMA100 Apache httpd server's mod_cgi module environment variables allows a remote unauthenticated attacker to potentially execute code as a 'nobody' user in the appliance. This vulnerability affected SMA 200, 210, 400, 410 and 500v appliances firmware 10.2.0.8-37sv, 10.2.1.1-19sv, 10.2.1.2-24sv and earlier versions.
```

- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
