### PR TITLE
Fixed werkzeug-debug.yaml

### DIFF
--- a/misconfiguration/debug/flask-werkzeug-debug.yaml
+++ b/misconfiguration/debug/flask-werkzeug-debug.yaml
@@ -1,9 +1,12 @@
-id: werkzeug-debug
+id: flask-werkzeug-debug
 
 info:
-  name: Werkzeug Debugger Exposure
+  name: Flask Werkzeug Debugger Exposure
   author: DhiyaneshDk
   severity: low
+  metadata:
+    verified: true
+    shodan-query: title:"TypeError"
   tags: werkzeug,exposure,debug
 
 requests:

--- a/misconfiguration/debug/flask-werkzeug-debug.yaml
+++ b/misconfiguration/debug/flask-werkzeug-debug.yaml
@@ -6,7 +6,7 @@ info:
   severity: low
   metadata:
     verified: true
-    shodan-query: title:"TypeError"
+    shodan-query: html:"Werkzeug powered traceback interpreter"
   tags: werkzeug,exposure,debug
 
 requests:

--- a/misconfiguration/debug/werkzeug-debug.yaml
+++ b/misconfiguration/debug/werkzeug-debug.yaml
@@ -1,12 +1,9 @@
-id: flask-werkzeug-debug
+id: werkzeug-debug
 
 info:
-  name: Flask Werkzeug Debugger Exposure
+  name: Werkzeug Debugger Exposure
   author: DhiyaneshDk
   severity: low
-  metadata:
-    verified: true
-    shodan-query: title:"TypeError"
   tags: werkzeug,exposure,debug
 
 requests:
@@ -19,9 +16,7 @@ requests:
       - type: word
         part: body
         words:
-          - 'TypeError:'
           - 'Werkzeug powered traceback interpreter'
-        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Werkzeug debugger available not only in Flask, you can use it standalone. Original template checks for `TypeError` in title (shodan-query) and in the body. However this is one of many exception classes from Python. It also can be `AttributeError`, `KeyError`, etc, etc. For example, if we use Flask and will try to render non-existent template, we will receive `jinja2.exceptions.TemplateNotFound` and there is no `TypeError` on this debug page. So I think it's only needed `Werkzeug powered traceback interpreter` in body and 500 status code.



- Fixed werkzeug-debug.yaml
- References
  *  https://docs.python.org/3/library/exceptions.html
  * https://werkzeug.palletsprojects.com/en/2.2.x/debug/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details

Flask application example that doesn't generate `TypeError`, but contains `Werkzeug powered traceback interpreter`

```python
from flask import Flask, render_template

app = Flask(__name__)

@app.route('/')
def hello():
    return render_template('not-exists')

if __name__ == '__main__':
    app.run(debug=True)
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)