### PR TITLE
CVE Annotation workflow improvements

### DIFF
--- a/.github/workflows/cve-annotate.yml
+++ b/.github/workflows/cve-annotate.yml
@@ -10,23 +10,25 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
+      - name: Get Github tag
+        id: meta
+        run: |
+          echo "::set-output name=tag::$(curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name)"
+
+      - name: Setup CVE annotate
+        if: steps.meta.outputs.tag != ''
+        env:
+          VERSION: ${{ steps.meta.outputs.tag }}
+        run: |
+          wget -q https://github.com/projectdiscovery/nuclei/releases/download/${VERSION}/cve-annotate.zip
+          sudo unzip cve-annotate.zip -d /usr/local/bin
+        working-directory: /tmp
 
       - name: Generate CVE Annotations
         id: cve-annotate
         run: |
-          if ! which cve-annotate > /dev/null; then
-            echo -e "Command cve-annotate not found! Installing\c"
-            go install github.com/projectdiscovery/nuclei/v2/cmd/cve-annotate@dev
-          fi
           cve-annotate -i ./cves/ -d .
           echo "::set-output name=changes::$(git status -s | wc -l)"
 

--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -6,25 +6,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
-      - name: Get latest Nuclei release version
-        id: nuclei-latest
-        uses: actions/github-script@v5
-        with:
-          result-encoding: string
-          script: |
-            const release = await github.rest.repos.getLatestRelease({
-              owner: 'projectdiscovery',
-              repo: 'nuclei',
-            });
-
-            return release.data.name
+      - name: Get Github tag
+        id: meta
+        run: |
+          echo "::set-output name=tag::$(curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name)"
 
       - name: Setup Nuclei
-        if: steps.nuclei-latest.outputs.result != ''
+        if: steps.meta.outputs.tag != ''
         env:
-          VERSION: ${{ steps.nuclei-latest.outputs.result }}
+          VERSION: ${{ steps.meta.outputs.tag }}
         run: |
           wget -q https://github.com/projectdiscovery/nuclei/releases/download/${VERSION}/nuclei_${VERSION:1}_linux_amd64.zip
           sudo unzip nuclei*.zip -d /usr/local/bin


### PR DESCRIPTION
### Template / PR Information

Instead of installing CVE Annotation, now it downloads the binary form release page to save some time.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)