### PR TITLE
Update phpmyadmin-panel.yaml

### DIFF
--- a/exposed-panels/phpmyadmin-panel.yaml
+++ b/exposed-panels/phpmyadmin-panel.yaml
@@ -12,7 +12,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/phpmyadmin/"
-      - "{{BaseURL}}/admin//phpmyadmin/"
+      - "{{BaseURL}}/admin/phpmyadmin/"
       - "{{BaseURL}}/_phpmyadmin/"
       - "{{BaseURL}}/administrator/components/com_joommyadmin/phpmyadmin/"
       - "{{BaseURL}}/apache-default/phpmyadmin/"


### PR DESCRIPTION
### Template / PR Information

I saw in phpmyadmin-panel.yaml there is a  path like 

- "{{BaseURL}}/admin//phpmyadmin/"
But it should be
 - "{{BaseURL}}/admin/phpmyadmin/"
 I mean remove 1 /

- Update phpmyadmin-panel.yaml
- References:

### Template Validation

I've validated this template locally?
- [ ] YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)