### PR TITLE
Create CVE-2022-0281

### DIFF
--- a/cves/2022/CVE-2022-0281.yaml
+++ b/cves/2022/CVE-2022-0281.yaml
@@ -1,40 +1,36 @@
 id: CVE-2022-0281
 
 info:
-  name: Microweber Information Disclosure
-  author: pikpikcu
-  severity: high
-  description: Microweber contains a vulnerability that allows exposure of sensitive information to an unauthorized actor in Packagist microweber/microweber prior to 1.2.11.
+  name: Exposure of Sensitive Information to an Unauthorized Actor in microweber prior to 1.2.11.
+  author: amit-jd
+  severity: medium
+  description: |
+    Any unauthorized/unauthenticated actor can find the PII data of all the users registered in the application. PII - Personally Identifiable Information leaked by this application is first name, last name, email id, picture, username, is_admin status.
   reference:
+    - https://huntr.dev/bounties/315f5ac6-1b5e-4444-ad8f-802371da3505/
+    - https://github.com/advisories/GHSA-7wv8-g97r-432h
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0281
-    - https://github.com/microweber/microweber/commit/e680e134a4215c979bfd2eaf58336be34c8fc6e6
-    - https://huntr.dev/bounties/315f5ac6-1b5e-4444-ad8f-802371da3505
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cve-id: CVE-2022-0281
     cwe-id: CWE-200
-  metadata:
-    shodan-query: http.favicon.hash:780351152
-  tags: cve,cve2022,microweber,disclosure
+  tags: micorweber, info,data
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/api/users/search_authors"
+      - '{{BaseURL}}/api/users/search_authors'
 
     matchers-condition: and
     matchers:
+      - type: word
+        words:
+          - 'first_name'
+          - 'email id'
+          - 'username'
+          - 'is_admin status'
+        part: body
+
       - type: status
         status:
           - 200
-
-      - type: word
-        part: body
-        words:
-          - '"username":'
-          - '"email":'
-          - '"display_name":'
-        condition: and
-
-# Enhanced by mp on 2022/02/28


### PR DESCRIPTION
### Template / PR Information

**Exposure of Sensitive Information in Microweber CMS Prior to 1.2.11**
Any unauthorized/unauthenticated actor can find the PII data of all the users registered in the application. PII - Personally Identifiable Information leaked by this application is:
1. first name,
2. last name,
3. email id,
4. picture,
5. username and
6. admin status

<!-- Please include any reference to your template if available -->


- Added CVE-2022-0281
- References:
[https://huntr.dev/bounties/315f5ac6-1b5e-4444-ad8f-802371da3505/](url)
[https://github.com/advisories/GHSA-7wv8-g97r-432h](url)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:
![image](https://user-images.githubusercontent.com/78851976/180422100-6c323e96-dace-40b3-8387-5a14a07dc836.png)