### PR TITLE
Adding access-control-disabled-hp-printer

### DIFF
--- a/misconfiguration/hp/access-control-disabled-hp-printer.yaml
+++ b/misconfiguration/hp/access-control-disabled-hp-printer.yaml
@@ -1,0 +1,25 @@
+id: access-control-disabled-hp-printer
+
+info:
+  name: Access control is disabled in HP printers
+  author: r3naissance
+  severity: low
+  metadata:
+    shodan-dork: http.title:"HP Designjet"
+  tags: hp,iot,unauth
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/hp/device/webAccess/index.htm?content=security"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Access control is currently disabled"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Certain HP printers have the entire control panel open to unauthorized users as default.
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)