### PR TITLE
Fix False Positive for PyPI Server Detect

### DIFF
--- a/technologies/pypiserver-detect.yaml
+++ b/technologies/pypiserver-detect.yaml
@@ -14,6 +14,7 @@ requests:
     path:
       - "{{BaseURL}}"
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body


### PR DESCRIPTION
### Template / PR Information

- Fix PyPI detect template by adding an AND condition on the matcher
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)