### PR TITLE
Create strapi-documentation.yaml

### DIFF
--- a/exposed-panels/strapi-documentation.yaml
+++ b/exposed-panels/strapi-documentation.yaml
@@ -1,7 +1,7 @@
 id: strapi-documentation
 
 info:
-  name: Strapi CMS - documentation plugin from marketplace (Make the documentation endpoint private. By default, the access is public)  
+  name: Strapi CMS - documentation plugin from marketplace (Make the documentation endpoint private. By default, the access is public)
   author: idealphase
   severity: info
   tags: strapi

--- a/exposed-panels/strapi-documentation.yaml
+++ b/exposed-panels/strapi-documentation.yaml
@@ -1,0 +1,25 @@
+id: strapi-documentation
+
+info:
+  name: Strapi CMS - documentation plugin from marketplace (Make the documentation endpoint private. By default, the access is public)  
+  author: idealphase
+  severity: info
+  tags: strapi
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/documentation'
+
+    matchers-condition: and
+    matchers:
+
+      - type: word
+        words:
+          - "<title>Swagger UI</title>"
+          - "x-strapi-config"
+          - "https://strapi.io/documentation/"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Create strapi-documentation.yaml

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Documentation plugin is in strapi marketplace and it's open access to public by default after Successfully installation. So, This nuclei-template able to find this open Swagger documentation of target strapi.
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
<img width="974" alt="strapi-documentation-2" src="https://user-images.githubusercontent.com/12832679/150507340-6cd76f86-ce89-49db-9be8-5683dd2f3061.png">)
![strapi-documentation-1](https://user-images.githubusercontent.com/12832679/150507326-bba32604-2396-4df6-9d74-3f3fa263df68.png)

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)