### PR TITLE
Added Profile header for additional WAP coverage on CJServer hosts

### DIFF
--- a/vulnerabilities/generic/oob-header-based-interaction.yaml
+++ b/vulnerabilities/generic/oob-header-based-interaction.yaml
@@ -31,6 +31,7 @@ requests:
       X-Host: spoofed.{{interactsh-url}}
       X-Forwarded-Server: spoofed.{{interactsh-url}}
       X-HTTP-Host-Override: spoofed.{{interactsh-url}}
+      Profile: http://{{interactsh-url}}/profile.xml
       Cache-Control: no-transform
 
     matchers-condition: or


### PR DESCRIPTION
### Template / PR Information

Added the Profile HTTP header after finding this also susceptible on certain CJServer instances. May AID in still getting OOB when WAF is filtering X-WAP-Profile. Confirmed working. 

Tested against known vulnerable host

### Template Validation

I've validated this template locally?
- [ x] YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)