### PR TITLE
fix: remove useless path aviatrix-panel

### DIFF
--- a/exposed-panels/aviatrix-login.yaml
+++ b/exposed-panels/aviatrix-login.yaml
@@ -1,4 +1,4 @@
-id: aviatrix-panel
+id: aviatrix-login
 
 info:
   name: Aviatrix Cloud Controller Panel Login
@@ -17,22 +17,17 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-      - "{{BaseURL}}/assets/img/favicon-32x32.png"
 
-    stop-at-first-match: true
-    matchers-condition: or
+    matchers-condition: and
     matchers:
-      - type: dsl
-        name: "title"
+      - type: word
+        part: body
+        words:
+          - '<title>Aviatrix'
+          - 'Controller</title>'
         condition: and
-        dsl:
-          - 'contains(body, "<title>Aviatrix")'
-          - 'contains(body, "Controller</title>")'
-          - 'status_code == 200'
 
-      - type: dsl
-        name: "favicon"
-        dsl:
-          - "status_code==200 && (\"7c1c26856345cd7edbf250ead0dc9332\" == md5(body))"
-
+      - type: status
+        status:
+          - 200
 # Enhanced by mp on 2022/03/23

--- a/exposed-panels/aviatrix-panel.yaml
+++ b/exposed-panels/aviatrix-panel.yaml
@@ -1,7 +1,7 @@
-id: aviatrix-login
+id: aviatrix-panel
 
 info:
-  name: Aviatrix Cloud Controller Panel Login
+  name: Aviatrix Cloud Controller Panel
   author: pikpikcu,philippedelteil,daffainfo
   severity: info
   description: An Aviatrix Cloud Controller login panel was detected.


### PR DESCRIPTION
`aviatrix-panel` template is about `exposed-panels` not `technologies`, so i remove `/assets/img/favicon-32x32.png` path and the dsl matcher because it detects the favicon hash not the login panel.