### PR TITLE
Fix VisionHub Default Login Template

### DIFF
--- a/default-logins/visionhub/visionhub-default-login.yaml
+++ b/default-logins/visionhub/visionhub-default-login.yaml
@@ -34,6 +34,12 @@ requests:
           - "Set-Cookie: admin"
         part: header
 
+      - type: word
+        words:
+          - "Set-Cookie: adminer_key"
+        part: header
+        negative: true
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated VisionHub Default Login template. 

The original template matches for `Set Cookie: admin` to determine whether the default login is valid. However, Adminer login panels would return `Set Cookie: adminer_key` to any request. This caused the template to flag false positives. I've added a negative match for `Set Cookie: adminer_key` to fix this issue
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->

Example HTTP response from Adminer Login Panel:

```
HTTP/2 200 OK
Date: Tue, 15 Nov 2022 18:22:37 GMT
Content-Type: text/html; charset=utf-8
Host: [redacted]
X-Powered-By: PHP/7.4.15
Set-Cookie: adminer_key=[redacted]; path=/VisionHubWebApi/api/Login; HttpOnly; SameSite=lax
```

<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)