### PR TITLE
CISCO WebVPN detect

### DIFF
--- a/exposed-panels/cisco/cisco-webvpn-detect.yaml
+++ b/exposed-panels/cisco/cisco-webvpn-detect.yaml
@@ -1,0 +1,40 @@
+id: cisco-webvpn-detect
+info:
+  name: CISCO WebVPN detect
+  author: ricardomaia
+  severity: info
+  reference:
+    - https://askanydifference.com/difference-between-cisco-clientless-ssl-vpn-and-anyconnect-with-table/
+  tags: panel,cisco,vpn
+  metadata:
+    fofa-query: fid="U1TP/SJklrT9VLIEpZkQNg=="
+    google-query: intitle:"SSLVPN Service"
+
+requests:
+  - method: GET
+    redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+    matchers-condition: and
+    path:
+      - "{{BaseURL}}/webvpn.html"
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        case-insensitive: true
+        condition: or
+        part: header
+        words:
+          - "webvpncontext"
+          - "CISCO"
+          - "AnyConnect"
+          - "SSL_Context"
+          - "WEBVPN"
+      - type: word
+        case-insensitive: true
+        condition: or
+        part: body
+        words:
+          - "CISCO"
+          - "AnyConnect"
+          - "SSLVPN Service"

--- a/exposed-panels/cisco/cisco-webvpn-detect.yaml
+++ b/exposed-panels/cisco/cisco-webvpn-detect.yaml
@@ -18,7 +18,7 @@ requests:
       - "{{BaseURL}}"
       - "{{BaseURL}}/webvpn.html"
 
-    redirects: true
+    host-redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and

--- a/exposed-panels/cisco/cisco-webvpn-detect.yaml
+++ b/exposed-panels/cisco/cisco-webvpn-detect.yaml
@@ -1,36 +1,40 @@
 id: cisco-webvpn-detect
+
 info:
-  name: CISCO WebVPN detect
+  name: Cisco WebVPN Detect
   author: ricardomaia
   severity: info
   reference:
     - https://askanydifference.com/difference-between-cisco-clientless-ssl-vpn-and-anyconnect-with-table/
-  tags: panel,cisco,vpn
   metadata:
+    verified: true
     fofa-query: fid="U1TP/SJklrT9VLIEpZkQNg=="
     google-query: intitle:"SSLVPN Service"
+  tags: panel,cisco,vpn
 
 requests:
   - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/webvpn.html"
+
     redirects: true
     max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and
-    path:
-      - "{{BaseURL}}/webvpn.html"
-      - "{{BaseURL}}"
     matchers:
       - type: word
-        case-insensitive: true
-        condition: or
         part: body
         words:
           - "CISCO"
           - "AnyConnect"
           - "SSLVPN Service"
+        condition: or
+        case-insensitive: true
+
       - type: regex
         part: header
-        condition: or
         regex:
           - "webvpncontext=00@.+"
           - "webvpn="
+        condition: or

--- a/exposed-panels/cisco/cisco-webvpn-detect.yaml
+++ b/exposed-panels/cisco/cisco-webvpn-detect.yaml
@@ -23,18 +23,14 @@ requests:
       - type: word
         case-insensitive: true
         condition: or
-        part: header
-        words:
-          - "webvpncontext"
-          - "CISCO"
-          - "AnyConnect"
-          - "SSL_Context"
-          - "WEBVPN"
-      - type: word
-        case-insensitive: true
-        condition: or
         part: body
         words:
           - "CISCO"
           - "AnyConnect"
           - "SSLVPN Service"
+      - type: regex
+        part: header
+        condition: or
+        regex:
+          - "webvpncontext=00@.+"
+          - "webvpn="


### PR DESCRIPTION
### Template / PR Information

"The CISCO Clientless SSL VPN creates a remote access VPN tunnel without requiring the installation of any hardware or software VPN client to provide access to a corporate network."

"The main difference between CISCO Clientless SSL VPN and AnyConnect is that CISCO Clientless SSL VPN provides only limited access to a corporate network’s internal resources, but that limited access is also valuable. whereas AnyConnect provides the user with full network access (or connectivity) of the required corporate network."

The selected targets on my tests uses a insecure version of TLS, so to view the login page into regular browser ou curl, you need downgrade TLS settings.

![image](https://user-images.githubusercontent.com/1353811/198379261-b1ae57bd-812b-41ee-a1fa-34543911a1e9.png)

![image](https://user-images.githubusercontent.com/1353811/198380265-70e012d3-719a-49fa-8f1a-bf5209817d65.png)

- References:
  - https://askanydifference.com/difference-between-cisco-clientless-ssl-vpn-and-anyconnect-with-table/
  - https://support.mozilla.org/en-US/questions/1101896
  - https://stackoverflow.com/questions/70042160/get-request-ssl-choose-client-versionunsupported-protocol

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

Fofa query: fid="U1TP/SJklrT9VLIEpZkQNg=="

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)