### PR TITLE
add CVE-2021-35587

### DIFF
--- a/cves/2021/CVE-2021-35587.yaml
+++ b/cves/2021/CVE-2021-35587.yaml
@@ -1,0 +1,44 @@
+id: CVE-2021-35587
+
+info:
+  name: Pre-auth RCE in Oracle Access Manager
+  author: cckuailong
+  description: |
+    Vulnerability in the Oracle Access Manager product of Oracle Fusion Middleware (component: OpenSSO Agent). Supported versions that are affected are 11.1.2.3.0, 12.2.1.3.0 and 12.2.1.4.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via HTTP to compromise Oracle Access Manager. Successful attacks of this vulnerability can result in takeover of Oracle Access Manager.
+  severity: critical
+  reference:
+    - https://testbnull.medium.com/oracle-access-manager-pre-auth-rce-cve-2021-35587-analysis-1302a4542316
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-35587
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2021-35587
+    cwe-id: CWE-502
+  tags: cve,cve2021,oam,rce,java,unauth
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/oam/server/opensso/sessionservice'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        case-insensitive: true
+        words:
+          - "X-ORACLE-DMS-ECID"
+          - "X-ORACLE-DMS-RID"
+        part: header
+        condition: or
+      
+      - type: word
+        words:
+          - "/oam/pages/css/general.css"
+          - "login-footer-version"
+          - "Oracle Corporation"
+        part: body
+        condition: and

--- a/cves/2021/CVE-2021-35587.yaml
+++ b/cves/2021/CVE-2021-35587.yaml
@@ -14,6 +14,8 @@ info:
     cvss-score: 9.80
     cve-id: CVE-2021-35587
     cwe-id: CWE-502
+  metadata:
+    fofa-query: body="/oam/pages/css/login_page.css"
   tags: cve,cve2021,oam,rce,java,unauth
 
 requests:
@@ -34,7 +36,7 @@ requests:
           - "X-ORACLE-DMS-RID"
         part: header
         condition: or
-      
+
       - type: word
         words:
           - "/oam/pages/css/general.css"

--- a/cves/2021/CVE-2021-35587.yaml
+++ b/cves/2021/CVE-2021-35587.yaml
@@ -30,17 +30,14 @@ requests:
           - 200
 
       - type: word
-        case-insensitive: true
-        words:
-          - "X-ORACLE-DMS-ECID"
-          - "X-ORACLE-DMS-RID"
         part: header
+        words:
+          - "x-oracle-dms-ecid"
+          - "x-oracle-dms-rid"
         condition: or
+        case-insensitive: true
 
       - type: word
+        part: body
         words:
           - "/oam/pages/css/general.css"
-          - "login-footer-version"
-          - "Oracle Corporation"
-        part: body
-        condition: and


### PR DESCRIPTION
### Template / PR Information

Pre-auth RCE in Oracle Access Manager

- References:
  https://testbnull.medium.com/oracle-access-manager-pre-auth-rce-cve-2021-35587-analysis-1302a4542316
  https://nvd.nist.gov/vuln/detail/CVE-2021-35587

### Template Validation

I've validated this template locally?
- YES

<img width="564" alt="3" src="https://user-images.githubusercontent.com/10824150/157569944-acc3ff5a-b6e3-4638-bb01-3f98fc5648cf.png">

In the recent patch of OAM 12c, they dropped support for OpenSSO, so the entrypoint "/oam/server/opensso/sessionservice" is also removed by accident. But not for the OAM 11g.

So we just have to test if "/oam/server/opensso/sessionservice" exists

More read in reapoc repo

https://github.com/cckuailong/reapoc/tree/main/2021/CVE-2021-35587/vultarget

#### Additional Details (leave it blank if not applicable)

Fofa: body="/oam/pages/css/login_page.css"

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)