### PR TITLE
fix: false negative sophos-fw-version-detect

### DIFF
--- a/exposed-panels/sophos-fw-version-detect.yaml
+++ b/exposed-panels/sophos-fw-version-detect.yaml
@@ -2,7 +2,7 @@ id: sophos-fw-version-detect
 
 info:
   name: Sophos Firewall version detection
-  author: organiccrap
+  author: organiccrap,daffainfo
   severity: info
   tags: panel,sophos
 
@@ -11,17 +11,23 @@ requests:
     path:
       - "{{BaseURL}}/webconsole/webpages/login.jsp"
       - "{{BaseURL}}/userportal/webpages/myaccount/login.jsp"
+
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
+
       - type: word
-        words:
-          - "<title>Sophos</title>"
-      - type: regex
         part: body
-        regex:
-          - "(\\d{2}.\\d{1,2}.\\d{1,2}.\\d{2,3})"
+        words:
+          - '<title>Sophos</title>'
+          - 'uiLangToHTMLLangAttributeValueMapping'
+        condition: or
+
     extractors:
       - type: regex
         part: body
         regex:
-          - "(\\d{2}.\\d{1,2}.\\d{1,2}.\\d{2,3})"
+          - "(?m)<link href=\"\/themes\/lite1\/css\/typography\.css\?version=([0-9.]+)\""

--- a/exposed-panels/sophos-fw-version-detect.yaml
+++ b/exposed-panels/sophos-fw-version-detect.yaml
@@ -18,9 +18,6 @@ requests:
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
 
       - type: word
         part: body
@@ -28,6 +25,10 @@ requests:
           - '<title>Sophos</title>'
           - 'uiLangToHTMLLangAttributeValueMapping'
         condition: or
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex

--- a/exposed-panels/sophos-fw-version-detect.yaml
+++ b/exposed-panels/sophos-fw-version-detect.yaml
@@ -30,4 +30,4 @@ requests:
       - type: regex
         part: body
         regex:
-          - "(?m)<link href=\"\/themes\/lite1\/css\/typography\.css\?version=([0-9.]+)\""
+          - "(?m)<link href=\"\/themes\/lite1\/css\/typography\.css\?version=([0-9.]+)\"

--- a/exposed-panels/sophos-fw-version-detect.yaml
+++ b/exposed-panels/sophos-fw-version-detect.yaml
@@ -1,9 +1,12 @@
 id: sophos-fw-version-detect
 
 info:
-  name: Sophos Firewall version detection
+  name: Sophos Firewall Version Detection
   author: organiccrap,daffainfo
   severity: info
+  metadata:
+    verified: true
+    shodan-query: title:"Sophos"
   tags: panel,sophos
 
 requests:
@@ -29,5 +32,6 @@ requests:
     extractors:
       - type: regex
         part: body
+        group: 1
         regex:
-          - "(?m)<link href=\"\/themes\/lite1\/css\/typography\.css\?version=([0-9.]+)\"
+          - 'href="\/themes\/lite1\/css\/typography\.css\?version=(([0-9a-z]+)([0-9.]+))'


### PR DESCRIPTION
- Added stop-at-first-match
- Fix matcher by replace regex matcher with words matcher and added status matcher
- Fix extractor regex
