### PR TITLE
Fixed Apollo-default-login

### DIFF
--- a/default-logins/apollo/apollo-default-login.yaml
+++ b/default-logins/apollo/apollo-default-login.yaml
@@ -42,11 +42,8 @@ requests:
           - '"email":'
         condition: or
 
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: header
-        words:
-          - "application/json"
+      - type: dsl
+        dsl:
+          - "status_code_1 == 302 && status_code_2 == 200"
+          - "contains(tolower(all_headers_2), 'application/json')"
+        condition: and

--- a/default-logins/apollo/apollo-default-login.yaml
+++ b/default-logins/apollo/apollo-default-login.yaml
@@ -47,9 +47,6 @@ requests:
           - 200
 
       - type: word
-        part: body_1
-        condition: or
-        negative: true
+        part: header
         words:
-          - "404"
-          - "Not Found"
+          - "application/json"

--- a/default-logins/apollo/apollo-default-login.yaml
+++ b/default-logins/apollo/apollo-default-login.yaml
@@ -45,3 +45,11 @@ requests:
       - type: status
         status:
           - 200
+
+      - type: word
+        part: body_1
+        condition: or
+        negative: true
+        words:
+          - "404"
+          - "Not Found"


### PR DESCRIPTION
### Template / PR Information

- Fixed Apollo-default-login

These are false positives: 
   - https://advertising.samsclub.com/
   - https://advertising.walmart.com/

Obviously the best fix would be something like `status_1 != 200 OR status_1 == 404` (negative condition), but I don't know how to do this... anyway for now this avoid false positives

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)