### PR TITLE
Detect more Kong headers

### DIFF
--- a/technologies/kong-detect.yaml
+++ b/technologies/kong-detect.yaml
@@ -15,44 +15,17 @@ requests:
       - "{{BaseURL}}"
 
     matchers:
-
-      - type: regex
+      - type: word
         part: header
-        regex:
-          - "[Ss]erver: [Kk]ong+"
+        words:
+          - "server: kong"
+          - "x-kong-response-latency"
+          - "x-kong-upstream_latency"
+          - "x-kong-proxy-latency"
+        condition: or
+        case-insensitive: true
 
     extractors:
       - type: kval
-        part: header
         kval:
           - server
-
-  - method: GET
-    path:
-      - "{{BaseURL}}"
-
-    matchers-condition: or
-    matchers:
-
-      - type: regex
-        part: header
-        regex:
-          - "[Xx]-[Kk]ong-[Rr]esponse-[Ll]atency"
-
-      - type: regex
-        part: header
-        regex:
-          - "[Xx]-[Kk]ong-[Uu]pstream-[Ll]atency"
-
-      - type: regex
-        part: header
-        regex:
-          - "[Xx]-[Kk]ong-[Pp]roxy-[Ll]atency"
-
-    extractors:
-      - type: kval
-        part: header
-        kval:
-          - x_kong_response_latency
-          - x_kong_upstream_latency
-          - x_kong_proxy_latency

--- a/technologies/kong-detect.yaml
+++ b/technologies/kong-detect.yaml
@@ -2,7 +2,7 @@ id: kong-detect
 
 info:
   name: Detect Kong
-  author: geeknik
+  author: geeknik,joshlarsen
   severity: info
   description: The Cloud-Native API Gateway
   reference:
@@ -14,7 +14,6 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    matchers-condition: and
     matchers:
 
       - type: regex
@@ -27,3 +26,33 @@ requests:
         part: header
         kval:
           - server
+
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: or
+    matchers:
+
+      - type: regex
+        part: header
+        regex:
+          - "[Xx]-[Kk]ong-[Rr]esponse-[Ll]atency"
+
+      - type: regex
+        part: header
+        regex:
+          - "[Xx]-[Kk]ong-[Uu]pstream-[Ll]atency"
+
+      - type: regex
+        part: header
+        regex:
+          - "[Xx]-[Kk]ong-[Pp]roxy-[Ll]atency"
+
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - x_kong_response_latency
+          - x_kong_upstream_latency
+          - x_kong_proxy_latency


### PR DESCRIPTION
### Template / PR Information

This PR extends the Kong detection template. Kong doesn't always return the `kong/X.X.X` server header. The administrator will often disable the obvious server header, but other headers can give away a Kong server. This update checks for additional Kong headers.

- References: https://github.com/Kong/kong

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details

This check is written as a new request so as not to alter the results of the existing `server` header check, which returns the value of that header in the results. The value of the new headers we are checking are not that interesting, we just want to know if they exist.

Example Shodan results with and without `server` header:
<img width="666" alt="Screen Shot 2022-05-16 at 10 43 46 AM" src="https://user-images.githubusercontent.com/2565382/168619854-fac9a728-fea3-4ab1-b44a-07b84a2ffcd2.png">

