### PR TITLE
Update Github Actions ( removes deprecated 'set-output' ) 

### DIFF
--- a/.github/workflows/cve-annotate.yml
+++ b/.github/workflows/cve-annotate.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Get Github tag
         id: meta
         run: |
-          echo "::set-output name=tag::$(curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name)"
+          curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name | xargs -I {} echo TAG={} >> $GITHUB_OUTPUT
 
       - name: Setup CVE annotate
-        if: steps.meta.outputs.tag != ''
+        if: steps.meta.outputs.TAG != ''
         env:
-          VERSION: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.TAG }}
         run: |
           wget -q https://github.com/projectdiscovery/nuclei/releases/download/${VERSION}/cve-annotate.zip
           sudo unzip cve-annotate.zip -d /usr/local/bin
@@ -30,10 +30,10 @@ jobs:
         id: cve-annotate
         run: |
           cve-annotate -i . -d .
-          echo "::set-output name=changes::$(git status -s | wc -l)"
+          git status -s | wc -l | xargs -I {} echo CHANGES={} >> $GITHUB_OUTPUT
 
       - name: Commit files
-        if: steps.cve-annotate.outputs.changes > 0
+        if: steps.cve-annotate.outputs.CHANGES > 0
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -42,7 +42,7 @@ jobs:
           git commit -m "Auto Generated CVE annotations [$(date)] :robot:" -a
 
       - name: Push changes
-        if: steps.cve-annotate.outputs.changes > 0
+        if: steps.cve-annotate.outputs.CHANGES > 0
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/readme-update.yml
+++ b/.github/workflows/readme-update.yml
@@ -30,17 +30,17 @@ jobs:
         id: readme-update
         run: |
           python .github/scripts/update-readme.py
-          echo "::set-output name=changes::$(git status -s | wc -l)"
+          git status -s | wc -l | xargs -I {} echo CHANGES={} >> $GITHUB_OUTPUT
 
       - name: Commit files
-        if: steps.readme-update.outputs.changes > 0
+        if: steps.readme-update.outputs.CHANGES > 0
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -m "Auto README Update [$(date)] :robot:" -a
 
       - name: Push changes
-        if: steps.readme-update.outputs.changes > 0
+        if: steps.readme-update.outputs.CHANGES > 0
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Get Github tag
         id: meta
         run: |
-          echo "::set-output name=tag::$(curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name)"
+          curl --silent "https://api.github.com/repos/projectdiscovery/nuclei/releases/latest" | jq -r .tag_name | xargs -I {} echo TAG={} >> $GITHUB_OUTPUT
 
       - name: Setup Nuclei
-        if: steps.meta.outputs.tag != ''
+        if: steps.meta.outputs.TAG != ''
         env:
-          VERSION: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.TAG }}
         run: |
           wget -q https://github.com/projectdiscovery/nuclei/releases/download/${VERSION}/nuclei_${VERSION:1}_linux_amd64.zip
           sudo unzip nuclei*.zip -d /usr/local/bin

--- a/.github/workflows/templates-stats.yml
+++ b/.github/workflows/templates-stats.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v2
         with: 
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Installing Template Stats
         run: |
@@ -37,10 +37,10 @@ jobs:
 
       - name: Get statistical changes
         id: stats
-        run: echo "::set-output name=changes::$(git status -s | wc -l)"
+        run: git status -s | wc -l | xargs -I {} echo CHANGES={} >> $GITHUB_OUTPUT
 
       - name: Commit files
-        if: steps.stats.outputs.changes > 0
+        if: steps.stats.outputs.CHANGES > 0
         run: |
           git add TEMPLATES-STATS.*
           git add TOP-10.md


### PR DESCRIPTION
# Description

- Updates Github Actions 
- Removes deprecated "set-output" in favour of "$GITHUB_OUTPUT" 
- Updated Github Actions:
   - Readme Update 
   - CVE annotate
   - Template Stats
   - Template Validate

closes #6108 