### PR TITLE
use path for CORS GET request

### DIFF
--- a/vulnerabilities/generic/cors-misconfig.yaml
+++ b/vulnerabilities/generic/cors-misconfig.yaml
@@ -13,7 +13,7 @@ info:
 requests:
   - raw:
       - |
-        GET / HTTP/1.1
+        GET {{Path}} HTTP/1.1
         Host: {{Hostname}}
         Origin: {{cors_origin}}
 


### PR DESCRIPTION
### Template / PR Information

This allows to test endpoints which do not end with a single slash (i.e. '/')
by specifying the path as a variable (e.g. -var Path=/v1/test).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)