### PR TITLE
Fixed CVE-2021-44103 

### DIFF
--- a/cves/2021/CVE-2021-44103.yaml
+++ b/cves/2021/CVE-2021-44103.yaml
@@ -47,8 +47,8 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_2, "\"admin\": false")'
-          - 'contains(body_3, "\"admin\": true")'
+          - 'contains(body_2, "\"admin\":false")'
+          - 'contains(body_3, "\"admin\":true")'
         condition: and
 
       - type: word
@@ -67,7 +67,7 @@ requests:
         internal: true
         group: 1
         regex:
-          - '"id": ([0-9]+)'
+          - '"id":([0-9]+)'
 
       - type: regex
         part: body
@@ -75,4 +75,4 @@ requests:
         internal: true
         group: 1
         regex:
-          - '"token": "(.*)"'
+          - '"token":"(.*)"'


### PR DESCRIPTION
### Template / PR Information

Remove the spaces from matchers and extractors' regexes. The JSON returned doesn't contain spaces between key and value.
Example: ```{"token":"value"}```

- Fixed CVE-2021-44103
- References:
    - http://n0hat.blogspot.com/2021/11/konga-0149-privilege-escalation-exploit.html
    - https://www.exploit-db.com/exploits/50521
    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44103

### Template Validation

I've validated this template locally?
- [x] Yes
- [ ] No

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)