### PR TITLE
Create CVE-2020-18268.yaml

### DIFF
--- a/CVE-2020-18268.yaml
+++ b/CVE-2020-18268.yaml
@@ -1,0 +1,28 @@
+id: CVE-2020-18268
+
+info:
+  name: Z-BlogPHP 1.5.2 Open redirect
+  author: 0x_Akoko
+  severity: medium
+  description: Open Redirect in Z-BlogPHP v1.5.2 and earlier allows remote attackers to obtain sensitive information via the "redirect" parameter in the component "zb_system/cmd.php."
+  reference:
+    - https://github.com/zblogcn/zblogphp/issues/216
+    - https://www.cvedetails.com/cve/CVE-2020-18268
+  tags: cve,cve2020,redirect,zblog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.10
+    cve-id: CVE-2020-18268
+    cwe-id: CWE-601
+
+requests:
+  - method: GET
+
+    path:
+      - '{{BaseURL}}/zblog/zb_system/cmd.php?atc=login&redirect=http://www.example.com'
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?example\.com(?:\s*?)$'
+        part: header

--- a/cves/2020/CVE-2020-18268.yaml
+++ b/cves/2020/CVE-2020-18268.yaml
@@ -8,21 +8,22 @@ info:
   reference:
     - https://github.com/zblogcn/zblogphp/issues/216
     - https://www.cvedetails.com/cve/CVE-2020-18268
-  tags: cve,cve2020,redirect,zblog
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.10
     cve-id: CVE-2020-18268
     cwe-id: CWE-601
+  tags: cve,cve2020,redirect,zblog
 
 requests:
   - method: GET
-
     path:
       - '{{BaseURL}}/zblog/zb_system/cmd.php?atc=login&redirect=http://www.example.com'
+      - '{{BaseURL}}/zb_system/cmd.php?atc=login&redirect=http://www.example.com'
 
+    stop-at-first-match: true
     matchers:
       - type: regex
-        regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?example\.com(?:\s*?)$'
         part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com\/?(\/|[^.].*)?$' # https://regex101.com/r/ZDYhFh/1

--- a/cves/2020/CVE-2020-18268.yaml
+++ b/cves/2020/CVE-2020-18268.yaml
@@ -13,15 +13,24 @@ info:
     cvss-score: 6.10
     cve-id: CVE-2020-18268
     cwe-id: CWE-601
-  tags: cve,cve2020,redirect,zblog
+  tags: cve,cve2020,redirect,zblogphp
 
 requests:
-  - method: GET
-    path:
-      - '{{BaseURL}}/zblog/zb_system/cmd.php?atc=login&redirect=http://www.example.com'
-      - '{{BaseURL}}/zb_system/cmd.php?atc=login&redirect=http://www.example.com'
+  - raw:
+      - |
+        POST /zb_system/cmd.php?act=verify HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 81
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
 
-    stop-at-first-match: true
+        btnPost=Log+In&username={{username}}&password={{md5("{{password}}")}}&savedate=0
+
+      - |
+        GET /zb_system/cmd.php?atc=login&redirect=http://www.example.com HTTP/2
+        Host: {{Hostname}}
+
+    cookie-reuse: true
     matchers:
       - type: regex
         part: header

--- a/cves/2020/CVE-2020-18268.yaml
+++ b/cves/2020/CVE-2020-18268.yaml
@@ -13,7 +13,7 @@ info:
     cvss-score: 6.10
     cve-id: CVE-2020-18268
     cwe-id: CWE-601
-  tags: cve,cve2020,redirect,zblogphp
+  tags: cve,cve2020,redirect,zblogphp,authenticated
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

### Z-BlogPHP 1.5.2 Open redirect

Open Redirect in Z-BlogPHP v1.5.2 and earlier allows remote attackers to obtain sensitive information via the "redirect" parameter in the component "zb_system/cmd.php."

**Authentication : Not required (Authentication is not required to exploit the vulnerability.)**

Vendor : https://www.zblogcn.com/
- Reference:
    - https://github.com/zblogcn/zblogphp/issues/216
    - https://www.cvedetails.com/cve/CVE-2020-18268

### Template Validation

I've validated this template locally?
- YES
