### PR TITLE
Meteor cloud (galaxy) subdomain takeover

### DIFF
--- a/takeovers/meteor-takeover.yaml
+++ b/takeovers/meteor-takeover.yaml
@@ -1,0 +1,21 @@
+id: rivalsec-meteor-takeover
+
+info:
+  name: Meteor subdomain takeover
+  author: rivalsec
+  severity: high
+  reference:
+    - https://rivalsec.github.io/blog/2022/12/02/meteor.html
+    - https://github.com/EdOverflow/can-i-take-over-xyz/issues/321
+  tags: takeover,meteor
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        words:
+          - "404 Not Found: No applications registered for host '"
+  

--- a/takeovers/meteor-takeover.yaml
+++ b/takeovers/meteor-takeover.yaml
@@ -18,4 +18,3 @@ requests:
       - type: word
         words:
           - "404 Not Found: No applications registered for host '"
-  


### PR DESCRIPTION
### Template / PR Information

Service name
Meteor cloud (galaxy)

Fingerprints
cname: *.galaxy-ingress.meteor.com.
response: 404 Not Found: No applications registered for host '*'.

Proof
https://rivalsec.github.io/blog/2022/12/02/meteor.html

Documentation
https://guide.meteor.com/deployment.html#galaxy
https://galaxy-guide.meteor.com/dns.html
custom subdomains can be used only with paid instances.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
