### PR TITLE
Detect hosts using deprecated versions of SSL/TLS.

### DIFF
--- a/ssl/deprecated-tls.yaml
+++ b/ssl/deprecated-tls.yaml
@@ -1,7 +1,7 @@
-id: tls-deprecated-version
+id: deprecated-tls
 
 info:
-  name: TLS Deprecated Version (inferior to TLS 1.2)
+  name: Deprecated TLS Detection (inferior to TLS 1.2)
   author: righettod
   severity: info
   reference: https://ssl-config.mozilla.org/#config=intermediate

--- a/ssl/tls-deprecated-version.yaml
+++ b/ssl/tls-deprecated-version.yaml
@@ -1,0 +1,20 @@
+id: tls-deprecated-version
+
+info:
+  name: TLS Deprecated Version (inferior to TLS 1.2)
+  author: righettod
+  severity: info
+  reference: https://ssl-config.mozilla.org/#config=intermediate
+  metadata:
+    shodan-query: ssl.version:sslv2 ssl.version:sslv3 ssl.version:tlsv1 ssl.version:tlsv1.1 
+  tags: ssl
+
+ssl:
+  - address: "{{Host}}:{{Port}}"
+    min_version: sslv3
+    max_version: tls11
+
+    extractors:
+      - type: json
+        json:
+          - " .tls_version"

--- a/ssl/tls-deprecated-version.yaml
+++ b/ssl/tls-deprecated-version.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   reference: https://ssl-config.mozilla.org/#config=intermediate
   metadata:
-    shodan-query: ssl.version:sslv2 ssl.version:sslv3 ssl.version:tlsv1 ssl.version:tlsv1.1 
+    shodan-query: ssl.version:sslv2 ssl.version:sslv3 ssl.version:tlsv1 ssl.version:tlsv1.1
   tags: ssl
 
 ssl:


### PR DESCRIPTION
### Template / PR Information

This PR add a template, in the SSL section, with the objective of identify hosts exposing a service using TLS for which the TLS versions supported is part of the deprecated ones from **SSL v2** to **TLS 1.1** both side included.

This template is more focused for defensive side to detect hosts using a "weak" TLS configuration.

- References:
  - https://ssl-config.mozilla.org/#config=intermediate
  - https://bettercrypto.org/#_configuration_a_strong_ciphers_fewer_clients
 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof of local test:

![image](https://user-images.githubusercontent.com/1573775/152792549-bbf3a5bf-5fc9-4ada-9a88-672588d97eeb.png)


#### Additional Details (leave it blank if not applicable)

### Additional References:

Thank you very much in advance 😃 
