### PR TITLE
Updated fingerprinthub-web-fingerprints template.

### DIFF
--- a/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/technologies/fingerprinthub-web-fingerprints.yaml
@@ -7488,6 +7488,7 @@ requests:
       - type: word
         part: header
         name: microsoft-exchange
+        condition: and
         words:
           - "Location: /owa/"
           - "Server: Microsoft"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated fingerprinthub-web-fingerprints
- References:
  - There is a little bug in microsoft-exchange fingerprint rule, without `condition:and`, all targets have word `Microsoft` in response header `Server` will be marked as microsoft-exchange, for example all IIS server will be marked as microsoft-exchage because of `Server: Microsoft-IIS/x.x` in response header.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
