### PR TITLE
Enable redirects for security-txt

### DIFF
--- a/miscellaneous/security.txt.yaml
+++ b/miscellaneous/security.txt.yaml
@@ -12,6 +12,8 @@ requests:
     path:
       - "{{BaseURL}}/.well-known/security.txt"
       - "{{BaseURL}}/security.txt"
+    redirects: true
+    max-redirects: 3
     matchers-condition: and
     matchers:
       - type: status


### PR DESCRIPTION
Enable following redirects when scanning for security.txt files.

### Template / PR Information

Update for the security-txt template, enabling redirects to find more security.txt files.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
I scanned the [Swiss TLD zonefile (.ch)](https://www.switch.ch/de/open-data/#tab-c5442a19-67cf-11e8-9cf6-5254009dc73c-3) for [security.txt](https://securitytxt.org/) files. The current template (no redirects) finds [926 sites](https://gist.github.com/antoinet/21ef80c7fc685f9da9fa6ffd15457f07), whereas with redirects enabled the template finds [1310 sites](https://gist.github.com/antoinet/9ba37ebc4dcdfb63b91db02929b7cf30) (+384).

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)