### PR TITLE
Add Joomla! detect template with version detection capabilities

### DIFF
--- a/technologies/joomla-detect.yaml
+++ b/technologies/joomla-detect.yaml
@@ -1,41 +1,48 @@
 id: joomla-detect
-
 info:
   name: Joomla! Detect
-  description: Joomla, also spelled Joomla! (with an exclamation mark) and sometimes abbreviated as J!, is a free and open-source content management system (CMS) for publishing web content on websites.
   author: ricardomaia
   severity: info
-
-  metadata:
-    verified: true
-    google-dork-administration: '"Joomla! Administration Login" inurl:"/index.php"'
-    google-dork-installer: 'intitle:"Joomla – Web Installer"'
-
+  description: |
+    Joomla, also spelled Joomla! (with an exclamation mark) and sometimes abbreviated as J!, is a free and open-source content management system (CMS) for publishing web content on websites.
   reference:
+    - https://www.joomla.org/
+    - https://github.com/joomla/joomla-cms
     - https://www.itoctopus.com/how-to-quickly-know-the-version-of-any-joomla-website
     - https://hackertarget.com/attacking-enumerating-joomla/
-  tags: tech,joomla,cms
+  metadata:
+    verified: true
+    google-dork: Joomla! Administration Login inurl:"/index.php" || intitle:"Joomla Web Installer"
+  tags: tech,joomla,cms,oss
 
 requests:
-  - method: GET # Sorted by confidence level
+  - method:
     path:
+      - "{{BaseURL}}" # >= 1.5.0 and <= 1.5.26
       - "{{BaseURL}}/language/en-GB/en-GB.xml" # >= 1.5.0 and <= 1.5.26
       - "{{BaseURL}}/administrator/manifests/files/joomla.xml" # >= 1.6.0
       - "{{BaseURL}}/README.txt"
       - "{{BaseURL}}/modules/custom.xml" # < 1.5.0
-      - "{{BaseURL}}" # >= 1.5.0 and <= 1.5.26
-    redirects: true
+
+    host-redirects: true
+    max-redirects: 2
     stop-at-first-match: true
     matchers-condition: or
     matchers:
       - type: regex
         regex:
           - '(?i)<meta.name="generator".content="(Joomla!).*/>'
-          - "(?i)<version>(.*)</version>"
           - '(?i)Joomla_([\d.|\d]+)_version_history'
-      - type: status
-        status:
-          - 200
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "<version>"
+          - "<creationDate>"
+          - "</metafile>"
+        condition: and
+
     extractors:
       - type: regex
         name: version

--- a/technologies/joomla-detect.yaml
+++ b/technologies/joomla-detect.yaml
@@ -1,0 +1,46 @@
+id: joomla-detect
+
+info:
+  name: Joomla! Detect
+  description: Joomla, also spelled Joomla! (with an exclamation mark) and sometimes abbreviated as J!, is a free and open-source content management system (CMS) for publishing web content on websites.
+  author: ricardomaia
+  severity: info
+
+  metadata:
+    verified: true
+    google-dork-administration: '"Joomla! Administration Login" inurl:"/index.php"'
+    google-dork-installer: 'intitle:"Joomla – Web Installer"'
+
+  reference:
+    - https://www.itoctopus.com/how-to-quickly-know-the-version-of-any-joomla-website
+    - https://hackertarget.com/attacking-enumerating-joomla/
+  tags: tech,joomla,cms
+
+requests:
+  - method: GET # Sorted by confidence level
+    path:
+      - "{{BaseURL}}/language/en-GB/en-GB.xml" # >= 1.5.0 and <= 1.5.26
+      - "{{BaseURL}}/administrator/manifests/files/joomla.xml" # >= 1.6.0
+      - "{{BaseURL}}/README.txt"
+      - "{{BaseURL}}/modules/custom.xml" # < 1.5.0
+      - "{{BaseURL}}" # >= 1.5.0 and <= 1.5.26
+    redirects: true
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        regex:
+          - '(?i)<meta.name="generator".content="(Joomla!).*/>'
+          - "(?i)<version>(.*)</version>"
+          - '(?i)Joomla_([\d.|\d]+)_version_history'
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - "(?i)<version>(.*)</version>"
+          - '(?i)Joomla_([\d.|\d]+)_version_history'


### PR DESCRIPTION
### Template / PR Information

Existing Joomla templates don't detect / extract the product version. This template uses different approaches to perform version detection, sorted from high to lower confidence level.

- References:
  - https://www.itoctopus.com/how-to-quickly-know-the-version-of-any-joomla-website
  - https://hackertarget.com/attacking-enumerating-joomla/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)