### PR TITLE
Symantec IM Management Console

### DIFF
--- a/exposed-panels/symantec/symantec-iam-console.yaml
+++ b/exposed-panels/symantec/symantec-iam-console.yaml
@@ -1,10 +1,11 @@
-id: symantec-identity-manager-management-console
+id: symantec-iam-console
 
 info:
   name: Symantec Identity Manager Management Console
   author: therealtoastycat
   severity: info
-  description: "Management Console to administrate Symantec Identity Manager environment, authentication is sometimes disabled."
+  description: |
+    Management Console to administrate Symantec Identity Manager environment, authentication is sometimes disabled.
   reference:
     - https://techdocs.broadcom.com/us/en/symantec-security-software/identity-security/identity-manager/14-4/configuring/environments-overview/management-console.html
   tags: symantec,panel,login
@@ -14,7 +15,6 @@ requests:
     path:
       - "{{BaseURL}}/iam/immanage/login.jsp"
 
-    redirects: false
     matchers-condition: and
     matchers:
       - type: word

--- a/exposed-panels/symantec/symantec-identity-manager-management-console.yaml
+++ b/exposed-panels/symantec/symantec-identity-manager-management-console.yaml
@@ -1,0 +1,27 @@
+id: symantec-identity-manager-management-console
+
+info:
+  name: Symantec Identity Manager Management Console
+  author: therealtoastycat
+  severity: info
+  description: "Management Console to administrate Symantec Identity Manager environment, authentication is sometimes disabled."
+  reference:
+    - https://techdocs.broadcom.com/us/en/symantec-security-software/identity-security/identity-manager/14-4/configuring/environments-overview/management-console.html
+  tags: symantec,panel,login
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/iam/immanage/login.jsp"
+
+    redirects: false
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<title>Management Console</title>"
+        part: body
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

I've created this template to detect the management console of Symantec Identity Manager. Authentication to this component is sometimes disabled, which may lead to a full takeover of the IM environment.
 
- References: https://techdocs.broadcom.com/us/en/symantec-security-software/identity-security/identity-manager/14-4/configuring/environments-overview/management-console.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)