### PR TITLE
Add Open Journal Systems (OJS) detect

### DIFF
--- a/technologies/open-journal-systems-detect.yaml
+++ b/technologies/open-journal-systems-detect.yaml
@@ -5,29 +5,29 @@ info:
   author: ricardomaia
   severity: info
   description: Open Journal Systems, also known as OJS, is a free software for the management of peer-reviewed academic journals, created by the Public Knowledge Project.
-
-  metadata:
-    verified: true
-    google-dork-administration: '"Joomla! Administration Login" inurl:"/index.php"'
-    google-dork-installer: 'intitle:"Joomla – Web Installer"'
-
   reference:
     - https://pkp.sfu.ca/ojs/
+  metadata:
+    verified: true
+    shodan-query: Open Journal Systems
   tags: tech,ojs
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     redirects: true
     matchers-condition: and
     matchers:
       - type: regex
         regex:
           - '(?i).*<meta.name="generator".content="Open.Journal.Systems.*>'
+
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         name: version

--- a/technologies/open-journal-systems-detect.yaml
+++ b/technologies/open-journal-systems-detect.yaml
@@ -9,7 +9,7 @@ info:
     - https://pkp.sfu.ca/ojs/
   metadata:
     verified: true
-    shodan-query: Open Journal Systems
+    shodan-query: html:"Open Journal Systems"
   tags: tech,ojs
 
 requests:

--- a/technologies/open-journal-systems-detect.yaml
+++ b/technologies/open-journal-systems-detect.yaml
@@ -1,0 +1,37 @@
+id: open-journal-systems-detect
+
+info:
+  name: Open Journal Systems Detect
+  author: ricardomaia
+  severity: info
+  description: Open Journal Systems, also known as OJS, is a free software for the management of peer-reviewed academic journals, created by the Public Knowledge Project.
+
+  metadata:
+    verified: true
+    google-dork-administration: '"Joomla! Administration Login" inurl:"/index.php"'
+    google-dork-installer: 'intitle:"Joomla – Web Installer"'
+
+  reference:
+    - https://pkp.sfu.ca/ojs/
+  tags: tech,ojs
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - '(?i).*<meta.name="generator".content="Open.Journal.Systems.*>'
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i).*<meta.name="generator".content="Open.Journal.Systems.([\d.|\d]+)'

--- a/technologies/open-journal-systems.yaml
+++ b/technologies/open-journal-systems.yaml
@@ -1,4 +1,4 @@
-id: open-journal-systems-detect
+id: open-journal-systems
 
 info:
   name: Open Journal Systems Detect
@@ -17,7 +17,8 @@ requests:
     path:
       - "{{BaseURL}}"
 
-    redirects: true
+    host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

Open Journal Systems, also known as OJS, is a free software for the management of peer-reviewed academic journals, created by the Public Knowledge Project.

This PR adds a template to perform OJS detection and version extraction.

- References:
  - https://pkp.sfu.ca/ojs/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Shodan query:  `http.component:"Open Journal Systems"`

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)