### PR TITLE
Update wordpress-plugins-detect.yaml to extract plugin name and version

### DIFF
--- a/fuzzing/wordpress-plugins-detect.yaml
+++ b/fuzzing/wordpress-plugins-detect.yaml
@@ -12,10 +12,10 @@ requests:
         GET /wp-content/plugins/{{pluginSlug}}/readme.txt HTTP/1.1
         Host: {{Hostname}}
 
+    threads: 50
     payloads:
       pluginSlug: helpers/wordlists/wordpress-plugins.txt
 
-    threads: 50
     matchers-condition: and
     matchers:
       - type: status
@@ -25,13 +25,11 @@ requests:
       - type: word
         words:
           - "== Description =="
+
     extractors:
       - type: regex
         part: body
         group: 1
         regex:
-          # extract the plugin name
-          - "===\\s(.*)\\s==="
-          # extract the plugin version
-          - "==\\sChangelog\\s==[\\r\\n]+=\\s(?P<version>\\d.[\\d.]*\\d)\\s="
-
+          - "===\\s(.*)\\s===" # extract the plugin name
+          - "(?m)Stable tag: ([0-9.]+)" # extract the plugin version

--- a/fuzzing/wordpress-plugins-detect.yaml
+++ b/fuzzing/wordpress-plugins-detect.yaml
@@ -26,10 +26,12 @@ requests:
         words:
           - "== Description =="
     extractors:
-    - type: regex
-      part: body
-      group: 1
-      regex:
-        - "===\\s(.*)\\s===" # extract the Plugin name
-        - "==\\sChangelog\\s==[\\r\\n]+=\\s(?P<version>\\d.[\\d.]*\\d)\\s=" # extract the plugin version
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          # extract the plugin name
+          - "===\\s(.*)\\s==="
+          # extract the plugin version
+          - "==\\sChangelog\\s==[\\r\\n]+=\\s(?P<version>\\d.[\\d.]*\\d)\\s="
 

--- a/fuzzing/wordpress-plugins-detect.yaml
+++ b/fuzzing/wordpress-plugins-detect.yaml
@@ -25,3 +25,11 @@ requests:
       - type: word
         words:
           - "== Description =="
+    extractors:
+    - type: regex
+      part: body
+      group: 1
+      regex:
+        - "===\\s(.*)\\s===" # extract the Plugin name
+        - "==\\sChangelog\\s==[\\r\\n]+=\\s(?P<version>\\d.[\\d.]*\\d)\\s=" # extract the plugin version
+


### PR DESCRIPTION
### Template / PR Information

Updated ./fuzzing/wordpress-plugins-detect.yaml to include an extractor.
The extractor is a regex against each identified plugins readme.txt file to get the plugins full name and version number.
Wordpress plugins use a standard format for the readme.txt file so the name and version number should be in a similar location and format across all plugins.

- References:

  - https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/
  - https://wordpress.org/plugins/readme.txt

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
