### PR TITLE
remove escaped quotes in expression

### DIFF
--- a/file/keys/private-key.yaml
+++ b/file/keys/private-key.yaml
@@ -13,12 +13,12 @@ file:
     extractors:
       - type: regex
         regex:
-          - "\"BEGIN OPENSSH PRIVATE KEY\""
-          - "\"BEGIN PRIVATE KEY\""
-          - "\"BEGIN RSA PRIVATE KEY\""
-          - "\"BEGIN DSA PRIVATE KEY\""
-          - "\"BEGIN EC PRIVATE KEY\""
-          - "\"BEGIN PGP PRIVATE KEY BLOCK\""
-          - "\"ssh-rsa\""
-          - "\"ssh-dsa\""
-          - "\"ssh-ed25519\""
+          - "BEGIN OPENSSH PRIVATE KEY"
+          - "BEGIN PRIVATE KEY"
+          - "BEGIN RSA PRIVATE KEY"
+          - "BEGIN DSA PRIVATE KEY"
+          - "BEGIN EC PRIVATE KEY"
+          - "BEGIN PGP PRIVATE KEY BLOCK"
+          - "ssh-rsa"
+          - "ssh-dsa"
+          - "ssh-ed25519"


### PR DESCRIPTION
#Description

This PR removes escaped quotes in the regular expression which are causing the template to miss all local private keys.
Closes #4682

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
