### PR TITLE
add CVE-2022-23944

### DIFF
--- a/cves/2022/CVE-2022-23944.yaml
+++ b/cves/2022/CVE-2022-23944.yaml
@@ -8,10 +8,11 @@ info:
   reference:
     - https://github.com/apache/incubator-shenyu/pull/2462/files
     - https://nvd.nist.gov/vuln/detail/CVE-2022-23944
+    - https://github.com/cckuailong/reapoc/blob/main/2022/CVE-2022-23944/vultarget/README.md
   classification:
     cve-id: CVE-2022-23944
     cwe-id: CWE-862
-  tags: cve,cve2022,shenyu,unauth
+  tags: cve,cve2022,shenyu,unauth,apache
 
 requests:
   - method: GET
@@ -25,8 +26,6 @@ requests:
         words:
           - '"message":"query success"'
           - '"code":200'
-          - '"page":{'
-          - '"dataList":['
         condition: and
 
       - type: status

--- a/cves/2022/CVE-2022-23944.yaml
+++ b/cves/2022/CVE-2022-23944.yaml
@@ -6,12 +6,12 @@ info:
   severity: medium
   description: User can access /plugin api without authentication. This issue affected Apache ShenYu 2.4.0 and 2.4.1.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-23944
     - https://github.com/apache/incubator-shenyu/pull/2462/files
-  tags: cve,cve2022,shenyu,
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-23944
   classification:
     cve-id: CVE-2022-23944
     cwe-id: CWE-862
+  tags: cve,cve2022,shenyu,unauth
 
 requests:
   - method: GET
@@ -27,7 +27,8 @@ requests:
           - '"code":200'
           - '"page":{'
           - '"dataList":['
-      
+        condition: and
+
       - type: status
         status:
           - 200

--- a/cves/2022/CVE-2022-23944.yaml
+++ b/cves/2022/CVE-2022-23944.yaml
@@ -1,0 +1,32 @@
+id: CVE-2022-23944
+
+info:
+  name: ShenYu Admin Unauth Access
+  author: cckuakilong
+  severity: medium
+  description: User can access /plugin api without authentication. This issue affected Apache ShenYu 2.4.0 and 2.4.1.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-23944
+    - https://github.com/apache/incubator-shenyu/pull/2462/files
+  tags: cve,cve2022,shenyu,
+  classification:
+    cve-id: CVE-2022-23944
+    cwe-id: CWE-862
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/plugin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "query success"
+          - "dataList"
+          - "page"
+
+      - type: status
+        status:
+          - 200

--- a/cves/2022/CVE-2022-23944.yaml
+++ b/cves/2022/CVE-2022-23944.yaml
@@ -23,10 +23,11 @@ requests:
       - type: word
         part: body
         words:
-          - "query success"
-          - "dataList"
-          - "page"
-
+          - '"message":"query success"'
+          - '"code":200'
+          - '"page":{'
+          - '"dataList":['
+      
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information

User can access /plugin api without authentication. This issue affected Apache ShenYu 2.4.0 and 2.4.1.

- References:
  https://nvd.nist.gov/vuln/detail/CVE-2022-23944
  https://github.com/apache/incubator-shenyu/pull/2462/files

### Template Validation

I've validated this template locally?
- [1 ] YES
- [ ] NO

vuln app: https://github.com/cckuailong/reapoc/tree/main/2022/CVE-2022-23944/vultarget

![image](https://user-images.githubusercontent.com/10824150/151119290-7ccd2a03-39fc-4dc0-9b0d-5d9703149409.png)

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)