### PR TITLE
Update CVE 2022 35405

### DIFF
--- a/cves/2022/CVE-2022-35405.yaml
+++ b/cves/2022/CVE-2022-35405.yaml
@@ -11,6 +11,7 @@ info:
     - https://xz.aliyun.com/t/11578
     - https://nvd.nist.gov/vuln/detail/CVE-2022-35405
     - https://www.manageengine.com/products/passwordmanagerpro/advisory/cve-2022-35405.html
+    - https://www.bigous.me/2022/09/06/CVE-2022-35405.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8

--- a/cves/2022/CVE-2022-35405.yaml
+++ b/cves/2022/CVE-2022-35405.yaml
@@ -20,39 +20,65 @@ info:
   tags: cve,cve2022,rce,zoho,passwordmanager,deserialization,unauth,msf
 
 requests:
-  - raw:
-      - |
-        POST /xmlrpc HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: text/xml
+# Password Manager Pro
+  - method: POST
+    path:
+      - "{{RootURL}}:7272/xmlrpc"
+    body: |
+        <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
 
-        <?xml version="1.0"?>
-        <methodCall>
-          <methodName>ProjectDiscovery</methodName>
-          <params>
-            <param>
-              <value>
-                <struct>
-                  <member>
-                    <name>test</name>
-                    <value>
-                      <serializable xmlns="http://ws.apache.org/xmlrpc/namespaces/extensions"></serializable>
-                    </value>
-                  </member>
-                </struct>
-              </value>
-            </param>
-          </params>
-        </methodCall>
-
-    matchers-condition: and
     matchers:
       - type: word
+        words:
+          - "faultString"
+          - "No such service [ProjectDiscovery]"
+          - "methodResponse"
+        condition: or
         part: body
-        words:
-          - "Failed to read result object: null"
 
+# PAM360
+  - method: POST
+    path:
+    - "{{RootURL}}:8282/xmlrpc"
+    body: |
+      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+    matchers:
       - type: word
-        part: header
         words:
-          - text/xml
+          - "faultString"
+          - "No such service [ProjectDiscovery]"
+          - "methodResponse"
+        condition: or
+        part: body
+
+# Hosts thats uses on port 80
+  - method: POST
+    path:
+    - "{{RootURL}}/xmlrpc"
+    body: |
+      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+
+    matchers:
+      - type: word
+        words:
+          - "faultString"
+          - "No such service [ProjectDiscovery]"
+          - "methodResponse"
+        condition: or
+        part: body
+
+# Access Manager Plus -> https://www.manageengine.com/privileged-session-management/help/setting-up-amp-over-wan.html
+  - method: POST
+    path:
+    - "{{RootURL}}:9292/xmlrpc"
+    body: |
+      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+
+    matchers:
+      - type: word
+        words:
+          - "faultString"
+          - "No such service [ProjectDiscovery]"
+          - "methodResponse"
+        condition: or
+        part: body

--- a/cves/2022/CVE-2022-35405.yaml
+++ b/cves/2022/CVE-2022-35405.yaml
@@ -17,11 +17,10 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2022-35405
   metadata:
-    shodan-query: http.title:"ManageEngine Password"
+    shodan-query: http.title:"ManageEngine"
   tags: cve,cve2022,rce,zoho,passwordmanager,deserialization,unauth,msf
 
 requests:
-# Password Manager Pro
   - method: POST
     path:
       - "{{RootURL}}:7272/xmlrpc"
@@ -36,8 +35,7 @@ requests:
           - "methodResponse"
         condition: or
         part: body
-
-# PAM360
+        
   - method: POST
     path:
     - "{{RootURL}}:8282/xmlrpc"
@@ -51,8 +49,7 @@ requests:
           - "methodResponse"
         condition: or
         part: body
-
-# Hosts thats uses on port 80
+        
   - method: POST
     path:
     - "{{RootURL}}/xmlrpc"
@@ -68,7 +65,6 @@ requests:
         condition: or
         part: body
 
-# Access Manager Plus -> https://www.manageengine.com/privileged-session-management/help/setting-up-amp-over-wan.html
   - method: POST
     path:
     - "{{RootURL}}:9292/xmlrpc"

--- a/cves/2022/CVE-2022-35405.yaml
+++ b/cves/2022/CVE-2022-35405.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-35405
 
 info:
   name: Zoho ManageEngine Password Manager Pro and PAM 360 - Unauthenticated Remote Command Execution
-  author: true13
+  author: viniciuspereiras,true13
   severity: critical
   description: |
     This is a de-serialization vulnerability that causes unauthenticated RCE in XML-RPC of Zoho Manage Engine Password Manager Pro, PAM360 and Access Manager Plus (Authenticated).
@@ -21,61 +21,34 @@ info:
   tags: cve,cve2022,rce,zoho,passwordmanager,deserialization,unauth,msf
 
 requests:
-  - method: POST
-    path:
-      - "{{RootURL}}:7272/xmlrpc"
-    body: |
+  - raw:
+      - |
+        POST /xmlrpc HTTP/1.1
+        Host: {{Hostname}}
+
+        <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+
+      - |
+        POST /xmlrpc HTTP/1.1
+        Host: {{Host}}:7272
+
+        <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+      - |
+        POST /xmlrpc HTTP/1.1
+        Host: {{Host}}:8282
+
+        <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
+      - |
+        POST /xmlrpc HTTP/1.1
+        Host: {{Host}}:9292
+
         <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
 
     matchers:
       - type: word
+        part: body
         words:
           - "faultString"
           - "No such service [ProjectDiscovery]"
           - "methodResponse"
         condition: or
-        part: body
-        
-  - method: POST
-    path:
-    - "{{RootURL}}:8282/xmlrpc"
-    body: |
-      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
-    matchers:
-      - type: word
-        words:
-          - "faultString"
-          - "No such service [ProjectDiscovery]"
-          - "methodResponse"
-        condition: or
-        part: body
-        
-  - method: POST
-    path:
-    - "{{RootURL}}/xmlrpc"
-    body: |
-      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
-
-    matchers:
-      - type: word
-        words:
-          - "faultString"
-          - "No such service [ProjectDiscovery]"
-          - "methodResponse"
-        condition: or
-        part: body
-
-  - method: POST
-    path:
-    - "{{RootURL}}:9292/xmlrpc"
-    body: |
-      <?xml version="1.0"?><methodCall><methodName>ProjectDiscovery</methodName><params><param><value>big0us</value></param></params></methodCall>
-
-    matchers:
-      - type: word
-        words:
-          - "faultString"
-          - "No such service [ProjectDiscovery]"
-          - "methodResponse"
-        condition: or
-        part: body

--- a/cves/2022/CVE-2022-35405.yaml
+++ b/cves/2022/CVE-2022-35405.yaml
@@ -1,11 +1,11 @@
 id: CVE-2022-35405
 
 info:
-  name: Zoho ManageEngine Password Manager Pro - Unauthenticated Remote Command Execution
+  name: Zoho ManageEngine Password Manager Pro and PAM 360 - Unauthenticated Remote Command Execution
   author: true13
   severity: critical
   description: |
-    This is a de-serialization vulnerability that causes unauthenticated RCE in XML-RPC of Zoho Manage Engine Password Manager Pro.
+    This is a de-serialization vulnerability that causes unauthenticated RCE in XML-RPC of Zoho Manage Engine Password Manager Pro, PAM360 and Access Manager Plus (Authenticated).
   reference:
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/http/zoho_password_manager_pro_xml_rpc_rce.rb
     - https://xz.aliyun.com/t/11578


### PR DESCRIPTION
### Template / PR Information
Hi, I'm the one who initially reported the vulnerability to ManageEngine and I have some interesting things to add to the template.
One of the things that there isn't so much clear information is that CVE doesn't only affect Password Manager Pro, it also affects PAM360 and Access Manager Plus, so I added that and its related ports to the template.
In addition to these additions and adding more information to the header I added more triggers.
Request ports added
 - 7272 (Password Manager Pro)
 - 8282 (PAM360)
 - 9292 (Access Manager Plus)
 - 80 (for custom installations)

-  Updated CVE-2020-XXX

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)