### PR TITLE
Add new template

### DIFF
--- a/default-logins/gitlab/gitlab-uninitialized-password.yaml
+++ b/default-logins/gitlab/gitlab-uninitialized-password.yaml
@@ -1,0 +1,36 @@
+id: gitlab-uninitialized-password
+info:
+  name: Detect uninitialized GitLab instances
+  author: GitLab Red Team
+  severity: high
+  description: |
+    Prior to version 14, GitLab installations required a root password to be
+    set via the web UI. If the administrator skipped this step, any visitor
+    could set a password and control the instance.
+  tags: panel,gitlab
+  reference:
+    - https://gitlab.com/gitlab-org/gitlab/-/issues/211328
+    - https://gitlab.com/gitlab-org/omnibus-gitlab/-/merge_requests/5331
+    - https://docs.gitlab.com/omnibus/installation/#set-up-the-initial-password
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/users/sign_in"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        condition: and
+        part: body
+        words:
+          - 'Change your password'
+          - 'New password'
+          - 'Confirm new password'
+      - type: word
+        part: header
+        words:
+          - 'gitlab_session'
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

This is a new template.

Prior to version 14, GitLab installations required a root password to be set via the web UI after installation. If the administrator skipped this step, any visitor could set a password and control the instance.

This template uses various pattern matches to find this scenario - high probability it is a GitLab instance (due to the cookie being returned) and specific strings present in the UI when an initial password is not set.

![Screenshot](https://user-images.githubusercontent.com/26131150/156701520-4e241d83-8a93-4c1d-b796-c55b8ea77fc4.png)


References:
    - https://gitlab.com/gitlab-org/gitlab/-/issues/211328
    - https://gitlab.com/gitlab-org/omnibus-gitlab/-/merge_requests/5331
    - https://docs.gitlab.com/omnibus/installation/#set-up-the-initial-password


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

The HTTP replies on a vulnerable instance are quite long, but here are some of the relevant bits:

```
HTTP/1.1 200 OK
...
Set-Cookie: _gitlab_session=[REDACTED]; path=/; expires=Fri, 04 Mar 2022 06:22:37 GMT; HttpOnly
...
...
<a class="nav-link active">Change your password</a>
...
<label for="user_password">New password</label>
...
<label for="user_password_confirmation">Confirm new password</label>
```

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
