### PR TITLE
Extract available endpoints from springboot-actuator

### DIFF
--- a/technologies/springboot-actuator.yaml
+++ b/technologies/springboot-actuator.yaml
@@ -2,7 +2,7 @@ id: springboot-actuator
 
 info:
   name: Detect Springboot Actuators
-  author: that_juan_,dwisiswant0,wdahlenb
+  author: that_juan_,dwisiswant0,wdahlenb,dr0pd34d
   severity: info
   tags: tech,springboot,actuator
 
@@ -29,3 +29,9 @@ requests:
         name: "favicon"
         dsl:
           - "status_code==200 && (\"116323821\" == mmh3(base64_py(body)))"
+      
+    extractors:
+      - type: json
+        name: available-endpoints
+        json:
+          - .[] | to_entries | .[].key

--- a/technologies/springboot-actuator.yaml
+++ b/technologies/springboot-actuator.yaml
@@ -29,7 +29,7 @@ requests:
         name: "favicon"
         dsl:
           - "status_code==200 && (\"116323821\" == mmh3(base64_py(body)))"
-      
+
     extractors:
       - type: json
         name: available-endpoints

--- a/technologies/springboot-actuator.yaml
+++ b/technologies/springboot-actuator.yaml
@@ -4,6 +4,8 @@ info:
   name: Detect Springboot Actuators
   author: that_juan_,dwisiswant0,wdahlenb,dr0pd34d
   severity: info
+  metadata:
+    shodan-query: http.favicon.hash:116323821
   tags: tech,springboot,actuator
 
 requests:


### PR DESCRIPTION

### Template / PR Information

I updated the template "springboot-actuator.yaml" to contain a list of available endpoints in order to see and process endpoints and also recognize unusual non-standard endpoints that are exposed.

Please let me know if "technology detect" templates are allowed to include extractors or if I should create a separate template and if I missed to read something, thank you! 🙏

Updated springboot-actuator.yaml

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)