### PR TITLE
Create extra-secrets.yaml extract more secrets

### DIFF
--- a/file/keys/extra-secrets.yaml
+++ b/file/keys/extra-secrets.yaml
@@ -1,0 +1,15 @@
+id: extra-secrets
+info:
+  name: Extra-secrets
+  author: mohamed ayadi
+  severity: high
+  tags: token,file
+
+file:
+  - extensions:
+      - all
+    extractors:
+      - type: regex
+        name: secrets
+        regex:
+          - "(?i)(([a-z0-9]+)[-|_])?(key|password|passwd|pass|pwd|private|credential|auth|cred|creds|secret|access|token)([-|_][a-z]+)?(\\s)*(:|=)+"


### PR DESCRIPTION
Hi,
if you run nuclei against a simple text file like this: https://gist.github.com/ayadim/c4e1f21a3ef4c79ba5773858d147eb38 
it will not extract all the secrets so I work on this template to have more chances to detect more sensitive data.

POC 
 https://regex101.com/r/QhNFBA/1


I've validated this template locally?
- [ X] YES
- [ ] NO

Regards