### PR TITLE
fix: Remove content-type header check for matrix

### DIFF
--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -36,18 +36,7 @@ requests:
     extractors:
       - type: json
         part: body
-        name: server-to-server
         json:
           - '."m.server" | select( . != null )'
-
-      - type: json
-        part: body
-        name: client-homeserver
-        json:
           - '."m.homeserver" | .base_url | select( . != null )'
-
-      - type: json
-        part: body
-        name: identity-server
-        json:
           - '."m.identity_server" | .base_url | select( . != null )'

--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -17,10 +17,15 @@ requests:
     matchers-condition: and
     matchers:
 
+      - type: regex
+        regex:
+          - '"m\.([a-z]+)":'
+
       - type: word
-        part: body
+        part: header
         words:
-          - "m."
+          - text/html
+        negative: true
 
       - type: status
         status:

--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -10,6 +10,8 @@ info:
 
 requests:
   - method: GET
+    redirects: true
+    max-redirects: 2
     path:
       - "{{BaseURL}}/.well-known/matrix/server"
       - "{{BaseURL}}/.well-known/matrix/client"

--- a/technologies/matrix-detect.yaml
+++ b/technologies/matrix-detect.yaml
@@ -22,11 +22,6 @@ requests:
         words:
           - "m."
 
-      - type: word
-        part: header
-        words:
-          - "text/plain"
-
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information
When #4733 was merged an extra matcher was added in 39b896fd701b94dbe10c4ba8c395f99024b8b33b to make it more specific. This extra matcher isn't correct as per the matrix spec and thus the template returns false-negatives. This PR removes the content-type matcher.

### Template Validation
I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
As per the [spec](https://spec.matrix.org/v1.3/server-server-api/#getwell-knownmatrixserver), the content-type SHOULD be (RFC SHOULD) set to `application/json`. Because this is a SHOULD and not a MUST, a lot of implementations either return a different content-type header or none at all.