### PR TITLE
Add detection template for JHipster

### DIFF
--- a/technologies/jhipster-detect.yaml
+++ b/technologies/jhipster-detect.yaml
@@ -1,7 +1,7 @@
 id: jhipster-detect
 
 info:
-  name: JHipster Detection
+  name: JHipster Detect
   author: righettod
   severity: info
   metadata:

--- a/technologies/jhipster-detect.yaml
+++ b/technologies/jhipster-detect.yaml
@@ -1,0 +1,28 @@
+id: jhipster-detect
+
+info:
+  name: JHipster Detection
+  author: righettod
+  severity: info
+  metadata:
+    verified: true
+    shodan-query: http.html:"JHipster"
+  tags: tech,jhipster
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+      - '{{BaseURL}}/i18n/en.json'
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'JHipster'
+          - '@jhipster'
+          - 'Welcome, Java Hipster!'
+          - 'jhipster-error'
+        condition: or
+        

--- a/technologies/jhipster-detect.yaml
+++ b/technologies/jhipster-detect.yaml
@@ -25,4 +25,3 @@ requests:
           - 'Welcome, Java Hipster!'
           - 'jhipster-error'
         condition: or
-        


### PR DESCRIPTION
### Template / PR Information

This PR add a template to detect the presence of the platform [JHipster](https://www.jhipster.tech/).

- References: https://www.jhipster.tech/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

![image](https://user-images.githubusercontent.com/1573775/188691602-59063e16-c43a-4c75-a3bc-1a3572330b8c.png)

#### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22JHipster%22

### Additional References:

None