### PR TITLE
Added phpPgAdmin version detect

### DIFF
--- a/technologies/phppgadmin-version.yaml
+++ b/technologies/phppgadmin-version.yaml
@@ -1,0 +1,30 @@
+id: phppgadmin-version
+
+info:
+  name: phpPgAdmin version detect
+  author: dr0pd34d
+  severity: info
+  description: phpPgAdmin is a third-party tool for PostgreSQL databases. The version is being rendered in the intro.php file.
+  tags: tech,phppgadmin
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/phppgadmin/intro.php"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '<span class="appname">phpPgAdmin</span> <span class="version">.*</span>'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'phpPgAdmin.*\(.*\)'


### PR DESCRIPTION
### Template / PR Information

The template "phppgadmin-panel" does detect the availability of the panel, but not the version as this is available on a separate path.
I created this template in order to extract the version number for further actions based on the version number.

- Added "technologies/phppgadmin-version.yaml"

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)