### PR TITLE
Add template to detect Matrix servers

### DIFF
--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -1,0 +1,42 @@
+id: matrix-server-detect
+
+info:
+  name: Detect a Matrix server
+  author: erethon
+  severity: info
+  description: Detects Matrix servers based on .well-known entries. See https://en.wikipedia.org/wiki/Matrix_(protocol)
+  reference: https://spec.matrix.org/v1.3/server-server-api/#getwell-knownmatrixserver, https://spec.matrix.org/v1.3/client-server-api/#getwell-knownmatrixclient
+  tags: tech,matrix
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/matrix/server"
+      - "{{BaseURL}}/.well-known/matrix/client"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "m."
+
+    extractors:
+      - type: json
+        part: body
+        name: server-to-server
+        json:
+          - '."m.server" | select( . != null )'
+      - type: json
+        part: body
+        name: client-homeserver
+        json:
+          - '."m.homeserver" | .base_url | select( . != null )'
+      - type: json
+        part: body
+        name: identity-server
+        json:
+          - '."m.identity_server" | .base_url | select( . != null )'

--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -1,7 +1,7 @@
-id: matrix-server-detect
+id: matrix-detect
 
 info:
-  name: Detect a Matrix server
+  name: Matrix Server Detect
   author: erethon
   severity: info
   description: Detects Matrix servers based on .well-known entries. See https://en.wikipedia.org/wiki/Matrix_(protocol)
@@ -16,13 +16,20 @@ requests:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
+
       - type: word
         part: body
         words:
           - "m."
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: json
@@ -30,11 +37,13 @@ requests:
         name: server-to-server
         json:
           - '."m.server" | select( . != null )'
+
       - type: json
         part: body
         name: client-homeserver
         json:
           - '."m.homeserver" | .base_url | select( . != null )'
+
       - type: json
         part: body
         name: identity-server


### PR DESCRIPTION
### Template / PR Information
This template uses .well-known/matrix/(client|server) HTTP endpoints to identify:
+ Matrix server federation endpoint
+ Matrix client to server endpoint
+ Matrix identity server endpoint

- References:
  - https://spec.matrix.org/v1.3/server-server-api/#getwell-knownmatrixserver
  - https://spec.matrix.org/v1.3/client-server-api/#getwell-knownmatrixclient
  
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Here's a run of the template against `matrix.org` showcasing the discovered endpoints
```
[2022-07-03 13:46:30] [matrix-server-detect:server-to-server] [http] [info] https://matrix.org/.well-known/matrix/server [matrix-federation.matrix.org:443]
[2022-07-03 13:46:30] [matrix-server-detect:client-homeserver] [http] [info] https://matrix.org/.well-known/matrix/client [https://matrix-client.matrix.org]
[2022-07-03 13:46:30] [matrix-server-detect:identity-server] [http] [info] https://matrix.org/.well-known/matrix/client [https://vector.im]
```

and here's a run against my server, which has less endpoints:

```
[2022-07-03 13:47:19] [matrix-server-detect:server-to-server] [http] [info] https://erethon.com/.well-known/matrix/server [matrix.erethon.com]
[2022-07-03 13:47:19] [matrix-server-detect:client-homeserver] [http] [info] https://erethon.com/.well-known/matrix/client [https://matrix.erethon.com]
```