### PR TITLE
Add missing term to detect Cisco Expressway-E

### DIFF
--- a/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/technologies/fingerprinthub-web-fingerprints.yaml
@@ -2,7 +2,7 @@ id: fingerprinthub-web-fingerprints
 
 info:
   name: FingerprintHub Technology Fingerprint
-  author: pdteam
+  author: pdteam,righettod
   severity: info
   description: FingerprintHub Technology Fingerprint tests run in nuclei.
   reference:
@@ -1986,6 +1986,7 @@ requests:
         name: cisco-expressway
         words:
           - expressway-e</legend>
+          - "Cisco Expressway-E"
 
       - type: word
         name: cisco-imc-supervisor


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add a missing terms to detect Cisco Expressway-E software:

![image](https://user-images.githubusercontent.com/1573775/203474731-0b5a7df1-166b-42d7-a3fb-16218add1c51.png)

- References: None

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof:

![image](https://user-images.githubusercontent.com/1573775/203474598-8c44ebde-4457-40fc-bcf6-7f8bc3294282.png)



#### Additional Details (leave it blank if not applicable)

None

### Additional References:

None