### PR TITLE
eyesofnetwork detect

### DIFF
--- a/cves/2020/CVE-2020-8654.yaml
+++ b/cves/2020/CVE-2020-8654.yaml
@@ -1,29 +1,41 @@
-id: eyesofnetwork-detect
+id: CVE-2020-8654
 
 info:
-  name: EyesOfNetwork Vulnerable Version Detect
+  name: EyesOfNetwork 5.3 - Authenticated RCE
   author: praetorian-thendrickson
   severity: high
   description: EyesOfNetwork version 5.1-5.3 is vulnerable to multiple exploits. Version 5.3 is vulnerable to CVE-2020-8654 (authenticated rce), CVE-2020-8655 (privesc), CVE-2020-8656 (SQLi - API version before 2.4.2), and 2020-8657 (hardcoded api key). Versions 5.1-5.3 are vulnerable to CVE-2020-9465 (SQLi).
-  tags: tech,cisa
-  reference: 
+  reference:
     - https://github.com/h4knet/eonrce
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
     - https://nvd.nist.gov/vuln/detail/CVE-2020-8657
+  tags: cve,cve2020,cisa,eyesofnetwork,rce,authenticated
+
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/css/eonweb.css"
+
+    extractors:
+      - type: regex
+        name: version
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '# VERSION : ([0-9.]+)'
+
     matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - "VERSION : 5.[1-3]"
+      - type: dsl
+        dsl:
+          - compare_versions(version, '< 5.4', '>= 5.1')
+
       - type: word
         part: body
         words:
-          -  "EyesOfNetwork"
+          - "EyesOfNetwork"
+
       - type: status
         status:
           - 200

--- a/vulnerabilities/other/eyesofnetwork-detect.yaml
+++ b/vulnerabilities/other/eyesofnetwork-detect.yaml
@@ -7,13 +7,9 @@ info:
   description: EyesOfNetwork version 5.1-5.3 is vulnerable to multiple exploits. Version 5.3 is vulnerable to CVE-2020-8654 (authenticated rce), CVE-2020-8655 (privesc), CVE-2020-8656 (SQLi - API version before 2.4.2), and 2020-8657 (hardcoded api key). Versions 5.1-5.3 are vulnerable to CVE-2020-9465 (SQLi).
   tags: tech,cisa
   reference: 
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-9465
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-8656
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-8655
-    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8654
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-8657
+    - https://github.com/h4knet/eonrce
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
-
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8657
 requests:
   - method: GET
     path:

--- a/vulnerabilities/other/eyesofnetwork-detect.yaml
+++ b/vulnerabilities/other/eyesofnetwork-detect.yaml
@@ -1,0 +1,33 @@
+id: eyesofnetwork-detect
+
+info:
+  name: EyesOfNetwork Vulnerable Version Detect
+  author: praetorian-thendrickson
+  severity: high
+  description: EyesOfNetwork version 5.1-5.3 is vulnerable to multiple exploits. Version 5.3 is vulnerable to CVE-2020-8654 (authenticated rce), CVE-2020-8655 (privesc), CVE-2020-8656 (SQLi - API version before 2.4.2), and 2020-8657 (hardcoded api key). Versions 5.1-5.3 are vulnerable to CVE-2020-9465 (SQLi).
+  tags: tech,cisa
+  reference: 
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-9465
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8656
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8655
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8654
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8657
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/css/eonweb.css"
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "VERSION : 5.[1-3]"
+      - type: word
+        part: body
+        words:
+          -  "EyesOfNetwork"
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

EyesOfNetwork is vulnerable to multiple CVEs. This [metasploit module](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb) does a good job of explaining the issues. There are five different CVEs potentially associated with an EyesOfNetwork instance with version number 5.1-5.3. This PR adds a template to detect it. 


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

I validated locally by downloading the EyesOfNetwork ISOs from https://www.eyesofnetwork.com/en and installing locally on a VM. I then tested the template against the running EyesOfNetwork instance. 


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)