### PR TITLE
Add template for MS SharePoint version detection

### DIFF
--- a/technologies/microsoft/microsoft-sharepoint-detect.yaml
+++ b/technologies/microsoft/microsoft-sharepoint-detect.yaml
@@ -1,0 +1,21 @@
+id: microsoft-sharepoint-detect
+
+info:
+  name: Microsoft SharePoint Detect
+  author: p-l-
+  severity: info
+  description: Check for SharePoint, using HTTP header MicrosoftSharePointTeamServices
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - "Microsoftsharepointteamservices:"
+        part: header
+    extractors:
+      - type: kval
+        kval:
+          - MicrosoftSharePointTeamServices

--- a/technologies/microsoft/microsoft-sharepoint-detect.yaml
+++ b/technologies/microsoft/microsoft-sharepoint-detect.yaml
@@ -5,16 +5,19 @@ info:
   author: p-l-
   severity: info
   description: Check for SharePoint, using HTTP header MicrosoftSharePointTeamServices
+  tags: sharepoint,iis,microsoft,tech
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     matchers:
-      - type: word
-        words:
-          - "Microsoftsharepointteamservices:"
+      - type: regex
         part: header
+        regex:
+          - "(?i)(Microsoftsharepointteamservices:)"
+
     extractors:
       - type: kval
         kval:


### PR DESCRIPTION
### Template / PR Information

MS SharePoint provides its version in a dedicated HTTP header. This header is already used by another template (cves/2020/CVE-2020-16952.yaml)

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

[Shodan](https://www.shodan.io/search?query=MicrosoftSharePointTeamServices) shows 27k hosts
