### PR TITLE
Add html-generator-detect

### DIFF
--- a/technologies/html-generator-detect.yaml
+++ b/technologies/html-generator-detect.yaml
@@ -10,7 +10,9 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
@@ -18,13 +20,15 @@ requests:
         case-insensitive: true
         words:
           - 'content-type: text/html'
+
       - type: regex
         part: body
         regex:
           - '(?i)<meta\s+?name="?generator"?\s+?content="[^"]+?"'
+
     extractors:
       - type: regex
         part: body
+        group: 1
         regex:
           - '(?i)<meta\s+?name="?generator"?\s+?content="([^"]+?)"'
-        group: 1

--- a/technologies/html-generator-detect.yaml
+++ b/technologies/html-generator-detect.yaml
@@ -1,0 +1,30 @@
+id: html-generator-detect
+
+info:
+  name: Generic HTML Generator Detection
+  author: dadevel
+  severity: info
+  tags: tech
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        case-insensitive: true
+        words:
+          - 'content-type: text/html'
+      - type: regex
+        part: body
+        regex:
+          - '(?i)<meta\s+?name="?generator"?\s+?content="[^"]+?"'
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '(?i)<meta\s+?name="?generator"?\s+?content="([^"]+?)"'
+        group: 1

--- a/technologies/html-generator-detect.yaml
+++ b/technologies/html-generator-detect.yaml
@@ -17,9 +17,8 @@ requests:
     matchers:
       - type: word
         part: header
-        case-insensitive: true
         words:
-          - 'content-type: text/html'
+          - 'text/html'
 
       - type: regex
         part: body

--- a/technologies/metatag-cms.yaml
+++ b/technologies/metatag-cms.yaml
@@ -1,10 +1,12 @@
-id: html-generator-detect
+id: metatag-cms
 
 info:
-  name: Generic HTML Generator Detection
+  name: Metatag CMS Detection
   author: dadevel
   severity: info
-  tags: tech
+  description: Generic CMS Detection using html meta generator tag
+  reference: https://www.w3schools.com/tags/att_meta_name.asp
+  tags: tech,cms
 
 requests:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

Add `technologies/html-generator-detect.yaml` for generic detection of content management systems and static site generators based on the HTML `meta` tag.

### Template Validation

I've validated this template locally? Yes.

#### Additional Details

![html-generator-detect](https://user-images.githubusercontent.com/57419228/151154803-7336051b-a653-4c75-84b7-73c16ed49c3b.jpg)