### PR TITLE
Add additional backup extension

### DIFF
--- a/exposures/backups/zip-backup-files.yaml
+++ b/exposures/backups/zip-backup-files.yaml
@@ -23,6 +23,7 @@ requests:
         - "lz"
         - "rar"
         - "tar.gz"
+        - "tar.bz2"
         - "xz"
         - "zip"
         - "z"


### PR DESCRIPTION
### Template / PR Information

Adds `tar.bz2` as another commonly used file extension for backup archives to the `zip-backup-files` template.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)