### PR TITLE
Add a word match 'wp-login.php' for wordpress

### DIFF
--- a/technologies/wordpress-detect.yaml
+++ b/technologies/wordpress-detect.yaml
@@ -27,6 +27,7 @@ requests:
 
       - type: word
         words:
+          - 'wp-login.php'
           - '/wp-content/themes/'
           - '/wp-includes/'
           - 'name="generator" content="wordpress'


### PR DESCRIPTION
### Template / PR Information
This change was needed to catch a WordPress instance in a large external scope. It would be possible to just grep for wp-login.php with a 200 status code, but having this in the nuclei output is more useful and requires less manual effort.

### Template Validation
I've validated this template locally?
YES

#### Additional Details (leave it blank if not applicable)

### Additional References:
