### PR TITLE
Add CVE-2022-22965 (spring4shell)

### DIFF
--- a/cves/2022/CVE-2022-22965.yaml
+++ b/cves/2022/CVE-2022-22965.yaml
@@ -1,0 +1,28 @@
+id: CVE-2022-22965
+
+info:
+  name: Spring Framework RCE via Data Binding on JDK 9+
+  author: arall
+  severity: critical
+  description: A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit. However, the nature of the vulnerability is more general, and there may be other ways to exploit it.
+  remediation: 5.3.x users should upgrade to 5.3.18+, 5.2.x users should upgrade to 5.2.20+.
+  reference:
+    - https://tanzu.vmware.com/security/cve-2022-22965
+    - https://www.lunasec.io/docs/blog/spring-rce-vulnerabilities/
+    - https://twitter.com/RandoriAttack/status/1509298490106593283
+  tags: cve,cve2021,rce,oast,log4j,injection
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-22965
+    cwe-id: CWE-770
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/?class.module.classLoader.URLs%5B0%5D=0'
+
+    matchers:
+      - type: status
+        status:
+          - 400

--- a/cves/2022/CVE-2022-22965.yaml
+++ b/cves/2022/CVE-2022-22965.yaml
@@ -18,11 +18,19 @@ info:
     cwe-id: CWE-770
 
 requests:
-  - method: GET
-    path:
-      - '{{BaseURL}}/?class.module.classLoader.URLs%5B0%5D=0'
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
+      - |
+        GET /?class.module.classLoader.URLs%5B0%5D=0 HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
     matchers:
-      - type: status
-        status:
-          - 400
+      - type: dsl
+        dsl:
+          - "status_code_1 != status_code_2"
+          - "status_code_2 == 400"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2022-22965
- References:
    - https://tanzu.vmware.com/security/cve-2022-22965
    - https://www.lunasec.io/docs/blog/spring-rce-vulnerabilities/
    - https://twitter.com/RandoriAttack/status/1509298490106593283

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Tested against https://github.com/lunasec-io/Spring4Shell-POC.

As mentioned in this [tweet](https://twitter.com/RandoriAttack/status/1509298490106593283):

>The following non-malicious request can be used to test susceptibility to the Spring Framework
 0day RCE. An HTTP 400 return code indicates vulnerability.
$ curl host:port/path?class.module.classLoader.URLs%5B0%5D=0

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)