### PR TITLE
Create prismaweb-credentials-disclosure.yaml

### DIFF
--- a/cves/2018/CVE-2018-9161.yaml
+++ b/cves/2018/CVE-2018-9161.yaml
@@ -1,4 +1,4 @@
-id: prismaweb-credentials-disclosure
+id: CVE-2018-9161
 
 info:
   name: PrismaWEB - Credentials Disclosure
@@ -7,7 +7,8 @@ info:
   description: The vulnerability exists due to the disclosure of hard-coded credentials allowing an attacker to effectively bypass authentication of PrismaWEB with administrator privileges. The credentials can be disclosed by simply navigating to the login_par.js JavaScript page that holds the username and password for the management interface that are being used via the Login() function in /scripts/functions_cookie.js script.
   reference:
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2018-5453.php
-  tags: prismaweb,disclosure
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-9161
+  tags: cve,cve2018,prismaweb,exposure
 
 requests:
   - method: GET

--- a/vulnerabilities/other/prismaweb-credentials-disclosure.yaml
+++ b/vulnerabilities/other/prismaweb-credentials-disclosure.yaml
@@ -1,0 +1,28 @@
+id: prismaweb-credentials-disclosure
+
+info:
+  name: PrismaWEB - Credentials Disclosure
+  author: gy741
+  severity: critical
+  description: The vulnerability exists due to the disclosure of hard-coded credentials allowing an attacker to effectively bypass authentication of PrismaWEB with administrator privileges. The credentials can be disclosed by simply navigating to the login_par.js JavaScript page that holds the username and password for the management interface that are being used via the Login() function in /scripts/functions_cookie.js script.
+  reference:
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2018-5453.php
+  tags: prismaweb,disclosure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/user/scripts/login_par.js"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'txtChkUser'
+          - 'txtChkPassword'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello,

Added prismaweb-credentials-disclosure.yaml

```
The vulnerability exists due to the disclosure of hard-coded credentials allowing an attacker to effectively bypass authentication of PrismaWEB with administrator privileges. The credentials can be disclosed by simply navigating to the login_par.js JavaScript page that holds the username and password for the management interface that are being used via the Login() function in /scripts/functions_cookie.js script.
```

- References: https://www.zeroscience.mk/en/vulnerabilities/ZSL-2018-5453.php

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
