### PR TITLE
Update CVE-2022-0679.yaml

### DIFF
--- a/cves/2022/CVE-2022-0679.yaml
+++ b/cves/2022/CVE-2022-0679.yaml
@@ -29,6 +29,7 @@ requests:
 
         action=narnoo_distributor_lib_request&lib_path=/etc/passwd
 
+    matchers-condition: and
     matchers:
       - type: regex
         part: body


### PR DESCRIPTION
Matcher condition should be `and` else it is generating false positives.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated CVE-2022-0679
- References:

### Template Validation

I've validated this template locally?
- YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)