### PR TITLE
feat: added version detection puppetboard

### DIFF
--- a/exposed-panels/puppetboard-panel.yaml
+++ b/exposed-panels/puppetboard-panel.yaml
@@ -1,10 +1,12 @@
 id: puppetboard-panel
 
 info:
-  name: Puppetlabs Puppetboard
-  author: c-sh0
+  name: Puppetboard Puppetboard
+  author: c-sh0,daffainfo
   severity: info
+  reference: https://github.com/voxpupuli/puppetboard
   metadata:
+    verified: true
     shodan-query: http.title:"Puppetboard"
   tags: panel,puppet,exposure
 
@@ -15,8 +17,22 @@ requests:
 
     host-redirects: true
     max-redirects: 2
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "<title>Puppetboard</title>"
+          - '<a href="https://github.com/voxpupuli/puppetboard" target="_blank">'
+          - 'puppetboard.css" rel="stylesheet"'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<a href="https://github.com/voxpupuli/puppetboard" target="_blank">([0-9.]+)</a></div>'

--- a/exposed-panels/puppetboard-panel.yaml
+++ b/exposed-panels/puppetboard-panel.yaml
@@ -24,7 +24,7 @@ requests:
         words:
           - '<a href="https://github.com/voxpupuli/puppetboard" target="_blank">'
           - 'puppetboard.css" rel="stylesheet"'
-        condition: or
+        condition: and
 
       - type: status
         status:

--- a/exposed-panels/puppetboard-panel.yaml
+++ b/exposed-panels/puppetboard-panel.yaml
@@ -1,7 +1,7 @@
 id: puppetboard-panel
 
 info:
-  name: Puppetboard Puppetboard
+  name: Puppetlabs Puppetboard
   author: c-sh0,daffainfo
   severity: info
   reference: https://github.com/voxpupuli/puppetboard


### PR DESCRIPTION
I decided to remove `<title>PuppetBoard</title>` matcher because it can lead to false negative, for example https://194.255.39.141 (I found this host when doing google dorking) and added version detection