### PR TITLE
partial template fix by not using payloads

### DIFF
--- a/default-logins/jenkins/jenkins-default.yaml
+++ b/default-logins/jenkins/jenkins-default.yaml
@@ -15,45 +15,27 @@ info:
 requests:
   - raw:
       - |
-        GET /login HTTP/1.1
+        GET / HTTP/1.1
         Host: {{Hostname}}
 
       - |
         POST /j_spring_security_check HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        Cookie: {{cookie}}
 
-        j_username={{username}}&j_password={{password}}&from=%2F&Submit=Sign+in
+        j_username=admin&j_password=admin&from=%2F&Submit=Sign+in
 
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
-        Cookie: {{cookie}}
 
-    attack: pitchfork
-    payloads:
-      username:
-        - admin
-        - jenkins
-      password:
-        - admin
-        - password
-
-    extractors:
-      - type: regex
-        name: cookie
-        internal: true
-        part: header
-        regex:
-          - 'JSESSIONID\..*=([a-z0-9.]+)'
-
+    cookie-reuse: true
     req-condition: true
     matchers:
       - type: dsl
-        condition: and
         dsl:
           - 'contains(body_3, "/logout")'
           - 'contains(body_3, "Dashboard [Jenkins]")'
+        condition: and
 
 # Enhanced by mp on 2022/03/10


### PR DESCRIPTION
### Template / PR Information

```console
echo http://redacted:8080 | nuclei -t default-logins/jenkins/jenkins-default.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.6.5

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.6.5 (latest)
[INF] Using Nuclei Templates 8.9.4 (latest)
[INF] Templates added in last update: 20
[INF] Templates loaded for scan: 1
[jenkins-weak-password] [http] [high] http://redacted:8080/
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)