### PR TITLE
Fix CVE-2020-16952 template

### DIFF
--- a/cves/2020/CVE-2020-16952.yaml
+++ b/cves/2020/CVE-2020-16952.yaml
@@ -32,7 +32,7 @@ requests:
         part: body
       - type: word
         words:
-          - "MicrosoftSharePointTeamServices"
+          - "Microsoftsharepointteamservices:"
         part: header
       - type: status
         status:

--- a/cves/2020/CVE-2020-16952.yaml
+++ b/cves/2020/CVE-2020-16952.yaml
@@ -5,35 +5,37 @@ info:
   author: dwisiswant0
   severity: high
   description: A remote code execution vulnerability exists in Microsoft SharePoint when the software fails to check the source markup of an application package, aka 'Microsoft SharePoint Remote Code Execution Vulnerability'.
-    This CVE ID is unique from CVE-2020-16951.
   reference:
-    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16952
     - https://srcincite.io/pocs/cve-2020-16952.py.txt
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16952
     - https://github.com/rapid7/metasploit-framework/blob/1a341ae93191ac5f6d8a9603aebb6b3a1f65f107/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
     cvss-score: 7.8
     cve-id: CVE-2020-16952
     cwe-id: CWE-346
-  tags: cve,cve2020,sharepoint,iis,microsoft
+  tags: cve,cve2020,sharepoint,iis,microsoft,ssi,rce
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     matchers-condition: and
     matchers:
       - type: regex
+        part: body
         regex:
           - "15\\.0\\.0\\.(4571|5275|4351|5056)"
           - "16\\.0\\.0\\.(10337|10364|10366)"
           # - "16.0.10364.20001"
         condition: or
-        part: body
-      - type: word
-        words:
-          - "Microsoftsharepointteamservices:"
+
+      - type: regex
         part: header
+        regex:
+          - "(?i)(Microsoftsharepointteamservices:)"
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
The headers are normalized by nuclei, and `MicrosoftSharePointTeamServices` will never match.

### Template / PR Information

- Fixes template CVE-2020-16952

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
