### PR TITLE
Using "host-redirects" instead of "redirects" to avoid scanning 3rd party / out of scope hosts

### DIFF
--- a/cnvd/2018/CNVD-2018-13393.yaml
+++ b/cnvd/2018/CNVD-2018-13393.yaml
@@ -18,7 +18,7 @@ requests:
     path:
       - '{{BaseURL}}/include/thumb.php?dir=http\..\admin\login\login_check.php'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-1000856.yaml
+++ b/cves/2018/CVE-2018-1000856.yaml
@@ -40,7 +40,7 @@ requests:
         Content-Type: application/x-www-form-urlencoded
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-11231.yaml
+++ b/cves/2018/CVE-2018-11231.yaml
@@ -27,7 +27,7 @@ requests:
 
         {"metadata":{"order_id":"1 and updatexml(1,concat(0x7e,(SELECT md5({{num}})),0x7e),1)"},"status":2}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-18069.yaml
+++ b/cves/2018/CVE-2018-18069.yaml
@@ -24,7 +24,7 @@ requests:
     body: |
       icl_post_action=save_theme_localization&locale_file_name_en=EN"><script>alert(0);</script>
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: dsl

--- a/cves/2018/CVE-2018-19749.yaml
+++ b/cves/2018/CVE-2018-19749.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-19751.yaml
+++ b/cves/2018/CVE-2018-19751.yaml
@@ -41,7 +41,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-19752.yaml
+++ b/cves/2018/CVE-2018-19752.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-19892.yaml
+++ b/cves/2018/CVE-2018-19892.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-19914.yaml
+++ b/cves/2018/CVE-2018-19914.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-19915.yaml
+++ b/cves/2018/CVE-2018-19915.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-20009.yaml
+++ b/cves/2018/CVE-2018-20009.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-20010.yaml
+++ b/cves/2018/CVE-2018-20010.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-20011.yaml
+++ b/cves/2018/CVE-2018-20011.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2018/CVE-2018-20526.yaml
+++ b/cves/2018/CVE-2018-20526.yaml
@@ -61,7 +61,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2018/CVE-2018-7602.yaml
+++ b/cves/2018/CVE-2018-7602.yaml
@@ -46,7 +46,7 @@ requests:
         form_build_id={{form_build_id}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/cves/2018/CVE-2018-9845.yaml
+++ b/cves/2018/CVE-2018-9845.yaml
@@ -20,7 +20,7 @@ requests:
     path:
       - "{{BaseURL}}/Admin"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2019/CVE-2019-14530.yaml
+++ b/cves/2019/CVE-2019-14530.yaml
@@ -33,7 +33,7 @@ requests:
         GET /custom/ajax_download.php?fileName=../../../../../../../../../etc/passwd HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2019/CVE-2019-15811.yaml
+++ b/cves/2019/CVE-2019-15811.yaml
@@ -34,7 +34,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2019/CVE-2019-16996.yaml
+++ b/cves/2019/CVE-2019-16996.yaml
@@ -20,7 +20,7 @@ requests:
     path:
       - "{{BaseURL}}/admin/?n=product&c=product_admin&a=dopara&app_type=shop&id=1%20union%20SELECT%201,2,3,25367*75643,5,6,7%20limit%205,1%20%23"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2019/CVE-2019-16997.yaml
+++ b/cves/2019/CVE-2019-16997.yaml
@@ -24,7 +24,7 @@ requests:
 
         appno= 1 union SELECT 98989*443131,1&editor=cn&site=web
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2019/CVE-2019-17418.yaml
+++ b/cves/2019/CVE-2019-17418.yaml
@@ -21,7 +21,7 @@ requests:
     path:
       - "{{BaseURL}}/admin/?n=language&c=language_general&a=doSearchParameter&editor=cn&word=search&appno=0+union+select+98989*443131,1--+&site=admin"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2019/CVE-2019-20224.yaml
+++ b/cves/2019/CVE-2019-20224.yaml
@@ -36,7 +36,7 @@ requests:
         date=0&time=0&period=0&interval_length=0&chart_type=netflow_area&max_aggregates=1&address_resolution=0&name=0&assign_group=0&filter_type=0&filter_id=0&filter_selected=0&ip_dst=0&ip_src=%22%3Bcurl+{{interactsh-url}}+%23&draw_button=Draw
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2020/CVE-2020-17506.yaml
+++ b/cves/2020/CVE-2020-17506.yaml
@@ -21,7 +21,7 @@ requests:
     path:
       - "{{BaseURL}}/fw.login.php?apikey=%27UNION%20select%201,%27YToyOntzOjM6InVpZCI7czo0OiItMTAwIjtzOjIyOiJBQ1RJVkVfRElSRUNUT1JZX0lOREVYIjtzOjE6IjEiO30=%27;"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/cves/2020/CVE-2020-20988.yaml
+++ b/cves/2020/CVE-2020-20988.yaml
@@ -35,7 +35,7 @@ requests:
 
     cookie-reuse: true
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: dsl

--- a/cves/2020/CVE-2020-5191.yaml
+++ b/cves/2020/CVE-2020-5191.yaml
@@ -35,7 +35,7 @@ requests:
 
         doctorspecilization=%3C%2Ftd%3E%3Cscript%3Ealert%28document.domain%29%3B%3C%2Fscript%3E%3Ctd%3E&submit=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2020/CVE-2020-5192.yaml
+++ b/cves/2020/CVE-2020-5192.yaml
@@ -38,7 +38,7 @@ requests:
 
         searchdata='+UNION+ALL+SELECT+NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,CONCAT(CONCAT(md5({{num}}),1),2),NULL--+PqeG&search=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2020/CVE-2020-7980.yaml
+++ b/cves/2020/CVE-2020-7980.yaml
@@ -29,7 +29,7 @@ requests:
 
         {"O_": "A", "F_": "EXEC_CMD", "S_": 123456789, "P1_": {"Q": "cat /etc/passwd", "F": "EXEC_CMD"}, "V_": 1}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2020/CVE-2020-8644.yaml
+++ b/cves/2020/CVE-2020-8644.yaml
@@ -32,7 +32,7 @@ requests:
         X-CSRF-Token={{csrf}}&username=%7B%7B%60echo%20%27CVE-2020-8644%27%20%7C%20rev%60%7D%7D&password=
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     extractors:
       - type: xpath

--- a/cves/2020/CVE-2020-8772.yaml
+++ b/cves/2020/CVE-2020-8772.yaml
@@ -39,7 +39,7 @@ requests:
 
         _IWP_JSON_PREFIX_{{base64("{\"iwp_action\":\"add_site\",\"params\":{\"username\":\"{{username}}\"}}")}}
 
-    redirects: true
+    host-redirects: true
     extractors:
       - type: regex
         name: username

--- a/cves/2020/CVE-2020-9043.yaml
+++ b/cves/2020/CVE-2020-9043.yaml
@@ -41,7 +41,7 @@ requests:
         GET /wp-admin/admin-ajax.php?action=my_wpc_signon&auth_key={{authkey}} HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     req-condition: true

--- a/cves/2021/CVE-2021-22205.yaml
+++ b/cves/2021/CVE-2021-22205.yaml
@@ -27,7 +27,7 @@ requests:
     path:
       - "{{BaseURL}}/users/sign_in"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers:
       - type: word

--- a/cves/2021/CVE-2021-22214.yaml
+++ b/cves/2021/CVE-2021-22214.yaml
@@ -35,7 +35,7 @@ requests:
     body: |
       {"content": "include:\n  remote: http://127.0.0.1:9100/test.yml"}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers:
       - type: word

--- a/cves/2021/CVE-2021-22873.yaml
+++ b/cves/2021/CVE-2021-22873.yaml
@@ -31,7 +31,7 @@ requests:
       - "{{BaseURL}}/www/delivery/lg.php?dest=http://interact.sh"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/cves/2021/CVE-2021-24358.yaml
+++ b/cves/2021/CVE-2021-24358.yaml
@@ -26,7 +26,7 @@ requests:
         GET /wp-login.php?action=theplusrp&key=&redirecturl=http://interact.sh&forgoturl=http://interact.sh&login={{username}} HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     matchers:
       - type: regex
         part: header

--- a/cves/2021/CVE-2021-24746.yaml
+++ b/cves/2021/CVE-2021-24746.yaml
@@ -23,7 +23,7 @@ requests:
       - "{{BaseURL}}/wp-json/wp/v2/posts"
       - "{{BaseURL}}/{{slug}}/?a&quot;&gt;&lt;script&gt;alert(document.domain)&lt;/script&gt;"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/cves/2021/CVE-2021-27651.yaml
+++ b/cves/2021/CVE-2021-27651.yaml
@@ -22,7 +22,7 @@ requests:
       - "{{BaseURL}}/prweb/PRAuth/app/default/"
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     extractors:
       - type: regex

--- a/cves/2021/CVE-2021-27748.yaml
+++ b/cves/2021/CVE-2021-27748.yaml
@@ -23,7 +23,7 @@ requests:
       - '{{BaseURL}}/docpicker/internal_proxy/http/interact.sh'
       - '{{BaseURL}}/wps/PA_WCM_Authoring_UI/proxy/http/interact.sh'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-31250.yaml
+++ b/cves/2021/CVE-2021-31250.yaml
@@ -24,7 +24,7 @@ requests:
     headers:
       Authorization: "Basic OmFkbWlu"
 
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
       - type: word

--- a/cves/2021/CVE-2021-36450.yaml
+++ b/cves/2021/CVE-2021-36450.yaml
@@ -33,7 +33,7 @@ requests:
 
         browserCheckEnabled=true&username=admin&language=en_US&defaultHttpPort=80&screenHeight=1080&screenWidth=1920&pageModelType=0&pageDirty=false&pageAction=Login&csrfp_login={{csrfp_login}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
 

--- a/cves/2021/CVE-2021-40438.yaml
+++ b/cves/2021/CVE-2021-40438.yaml
@@ -22,7 +22,7 @@ requests:
     path:
       - '{{BaseURL}}/?unix:{{repeat("A", 7701)}}|http://interact.sh/'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/cves/2021/CVE-2021-42551.yaml
+++ b/cves/2021/CVE-2021-42551.yaml
@@ -21,7 +21,7 @@ requests:
       - '{{BaseURL}}/NetBiblio/search/shortview?searchField=W&searchType=Simple&searchTerm=x%27%2Balert%281%29%2B%27x'
       - '{{BaseURL}}/NetBiblio/search/shortview?searchField=W&searchType=Simple&searchTerm=x%5C%27%2Balert%281%29%2C%2F%2F'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: and
     matchers:

--- a/cves/2021/CVE-2021-42663.yaml
+++ b/cves/2021/CVE-2021-42663.yaml
@@ -33,7 +33,7 @@ requests:
         GET /views/index.php?msg=%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-42667.yaml
+++ b/cves/2021/CVE-2021-42667.yaml
@@ -36,7 +36,7 @@ requests:
         GET /views/?v=USER&ID=1%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2Cmd5({{num}})%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%3B--%20- HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-46068.yaml
+++ b/cves/2021/CVE-2021-46068.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-46069.yaml
+++ b/cves/2021/CVE-2021-46069.yaml
@@ -41,7 +41,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-46071.yaml
+++ b/cves/2021/CVE-2021-46071.yaml
@@ -41,7 +41,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-46072.yaml
+++ b/cves/2021/CVE-2021-46072.yaml
@@ -40,7 +40,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2021/CVE-2021-46073.yaml
+++ b/cves/2021/CVE-2021-46073.yaml
@@ -41,7 +41,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-0220.yaml
+++ b/cves/2022/CVE-2022-0220.yaml
@@ -30,7 +30,7 @@ requests:
 
         action=check_privacy_settings&settings%5B40%5D=40&settings%5B41%5D=%3cbody%20onload%3dalert(document.domain)%3e&nonce={{nonce}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     req-condition: true
     matchers:

--- a/cves/2022/CVE-2022-22972.yaml
+++ b/cves/2022/CVE-2022-22972.yaml
@@ -37,7 +37,7 @@ requests:
 
         protected_state={{protected_state}}&userstore={{userstore}}&username=administrator&password=horizon&userstoreDisplay={{userstoreDisplay}}&horizonRelayState={{horizonRelayState}}&stickyConnectorId={{stickyConnectorId}}&action=Sign+in
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     cookie-reuse: true
     extractors:

--- a/cves/2022/CVE-2022-29005.yaml
+++ b/cves/2022/CVE-2022-29005.yaml
@@ -38,7 +38,7 @@ requests:
         Host: {{Hostname}}
 
     req-condition: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers:

--- a/cves/2022/CVE-2022-29272.yaml
+++ b/cves/2022/CVE-2022-29272.yaml
@@ -31,7 +31,7 @@ requests:
 
         nsp={{nsp_token}}&page=auth&debug=&pageopt=login&redirect=%2Fwww.interact.sh&username={{username}}&password={{password}}&loginButton=Login
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/cves/2022/CVE-2022-32025.yaml
+++ b/cves/2022/CVE-2022-32025.yaml
@@ -37,7 +37,7 @@ requests:
         Host: {{Hostname}}
 
     skip-variables-check: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-32026.yaml
+++ b/cves/2022/CVE-2022-32026.yaml
@@ -37,7 +37,7 @@ requests:
         Host: {{Hostname}}
 
     skip-variables-check: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-32028.yaml
+++ b/cves/2022/CVE-2022-32028.yaml
@@ -37,7 +37,7 @@ requests:
         Host: {{Hostname}}
 
     skip-variables-check: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-32094.yaml
+++ b/cves/2022/CVE-2022-32094.yaml
@@ -28,7 +28,7 @@ requests:
 
         username=admin%27+or+%271%27%3D%271%27%23&password=admin%27+or+%271%27%3D%271%27%23&submit=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-34590.yaml
+++ b/cves/2022/CVE-2022-34590.yaml
@@ -28,7 +28,7 @@ requests:
 
         username=admin%27+or+%271%27%3D%271%27%23&password=admin%27+or+%271%27%3D%271%27%23&submit=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/cves/2022/CVE-2022-38637.yaml
+++ b/cves/2022/CVE-2022-38637.yaml
@@ -29,7 +29,7 @@ requests:
 
         username=admin%27+or+%271%27%3D%271%27%23&password=admin%27+or+%271%27%3D%271%27%23&submit=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/default-logins/apache/tomcat-examples-login.yaml
+++ b/default-logins/apache/tomcat-examples-login.yaml
@@ -35,7 +35,7 @@ requests:
       password:
         - tomcat
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/default-logins/dvwa/dvwa-default-login.yaml
+++ b/default-logins/dvwa/dvwa-default-login.yaml
@@ -51,7 +51,7 @@ requests:
         kval:
           - PHPSESSID
 
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/default-logins/others/inspur-clusterengine-default-login.yaml
+++ b/default-logins/others/inspur-clusterengine-default-login.yaml
@@ -26,7 +26,7 @@ requests:
       password:
         - 123456
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/default-logins/others/kingsoft-v8-default-login.yaml
+++ b/default-logins/others/kingsoft-v8-default-login.yaml
@@ -22,7 +22,7 @@ requests:
         - admin
       password:
         - admin
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/default-logins/others/telecom-gateway-default-login.yaml
+++ b/default-logins/others/telecom-gateway-default-login.yaml
@@ -22,7 +22,7 @@ requests:
       password:
         - admin
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/adminset-panel.yaml
+++ b/exposed-panels/adminset-panel.yaml
@@ -18,7 +18,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ampps-admin-panel.yaml
+++ b/exposed-panels/ampps-admin-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/ampps-admin/index.php?act=login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ampps-panel.yaml
+++ b/exposed-panels/ampps-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/ampps/index.php?act=login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/archibus-webcentral-panel.yaml
+++ b/exposed-panels/archibus-webcentral-panel.yaml
@@ -18,7 +18,7 @@ requests:
       - '{{BaseURL}}/archibus/login.axvw'
       - '{{BaseURL}}/archibus/schema/ab-core/views/sign-in/ab-sign-in.jsp'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/avatier-password-management.yaml
+++ b/exposed-panels/avatier-password-management.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - '{{BaseURL}}/aims/ps/'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/bitrix-panel.yaml
+++ b/exposed-panels/bitrix-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/bitrix/admin/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/black-duck-panel.yaml
+++ b/exposed-panels/black-duck-panel.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/buddy-panel.yaml
+++ b/exposed-panels/buddy-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/buildbot-panel.yaml
+++ b/exposed-panels/buildbot-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/cas-login.yaml
+++ b/exposed-panels/cas-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/cas/login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/checkpoint-panel.yaml
+++ b/exposed-panels/checkpoint-panel.yaml
@@ -12,7 +12,7 @@ requests:
       - "{{BaseURL}}/sslvpn/Login/Login"
       - "{{BaseURL}}/Login/Login"
     matchers-condition: and
-    redirects: true
+    host-redirects: true
     matchers:
       - type: status
         status:

--- a/exposed-panels/cisco/cisco-asa-panel.yaml
+++ b/exposed-panels/cisco/cisco-asa-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/+CSCOE+/logon.html"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/cisco/cisco-secure-desktop.yaml
+++ b/exposed-panels/cisco/cisco-secure-desktop.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/CACHE/sdesktop/install/start.htm"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/cisco/cisco-telepresence.yaml
+++ b/exposed-panels/cisco/cisco-telepresence.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/login.html"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/clave-login-panel.yaml
+++ b/exposed-panels/clave-login-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - '{{BaseURL}}/admin.php'
 
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
       - type: status

--- a/exposed-panels/cobbler-webgui.yaml
+++ b/exposed-panels/cobbler-webgui.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/cobbler_web"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/concrete5/concrete5-panel.yaml
+++ b/exposed-panels/concrete5/concrete5-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}/index.php/login'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/exposed-panels/csod-panel.yaml
+++ b/exposed-panels/csod-panel.yaml
@@ -11,7 +11,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-    redirects: true
+    host-redirects: true
     max-redirects: 5
     matchers:
       - type: word

--- a/exposed-panels/cvent-panel-detect.yaml
+++ b/exposed-panels/cvent-panel-detect.yaml
@@ -19,7 +19,7 @@ requests:
       - '{{BaseURL}}/events/EventRsvp.aspx'
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/cwp-webpanel.yaml
+++ b/exposed-panels/cwp-webpanel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/digitalrebar-login.yaml
+++ b/exposed-panels/digitalrebar-login.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/ui"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/dzzoffice/dzzoffice-panel.yaml
+++ b/exposed-panels/dzzoffice/dzzoffice-panel.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/user.php?mod=login"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/emby-panel.yaml
+++ b/exposed-panels/emby-panel.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/entrust-identityguard.yaml
+++ b/exposed-panels/entrust-identityguard.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: dsl

--- a/exposed-panels/eventum-panel.yaml
+++ b/exposed-panels/eventum-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/ez-publish-panel.yaml
+++ b/exposed-panels/ez-publish-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/flip-cms-panel.yaml
+++ b/exposed-panels/flip-cms-panel.yaml
@@ -17,7 +17,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/fortinet-fortigate-panel.yaml
+++ b/exposed-panels/fortinet-fortigate-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/remote/login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/geoserver-login-panel.yaml
+++ b/exposed-panels/geoserver-login-panel.yaml
@@ -15,7 +15,7 @@ requests:
       - "{{BaseURL}}/web"
       - "{{BaseURL}}/geoserver/web/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/github-enterprise-detect.yaml
+++ b/exposed-panels/github-enterprise-detect.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/gitlab-detect.yaml
+++ b/exposed-panels/gitlab-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/users/sign_in"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/go-anywhere-client.yaml
+++ b/exposed-panels/go-anywhere-client.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/webclient/Login.xhtml"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/goanywhere-mft-login.yaml
+++ b/exposed-panels/goanywhere-mft-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/goanywhere/auth/Login.xhtml"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/gocron-panel.yaml
+++ b/exposed-panels/gocron-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/gradle/gradle-enterprise-panel.yaml
+++ b/exposed-panels/gradle/gradle-enterprise-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/hashicorp-consul-webgui.yaml
+++ b/exposed-panels/hashicorp-consul-webgui.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/ui/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/highmail-admin-panel.yaml
+++ b/exposed-panels/highmail-admin-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}"
       - "{{BaseURL}}/login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/homematic-panel.yaml
+++ b/exposed-panels/homematic-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/hybris-administration-console.yaml
+++ b/exposed-panels/hybris-administration-console.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ibm/ibm-maximo-login.yaml
+++ b/exposed-panels/ibm/ibm-maximo-login.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}/maximo/webclient/login/login.jsp"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ibm/ibm-websphere-admin-panel.yaml
+++ b/exposed-panels/ibm/ibm-websphere-admin-panel.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}/console"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ibm/ibm-websphere-panel.yaml
+++ b/exposed-panels/ibm/ibm-websphere-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{RootURL}}/wps/portal'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/incapptic-connect-panel.yaml
+++ b/exposed-panels/incapptic-connect-panel.yaml
@@ -18,7 +18,7 @@ requests:
       - '{{BaseURL}}'
       - '{{BaseURL}}/static/img/custom_icons/favicon.ico'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     stop-at-first-match: true
     matchers-condition: or

--- a/exposed-panels/intelbras-panel.yaml
+++ b/exposed-panels/intelbras-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/intellian-aptus-panel.yaml
+++ b/exposed-panels/intellian-aptus-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/cgi-bin/getagent.cgi?type=s&xxxx"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ipdiva-mediation-panel.yaml
+++ b/exposed-panels/ipdiva-mediation-panel.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/mediation/authenticate"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/ixcache-panel.yaml
+++ b/exposed-panels/ixcache-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/jamf-login.yaml
+++ b/exposed-panels/jamf-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/jamf-panel.yaml
+++ b/exposed-panels/jamf-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/jira-detect.yaml
+++ b/exposed-panels/jira-detect.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{BaseURL}}/login.jsp"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/jupyter-notebook.yaml
+++ b/exposed-panels/jupyter-notebook.yaml
@@ -21,7 +21,7 @@ requests:
       - "{{BaseURL}}/hub/login"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/kafka-center-login.yaml
+++ b/exposed-panels/kafka-center-login.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/kafka-consumer-monitor.yaml
+++ b/exposed-panels/kafka-consumer-monitor.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/kentico-login.yaml
+++ b/exposed-panels/kentico-login.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/CMSPages/logon.aspx"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/key-cloak-admin-panel.yaml
+++ b/exposed-panels/key-cloak-admin-panel.yaml
@@ -12,7 +12,7 @@ requests:
       - "{{BaseURL}}/auth/admin/master/console/"
       - "{{BaseURL}}/auth/admin"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
 

--- a/exposed-panels/kibana-panel.yaml
+++ b/exposed-panels/kibana-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/app/kibana"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/labtech-panel.yaml
+++ b/exposed-panels/labtech-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/WCC2/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/linksys-wifi-login.yaml
+++ b/exposed-panels/linksys-wifi-login.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers-condition: and

--- a/exposed-panels/magento-admin-panel.yaml
+++ b/exposed-panels/magento-admin-panel.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - '{{BaseURL}}/admin'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/mailwatch-login.yaml
+++ b/exposed-panels/mailwatch-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/mailscanner/login.php"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/matomo-login-portal.yaml
+++ b/exposed-panels/matomo-login-portal.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{BaseURL}}/matomo"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/microfocus-vibe-panel.yaml
+++ b/exposed-panels/microfocus-vibe-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/ssf/s/portalLogin"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/mitel-panel-detect.yaml
+++ b/exposed-panels/mitel-panel-detect.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/server-common/cgi-bin/login"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/mybb-forum-detect.yaml
+++ b/exposed-panels/mybb-forum-detect.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}/portal.php'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/nagios-xi-panel.yaml
+++ b/exposed-panels/nagios-xi-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/nagiosxi/login.php"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/nagvis-panel.yaml
+++ b/exposed-panels/nagvis-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/nagvis/frontend/nagvis-js/index.php"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/neos-panel.yaml
+++ b/exposed-panels/neos-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}/neos/login'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/netflix-conductor-ui.yaml
+++ b/exposed-panels/netflix-conductor-ui.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ocomon-panel.yaml
+++ b/exposed-panels/ocomon-panel.yaml
@@ -17,7 +17,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/ocs-inventory-login.yaml
+++ b/exposed-panels/ocs-inventory-login.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/ocsreports"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/okta-panel.yaml
+++ b/exposed-panels/okta-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/open-stack-dashboard-login.yaml
+++ b/exposed-panels/open-stack-dashboard-login.yaml
@@ -14,7 +14,7 @@ requests:
       - '{{BaseURL}}/dashboard/auth/login/'
       - '{{BaseURL}}/horizon/auth/login/?next=/horizon/'
 
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
       - type: word

--- a/exposed-panels/openam-panel.yaml
+++ b/exposed-panels/openam-panel.yaml
@@ -32,7 +32,7 @@ requests:
       - "{{BaseURL}}/am/json/serverinfo/*"
       - "{{BaseURL}}/openam/json/serverinfo/*"
 
-    redirects: true
+    host-redirects: true
     stop-at-first-match: true
     max-redirects: 2
     matchers-condition: and

--- a/exposed-panels/openbmcs-detect.yaml
+++ b/exposed-panels/openbmcs-detect.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/opengear-login.yaml
+++ b/exposed-panels/opengear-login.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers:

--- a/exposed-panels/openwrt-login.yaml
+++ b/exposed-panels/openwrt-login.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}/cgi-bin/luci/"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/oracle-people-sign-in.yaml
+++ b/exposed-panels/oracle-people-sign-in.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/osticket-panel.yaml
+++ b/exposed-panels/osticket-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/login.php"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/panabit-panel.yaml
+++ b/exposed-panels/panabit-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}/login/login.htm"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/pichome-panel.yaml
+++ b/exposed-panels/pichome-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/user.php?mod=login"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/puppetboard-panel.yaml
+++ b/exposed-panels/puppetboard-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/qmail-admin-login.yaml
+++ b/exposed-panels/qmail-admin-login.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}/cgi-bin/qmailadmin"
       - "{{BaseURL}}/cgi-ssl/qmailadmin/qmailadmin"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/raspberrymatic-panel.yaml
+++ b/exposed-panels/raspberrymatic-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/login.htm"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/residential-gateway-login.yaml
+++ b/exposed-panels/residential-gateway-login.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/cgi-bin/wwwctrl.cgi?action=home"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/roxy-fileman.yaml
+++ b/exposed-panels/roxy-fileman.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}/fileman/asp_net/main.ashx"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/rundeck-login.yaml
+++ b/exposed-panels/rundeck-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}/user/login'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/exposed-panels/sap-hana-xsengine-panel.yaml
+++ b/exposed-panels/sap-hana-xsengine-panel.yaml
@@ -10,7 +10,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/sap/hana/xs/formLogin/login.html"
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/exposed-panels/scs-landfill-control.yaml
+++ b/exposed-panels/scs-landfill-control.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
       - type: status

--- a/exposed-panels/seafile-panel.yaml
+++ b/exposed-panels/seafile-panel.yaml
@@ -15,7 +15,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/media/favicons/favicon.png"
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: dsl

--- a/exposed-panels/seeddms-panel.yaml
+++ b/exposed-panels/seeddms-panel.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{BaseURL}}/out/out.Login.php?referuri=%2Fout%2Fout.ViewFolder.php"
       - "{{BaseURL}}/dms/out/out.Login.php?referuri=%2Fout%2Fout.ViewFolder.php"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/splunk-enterprise-panel.yaml
+++ b/exposed-panels/splunk-enterprise-panel.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - '{{BaseURL}}/en-US/account/login'
 
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
       - type: word

--- a/exposed-panels/squirrelmail-login.yaml
+++ b/exposed-panels/squirrelmail-login.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}/webmail/src/login.php"
       - "{{BaseURL}}/squirrelmail/src/login.php"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/sqwebmail-login-panel.yaml
+++ b/exposed-panels/sqwebmail-login-panel.yaml
@@ -15,7 +15,7 @@ requests:
       - "{{BaseURL}}/cgi-bin/sqwebmail"
       - "{{BaseURL}}/cgi-bin/webmail"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/stridercd-panel.yaml
+++ b/exposed-panels/stridercd-panel.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/subrion-login.yaml
+++ b/exposed-panels/subrion-login.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/panel"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/synology-rackstation-login.yaml
+++ b/exposed-panels/synology-rackstation-login.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/exposed-panels/synopsys-coverity-panel.yaml
+++ b/exposed-panels/synopsys-coverity-panel.yaml
@@ -18,7 +18,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/exposed-panels/teampass-panel.yaml
+++ b/exposed-panels/teampass-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/teampass"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/telerik-server-login.yaml
+++ b/exposed-panels/telerik-server-login.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/Account/Login"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/tembosocial-panel.yaml
+++ b/exposed-panels/tembosocial-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/admin.php"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/terraform-enterprise-panel.yaml
+++ b/exposed-panels/terraform-enterprise-panel.yaml
@@ -18,7 +18,7 @@ requests:
     path:
       - '{{BaseURL}}/session'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/thruk-login.yaml
+++ b/exposed-panels/thruk-login.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/thruk/cgi-bin/login.cgi?thruk/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/tiny-file-manager.yaml
+++ b/exposed-panels/tiny-file-manager.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/tufin-securetrack-login.yaml
+++ b/exposed-panels/tufin-securetrack-login.yaml
@@ -17,7 +17,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers-condition: and

--- a/exposed-panels/unifi-panel.yaml
+++ b/exposed-panels/unifi-panel.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/versa-sdwan.yaml
+++ b/exposed-panels/versa-sdwan.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}/versa/login.html"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/exposed-panels/vmware-horizon-panel.yaml
+++ b/exposed-panels/vmware-horizon-panel.yaml
@@ -15,7 +15,7 @@ requests:
       - '{{BaseURL}}/portal/webclient/index.html'
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/exposed-panels/wallix-accessmanager-panel.yaml
+++ b/exposed-panels/wallix-accessmanager-panel.yaml
@@ -17,7 +17,7 @@ requests:
       - '{{BaseURL}}/wabam/favicon.ico'
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: or
     matchers:

--- a/exposed-panels/webmin-panel.yaml
+++ b/exposed-panels/webmin-panel.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/webmin/"
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/exposed-panels/weiphp-panel.yaml
+++ b/exposed-panels/weiphp-panel.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/index.php"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/zimbra-web-login.yaml
+++ b/exposed-panels/zimbra-web-login.yaml
@@ -18,7 +18,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/zoneminder-login.yaml
+++ b/exposed-panels/zoneminder-login.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposed-panels/zuul-panel.yaml
+++ b/exposed-panels/zuul-panel.yaml
@@ -16,7 +16,7 @@ requests:
       - '{{BaseURL}}/api/tenants'
       - '{{BaseURL}}/api/status'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: or

--- a/exposures/configs/circleci-config.yaml
+++ b/exposures/configs/circleci-config.yaml
@@ -10,7 +10,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     path:
       - "{{BaseURL}}/.circleci/config.yml"

--- a/exposures/configs/circleci-ssh-config.yaml
+++ b/exposures/configs/circleci-ssh-config.yaml
@@ -8,7 +8,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     path:
       - "{{BaseURL}}/.circleci/ssh-config"

--- a/exposures/configs/docker-compose-config.yaml
+++ b/exposures/configs/docker-compose-config.yaml
@@ -8,7 +8,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     path:
       - "{{BaseURL}}/docker-compose.yml"

--- a/exposures/configs/gruntfile-exposure.yaml
+++ b/exposures/configs/gruntfile-exposure.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{BaseURL}}/Gruntfile.js"
       - "{{BaseURL}}/Gruntfile.coffee"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposures/configs/yii-debugger.yaml
+++ b/exposures/configs/yii-debugger.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/web/debug/default/view"
       - "{{BaseURL}}/sapi/debug/default/view"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposures/files/drupal-install.yaml
+++ b/exposures/files/drupal-install.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/install.php?profile=default"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers:
       - type: word

--- a/exposures/files/ws-ftp-ini.yaml
+++ b/exposures/files/ws-ftp-ini.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}/ws_ftp.ini'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/exposures/logs/laravel-telescope.yaml
+++ b/exposures/logs/laravel-telescope.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}/telescope/requests"
 
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/exposures/tokens/generic/credentials-disclosure.yaml
+++ b/exposures/tokens/generic/credentials-disclosure.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     extractors:

--- a/fuzzing/header-command-injection.yaml
+++ b/fuzzing/header-command-injection.yaml
@@ -19,7 +19,7 @@ requests:
       payload: helpers/payloads/command-injection.txt
     attack: clusterbomb
 
-    redirects: true
+    host-redirects: true
     stop-at-first-match: true
     matchers-condition: or
     matchers:

--- a/iot/liveview-axis-camera.yaml
+++ b/iot/liveview-axis-camera.yaml
@@ -14,7 +14,7 @@ requests:
       - '{{BaseURL}}/view/viewer_index.shtml'
       - '{{BaseURL}}/pics/logo_70x29px.gif'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: or

--- a/iot/network-camera-detect.yaml
+++ b/iot/network-camera-detect.yaml
@@ -10,7 +10,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/CgiStart?page=Single"
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/iot/octoprint-3dprinter-detect.yaml
+++ b/iot/octoprint-3dprinter-detect.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/miscellaneous/old-copyright.yaml
+++ b/miscellaneous/old-copyright.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: and
     matchers:

--- a/miscellaneous/robots-txt.yaml
+++ b/miscellaneous/robots-txt.yaml
@@ -12,7 +12,7 @@ requests:
       - "{{BaseURL}}/robots.txt"
 
     matchers-condition: and
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/miscellaneous/security-txt.yaml
+++ b/miscellaneous/security-txt.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{RootURL}}/security.txt"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/miscellaneous/xml-schema-detect.yaml
+++ b/miscellaneous/xml-schema-detect.yaml
@@ -12,7 +12,7 @@ requests:
       - "{{BaseURL}}/schema"
 
     matchers-condition: and
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         words:

--- a/misconfiguration/ampps-dirlisting.yaml
+++ b/misconfiguration/ampps-dirlisting.yaml
@@ -13,7 +13,7 @@ requests:
       - "{{BaseURL}}/files/"
       - "{{BaseURL}}/icons/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/misconfiguration/docker-registry.yaml
+++ b/misconfiguration/docker-registry.yaml
@@ -10,7 +10,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}/v2/_catalog"
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/misconfiguration/gitlab/gitlab-uninitialized-password.yaml
+++ b/misconfiguration/gitlab/gitlab-uninitialized-password.yaml
@@ -21,7 +21,7 @@ requests:
     path:
       - "{{BaseURL}}/users/sign_in"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/misconfiguration/http-missing-security-headers.yaml
+++ b/misconfiguration/http-missing-security-headers.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: or
     matchers:

--- a/misconfiguration/jupyter-notebooks-exposed.yaml
+++ b/misconfiguration/jupyter-notebooks-exposed.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/misconfiguration/kafka-cruise-control.yaml
+++ b/misconfiguration/kafka-cruise-control.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/misconfiguration/misconfigured-concrete5.yaml
+++ b/misconfiguration/misconfigured-concrete5.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/misconfiguration/nextcloud-install.yaml
+++ b/misconfiguration/nextcloud-install.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/misconfiguration/roxyfileman-fileupload.yaml
+++ b/misconfiguration/roxyfileman-fileupload.yaml
@@ -63,7 +63,7 @@ requests:
         Host: {{Hostname}}
 
     cookie-reuse: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/misconfiguration/selenium-exposure.yaml
+++ b/misconfiguration/selenium-exposure.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - "{{BaseURL}}/wd/hub"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/misconfiguration/teamcity/teamcity-registration-enabled.yaml
+++ b/misconfiguration/teamcity/teamcity-registration-enabled.yaml
@@ -23,7 +23,7 @@ requests:
         GET /registerUser.html?init=1 HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/acontent-detect.yaml
+++ b/technologies/acontent-detect.yaml
@@ -10,7 +10,7 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-    redirects: true
+    host-redirects: true
     matchers-condition: and
     matchers:
 

--- a/technologies/activecollab-detect.yaml
+++ b/technologies/activecollab-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/adobe/adobe-coldfusion-detect.yaml
+++ b/technologies/adobe/adobe-coldfusion-detect.yaml
@@ -20,7 +20,7 @@ requests:
       - "{{BaseURL}}/CFIDE/administrator/images/componentutilslogin.jpg"
       - "{{BaseURL}}/cfide/administrator/images/componentutilslogin.jpg"
 
-    redirects: true
+    host-redirects: true
     stop-at-first-match: true
     max-redirects: 2
     matchers:

--- a/technologies/aem-detection.yaml
+++ b/technologies/aem-detection.yaml
@@ -19,7 +19,7 @@ requests:
     path:
       - "{{BaseURL}}/libs/granite/core/content/login/favicon.ico"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers:

--- a/technologies/apache/apache-cocoon-detect.yaml
+++ b/technologies/apache/apache-cocoon-detect.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/apache/apache-tapestry-detect.yaml
+++ b/technologies/apache/apache-tapestry-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/avideo-detect.yaml
+++ b/technologies/avideo-detect.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/b2b-builder-detect.yaml
+++ b/technologies/b2b-builder-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/bigip-detection.yaml
+++ b/technologies/bigip-detection.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     matchers:
       - type: word
         part: header

--- a/technologies/carestream-vue-detect.yaml
+++ b/technologies/carestream-vue-detect.yaml
@@ -15,7 +15,7 @@ requests:
       - "{{BaseURL}}/portal/favicon.ico"
       - "{{BaseURL}}/portal/images/MyVue/MyVueHelp.png"
 
-    redirects: true
+    host-redirects: true
     stop-at-first-match: true
     max-redirects: 2
     matchers-condition: or

--- a/technologies/confluence-detect.yaml
+++ b/technologies/confluence-detect.yaml
@@ -17,7 +17,7 @@ requests:
       - "{{BaseURL}}/confluence"
       - "{{BaseURL}}/wiki"
 
-    redirects: true
+    host-redirects: true
     stop-at-first-match: true
     matchers-condition: or
     matchers:

--- a/technologies/craft-cms-detect.yaml
+++ b/technologies/craft-cms-detect.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/dedecms-detect.yaml
+++ b/technologies/dedecms-detect.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/favicon-detection.yaml
+++ b/technologies/favicon-detection.yaml
@@ -17,7 +17,7 @@ requests:
     path:
       - "{{BaseURL}}/favicon.ico"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers:

--- a/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/technologies/fingerprinthub-web-fingerprints.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers-condition: or

--- a/technologies/google/firebase-urls.yaml
+++ b/technologies/google/firebase-urls.yaml
@@ -12,7 +12,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
 
     matchers-condition: and

--- a/technologies/hanwang-detect.yaml
+++ b/technologies/hanwang-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/intercom.yaml
+++ b/technologies/intercom.yaml
@@ -12,7 +12,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers:
       - type: word

--- a/technologies/jenkins-detect.yaml
+++ b/technologies/jenkins-detect.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}"
       - "{{BaseURL}}/whoAmI/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/technologies/jsf-detection.yaml
+++ b/technologies/jsf-detection.yaml
@@ -12,7 +12,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 3
     matchers-condition: or
     matchers:

--- a/technologies/kodexplorer-detect.yaml
+++ b/technologies/kodexplorer-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/technologies/metatag-cms.yaml
+++ b/technologies/metatag-cms.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/neos-detect.yaml
+++ b/technologies/neos-detect.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/nextcloud-detect.yaml
+++ b/technologies/nextcloud-detect.yaml
@@ -17,7 +17,7 @@ requests:
       - '{{BaseURL}}/nextcloud/index.php/login'
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/octobercms-detect.yaml
+++ b/technologies/octobercms-detect.yaml
@@ -16,7 +16,7 @@ requests:
       - "{{BaseURL}}/modules/system/assets/js/framework.combined-min.js"
 
     stop-at-first-match: true
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers:
       - type: word

--- a/technologies/php-fusion-detect.yaml
+++ b/technologies/php-fusion-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/prestashop-detect.yaml
+++ b/technologies/prestashop-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/technologies/roundcube-webmail-portal.yaml
+++ b/technologies/roundcube-webmail-portal.yaml
@@ -14,7 +14,7 @@ requests:
       - "{{BaseURL}}"
       - "{{BaseURL}}/webmail/"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/technologies/sap/sap-igs-detect.yaml
+++ b/technologies/sap/sap-igs-detect.yaml
@@ -12,7 +12,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/sap/sap-netweaver-detect.yaml
+++ b/technologies/sap/sap-netweaver-detect.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: regex

--- a/technologies/sap/sap-netweaver-webgui.yaml
+++ b/technologies/sap/sap-netweaver-webgui.yaml
@@ -12,7 +12,7 @@ requests:
     path:
       - "{{BaseURL}}/sap/bc/gui/sap/its/webgui"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/sap/sap-web-dispatcher-admin-portal.yaml
+++ b/technologies/sap/sap-web-dispatcher-admin-portal.yaml
@@ -11,7 +11,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     path:

--- a/technologies/sap/sap-web-dispatcher.yaml
+++ b/technologies/sap/sap-web-dispatcher.yaml
@@ -9,7 +9,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     path:

--- a/technologies/shiro-detect.yaml
+++ b/technologies/shiro-detect.yaml
@@ -13,7 +13,7 @@ requests:
     headers:
       Cookie: JSESSIONID={{randstr}};rememberMe=123;
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers:
       - type: word

--- a/technologies/spring-detect.yaml
+++ b/technologies/spring-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}/error"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/tech-detect.yaml
+++ b/technologies/tech-detect.yaml
@@ -11,7 +11,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/technologies/typo3-detect.yaml
+++ b/technologies/typo3-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
 
     matchers-condition: or

--- a/technologies/wordpress-detect.yaml
+++ b/technologies/wordpress-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: or
     matchers:

--- a/technologies/yeswiki-detect.yaml
+++ b/technologies/yeswiki-detect.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - '{{BaseURL}}'
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/technologies/ymhome-detect.yaml
+++ b/technologies/ymhome-detect.yaml
@@ -13,7 +13,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/token-spray/api-improvmx.yaml
+++ b/token-spray/api-improvmx.yaml
@@ -18,7 +18,7 @@ requests:
         Authorization: Basic {{base64(':' + token)}}
         Host: api.improvmx.com
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers:
       - type: word

--- a/vulnerabilities/dedecms/dedecms-carbuyaction-fileinclude.yaml
+++ b/vulnerabilities/dedecms/dedecms-carbuyaction-fileinclude.yaml
@@ -18,7 +18,7 @@ requests:
       - '{{BaseURL}}/plus/carbuyaction.php?dopost=return&code=../../'
     headers:
       Cookie: code=cod
-    redirects: true
+    host-redirects: true
 
     matchers-condition: and
     matchers:

--- a/vulnerabilities/generic/top-xss-params.yaml
+++ b/vulnerabilities/generic/top-xss-params.yaml
@@ -20,7 +20,7 @@ requests:
       - "{{BaseURL}}/?api=%27%3E%22%3Csvg%2Fonload=confirm%28%27api%27%29%3E&api_key=%27%3E%22%3Csvg%2Fonload=confirm%28%27api_key%27%29%3E&begindate=%27%3E%22%3Csvg%2Fonload=confirm%28%27begindate%27%29%3E&callback=%27%3E%22%3Csvg%2Fonload=confirm%28%27callback%27%29%3E&categoryid=%27%3E%22%3Csvg%2Fonload=confirm%28%27categoryid%27%29%3E&csrf_token=%27%3E%22%3Csvg%2Fonload=confirm%28%27csrf_token%27%29%3E&email=%27%3E%22%3Csvg%2Fonload=confirm%28%27email%27%29%3E&emailto=%27%3E%22%3Csvg%2Fonload=confirm%28%27emailto%27%29%3E&enddate=%27%3E%22%3Csvg%2Fonload=confirm%28%27enddate%27%29%3E&immagine=%27%3E%22%3Csvg%2Fonload=confirm%28%27immagine%27%29%3E&item=%27%3E%22%3Csvg%2Fonload=confirm%28%27item%27%29%3E&jsonp=%27%3E%22%3Csvg%2Fonload=confirm%28%27jsonp%27%29%3E&l=%27%3E%22%3Csvg%2Fonload=confirm%28%27l%27%29%3E&lang=%27%3E%22%3Csvg%2Fonload=confirm%28%27lang%27%29%3E&list_type=%27%3E%22%3Csvg%2Fonload=confirm%28%27list_type%27%29%3E"
       - "{{BaseURL}}/?month=%27%3E%22%3Csvg%2Fonload=confirm%28%27month%27%29%3E&page_id=%27%3E%22%3Csvg%2Fonload=confirm%28%27page_id%27%29%3E&password=%27%3E%22%3Csvg%2Fonload=confirm%28%27password%27%29%3E&terms=%27%3E%22%3Csvg%2Fonload=confirm%28%27terms%27%29%3E&token=%27%3E%22%3Csvg%2Fonload=confirm%28%27token%27%29%3E&type=%27%3E%22%3Csvg%2Fonload=confirm%28%27type%27%29%3E&unsubscribe_token=%27%3E%22%3Csvg%2Fonload=confirm%28%27unsubscribe_token%27%29%3E&year=%27%3E%22%3Csvg%2Fonload=confirm%28%27year%27%29%3E"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/vulnerabilities/jira/jira-unauthenticated-installed-gadgets.yaml
+++ b/vulnerabilities/jira/jira-unauthenticated-installed-gadgets.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{BaseURL}}/rest/config/1.0/directory"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/joomla/rusty-joomla.yaml
+++ b/vulnerabilities/joomla/rusty-joomla.yaml
@@ -28,7 +28,7 @@ requests:
 
         username=%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0%5C0&password=AAA%22%3Bs%3A11%3A%22maonnalezzo%22%3BO%3A21%3A%22JDatabaseDriverMysqli%22%3A3%3A%7Bs%3A4%3A%22%5C0%5C0%5C0a%22%3BO%3A17%3A%22JSimplepieFactory%22%3A0%3A%7B%7Ds%3A21%3A%22%5C0%5C0%5C0disconnectHandlers%22%3Ba%3A1%3A%7Bi%3A0%3Ba%3A2%3A%7Bi%3A0%3BO%3A9%3A%22SimplePie%22%3A5%3A%7Bs%3A8%3A%22sanitize%22%3BO%3A20%3A%22JDatabaseDriverMysql%22%3A0%3A%7B%7Ds%3A5%3A%22cache%22%3Bb%3A1%3Bs%3A19%3A%22cache_name_function%22%3Bs%3A7%3A%22print_r%22%3Bs%3A10%3A%22javascript%22%3Bi%3A9999%3Bs%3A8%3A%22feed_url%22%3Bs%3A40%3A%22http%3A%2F%2Frusty.jooml%2F%3Bpkwxhxqxmdkkmscotwvh%22%3B%7Di%3A1%3Bs%3A4%3A%22init%22%3B%7D%7Ds%3A13%3A%22%5C0%5C0%5C0connection%22%3Bi%3A1%3B%7Ds%3A6%3A%22return%22%3Bs%3A102%3A&option=com_users&task=user.login&{{csrf}}=1
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     extractors:

--- a/vulnerabilities/other/carrental-xss.yaml
+++ b/vulnerabilities/other/carrental-xss.yaml
@@ -49,7 +49,7 @@ requests:
         GET /admin/index.php?page=categories HTTP/1.1
         Host: {{Hostname}}
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     cookie-reuse: true
     matchers-condition: and

--- a/vulnerabilities/other/cvms-sqli.yaml
+++ b/vulnerabilities/other/cvms-sqli.yaml
@@ -21,7 +21,7 @@ requests:
 
         username=admin%27+or+%271%27%3D%271%27%23&password=nuclei&login=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/dss-download-fileread.yaml
+++ b/vulnerabilities/other/dss-download-fileread.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}/portal/attachment_downloadByUrlAtt.action?filePath=file:///etc/passwd"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/ems-sqli.yaml
+++ b/vulnerabilities/other/ems-sqli.yaml
@@ -22,7 +22,7 @@ requests:
 
         mailuid=admin' or 1=1#&pwd=nuclei&login-submit=Login
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/onlinefarm-management-xss.yaml
+++ b/vulnerabilities/other/onlinefarm-management-xss.yaml
@@ -25,7 +25,7 @@ requests:
 
         comment=%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E&rating=0
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/pyspider-unauthorized-access.yaml
+++ b/vulnerabilities/other/pyspider-unauthorized-access.yaml
@@ -17,7 +17,7 @@ requests:
 
         webdav_mode=false&script=from+pyspider.libs.base_handler+import+*%0Aclass+Handler(BaseHandler)%3A%0A++++def+on_start(self)%3A%0A++++++++print(str(452345672+%2B+567890765))&task=%7B%0A++%22process%22%3A+%7B%0A++++%22callback%22%3A+%22on_start%22%0A++%7D%2C%0A++%22project%22%3A+%22pyspidervulntest%22%2C%0A++%22taskid%22%3A+%22data%3A%2Con_start%22%2C%0A++%22url%22%3A+%22data%3A%2Con_start%22%0A%7D
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/seacms-sqli.yaml
+++ b/vulnerabilities/other/seacms-sqli.yaml
@@ -16,7 +16,7 @@ requests:
     path:
       - "{{BaseURL}}/comment/api/index.php?gid=1&page=2&rlist[]=@`%27`,%20extractvalue(1,%20concat_ws(0x20,%200x5c,(select%20md5({{num}})))),@`%27`"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/servicenow-helpdesk-credential.yaml
+++ b/vulnerabilities/other/servicenow-helpdesk-credential.yaml
@@ -14,7 +14,7 @@ requests:
     path:
       - "{{RootURL}}/HelpTheHelpDesk.jsdbx"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/zms-auth-bypass.yaml
+++ b/vulnerabilities/other/zms-auth-bypass.yaml
@@ -22,7 +22,7 @@ requests:
 
         username=dw1%27+or+1%3D1+%23&password=dw1%27+or+1%3D1+%23&login=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 1
     matchers-condition: and
     matchers:

--- a/vulnerabilities/other/zms-sqli.yaml
+++ b/vulnerabilities/other/zms-sqli.yaml
@@ -21,7 +21,7 @@ requests:
 
         username=admin%27+or+%271%27%3D%271&password=any&login=
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/weaver/ecology/ecology-syncuserinfo-sqli.yaml
+++ b/vulnerabilities/weaver/ecology/ecology-syncuserinfo-sqli.yaml
@@ -15,7 +15,7 @@ requests:
     path:
       - "{{BaseURL}}/mobile/plugin/SyncUserInfo.jsp?userIdentifiers=-1)union(select(3),null,null,null,null,null,str(98989*44313),null"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:

--- a/vulnerabilities/wordpress/wordpress-rdf-user-enum.yaml
+++ b/vulnerabilities/wordpress/wordpress-rdf-user-enum.yaml
@@ -10,7 +10,7 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/feed/rdf'
-    redirects: true
+    host-redirects: true
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION

### Template / PR Information

Using `host-redirects` instead of `redirects` to avoid scanning 3rd party / out-of-scope hosts

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)