### PR TITLE
Update api-google-drive.yaml

### DIFF
--- a/token-spray/api-google-drive.yaml
+++ b/token-spray/api-google-drive.yaml
@@ -13,7 +13,7 @@ requests:
   - raw:
       - |
         GET https://www.googleapis.com/drive/v3/files/{{randstr}}.txt/%3fkey={{token}}&supportsAllDrives=true HTTP/1.1
-        Referer: {{BaseURL}}
+        Referer: {{referer}}
         Content-Type:application/json
 
     matchers:


### PR DESCRIPTION

### Template / PR Information

This template is meant to be used like so:

`nuclei -t token-spray/api-google-drive.yaml -var token=google_api_key -var referer=https://www.hostname_where_google_api_key_was_found.com`

The way the template was edited to include `Referer: {{BaseURL}}` won't work because it adds `Referer: www.googleapis.com` which results in an ipRefererBlocked error from Google. 

If you can't define the referer, this template is useless and should be deleted. So please accept this change back to my original vision for this template. Thank you.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO