### PR TITLE
Fixed jupyter-notebook false-positive 

### DIFF
--- a/exposed-panels/jupyter-notebook.yaml
+++ b/exposed-panels/jupyter-notebook.yaml
@@ -23,6 +23,7 @@ requests:
     stop-at-first-match: true
     redirects: true
     max-redirects: 2
+    matchers-condition: and
     matchers:
       - type: word
         part: body


### PR DESCRIPTION
### Template / PR Information

- Fixed jupyter-notebook false-positive 
- It triggered to every endpoint that returned a 200 status code, as seen on the following screenshot. 
![image](https://user-images.githubusercontent.com/56135029/184357694-2f264d8f-0c90-45a8-8ce7-81ac2c6247af.png)


### Template Validation

I've validated this template locally.
