### PR TITLE
update flywheel takeover template to reflect new language

### DIFF
--- a/takeovers/flywheel-takeover.yaml
+++ b/takeovers/flywheel-takeover.yaml
@@ -6,14 +6,26 @@ info:
   severity: high
   reference:
     - https://smaranchand.com.np/2021/06/flywheel-subdomain-takeover
-  tags: takeover
+  metadata:
+    verified: true
+    shodan-query: http.html:"Flywheel"
+  tags: takeover,flywheel
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
+    matchers-condition: or
     matchers:
       - type: word
+        part: body
+        words:
+          - "We're sorry, you've landed on a page that is hosted by Flywheel"
+          - "<h1>Oops! That's not the site<br>you're looking&nbsp;for.</h1>"
+        condition: and
+
+      - type: word
+        part: body
         words:
           - "We are sorry, you've landed on a page that is hosted by Flywheel"
-        condition: and

--- a/takeovers/flywheel-takeover.yaml
+++ b/takeovers/flywheel-takeover.yaml
@@ -15,6 +15,5 @@ requests:
     matchers:
       - type: word
         words:
-          - "We're sorry, you've landed on a page that is hosted by Flywheel"
-          - "<h1>Oops! That's not the site<br>you're looking&nbsp;for.</h1>"
+          - "We are sorry, you've landed on a page that is hosted by Flywheel"
         condition: and


### PR DESCRIPTION
### Template / PR Information

The flywheel takeover template no longer matches the language used by Flywheel. Specifically, the replaced the "we're" with "We are", which was causing the template to produce false negatives.

- Fixed flywheel-takeover

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)