### PR TITLE
Tomcat Manager: detection and bf templates fixes for newver versions

### DIFF
--- a/default-logins/apache/tomcat-default-login.yaml
+++ b/default-logins/apache/tomcat-default-login.yaml
@@ -2,7 +2,7 @@ id: tomcat-default-login
 
 info:
   name: Apache Tomcat Manager Default Login
-  author: pdteam,sinKettu
+  author: pdteam
   severity: high
   description: Apache Tomcat Manager default login credentials were discovered. This template checks for multiple variations.
   reference:
@@ -68,6 +68,7 @@ requests:
         words:
           - "Apache Tomcat"
           - "Server Information"
+          - "Hostname"
         condition: and
 
       - type: status

--- a/default-logins/apache/tomcat-default-login.yaml
+++ b/default-logins/apache/tomcat-default-login.yaml
@@ -2,7 +2,7 @@ id: tomcat-default-login
 
 info:
   name: Apache Tomcat Manager Default Login
-  author: pdteam
+  author: pdteam,sinKettu
   severity: high
   description: Apache Tomcat Manager default login credentials were discovered. This template checks for multiple variations.
   reference:
@@ -68,7 +68,6 @@ requests:
         words:
           - "Apache Tomcat"
           - "Server Information"
-          - "Hostname"
         condition: and
 
       - type: status

--- a/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/exposed-panels/apache/public-tomcat-manager.yaml
@@ -2,7 +2,7 @@ id: public-tomcat-manager
 
 info:
   name: Apache Tomcat Manager Disclosure
-  author: Ahmed Sherif,geeknik
+  author: Ahmed Sherif,geeknik,sinKettu
   severity: info
   description: An Apache Tomcat Manager panel was discovered.
   classification:
@@ -17,7 +17,9 @@ requests:
       - '{{BaseURL}}/manager/html'
       - '{{BaseURL}}/host-manager/html'
 
-    matchers-condition: and
+    # Not all the versions print 'Apache Tomcat' on 401th page --> condition is 'or'
+    # Tested on Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips PHP/5.6.40
+    matchers-condition: or
     matchers:
       - type: word
         words:

--- a/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/exposed-panels/apache/public-tomcat-manager.yaml
@@ -17,9 +17,7 @@ requests:
       - '{{BaseURL}}/manager/html'
       - '{{BaseURL}}/host-manager/html'
 
-    # Not all the versions print 'Apache Tomcat' on 401th page --> condition is 'or'
-    # Tested on Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips PHP/5.6.40
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         words:

--- a/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/exposed-panels/apache/public-tomcat-manager.yaml
@@ -2,7 +2,7 @@ id: public-tomcat-manager
 
 info:
   name: Apache Tomcat Manager Disclosure
-  author: Ahmed Sherif,geeknik,sinKettu
+  author: Ahmed Sherif,geeknik
   severity: info
   description: An Apache Tomcat Manager panel was discovered.
   classification:

--- a/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/exposed-panels/apache/public-tomcat-manager.yaml
@@ -2,7 +2,7 @@ id: public-tomcat-manager
 
 info:
   name: Apache Tomcat Manager Disclosure
-  author: Ahmed Sherif,geeknik
+  author: Ahmed Sherif,geeknik,sinKettu
   severity: info
   description: An Apache Tomcat Manager panel was discovered.
   classification:
@@ -22,11 +22,11 @@ requests:
       - type: word
         words:
           - "Apache Tomcat"
+          - "Tomcat Manager"
+        condition: or
 
       - type: status
         status:
           - 401
           - 200
         condition: or
-
-# Enhanced by mp on 2022/03/16


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed 'public-tomcat-manager', 'tomcat-default-login'

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Previous versions of templates I mentioned above is not fully fitting newer versions of Apache server. I've tested these templates on servers of company I'm working in and these templates were not able to detect Tomcat and BF credentials. Last version of OpenVAS detected it successfully in the same time. I've tested why and offer you fixes.

Tested on `Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips PHP/5.6.40`

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)