### PR TITLE
 Add template to detect SSL Issuer

### DIFF
--- a/ssl/detect-ssl-issuer.yaml
+++ b/ssl/detect-ssl-issuer.yaml
@@ -1,0 +1,15 @@
+id: detect-ssl-issuer
+
+info:
+  name: Detect SSL Certificate Issuer
+  author: Lingtren
+  severity: info
+  tags: ssl
+
+ssl:
+  - address: "{{Host}}:{{Port}}"
+
+    extractors:
+      - type: json
+        json:
+          - " .issuer_organization[]"


### PR DESCRIPTION
### Template / PR Information

This template `ssl/detect-ssl-issuer.yaml` can be used to find the company which issued the SSL certificate.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Screenshot:
![image](https://user-images.githubusercontent.com/2859879/190959971-42ed1ff0-515f-4cc7-9a87-2d75d07cd493.png)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)