### PR TITLE
Create compliance/headers templates

### DIFF
--- a/compliance/headers/require-content-type-options.yaml
+++ b/compliance/headers/require-content-type-options.yaml
@@ -1,0 +1,20 @@
+id: require-content-type-options
+
+info:
+  name: Require X-Content-Type-Options
+  author: glassrye
+  severity: high
+  description: Look for the X-Content-Type-Options header and fail if not there.
+  tags: compliance
+
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    headers:
+      Content-Type: application/json
+    matchers:
+      - type: dsl
+        dsl:
+          - "!contains(tolower(all_headers), 'x-content-type-options')"

--- a/compliance/headers/require-sts-header.yaml
+++ b/compliance/headers/require-sts-header.yaml
@@ -1,0 +1,20 @@
+id: require-sts-header
+
+info:
+  name: Require Sts Header
+  author: glassrye
+  severity: high
+  description: Looks for the Strict-Transport-Security header in the response
+  tags: compliance
+
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    headers:
+      Content-Type: application/json
+    matchers:
+      - type: dsl
+        dsl:
+         - "!contains(tolower(all_headers), 'strict-transport-security')"


### PR DESCRIPTION

### Template / PR Information

Some compliance frameworks, most notably PCI require most web applications to set specific headers. This is along side requirements around XSS vulnerabilities, etc. 

I needed to test for the existence of the X-Content-Type-Options and Strict-Transport-Security headers. These are well defined in the OWASP standards. I've added a new tag: compliance and and set the severity at `high` for these as they are automatic PCI failures.

- Added compliance/headers/require-content-type-options.yaml
- Added compliance/headers/require-sts-header.yaml

- References:
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)