### PR TITLE
Added fastcgi-echo-detection template

### DIFF
--- a/exposures/logs/fastcgi-echo-detect.yaml
+++ b/exposures/logs/fastcgi-echo-detect.yaml
@@ -27,6 +27,11 @@ requests:
           - "<title>FastCGI echo</title>"
         condition: and
 
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
       - type: status
         status:
           - 200

--- a/exposures/logs/fastcgi-echo-detect.yaml
+++ b/exposures/logs/fastcgi-echo-detect.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   description: |
     FastCGI module delivered with the Apache httpd server that is incorporated into the Oracle Application Server.FastCGI echo programs (echo and echo2) should be always removed or disabled in all Oracle Application Servers implementations as they can provide information at an attacker
-  reference: 
+  reference:
     - https://www.exploit-db.com/ghdb/183
     - https://www.integrigy.com/oracle-application-server-fastcgi-echo-vulnerability-reports
   metadata:

--- a/exposures/logs/fastcgi-echo-detect.yaml
+++ b/exposures/logs/fastcgi-echo-detect.yaml
@@ -4,12 +4,15 @@ info:
   name: Fastcgi Echo Program Detection
   author: powerexploit
   severity: info
-  description: FastCGI module delivered with the Apache httpd server that is incorporated into the Oracle Application Server. 
-               FastCGI echo programs (echo and echo2) should be always removed or disabled in all Oracle Application Servers implementations as they can provide information at an attacker
+  description: |
+    FastCGI module delivered with the Apache httpd server that is incorporated into the Oracle Application Server.FastCGI echo programs (echo and echo2) should be always removed or disabled in all Oracle Application Servers implementations as they can provide information at an attacker
   reference: 
     - https://www.exploit-db.com/ghdb/183
     - https://www.integrigy.com/oracle-application-server-fastcgi-echo-vulnerability-reports
-  tags: logs, oracle, exposure
+  metadata:
+    verified: true
+    google-dork: inurl:fcgi-bin/echo
+  tags: logs,oracle,exposure
 
 requests:
   - method: GET

--- a/exposures/logs/fastcgi-echo-detect.yaml
+++ b/exposures/logs/fastcgi-echo-detect.yaml
@@ -22,7 +22,7 @@ requests:
         part: body
         words:
           - "<title>FastCGI echo</title>"
-        condition: or
+        condition: and
 
       - type: status
         status:

--- a/exposures/logs/fastcgi-echo-detect.yaml
+++ b/exposures/logs/fastcgi-echo-detect.yaml
@@ -1,0 +1,29 @@
+id: fastcgi-echo-detect
+
+info:
+  name: Fastcgi Echo Program Detection
+  author: powerexploit
+  severity: info
+  description: FastCGI module delivered with the Apache httpd server that is incorporated into the Oracle Application Server. 
+               FastCGI echo programs (echo and echo2) should be always removed or disabled in all Oracle Application Servers implementations as they can provide information at an attacker
+  reference: 
+    - https://www.exploit-db.com/ghdb/183
+    - https://www.integrigy.com/oracle-application-server-fastcgi-echo-vulnerability-reports
+  tags: logs, oracle, exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/fcgi-bin/echo"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>FastCGI echo</title>"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/exposures/logs/fastcgi-echo.yaml
+++ b/exposures/logs/fastcgi-echo.yaml
@@ -1,7 +1,7 @@
-id: fastcgi-echo-detect
+id: fastcgi-echo
 
 info:
-  name: Fastcgi Echo Program Detection
+  name: Fastcgi Echo Endpoint Exposure
   author: powerexploit
   severity: info
   description: |
@@ -12,7 +12,7 @@ info:
   metadata:
     verified: true
     google-dork: inurl:fcgi-bin/echo
-  tags: logs,oracle,exposure
+  tags: exposure,logs,oracle,fastcgi
 
 requests:
   - method: GET
@@ -25,7 +25,6 @@ requests:
         part: body
         words:
           - "<title>FastCGI echo</title>"
-        condition: and
 
       - type: word
         part: header


### PR DESCRIPTION
### Template / PR Information

FastCGI echo programs (echo and echo2) should be always removed or disabled in all Oracle Application Servers implementations as they can provide information at an attacker.


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)