### PR TITLE
Naming screenshot output with url_encoded BaseURL.

### DIFF
--- a/headless/screenshot.yaml
+++ b/headless/screenshot.yaml
@@ -8,7 +8,7 @@ info:
   tags: headless,screenshot
 
 variables:
-  file: "{{Hostname}}"
+  file: "{{url_encode(BaseURL)}}"
 
 headless:
   - steps:


### PR DESCRIPTION
I'm trying to use nuclei for a screenshot. I'm trying to do some automation.  
Steps:-
1. FFUF on the target for directory discovery. 
2. Give ffuf's out in nuclei for screenshots using a screenshot.yaml ( headless/screenshot.yml)

Problem:-
Since I'm trying to screenshot each directory of the same target ( example.com ), every screenshot has the same Hostname. Now, every image is replaced by a new screenshot and in the output folder, I will have only one image of the last path.

Solution:- 
In the screenshot.yaml template, it is using {{Hostname}} as an output file. Now I changed the output using {{BaseURL}}. But since it has "/" in the base it won't take screenshots. So url_encoded the BaseURL and use it as a screenshot name.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)