### PR TITLE
Add vbulletin-detect.yaml

### DIFF
--- a/technologies/vbulletin-detect.yaml
+++ b/technologies/vbulletin-detect.yaml
@@ -5,23 +5,21 @@ info:
   author: ricardomaia
   severity: info
   description: vBulletin is a proprietary forum and community publishing software written in PHP.
-
+  reference:
+    - https://www.vbulletin.com/
   metadata:
     verified: true
     build-with-query: https://trends.builtwith.com/websitelist/vBulletin
     google-query: intext:"Powered By vBulletin"
-
-  reference:
-    - https://www.vbulletin.com/
   tags: tech,vbulletin
 
 requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-    redirects: true
+
+    host-redirects: true
     max-redirects: 2
-    stop-at-first-match: true
     matchers-condition: or
     matchers:
       - type: regex
@@ -29,10 +27,12 @@ requests:
           - "(?i)meta.name=.generator.*content=.vBulletin"
           - '(?i)\*.vBulletin.([\d.|\d]+).CSS'
         condition: or
+
       - type: word
         case-insensitive: true
         words:
           - "Powered By vBulletin"
+
     extractors:
       - type: regex
         name: version

--- a/technologies/vbulletin-detect.yaml
+++ b/technologies/vbulletin-detect.yaml
@@ -1,0 +1,43 @@
+id: vbulletin-detect
+
+info:
+  name: vBulletin Detect
+  author: ricardomaia
+  severity: info
+  description: vBulletin is a proprietary forum and community publishing software written in PHP.
+
+  metadata:
+    verified: true
+    build-with-query: https://trends.builtwith.com/websitelist/vBulletin
+    google-query: intext:"Powered By vBulletin"
+
+  reference:
+    - https://www.vbulletin.com/
+  tags: tech,vbulletin
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        regex:
+          - "(?i)meta.name=.generator.*content=.vBulletin"
+          - '(?i)\*.vBulletin.([\d.|\d]+).CSS'
+        condition: or
+      - type: word
+        case-insensitive: true
+        words:
+          - "Powered By vBulletin"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)meta.name=.generator.*content=.vbulletin.([\d.|\d]+)'
+          - '(?i)\*.vBulletin.([\d.|\d]+).CSS'

--- a/technologies/vbulletin-detect.yaml
+++ b/technologies/vbulletin-detect.yaml
@@ -9,8 +9,8 @@ info:
     - https://www.vbulletin.com/
   metadata:
     verified: true
-    build-with-query: https://trends.builtwith.com/websitelist/vBulletin
-    google-query: intext:"Powered By vBulletin"
+    shodan-query: title:"Powered By vBulletin"
+    google-dork: intext:"Powered By vBulletin"
   tags: tech,vbulletin
 
 requests:
@@ -20,18 +20,15 @@ requests:
 
     host-redirects: true
     max-redirects: 2
-    matchers-condition: or
     matchers:
-      - type: regex
-        regex:
-          - "(?i)meta.name=.generator.*content=.vBulletin"
-          - '(?i)\*.vBulletin.([\d.|\d]+).CSS'
-        condition: or
-
       - type: word
-        case-insensitive: true
+        part: body
         words:
           - "Powered By vBulletin"
+          - 'content="vBulletin'
+          - 'id="vbulletin_css'
+        condition: or
+        case-insensitive: true
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

vBulletin is a proprietary forum and community publishing software written in PHP and used by 25.000+ users according to BuildWith website (https://trends.builtwith.com/websitelist/vBulletin)

This PR add a template to detection and version extration of vBulletin.

![image](https://user-images.githubusercontent.com/1353811/204738101-ab7f4d01-170f-4ab7-bf61-5b04130e601b.png)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

 build-with-query: https://trends.builtwith.com/websitelist/vBulletin
google-query: intext:"Powered By vBulletin"

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)