### PR TITLE
Detect deprecated XSS Protection headers

### DIFF
--- a/misconfiguration/xss-deprecated-header.yaml
+++ b/misconfiguration/xss-deprecated-header.yaml
@@ -3,12 +3,12 @@ id: xss-deprecated-header-detect
 info:
   name: Detect Deprecated XSS Protection Header
   author: joshlarsen
-  severity: low
+  severity: info
   description: Setting the XSS-Protection header is deprecated by most browsers. Setting the header to anything other than `0` can actually introduce an XSS vulnerability.
   reference:
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
     - https://owasp.org/www-project-secure-headers/#x-xss-protection
-  tags: xss,misconfig
+  tags: xss,misconfig,generic
 
 requests:
   - method: GET

--- a/misconfiguration/xss-deprecated-header.yaml
+++ b/misconfiguration/xss-deprecated-header.yaml
@@ -34,4 +34,3 @@ requests:
         part: header
         kval:
           - x_xss_protection
-

--- a/misconfiguration/xss-deprecated-header.yaml
+++ b/misconfiguration/xss-deprecated-header.yaml
@@ -1,0 +1,37 @@
+id: xss-deprecated-header-detect
+
+info:
+  name: Detect Deprecated XSS Protection Header
+  author: joshlarsen
+  severity: low
+  description: Setting the XSS-Protection header is deprecated by most browsers. Setting the header to anything other than `0` can actually introduce an XSS vulnerability.
+  reference:
+    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    - https://owasp.org/www-project-secure-headers/#x-xss-protection
+  tags: xss,misconfig
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        part: header
+        regex:
+          - "(?i)x-xss-protection: 0"
+        negative: true
+
+      - type: regex
+        part: header
+        regex:
+          - "(?i)x-xss-protection: 1+"
+
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - x_xss_protection
+


### PR DESCRIPTION
### Template / PR Information

This PR checks for sites that still set the deprecated `x-xss-protection` header. At one point, this header provided some mitigation against XSS attacks. Now we know that setting the header can actually introduce the vulnerability where there was none previously.

- References:
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
    - https://owasp.org/www-project-secure-headers/#x-xss-protection

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details

The only valid setting is:

```
x-xss-protection: 0
```

Any other setting of this header is considered a misconfiguration.
