### PR TITLE
add airflow cve-2022-24288

### DIFF
--- a/cves/2022/CVE-2022-24288.yaml
+++ b/cves/2022/CVE-2022-24288.yaml
@@ -8,10 +8,10 @@ info:
   reference: https://github.com/advisories/GHSA-3v7g-4pg3-7r6j
   tags: cve,cve2022,airflow,rce
   classification:
-      cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-      cvss-score: 8.8
-      cve-id: CVE-2022-24288
-      cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-24288
+    cwe-id: CWE-78
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-24288.yaml
+++ b/cves/2022/CVE-2022-24288.yaml
@@ -6,42 +6,23 @@ info:
   severity: critical
   description: In Apache Airflow, prior to version 2.2.4, some example DAGs did not properly sanitize user-provided params, making them susceptible to OS Command Injection from the web UI.
   reference: https://github.com/advisories/GHSA-3v7g-4pg3-7r6j
-  tags: cve,cve2022,airflow,rce
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
     cve-id: CVE-2022-24288
     cwe-id: CWE-78
+  metadata:
+    shodan-query: title:"Airflow - DAGs"
+  tags: cve,cve2022,airflow,rce
 
 requests:
-  - raw:
-      - |
-        GET /admin/airflow/code?root=&dag_id=example_passing_params_via_test_command HTTP/1.1
-        Host: {{Hostname}}
-        Cache-Control: max-age=0
-        Upgrade-Insecure-Requests: 1
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-        Referer: http://{{Hostname}}/admin/airflow/dag_details?dag_id=example_passing_params_via_test_command
-        Accept-Encoding: gzip, deflate
-        Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7
-        Connection: close
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin/airflow/code?root=&dag_id=example_passing_params_via_test_command"
+      - "{{BaseURL}}/code?dag_id=example_passing_params_via_test_command"
 
-      - |
-        GET /code?dag_id=example_passing_params_via_test_command HTTP/1.1
-        Host: {{Hostname}}
-        Upgrade-Insecure-Requests: 1
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-        Referer: http://{{Hostname}}/tree?dag_id=example_passing_params_via_test_command
-        Accept-Encoding: gzip, deflate
-        Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7
-        Connection: close
-
-    cookie-reuse: true
-    req-condition: true
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
       - type: word
         words:
-          - 'foo was passed in via Airflow CLI Test command with value {{ params.foo }}'
+          - 'foo was passed in via Airflow CLI Test command with value {{ params.foo }}' # Works with unauthenticated airflow instance

--- a/cves/2022/CVE-2022-24288.yaml
+++ b/cves/2022/CVE-2022-24288.yaml
@@ -1,0 +1,47 @@
+id: CVE-2022-24288
+
+info:
+  name: Apache Airflow CVE-2022-24288 OS Command Injection
+  author: xeldax
+  severity: critical
+  description: In Apache Airflow, prior to version 2.2.4, some example DAGs did not properly sanitize user-provided params, making them susceptible to OS Command Injection from the web UI.
+  reference: https://github.com/advisories/GHSA-3v7g-4pg3-7r6j
+  tags: cve,cve2022,airflow,rce
+  classification:
+      cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+      cvss-score: 8.8
+      cve-id: CVE-2022-24288
+      cwe-id: CWE-78
+
+requests:
+  - raw:
+      - |
+        GET /admin/airflow/code?root=&dag_id=example_passing_params_via_test_command HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: http://{{Hostname}}/admin/airflow/dag_details?dag_id=example_passing_params_via_test_command
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7
+        Connection: close
+
+      - |
+        GET /code?dag_id=example_passing_params_via_test_command HTTP/1.1
+        Host: {{Hostname}}
+        Upgrade-Insecure-Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+        Referer: http://{{Hostname}}/tree?dag_id=example_passing_params_via_test_command
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7
+        Connection: close
+
+    cookie-reuse: true
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'foo was passed in via Airflow CLI Test command with value {{ params.foo }}'

--- a/misconfiguration/airflow/unauthenticated-airflow.yaml
+++ b/misconfiguration/airflow/unauthenticated-airflow.yaml
@@ -5,24 +5,22 @@ info:
   author: dhiyaneshDK
   severity: high
   tags: apache,airflow,unauth
+  metadata:
+    shodan-query: title:"Airflow - DAGs"
 
 requests:
   - method: GET
     path:
+      - "{{BaseURL}}"
       - "{{BaseURL}}/admin/"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
-        words:
-          - "Content-Type: text/html"
-        part: header
-
-      - type: word
+        part: body
         words:
           - "<title>Airflow - DAGs</title>"
-        part: body
-        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

In Apache Airflow, prior to version 2.2.4, some example DAGs did not properly sanitize user-provided params, making them susceptible to OS Command Injection from the web UI.

- Add airflow cve-2022-24288
- References:
   https://github.com/advisories/GHSA-3v7g-4pg3-7r6j
   
   https://nvd.nist.gov/vuln/detail/CVE-2022-24288

### Template Validation

I've validated this template locally?
YES
 
![image](https://user-images.githubusercontent.com/18378246/157608305-0cf84015-6fe2-4110-b306-af62e8dc403d.png)



#### Additional Details (leave it blank if not applicable)

If match the below vulnerable code, the airflow is vulnerable to cve-2022-24288

![image](https://user-images.githubusercontent.com/18378246/157608796-036bf279-54c3-4842-a572-6815db0c8e29.png)


### Additional References:
- [AirFlow Vul Code](https://github.com/apache/airflow/blob/main/airflow/example_dags/example_passing_params_via_test_command.py)
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)