### PR TITLE
Fix IIS Internal IP Disclosure

### DIFF
--- a/cves/2022/CVE-2022-30776.yaml
+++ b/cves/2022/CVE-2022-30776.yaml
@@ -11,6 +11,11 @@ info:
     - https://www.atmail.com/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-30776
     - https://help.atmail.com/hc/en-us/sections/115003283988
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-30776
+    cwe-id: CWE-79
   metadata:
     shodan-query: http.html:"atmail"
     verified: "true"

--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -14,11 +14,17 @@ requests:
         GET / HTTP/1.0
         Accept: */*
 
+      - |+
+        GET / HTTP/1.0
+        Host:
+        Accept: */*
+
+    stop-at-first-match: true
     unsafe: true # Use Unsafe HTTP library for malformed HTTP requests.
     matchers-condition: and
     matchers:
       - type: regex
-        part: header
+        part: location
         regex:
           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'
 
@@ -29,6 +35,6 @@ requests:
 
     extractors:
       - type: regex
-        part: header
+        part: location
         regex:
           - '([0-9]{1,3}[\.]){3}[0-9]{1,3}'

--- a/misconfiguration/iis-internal-ip-disclosure.yaml
+++ b/misconfiguration/iis-internal-ip-disclosure.yaml
@@ -12,7 +12,6 @@ requests:
   - raw:
       - |+
         GET / HTTP/1.0
-        Host:
         Accept: */*
 
     unsafe: true # Use Unsafe HTTP library for malformed HTTP requests.
@@ -25,6 +24,7 @@ requests:
 
       - type: status
         status:
+          - 301
           - 302
 
     extractors:


### PR DESCRIPTION
In some cases, the IIS Internal IP Disclosure template does not works. The "Host" header need to be completly removed to avoid getting a 400 Bad Request (Invalid Host Header) error. In addition, the status code used to check the vulnerability can be 302 or 301. 

- Fixed IIS Internal IP Disclosure

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO