### PR TITLE
Create express-routes-disclosure.yaml

### DIFF
--- a/fuzzing/express-routes-disclosure.yaml
+++ b/fuzzing/express-routes-disclosure.yaml
@@ -1,0 +1,26 @@
+id: express-full-path-disclosure
+
+info:
+  name: Express JS Routes exposure
+  author: nithissh
+  severity: low
+  description: when a malformed URI like %ff was passed as a subdirectory. The server get crashes and leaks some internal paths
+  tags: tags
+
+requests:
+- raw:
+  - |+
+    GET /%ff HTTP/2
+    Host: {{Hostname}}
+
+
+  matchers-condition: and
+  matchers:
+  - type: word
+    part: body
+    words:
+    - 'URIError: Failed to decode param'
+    - 'node_modules'
+  - type: status
+    status:
+    - 500


### PR DESCRIPTION
### Template / PR Information

This template will help in finding a full path disclosure vulnerability in web applications that use **Express-JS**. When we pass a malformed URI like **%ff** as a subdirectory the server can't handle the request. The server will get an **Internal server Error** and will disclose **Internal paths**

- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

**Command Run:** nuclei -u https://localhost:8080 -t ./express-routes-disclosure.yaml -debug

**Request:**
```
GET /%ff HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/44.0.2403.155 Safari/537.36
Connection: close
Accept-Encoding: gzip
```
**Response:**
```
HTTP/2 500 Internal Server Error
Date: Sun, 27 Feb 2022 16:51:38 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 4199
Cf-Ray: 6e42eb4588e39361-MAA
Access-Control-Allow-Origin: *
Etag: W/"1067-RV/Gi3cHQWKrTngcFb5zhp5RQ+8"
Cf-Cache-Status: DYNAMIC
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
X-Powered-By: Express
Vary: Accept-Encoding
Server: cloudflare

{"code":500,"status":"Internal Server Error","timestamp":"2022-02-27T22:21:38+05:30","message":"Failed to decode param '/%FF'","error":{"name":"URIError","reason":"Failed to decode param '/%FF'","stack":"URIError: Failed to decode param '/%FF'\n    at decodeURIComponent (<anonymous>)\n    at decode_param (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/layer.js:172:12)\n    at Layer.match (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/layer.js:123:27)\n    at matchLayer (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:574:18)\n    at next (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:220:15)\n    at cors (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:188:7)\n    at /opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:224:17\n    at originCallback (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:214:15)\n    at /opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:219:13\n    at optionsCallback (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:199:9)\n    at corsMiddleware (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/cors/lib/index.js:204:7)\n    at Layer.handle [as handle_request] (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:317:13)\n    at /opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:335:12)\n    at next (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:275:10)\n    at urlencodedParser (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/body-parser/lib/types/urlencoded.js:91:7)\n    at Layer.handle [as handle_request] (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:317:13)\n    at /opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:335:12)\n    at next (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:275:10)\n    at jsonParser (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/body-parser/lib/types/json.js:110:7)\n    at Layer.handle [as handle_request] (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:317:13)\n    at /opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:335:12)\n    at next (/opt/localhost/nodeapps/localhost-api-service/localhost-api-service-1.3.14-SNAPSHOT-1/node_modules/express/lib/router/index.js:275:10)"}}
```



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)