### PR TITLE
Added New Exposed Panel FortiOS Management Interface Login Template

### DIFF
--- a/exposed-panels/fortinet/fortios-management-panel.yaml
+++ b/exposed-panels/fortinet/fortios-management-panel.yaml
@@ -1,0 +1,30 @@
+id: fortinet-fortios-management-panel
+
+info:
+  name: Fortinet FortiOS Management Interface Panel
+  author: mbmy
+  severity: info
+  tags: panel,fortinet,fortios,fortigate,fortiproxy,fortiap
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login?redir=/ng"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<html class="main-app">'
+          - '<f-icon class="fa-warning'
+          - "</f-icon>"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "APSCOOKIE_"
+
+      - type: status
+        status:
+          - 200

--- a/exposed-panels/fortinet/fortios-management-panel.yaml
+++ b/exposed-panels/fortinet/fortios-management-panel.yaml
@@ -4,12 +4,15 @@ info:
   name: Fortinet FortiOS Management Interface Panel
   author: mbmy
   severity: info
+  metadata:
+    verified: true
+    shodan-query: http.favicon.hash:945408572
   tags: panel,fortinet,fortios,fortigate,fortiproxy,fortiap
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/login?redir=/ng"
+      - "{{BaseURL}}"
 
     matchers-condition: and
     matchers:

--- a/exposed-panels/fortinet/fortios-management-panel.yaml
+++ b/exposed-panels/fortinet/fortios-management-panel.yaml
@@ -14,6 +14,8 @@ requests:
     path:
       - "{{BaseURL}}/login?redir=/ng"
 
+    host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word

--- a/exposed-panels/fortinet/fortios-management-panel.yaml
+++ b/exposed-panels/fortinet/fortios-management-panel.yaml
@@ -12,7 +12,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}"
+      - "{{BaseURL}}/login?redir=/ng"
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information

This template is specifically to identify the management interface of FortiOS devices. The current FortiOS panel template is actually identifying the SSL VPN login portal. There is another PR currently (https://github.com/projectdiscovery/nuclei-templates/pull/5679) that is targeting the API interface for FortiOS from the recent CVE-2022-40684 authentication bypass, however that does not identify the actual login panel for the devices. In my initial testing, this works for Fortigate Firewalls, FortiProxy and FortiAP devices. It it also seemingly works in situations when there is a login disclaimer selected to be shown in front of the management interface.



### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)