### PR TITLE
Create CVE-2021-25074.yaml

### DIFF
--- a/CVE-2021-25074.yaml
+++ b/CVE-2021-25074.yaml
@@ -1,0 +1,28 @@
+id: CVE-2021-25074
+
+info:
+  name: WebP Converter for Media < 4.0.3 - Unauthenticated Open redirect
+  author: 0x_Akoko
+  severity: medium
+  description: The plugin contains a file (passthru.php) which does not validate the src parameter before redirecting the user to it, leading to an Open Redirect issue
+  reference:
+    - https://wpscan.com/vulnerability/f3c0a155-9563-4533-97d4-03b9bac83164
+    - https://www.cvedetails.com/cve/CVE-2021-25074
+  tags: cve,cve2021,redirect,webp,wordpress
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.10
+    cve-id: CVE-2021-25074
+    cwe-id: CWE-601
+
+requests:
+  - method: GET
+
+    path:
+      - '{{BaseURL}}/wp-content/plugins/webp-converter-for-media/includes/passthru.php?src=https://example.com'
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_]*\.)?example\.com(?:\s*?)$'
+        part: header


### PR DESCRIPTION
### Template / PR Information

### WebP Converter for Media < 4.0.3 - Unauthenticated Open redirect

**Authentication | Not required (Authentication is not required to exploit the vulnerability.)**

Fixed in version 4.0.3
CVE : CVE-2021-25028
- Reference:
    - https://wpscan.com/vulnerability/f3c0a155-9563-4533-97d4-03b9bac83164
    - https://www.cvedetails.com/cve/CVE-2021-25074

### Template Validation

I've validated this template locally?
- YES
