### PR TITLE
Fix Drupal user enum redirect template

### DIFF
--- a/misconfiguration/drupal/drupal-user-enum-redirect.yaml
+++ b/misconfiguration/drupal/drupal-user-enum-redirect.yaml
@@ -19,7 +19,7 @@ requests:
     matchers:
       - type: regex
         regex:
-          - '(?i)Location: http(s|):\/\/[\w\.\-]+(\/ar|\/en|)\/users\/\w+'
+          - '(?i)Location: https?:\/\/[\w\.\-]+[:\/\w-]*\/users\/\w+'
         part: header
 
       - type: status

--- a/misconfiguration/drupal/drupal-user-enum-redirect.yaml
+++ b/misconfiguration/drupal/drupal-user-enum-redirect.yaml
@@ -4,7 +4,10 @@ info:
   name: Drupal User Enumeration [Redirect]
   author: 0w4ys
   severity: info
-  tags: drupal
+  metadata:
+    verified: true
+    shodan-query: http.component:"Drupal"
+  tags: drupal,misconfig
 
 requests:
   - method: GET

--- a/misconfiguration/drupal/drupal-user-enum-redirect.yaml
+++ b/misconfiguration/drupal/drupal-user-enum-redirect.yaml
@@ -1,7 +1,7 @@
 id: drupal-user-enum-redirect
 
 info:
-  name: Drupal User Enumration [Redirect]
+  name: Drupal User Enumeration [Redirect]
   author: 0w4ys
   severity: info
   tags: drupal


### PR DESCRIPTION
### Template / PR Information

Template regular expression does not match any URI containing a port and matches only targets which have `/ar` or `/en` routes in it

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
New regex matches: https://regex101.com/r/xmPGXO/2

Old regex matches: https://regex101.com/r/s6JuvB/1

### Additional References:

- N/A