### PR TITLE
Tomcat Manager Exposed Panel: more flexible and accurate template

### DIFF
--- a/default-logins/apache/tomcat-default-login.yaml
+++ b/default-logins/apache/tomcat-default-login.yaml
@@ -2,7 +2,7 @@ id: tomcat-default-login
 
 info:
   name: Apache Tomcat Manager Default Login
-  author: pdteam
+  author: pdteam,sinKettu
   severity: high
   description: Apache Tomcat Manager default login credentials were discovered. This template checks for multiple variations.
   reference:
@@ -68,8 +68,20 @@ requests:
         words:
           - "Apache Tomcat"
           - "Server Information"
-          - "Hostname"
         condition: and
+
+      - type: word
+        part: body
+        condition: or
+        words:
+          - "Tomcat Version"
+          - "JVM Version"
+          - "JVM Vendor"
+          - "OS Name"
+          - "OS Version"
+          - "OS Architecture"
+          - "Hostname"
+          - "IP Address"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Improved `default-logins/apache/tomcat-default-login.yaml`
- References:

### Template Validation

I've validated this template locally?
- [ X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Hello!
I suggest some improving for Tomcat Manager exposed panel template (with brute force for default creds).
In current version this template relies on `Hostname` word-matcher, but I faced with situations when there is no such word in Tomcat response.
`Hostname` word appears in "Server Information" block, i.e.

``` text
354-<tr>
355- <td colspan="8" class="title">Server Information</td>
356-</tr>
357-<tr>
358- <td class="header-center"><small>Tomcat Version</small></td>
359- <td class="header-center"><small>JVM Version</small></td>
360- <td class="header-center"><small>JVM Vendor</small></td>
361- <td class="header-center"><small>OS Name</small></td>
362- <td class="header-center"><small>OS Version</small></td>
363- <td class="header-center"><small>OS Architecture</small></td>
364: <td class="header-center"><small>Hostname</small></td>
365- <td class="header-center"><small>IP Address</small></td>
366-</tr>
```
so my idea is to replace matcher for only `Hostname` to all useful words from this statement (or-conditional).

I've tested it on Tomcat 9.0 from docker image.

``` shell
$ sudo docker run -d --rm --name tmc -p 1080:8080 sinfox/test-tomcat:latest /bin/bash -c "catalina.sh run"
911db043cee3782eeb4c6d167d3b3af0ad60bbf658b4dd6c139db3a9122ca120
$ nuclei -silent -t new-tomcat-default-login.yaml -u http://127.0.0.1:1080
[2022-11-17 11:58:53] [tomcat-default-login] [http] [high] http://127.0.0.1:1080/manager/html [username=tomcat,password=s3cret]
$
```
Docker image from listing is available on Docker Hub.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)