### PR TITLE
Added wildfly-default-login template

### DIFF
--- a/default-logins/wildfly/wildfly-default-login.yaml
+++ b/default-logins/wildfly/wildfly-default-login.yaml
@@ -12,21 +12,24 @@ requests:
       - |
         GET /management HTTP/1.1
         Host: {{Hostname}}
+
     digest-username: admin
     digest-password: admin
-
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
+
       - type: word
-        words:
-          - "application/json"
-        part: header
-      - type: word
+        part: body
         words:
           - "management-major-version"
           - "product-version"
         condition: and
 
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200

--- a/default-logins/wildfly/wildfly-default-login.yaml
+++ b/default-logins/wildfly/wildfly-default-login.yaml
@@ -1,0 +1,32 @@
+id: wildfly-default-login
+
+info:
+  name: Wildfly Default Login
+  author: s0obi
+  severity: high
+  description: Wildfly default login was discovered.
+  tags: wildfly,default-login
+
+requests:
+  - raw:
+      - |
+        GET /management HTTP/1.1
+        Host: {{Hostname}}
+    digest-username: admin
+    digest-password: admin
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "application/json"
+        part: header
+      - type: word
+        words:
+          - "management-major-version"
+          - "product-version"
+        condition: and
+


### PR DESCRIPTION
### Template / PR Information

This template will add capability to detect Wildfly management console default password (admin/admin). Even if modern versions of Wildfly don't have default password, it's really frequent to find this weak credential on management consoles.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

**How to test it ?**

```bash
docker run -p 8080:8080 -p 9990:9990 --name wildfly -it quay.io/wildfly/wildfly /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0
docker exec wildfly /opt/jboss/wildfly/bin/add-user.sh admin admin --silent
nuclei -u http://localhost:9990 -t default-logins/wildfly/wildfly-default-login.yaml
```

### Additional References:

- [WildFly Documentation](https://docs.wildfly.org/26.1/#administrator-guides)