### PR TITLE
Added Zimbra Collaboration Suite Web Client Sign In Signature

### DIFF
--- a/exposed-panels/Zimbra-Collaboration-Suite-Web-Client.yaml
+++ b/exposed-panels/Zimbra-Collaboration-Suite-Web-Client.yaml
@@ -1,0 +1,38 @@
+id: Zimbra-Collaboration-Suite-Web-Client
+
+info:
+  name: Zimbra Collaboration Suite Web Client - Sign In
+  author: powerexploit
+  severity: info
+  description: Zimbra Collaboration Suite simplifies the communication environment, connects people over multiple channels, and provides a single place to manage collaboration and communication.
+
+  reference:
+    - https://www.zimbra.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Zimbra Collaboration Suite"
+  tags: panel,zimbra
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Zimbra Collaboration Suite Log In</title>"
+          - "<title>Zimbra Web Client Sign In</title>"
+          - "<title>Zimbra Web Client Log In</title>"
+
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'v=([0-9]+)'

--- a/exposed-panels/Zimbra-Collaboration-Suite-Web-Client.yaml
+++ b/exposed-panels/Zimbra-Collaboration-Suite-Web-Client.yaml
@@ -5,7 +5,6 @@ info:
   author: powerexploit
   severity: info
   description: Zimbra Collaboration Suite simplifies the communication environment, connects people over multiple channels, and provides a single place to manage collaboration and communication.
-
   reference:
     - https://www.zimbra.com/
   metadata:

--- a/exposed-panels/zimbra-web-login.yaml
+++ b/exposed-panels/zimbra-web-login.yaml
@@ -1,10 +1,11 @@
-id: Zimbra-Collaboration-Suite-Web-Client
+id: zimbra-web-login
 
 info:
   name: Zimbra Collaboration Suite Web Client - Sign In
   author: powerexploit
   severity: info
-  description: Zimbra Collaboration Suite simplifies the communication environment, connects people over multiple channels, and provides a single place to manage collaboration and communication.
+  description: |
+    Zimbra Collaboration Suite simplifies the communication environment, connects people over multiple channels, and provides a single place to manage collaboration and communication.
   reference:
     - https://www.zimbra.com/
   metadata:
@@ -17,18 +18,22 @@ requests:
     path:
       - "{{BaseURL}}"
 
+    redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "<title>Zimbra Collaboration Suite Log In</title>"
-          - "<title>Zimbra Web Client Sign In</title>"
-          - "<title>Zimbra Web Client Log In</title>"
+          - "Zimbra Collaboration Suite Log In"
+          - "Zimbra Web Client Sign In"
+          - "Zimbra Web Client Log In"
+        condition: or
 
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
### Template / PR Information

Zimbra Collaboration Suite simplifies the communication environment, connects people over multiple channels, and provides a single place to manage collaboration and communication.

I have found that the older template contains a flow that it only looks for Zimbra administrator web client sign in- 
https://github.com/projectdiscovery/nuclei-templates/blob/master/exposed-panels/zimbra-web-client.yaml.

This template will help to identify all Zimbra collaboration Suite web client Sign In with their current  running versions.


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)