### PR TITLE
Create CVE-2022-21661.yaml

### DIFF
--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,0 +1,484 @@
+id: CVE-2022-21661
+
+info:
+  name: WordPress Core 5.8.2 - WP_Query SQL Injection
+  author: gy741
+  severity: high
+  description: WordPress is a free and open-source content management system written in PHP and paired with a MariaDB database. Due to improper sanitization in WP_Query, there can be cases where SQL injection is possible through plugins or themes that use it in a certain way. This has been patched in WordPress version 5.8.3. Older affected versions are also fixed via security release, that go back till 3.7.37. We strongly recommend that you keep auto-updates enabled. There are no known workarounds for this vulnerability.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-21661
+    - https://packetstormsecurity.com/files/165540/WordPress-Core-5.8.2-SQL-Injection.html
+    - https://wordpress.org/news/2022/01/wordpress-5-8-3-security-release/
+  tags: sqli,cve,cve2022,wordpress
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.50
+    cve-id: CVE-2022-21661
+    cwe-id: CWE-89
+
+requests:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.99
+        Cache-Control: max-age=0
+        Connection: close
+        Content-Type: application/x-www-form-urlencoded
+
+        action=<action_name>&nonce=a85a0c3bfa&query_vars={"tax_query":{"0":{"field":"term_taxonomy_id","terms":["<inject>"]}}}
+
+    matchers:
+      - type: regex
+        regex:
+          # MySQL
+          - "SQL syntax.*?MySQL"
+          - "Warning.*?\\Wmysqli?_"
+          - "MySQLSyntaxErrorException"
+          - "valid MySQL result"
+          - "check the manual that (corresponds to|fits) your MySQL server version"
+          - "Unknown column '[^ ]+' in 'field list'"
+          - "MySqlClient\\."
+          - "com\\.mysql\\.jdbc"
+          - "Zend_Db_(Adapter|Statement)_Mysqli_Exception"
+          - "Pdo[./_\\\\]Mysql"
+          - "MySqlException"
+          - "SQLSTATE\\[\\d+\\]: Syntax error or access violation"
+          # MariaDB
+          - "check the manual that (corresponds to|fits) your MariaDB server version"
+          # Drizzle
+          - "check the manual that (corresponds to|fits) your Drizzle server version"
+          # MemSQL
+          - "MemSQL does not support this type of query"
+          - "is not supported by MemSQL"
+          - "unsupported nested scalar subselect"
+          # PostgreSQL
+          - "PostgreSQL.*?ERROR"
+          - "Warning.*?\\Wpg_"
+          - "valid PostgreSQL result"
+          - "Npgsql\\."
+          - "PG::SyntaxError:"
+          - "org\\.postgresql\\.util\\.PSQLException"
+          - "ERROR:\\s\\ssyntax error at or near"
+          - "ERROR: parser: parse error at or near"
+          - "PostgreSQL query failed"
+          - "org\\.postgresql\\.jdbc"
+          - "Pdo[./_\\\\]Pgsql"
+          - "PSQLException"
+          # Microsoft SQL Server
+          - "Driver.*? SQL[\\-\\_\\ ]*Server"
+          - "OLE DB.*? SQL Server"
+          - "\\bSQL Server[^&lt;&quot;]+Driver"
+          - "Warning.*?\\W(mssql|sqlsrv)_"
+          - "\\bSQL Server[^&lt;&quot;]+[0-9a-fA-F]{8}"
+          - "System\\.Data\\.SqlClient\\.SqlException\\.(SqlException|SqlConnection\\.OnError)"
+          - "(?s)Exception.*?\\bRoadhouse\\.Cms\\."
+          - "Microsoft SQL Native Client error '[0-9a-fA-F]{8}"
+          - "\\[SQL Server\\]"
+          - "ODBC SQL Server Driver"
+          - "ODBC Driver \\d+ for SQL Server"
+          - "SQLServer JDBC Driver"
+          - "com\\.jnetdirect\\.jsql"
+          - "macromedia\\.jdbc\\.sqlserver"
+          - "Zend_Db_(Adapter|Statement)_Sqlsrv_Exception"
+          - "com\\.microsoft\\.sqlserver\\.jdbc"
+          - "Pdo[./_\\\\](Mssql|SqlSrv)"
+          - "SQL(Srv|Server)Exception"
+          - "Unclosed quotation mark after the character string"
+          # Microsoft Access
+          - "Microsoft Access (\\d+ )?Driver"
+          - "JET Database Engine"
+          - "Access Database Engine"
+          - "ODBC Microsoft Access"
+          - "Syntax error \\(missing operator\\) in query expression"
+          # Oracle
+          - "\\bORA-\\d{5}"
+          - "Oracle error"
+          - "Oracle.*?Driver"
+          - "Warning.*?\\W(oci|ora)_"
+          - "quoted string not properly terminated"
+          - "SQL command not properly ended"
+          - "macromedia\\.jdbc\\.oracle"
+          - "oracle\\.jdbc"
+          - "Zend_Db_(Adapter|Statement)_Oracle_Exception"
+          - "Pdo[./_\\\\](Oracle|OCI)"
+          - "OracleException"
+          # IBM DB2
+          - "CLI Driver.*?DB2"
+          - "DB2 SQL error"
+          - "\\bdb2_\\w+\\("
+          - "SQLCODE[=:\\d, -]+SQLSTATE"
+          - "com\\.ibm\\.db2\\.jcc"
+          - "Zend_Db_(Adapter|Statement)_Db2_Exception"
+          - "Pdo[./_\\\\]Ibm"
+          - "DB2Exception"
+          - "ibm_db_dbi\\.ProgrammingError"
+          # Informix
+          - "Warning.*?\\Wifx_"
+          - "Exception.*?Informix"
+          - "Informix ODBC Driver"
+          - "ODBC Informix driver"
+          - "com\\.informix\\.jdbc"
+          - "weblogic\\.jdbc\\.informix"
+          - "Pdo[./_\\\\]Informix"
+          - "IfxException"
+          # Firebird
+          - "Dynamic SQL Error"
+          - "Warning.*?\\Wibase_"
+          - "org\\.firebirdsql\\.jdbc"
+          - "Pdo[./_\\\\]Firebird"
+          # SQLite
+          - "SQLite/JDBCDriver"
+          - "SQLite\\.Exception"
+          - "(Microsoft|System)\\.Data\\.SQLite\\.SQLiteException"
+          - "Warning.*?\\W(sqlite_|SQLite3::)"
+          - "\\[SQLITE_ERROR\\]"
+          - "SQLite error \\d+:"
+          - "sqlite3.OperationalError:"
+          - "SQLite3::SQLException"
+          - "org\\.sqlite\\.JDBC"
+          - "Pdo[./_\\\\]Sqlite"
+          - "SQLiteException"
+          # SAP MaxDB
+          - "SQL error.*?POS([0-9]+)"
+          - "Warning.*?\\Wmaxdb_"
+          - "DriverSapDB"
+          - "-3014.*?Invalid end of SQL statement"
+          - "com\\.sap\\.dbtech\\.jdbc"
+          - "\\[-3008\\].*?: Invalid keyword or missing delimiter"
+          # Sybase
+          - "Warning.*?\\Wsybase_"
+          - "Sybase message"
+          - "Sybase.*?Server message"
+          - "SybSQLException"
+          - "Sybase\\.Data\\.AseClient"
+          - "com\\.sybase\\.jdbc"
+          # Ingres
+          - "Warning.*?\\Wingres_"
+          - "Ingres SQLSTATE"
+          - "Ingres\\W.*?Driver"
+          - "com\\.ingres\\.gcf\\.jdbc"
+          # FrontBase
+          - "Exception (condition )?\\d+\\. Transaction rollback"
+          - "com\\.frontbase\\.jdbc"
+          - "Syntax error 1. Missing"
+          - "(Semantic|Syntax) error [1-4]\\d{2}\\."
+          # HSQLDB
+          - "Unexpected end of command in statement \\["
+          - "Unexpected token.*?in statement \\["
+          - "org\\.hsqldb\\.jdbc"
+          # H2
+          - "org\\.h2\\.jdbc"
+          - "\\[42000-192\\]"
+          # MonetDB
+          - "![0-9]{5}![^\\n]+(failed|unexpected|error|syntax|expected|violation|exception)"
+          - "\\[MonetDB\\]\\[ODBC Driver"
+          - "nl\\.cwi\\.monetdb\\.jdbc"
+          # Apache Derby
+          - "Syntax error: Encountered"
+          - "org\\.apache\\.derby"
+          - "ERROR 42X01"
+          # Vertica
+          - ", Sqlstate: (3F|42).{3}, (Routine|Hint|Position):"
+          - "/vertica/Parser/scan"
+          - "com\\.vertica\\.jdbc"
+          - "org\\.jkiss\\.dbeaver\\.ext\\.vertica"
+          - "com\\.vertica\\.dsi\\.dataengine"
+          # Mckoi
+          - "com\\.mckoi\\.JDBCDriver"
+          - "com\\.mckoi\\.database\\.jdbc"
+          - "&lt;REGEX_LITERAL&gt;"
+          # Presto
+          - "com\\.facebook\\.presto\\.jdbc"
+          - "io\\.prestosql\\.jdbc"
+          - "com\\.simba\\.presto\\.jdbc"
+          - "UNION query has different number of fields: \\d+, \\d+"
+          # Altibase
+          - "Altibase\\.jdbc\\.driver"
+          # MimerSQL
+          - "com\\.mimer\\.jdbc"
+          - "Syntax error,[^\\n]+assumed to mean"
+          # CrateDB
+          - "io\\.crate\\.client\\.jdbc"
+          # Cache
+          - "encountered after end of query"
+          - "A comparison operator is required here"
+          # Raima Database Manager
+          - "-10048: Syntax error"
+          - "rdmStmtPrepare\\(.+?\\) returned"
+          # Virtuoso
+          - "SQ074: Line \\d+:"
+          - "SR185: Undefined procedure"
+          - "SQ200: No table "
+          - "Virtuoso S0002 Error"
+          - "\\[(Virtuoso Driver|Virtuoso iODBC Driver)\\]\\[Virtuoso Server\\]"
+        condition: or
+
+    extractors:
+      - type: regex
+        name: MySQL
+        regex:
+          - "SQL syntax.*?MySQL"
+          - "Warning.*?\\Wmysqli?_"
+          - "MySQLSyntaxErrorException"
+          - "valid MySQL result"
+          - "check the manual that (corresponds to|fits) your MySQL server version"
+          - "Unknown column '[^ ]+' in 'field list'"
+          - "MySqlClient\\."
+          - "com\\.mysql\\.jdbc"
+          - "Zend_Db_(Adapter|Statement)_Mysqli_Exception"
+          - "Pdo[./_\\\\]Mysql"
+          - "MySqlException"
+          - "SQLSTATE[\\d+]: Syntax error or access violation"
+
+      - type: regex
+        name: MariaDB
+        regex:
+          - "check the manual that (corresponds to|fits) your MariaDB server version"
+
+      - type: regex
+        name: Drizzel
+        regex:
+          - "check the manual that (corresponds to|fits) your Drizzle server version"
+
+      - type: regex
+        name: MemSQL
+        regex:
+          - "MemSQL does not support this type of query"
+          - "is not supported by MemSQL"
+          - "unsupported nested scalar subselect"
+
+      - type: regex
+        name: PostgreSQL
+        regex:
+          - "PostgreSQL.*?ERROR"
+          - "Warning.*?\\Wpg_"
+          - "valid PostgreSQL result"
+          - "Npgsql\\."
+          - "PG::SyntaxError:"
+          - "org\\.postgresql\\.util\\.PSQLException"
+          - "ERROR:\\s\\ssyntax error at or near"
+          - "ERROR: parser: parse error at or near"
+          - "PostgreSQL query failed"
+          - "org\\.postgresql\\.jdbc"
+          - "Pdo[./_\\\\]Pgsql"
+          - "PSQLException"
+
+      - type: regex
+        name: MicrosoftSQLServer
+        regex:
+          - "Driver.*? SQL[\\-\\_\\ ]*Server"
+          - "OLE DB.*? SQL Server"
+          - "\\bSQL Server[^&lt;&quot;]+Driver"
+          - "Warning.*?\\W(mssql|sqlsrv)_"
+          - "\\bSQL Server[^&lt;&quot;]+[0-9a-fA-F]{8}"
+          - "System\\.Data\\.SqlClient\\.SqlException\\.(SqlException|SqlConnection\\.OnError)"
+          - "(?s)Exception.*?\\bRoadhouse\\.Cms\\."
+          - "Microsoft SQL Native Client error '[0-9a-fA-F]{8}"
+          - "\\[SQL Server\\]"
+          - "ODBC SQL Server Driver"
+          - "ODBC Driver \\d+ for SQL Server"
+          - "SQLServer JDBC Driver"
+          - "com\\.jnetdirect\\.jsql"
+          - "macromedia\\.jdbc\\.sqlserver"
+          - "Zend_Db_(Adapter|Statement)_Sqlsrv_Exception"
+          - "com\\.microsoft\\.sqlserver\\.jdbc"
+          - "Pdo[./_\\\\](Mssql|SqlSrv)"
+          - "SQL(Srv|Server)Exception"
+          - "Unclosed quotation mark after the character string"
+
+      - type: regex
+        name: MicrosoftAccess
+        regex:
+          - "Microsoft Access (\\d+ )?Driver"
+          - "JET Database Engine"
+          - "Access Database Engine"
+          - "ODBC Microsoft Access"
+          - "Syntax error \\(missing operator\\) in query expression"
+
+      - type: regex
+        name: Oracle
+        regex:
+          - "\\bORA-\\d{5}"
+          - "Oracle error"
+          - "Oracle.*?Driver"
+          - "Warning.*?\\W(oci|ora)_"
+          - "quoted string not properly terminated"
+          - "SQL command not properly ended"
+          - "macromedia\\.jdbc\\.oracle"
+          - "oracle\\.jdbc"
+          - "Zend_Db_(Adapter|Statement)_Oracle_Exception"
+          - "Pdo[./_\\\\](Oracle|OCI)"
+          - "OracleException"
+
+      - type: regex
+        name: IBMDB2
+        regex:
+          - "CLI Driver.*?DB2"
+          - "DB2 SQL error"
+          - "\\bdb2_\\w+\\("
+          - "SQLCODE[=:\\d, -]+SQLSTATE"
+          - "com\\.ibm\\.db2\\.jcc"
+          - "Zend_Db_(Adapter|Statement)_Db2_Exception"
+          - "Pdo[./_\\\\]Ibm"
+          - "DB2Exception"
+          - "ibm_db_dbi\\.ProgrammingError"
+
+      - type: regex
+        name: Informix
+        regex:
+          - "Warning.*?\\Wifx_"
+          - "Exception.*?Informix"
+          - "Informix ODBC Driver"
+          - "ODBC Informix driver"
+          - "com\\.informix\\.jdbc"
+          - "weblogic\\.jdbc\\.informix"
+          - "Pdo[./_\\\\]Informix"
+          - "IfxException"
+
+      - type: regex
+        name: Firebird
+        regex:
+          - "Dynamic SQL Error"
+          - "Warning.*?\\Wibase_"
+          - "org\\.firebirdsql\\.jdbc"
+          - "Pdo[./_\\\\]Firebird"
+
+      - type: regex
+        name: SQLite
+        regex:
+          - "SQLite/JDBCDriver"
+          - "SQLite\\.Exception"
+          - "(Microsoft|System)\\.Data\\.SQLite\\.SQLiteException"
+          - "Warning.*?\\W(sqlite_|SQLite3::)"
+          - "\\[SQLITE_ERROR\\]"
+          - "SQLite error \\d+:"
+          - "sqlite3.OperationalError:"
+          - "SQLite3::SQLException"
+          - "org\\.sqlite\\.JDBC"
+          - "Pdo[./_\\\\]Sqlite"
+          - "SQLiteException"
+
+      - type: regex
+        name: SAPMaxDB
+        regex:
+          - "SQL error.*?POS([0-9]+)"
+          - "Warning.*?\\Wmaxdb_"
+          - "DriverSapDB"
+          - "-3014.*?Invalid end of SQL statement"
+          - "com\\.sap\\.dbtech\\.jdbc"
+          - "\\[-3008\\].*?: Invalid keyword or missing delimiter"
+
+      - type: regex
+        name: Sybase
+        regex:
+          - "Warning.*?\\Wsybase_"
+          - "Sybase message"
+          - "Sybase.*?Server message"
+          - "SybSQLException"
+          - "Sybase\\.Data\\.AseClient"
+          - "com\\.sybase\\.jdbc"
+
+      - type: regex
+        name: Ingres
+        regex:
+          - "Warning.*?\\Wingres_"
+          - "Ingres SQLSTATE"
+          - "Ingres\\W.*?Driver"
+          - "com\\.ingres\\.gcf\\.jdbc"
+
+      - type: regex
+        name: FrontBase
+        regex:
+          - "Exception (condition )?\\d+\\. Transaction rollback"
+          - "com\\.frontbase\\.jdbc"
+          - "Syntax error 1. Missing"
+          - "(Semantic|Syntax) error \\[1-4\\]\\d{2}\\."
+
+      - type: regex
+        name: HSQLDB
+        regex:
+          - "Unexpected end of command in statement \\["
+          - "Unexpected token.*?in statement \\["
+          - "org\\.hsqldb\\.jdbc"
+
+      - type: regex
+        name: H2
+        regex:
+          - "org\\.h2\\.jdbc"
+          - "\\[42000-192\\]"
+
+      - type: regex
+        name: MonetDB
+        regex:
+          - "![0-9]{5}![^\\n]+(failed|unexpected|error|syntax|expected|violation|exception)"
+          - "\\[MonetDB\\]\\[ODBC Driver"
+          - "nl\\.cwi\\.monetdb\\.jdbc"
+
+      - type: regex
+        name: ApacheDerby
+        regex:
+          - "Syntax error: Encountered"
+          - "org\\.apache\\.derby"
+          - "ERROR 42X01"
+
+      - type: regex
+        name: Vertica
+        regex:
+          - ", Sqlstate: (3F|42).{3}, (Routine|Hint|Position):"
+          - "/vertica/Parser/scan"
+          - "com\\.vertica\\.jdbc"
+          - "org\\.jkiss\\.dbeaver\\.ext\\.vertica"
+          - "com\\.vertica\\.dsi\\.dataengine"
+
+      - type: regex
+        name: Mckoi
+        regex:
+          - "com\\.mckoi\\.JDBCDriver"
+          - "com\\.mckoi\\.database\\.jdbc"
+          - "&lt;REGEX_LITERAL&gt;"
+
+      - type: regex
+        name: Presto
+        regex:
+          - "com\\.facebook\\.presto\\.jdbc"
+          - "io\\.prestosql\\.jdbc"
+          - "com\\.simba\\.presto\\.jdbc"
+          - "UNION query has different number of fields: \\d+, \\d+"
+
+      - type: regex
+        name: Altibase
+        regex:
+          - "Altibase\\.jdbc\\.driver"
+
+      - type: regex
+        name: MimerSQL
+        regex:
+          - "com\\.mimer\\.jdbc"
+          - "Syntax error,[^\\n]+assumed to mean"
+
+      - type: regex
+        name: CrateDB
+        regex:
+          - "io\\.crate\\.client\\.jdbc"
+
+      - type: regex
+        name: Cache
+        regex:
+          - "encountered after end of query"
+          - "A comparison operator is required here"
+
+      - type: regex
+        name: RaimaDatabaseManager
+        regex:
+          - "-10048: Syntax error"
+          - "rdmStmtPrepare\\(.+?\\) returned"
+
+      - type: regex
+        name: Virtuoso
+        regex:
+          - "SQ074: Line \\d+:"
+          - "SR185: Undefined procedure"
+          - "SQ200: No table "
+          - "Virtuoso S0002 Error"
+          - "\\[(Virtuoso Driver|Virtuoso iODBC Driver)\\]\\[Virtuoso Server\\]"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2022-21661

The method of detecting vulnerabilities is ambiguous.

In the market, cases with the debug option activated are being shared.

If the debug option is enabled and vulnerable, an SQL error is output.

I developed a template based on it.

Detection was based on [error-based-sql-injection.yaml](https://github.com/projectdiscovery/nuclei-templates/blob/master/vulnerabilities/generic/error-based-sql-injection.yaml) developed by @geeknik 

```
WordPress is a free and open-source content management system written in PHP and paired with a MariaDB database. Due to improper sanitization in WP_Query, there can be cases where SQL injection is possible through plugins or themes that use it in a certain way. This has been patched in WordPress version 5.8.3. Older affected versions are also fixed via security release, that go back till 3.7.37. We strongly recommend that you keep auto-updates enabled. There are no known workarounds for this vulnerability.
```

- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO