### PR TITLE
Create fuji-xerox-printer-detect.yaml

### DIFF
--- a/exposed-panels/fuji-xerox-printer-detect.yaml
+++ b/exposed-panels/fuji-xerox-printer-detect.yaml
@@ -1,23 +1,21 @@
 id: fuji-xerox-printer-detect
 
 info:
-  name: Fuji xerox - Printer Detection
+  name: Fuji xerox - Printer Detect
   author: gy741
   severity: info
-  tags: iot,panel,fuji-xerox,printer
+  tags: iot,panel,fuji,printer
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}"
+      - "{{BaseURL}}/hdstat.htm"
 
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - "ApeosPort"
           - "Fuji Xerox Co., Ltd"
-        condition: and
 
       - type: status
         status:

--- a/exposed-panels/fuji-xerox-printer-detect.yaml
+++ b/exposed-panels/fuji-xerox-printer-detect.yaml
@@ -1,0 +1,24 @@
+id: fuji-xerox-printer-detect
+
+info:
+  name: Fuji xerox - Printer Detection
+  author: gy741
+  severity: info
+  tags: iot,panel,fuji-xerox,printer
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "ApeosPort"
+          - "Fuji Xerox Co., Ltd"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/exposed-panels/fuji-xerox-printer-detect.yaml
+++ b/exposed-panels/fuji-xerox-printer-detect.yaml
@@ -4,6 +4,9 @@ info:
   name: Fuji xerox - Printer Detect
   author: gy741
   severity: info
+  metadata:
+    verified: true
+    shodan-query: http.html:"Fuji Xerox Co., Ltd"
   tags: iot,panel,fuji,printer
 
 requests:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added  fuji-xerox-printer-detect.yaml

It targets the "ApeosPort" product.

There may be more other models.

- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Checked in the internal network.