### PR TITLE
Updated elmah-log-file.yaml

### DIFF
--- a/exposures/logs/elmah-log-file.yaml
+++ b/exposures/logs/elmah-log-file.yaml
@@ -1,7 +1,7 @@
 id: elmah-log-file
 
 info:
-  name: elmah.axd Disclosure
+  name: ELMAH Exposure
   author: shine,idealphase
   severity: medium
   description: |
@@ -9,20 +9,21 @@ info:
   reference:
     - https://code.google.com/archive/p/elmah/
     - https://www.troyhunt.com/aspnet-session-hijacking-with-google/
-  tags: logs,exposure
+  metadata:
+    verified: true
+  tags: logs,elmah,exposure
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/elmah.axd"
       - "{{BaseURL}}/elmah"
+      - "{{BaseURL}}/elmah.axd"
 
     stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
     matchers-condition: and
     matchers:
-
       - type: word
         words:
           - 'Error Log for'

--- a/exposures/logs/elmah-log-file.yaml
+++ b/exposures/logs/elmah-log-file.yaml
@@ -2,7 +2,7 @@ id: elmah-log-file
 
 info:
   name: elmah.axd Disclosure
-  author: shine, idealphase
+  author: shine,idealphase
   severity: medium
   description: |
     ELMAH (Error Logging Modules and Handlers) is an application-wide error logging facility that is completely pluggable. It can be dynamically added to a running ASP.NET web application, or even all ASP.NET web applications on a machine, without any need for re-compilation or re-deployment.

--- a/exposures/logs/elmah-log-file.yaml
+++ b/exposures/logs/elmah-log-file.yaml
@@ -2,15 +2,24 @@ id: elmah-log-file
 
 info:
   name: elmah.axd Disclosure
-  author: shine
+  author: shine, idealphase
   severity: medium
+  description: |
+    ELMAH (Error Logging Modules and Handlers) is an application-wide error logging facility that is completely pluggable. It can be dynamically added to a running ASP.NET web application, or even all ASP.NET web applications on a machine, without any need for re-compilation or re-deployment.
+  reference:
+    - https://code.google.com/archive/p/elmah/
+    - https://www.troyhunt.com/aspnet-session-hijacking-with-google/
   tags: logs,exposure
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}/elmah.axd"
+      - "{{BaseURL}}/elmah"
 
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
 


### PR DESCRIPTION
Updated redirect, description and reference

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- https://code.google.com/archive/p/elmah/
- https://www.troyhunt.com/aspnet-session-hijacking-with-google/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
Before updating, I found URI /elmah but, orignal template doesn't redirect 302 Status. So, it didn't see the /elmah URI and shown below.
![elmah1](https://user-images.githubusercontent.com/12832679/202987246-b8ac8e99-f587-40c2-9f91-3cc25de080a7.png)

After my updating, nuclei able to detect elmah URI as shown in the following figure.
![elmah2](https://user-images.githubusercontent.com/12832679/202987372-4ba24c08-1b9f-4979-965f-1a50f794cf3f.png)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)