### PR TITLE
Update wordpress-detect.yaml

### DIFF
--- a/technologies/wordpress-detect.yaml
+++ b/technologies/wordpress-detect.yaml
@@ -2,7 +2,7 @@ id: wordpress-detect
 
 info:
   name: WordPress Detect
-  author: pdteam,daffainfo
+  author: pdteam,daffainfo,ricardomaia
   severity: info
   metadata:
     verified: true
@@ -11,40 +11,45 @@ info:
 
 requests:
   - method: GET
-    path:
-      - '{{BaseURL}}'
-      - '{{BaseURL}}/feed/'
-      - '{{BaseURL}}/?feed=rss2' #alternative if /feed/ is blocked
-
     stop-at-first-match: true
-    matchers-condition: or
+    path:
+      - "{{BaseURL}}/feed/"
+      - "{{BaseURL}}/wp-admin/install.php"
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/?feed=rss2" # alternative if /feed/ is blocked
+
+    matchers-condition: and
     matchers:
       - type: regex
         regex:
+          - '<generator>https?:\/\/wordpress\.org.*</generator>'
+          - "wp-login.php"
+          - '\/wp-content/themes\/'
+          - '\/wp-includes\/'
+          - 'name="generator" content="wordpress'
           - '<link[^>]+s\d+\.wp\.com'
           - '<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\d.]+) -'
-          - '<!--[^>]+WP-Super-Cache'
+          - "<!--[^>]+WP-Super-Cache"
         condition: or
-
-      - type: word
-        part: body
-        words:
-          - '<generator>'
-          - '<link>'
-          - '<title>'
-        condition: and
-
-      - type: word
-        words:
-          - 'wp-login.php'
-          - '/wp-content/themes/'
-          - '/wp-includes/'
-          - 'name="generator" content="wordpress'
-          - '<!-- performance optimized by w3 total cache. learn more: http://www.w3-edge.com/wordpress-plugins/'
-        condition: or
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex
+        name: version_by_generator
         group: 1
         regex:
           - '(?m)https:\/\/wordpress.org\/\?v=([0-9.]+)'
+
+      - type: regex
+        name: version_by_js
+        group: 1
+        regex:
+          - 'wp-emoji-release\.min\.js\?ver=((\d+\.?)+)\b'
+
+      - type: regex
+        name: version_by_css
+        group: 1
+        regex:
+          - 'install\.min\.css\?ver=((\d+\.?)+)\b'


### PR DESCRIPTION
### Template / PR Information

The current detection template for Wordpress is unable to detect/extract the product version. This PR presents different approaches to performing version detection, ranked from highest to lowest confidence level.

The following images demonstrate the differences between the scan results against the same targets.

PR template:
<img src="https://user-images.githubusercontent.com/1353811/201819805-b0a3f450-70d7-480c-9c8f-528f83de3076.png" width="600" />

Existent template:
<img src="https://user-images.githubusercontent.com/1353811/201820088-2a96974a-91e2-4c8d-b5dc-81a81d8a8457.png" width="600" />

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)