### PR TITLE
Add ldap-anonymous-login template

### DIFF
--- a/network/default-login/ldap-anonymous-login.yaml
+++ b/network/default-login/ldap-anonymous-login.yaml
@@ -8,11 +8,11 @@ info:
   reference:
     - https://www.tenable.com/plugins/nessus/10723
     - https://ldap.com/ldapv3-wire-protocol-reference-bind
+  remediation: Configure the service to disallow NULL BINDs.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cwe-id: CWE-284
-  remediation: Configure the service to disallow NULL BINDs.
   tags: network,ldap,default-login
 
 network:

--- a/network/ldap-anonymous-login.yaml
+++ b/network/ldap-anonymous-login.yaml
@@ -1,0 +1,31 @@
+id: ldap-anonymous-login
+
+info:
+  name: LDAP Server NULL Bind Connection Information Disclosure
+  author: s0obi
+  severity: medium
+  description: The remote LDAP server allows anonymous access
+  reference:
+    - https://www.tenable.com/plugins/nessus/10723
+    - https://ldap.com/ldapv3-wire-protocol-reference-bind
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-284
+  remediation: Configure the service to disallow NULL BINDs.
+  tags: network,ldap,default-login
+
+network:
+  - inputs:
+      - data: 300c020101600702010304008000
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+      - "{{Host}}:389"
+    read-size: 1024
+
+    matchers:
+      - type: binary
+        binary:
+          - "300c02010161070a010004000400"


### PR DESCRIPTION
### Template / PR Information

This template will detect LDAP servers accepting anonymous connections.
Although the queries that are allowed are likely to be fairly restricted, this may result in disclosure of information that an attacker could find useful.

Please find in reference the details about the binary messages.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

In order to test the template, run OpenLDAP with Anonymous access enabled : 
```yaml
version: '2'

networks:
  my-network:
    driver: bridge
services:
  openldap:
    image: bitnami/openldap:2
    ports:
      - '1389:1389'
      - '1636:1636'
    environment:
      - LDAP_ADMIN_USERNAME=admin
      - LDAP_ADMIN_PASSWORD=adminpassword
      - LDAP_USERS=user01,user02
      - LDAP_PASSWORDS=password1,password2
      - LDAP_CONFIG_ADMIN_ENABLED=true
    networks:
      - my-network
    volumes:
      - 'openldap_data:/bitnami/openldap'
volumes:
  openldap_data:
    driver: local
```

Run the template : 

```bash
$ nuclei -u localhost:1389 -t network/ldap-anonymous-login.yaml
[...]
[INF] Templates loaded for scan: 1
[2022-11-19 22:55:38] [ldap-anonymous-login] [network] [medium] localhost:1389
```

### Additional References:

- https://www.tenable.com/plugins/nessus/10723
- https://ldap.com/ldapv3-wire-protocol-reference-bind