### PR TITLE
Add detection of Persis software.

### DIFF
--- a/exposed-panels/persis-panel.yaml
+++ b/exposed-panels/persis-panel.yaml
@@ -23,7 +23,7 @@ requests:
         words:
           - "<title>Persis</title>"
           - "/persis/"
-        condition: or        
+        condition: or
 
       - type: status
         status:

--- a/exposed-panels/persis-panel.yaml
+++ b/exposed-panels/persis-panel.yaml
@@ -15,7 +15,11 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+      - "{{BaseURL}}/main"
 
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
@@ -23,6 +27,9 @@ requests:
         words:
           - "<title>Persis</title>"
           - "/persis/"
+          - "persis.require"
+          - "persis.ui.progress"
+          - "images_persis/"
         condition: or
 
       - type: status

--- a/exposed-panels/persis-panel.yaml
+++ b/exposed-panels/persis-panel.yaml
@@ -14,7 +14,7 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}"  
+      - "{{BaseURL}}"
 
     matchers-condition: and
     matchers:
@@ -23,11 +23,11 @@ requests:
         words:
           - "<title>Persis</title>"
           - "/persis/"
-        condition: or          
+        condition: or        
 
       - type: status
         status:
           - 200
           - 301
           - 302
-        condition: or          
+        condition: or

--- a/exposed-panels/persis-panel.yaml
+++ b/exposed-panels/persis-panel.yaml
@@ -1,0 +1,33 @@
+id: persis-panel
+
+info:
+  name: Persis Panel
+  author: righettod
+  severity: info
+  reference:
+    - https://www.persis.de/
+  metadata:
+    verified: true
+    shodan-query: title:"Persis"
+  tags: panel,persis
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"  
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Persis</title>"
+          - "/persis/"
+        condition: or          
+
+      - type: status
+        status:
+          - 200
+          - 301
+          - 302
+        condition: or          


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect an instance of the [Persis](https://www.persis.de) HR software, developed by a German company (no English version of the homepage found 😢).

- References: https://www.persis.de

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof for test case 1:

![Test01](https://user-images.githubusercontent.com/1573775/204085177-d1dce4e5-606c-4280-aa78-d848ef24e09b.png)

Proof for test case 2:

![Test02](https://user-images.githubusercontent.com/1573775/204085187-65419d76-659b-46c1-90b7-cdeb422c469f.png)


### Additional Details (leave it blank if not applicable)

Shodan query: 

https://www.shodan.io/search?query=http.title%3A%22Persis%22

![image](https://user-images.githubusercontent.com/1573775/204085227-f748a803-7d0f-4767-b0a0-dc3ee4ad2b6c.png)


### Additional References:

None