### PR TITLE
Adding .axd extensions to all paths

### DIFF
--- a/technologies/telerik/telerik-dialoghandler-detect.yaml
+++ b/technologies/telerik/telerik-dialoghandler-detect.yaml
@@ -28,6 +28,22 @@ requests:
       - '{{BaseURL}}/common/admin/Calendar/Telerik.Web.UI.DialogHandler.aspx?dp=1'
       - '{{BaseURL}}/cms/portlets/Telerik.Web.UI.DialogHandler.aspx?dp=1'
       - '{{BaseURL}}/dashboard/UserControl/CMS/Page/Telerik.Web.UI.DialogHandler.aspx/Desktopmodules/Admin/dnnWerk.Users/DialogHandler.aspx?dp=1'
+      - '{{BaseURL}}/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/desktopmodules/telerikwebui/radeditorprovider/telerik.web.ui.dialoghandler.axd?dp=1'
+      - '{{BaseURL}}/desktopmodules/dnnwerk.radeditorprovider/dialoghandler.axd?dp=1'
+      - '{{BaseURL}}/DesktopModules/Admin/RadEditorProvider/DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/DesktopModule/UIQuestionControls/UIAskQuestion/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/Modules/CMS/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/Admin/ServerSide/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/DesktopModules/TNComments/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/Providers/HtmlEditorProviders/Telerik/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/App_Master/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/common/admin/PhotoGallery2/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/common/admin/Jobs2/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/AsiCommon/Controls/ContentManagement/ContentDesigner/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/common/admin/Calendar/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/cms/portlets/Telerik.Web.UI.DialogHandler.axd?dp=1'
+      - '{{BaseURL}}/dashboard/UserControl/CMS/Page/Telerik.Web.UI.DialogHandler.axd/Desktopmodules/Admin/dnnWerk.Users/DialogHandler.axd?dp=1'
 
     stop-at-first-match: true
     matchers-condition: and

--- a/technologies/telerik/telerik-dialoghandler-detect.yaml
+++ b/technologies/telerik/telerik-dialoghandler-detect.yaml
@@ -2,7 +2,7 @@ id: telerik-dialoghandler-detect
 
 info:
   name: Detect Telerik Web UI Dialog Handler
-  author: organiccrap,zhenwarx
+  author: organiccrap,zhenwarx,nielsing
   severity: info
   reference:
     - https://captmeelo.com/pentest/2018/08/03/pwning-with-telerik.html

--- a/technologies/telerik/telerik-dialoghandler-detect.yaml
+++ b/technologies/telerik/telerik-dialoghandler-detect.yaml
@@ -29,21 +29,6 @@ requests:
       - '{{BaseURL}}/cms/portlets/Telerik.Web.UI.DialogHandler.aspx?dp=1'
       - '{{BaseURL}}/dashboard/UserControl/CMS/Page/Telerik.Web.UI.DialogHandler.aspx/Desktopmodules/Admin/dnnWerk.Users/DialogHandler.aspx?dp=1'
       - '{{BaseURL}}/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/desktopmodules/telerikwebui/radeditorprovider/telerik.web.ui.dialoghandler.axd?dp=1'
-      - '{{BaseURL}}/desktopmodules/dnnwerk.radeditorprovider/dialoghandler.axd?dp=1'
-      - '{{BaseURL}}/DesktopModules/Admin/RadEditorProvider/DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/DesktopModule/UIQuestionControls/UIAskQuestion/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/Modules/CMS/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/Admin/ServerSide/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/DesktopModules/TNComments/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/Providers/HtmlEditorProviders/Telerik/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/App_Master/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/common/admin/PhotoGallery2/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/common/admin/Jobs2/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/AsiCommon/Controls/ContentManagement/ContentDesigner/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/common/admin/Calendar/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/cms/portlets/Telerik.Web.UI.DialogHandler.axd?dp=1'
-      - '{{BaseURL}}/dashboard/UserControl/CMS/Page/Telerik.Web.UI.DialogHandler.axd/Desktopmodules/Admin/dnnWerk.Users/DialogHandler.axd?dp=1'
 
     stop-at-first-match: true
     matchers-condition: and


### PR DESCRIPTION
### Template / PR Information
I updated the Telerik template for CVE-2017-9248 to include paths with an `.axd` extension. I recently found multiple websites which respond with a 404 on the `.aspx` paths but with the correct error message for `.axd` paths. I have only validated this for the base path of `/Telerik.Web.UI.DIalogHandler.axd`, so the other paths might not apply. I decided to include them anyways and let the reviewer make the final decision on whether they should be included as well or not. 

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO