### PR TITLE
Added Audiocodes Default Login Template

### DIFF
--- a/default-logins/audiocodes/Audiocodes-default-login.yaml
+++ b/default-logins/audiocodes/Audiocodes-default-login.yaml
@@ -1,0 +1,39 @@
+id: audiocodes-default-login
+
+info:
+  name: Audiocodes 310HD, 320HD, 420HD, 430HD & 440HD Default Login 
+  author: d4vy
+  severity: high
+  description: Audiocodes 310HD, 320HD, 420HD, 430HD & 440HD default login credentials were discovered.
+  reference:
+    - https://wiki.freepbx.org/display/FPG/Supported+Devices-Audio+Codes#:~:text=Reset%20to%20Factory%20Defaults,-Press%20the%20Menu&text=Then%2C%20enter%20the%20Admin%20password,is%20%221234%22%20by%20default
+  classification:
+    cwe-id: CWE-798
+  tags: iot,audiocodes,default-login
+
+requests:
+  - raw:
+      - |
+        POST /login.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Content-Length: 27
+
+        user=admin&psw=MTIzNA%3D%3D
+
+    unsafe: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "redirect"
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "Login failed. Check username and password"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
**Template / PR Information**

This template allows you to test the login page with default credentials (admin/1234) for Audiocodes 310HD, 320HD, 420HD, 430HD & 440HD

References: https://wiki.freepbx.org/display/FPG/Supported+Devices-Audio+Codes#:~:text=Reset%20to%20Factory%20Defaults,-Press%20the%20Menu&text=Then%2C%20enter%20the%20Admin%20password,is%20%221234%22%20by%20default

**Template Validation**

I've validated this template locally?
- [x] YES
- [ ] NO


**Additional Details (leave it blank if not applicable)**
