### PR TITLE
Fix typo

### DIFF
--- a/misconfiguration/http-missing-security-headers.yaml
+++ b/misconfiguration/http-missing-security-headers.yaml
@@ -32,9 +32,9 @@ requests:
         condition: and
 
       - type: dsl
-        name: permission-policy
+        name: permissions-policy
         dsl:
-          - "!regex('(?i)permission-policy', all_headers)"
+          - "!regex('(?i)permissions-policy', all_headers)"
           - "status_code != 301 && status_code != 302"
         condition: and
 


### PR DESCRIPTION
### Template / PR Information

The correct name of this header is 'Permissions-Policy' (with an 's') according to the documentation: https://developer.chrome.com/en/docs/privacy-sandbox/permissions-policy/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
