### PR TITLE
Added S3 torrent Template

### DIFF
--- a/misconfiguration/s3-torrent.yaml
+++ b/misconfiguration/s3-torrent.yaml
@@ -1,21 +1,21 @@
 id: s3-torrent
 
 info:
-  name: Detect S3 torrent downloads allowed
+  name: S3 torrent Downloads Allowed
   author: ambassify
   severity: info
   description: Detects if endpoint allows magic S3 torrent argument to download files
-  tags: aws,s3,bucket
+  tags: misconfig,aws,s3,bucket
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/?torrent"
 
-    matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - 'RequestTorrentOfBucketError'
           - 's3-tracker'
-        part: body
+        condition: or

--- a/misconfiguration/s3-torrent.yaml
+++ b/misconfiguration/s3-torrent.yaml
@@ -1,0 +1,21 @@
+id: s3-torrent
+
+info:
+  name: Detect S3 torrent downloads allowed
+  author: ambassify
+  severity: info
+  description: Detects if endpoint allows magic S3 torrent argument to download files
+  tags: aws,s3,bucket
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?torrent"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'RequestTorrentOfBucketError'
+          - 's3-tracker'
+        part: body


### PR DESCRIPTION
### Template / PR Information
S3 has kind of a hidden feature that's not documented at all.
What you can do with a file that is hosted from S3 is to add `?torrent` which will download a torrent file which can be used to download the source file through torrent.
At the core this isn't a real issue because the fact that the file is public and static.
But we had an issue in our caching at one morning that resulted in our nginx cache presenting these torrent downloads to all our visitors which looks pretty shady to customers like you can imagine.
Since then we blocked this requests in our nginx. 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)