### PR TITLE
Fixed VirusTotal and SecurityTrails API tests

### DIFF
--- a/token-spray/api-securitytrails.yaml
+++ b/token-spray/api-securitytrails.yaml
@@ -22,6 +22,4 @@ requests:
       - type: word
         part: body
         words:
-          - '"message"'
-          - '"endpoint"'
-        condition: and
+          - success

--- a/token-spray/api-virustotal.yaml
+++ b/token-spray/api-virustotal.yaml
@@ -24,7 +24,7 @@ requests:
       - type: word
         part: body
         words:
-          - "'verbose_msg':"
-          - "'scan_date':"
-          - "'permalink':"
+          - '"verbose_msg":'
+          - '"scan_date":'
+          - '"permalink":'
         condition: and


### PR DESCRIPTION
### PR Information

- Fixed `SecurityTrails API Test` and `VirusTotal API Test` templates

* The SecurityTrails ping request has `success` in the response:

![securitytrails](https://user-images.githubusercontent.com/56135029/183291913-3ae2ae2a-ee77-4617-b81c-fafa2c52b040.png)

* The VirusTotal API uses double quotes in the responses: 

![vt](https://user-images.githubusercontent.com/56135029/183292034-ecb9d69b-c9d2-4e6a-adc0-6fe38adc486c.png)

### Template Validation

I've validated these templates locally :)