### PR TITLE
Create gpc-json.yaml

### DIFF
--- a/miscellaneous/gpc-json.yaml
+++ b/miscellaneous/gpc-json.yaml
@@ -17,13 +17,11 @@ requests:
       - "{{RootURL}}/gpc.json"
 
     stop-at-first-match: true
-    host-redirects: true
-    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - "gpc"
+          - '"gpc"'
 
       - type: status
         status:
@@ -34,18 +32,6 @@ requests:
           - "len(body) <= 1024 && len(body) > 0"
 
     extractors:
-      - type: json
-        part: body
-        name: gpc-value
-        json:
-          - ".gpc"
-
-      - type: json
-        part: body
-        name: gpc-last-update
-        json:
-          - ".lastUpdate?"
-
       - type: json
         part: body
         name: gpc-version

--- a/miscellaneous/gpc-json.yaml
+++ b/miscellaneous/gpc-json.yaml
@@ -36,13 +36,13 @@ requests:
         name: gpc-value
         json:
           - ".gpc"
-      
+
       - type: json
         part: body
         name: gpc-last-update
         json:
           - ".lastUpdate?"
-      
+
       - type: json
         part: body
         name: gpc-version

--- a/miscellaneous/gpc-json.yaml
+++ b/miscellaneous/gpc-json.yaml
@@ -1,11 +1,14 @@
 id: gpc-json
 
 info:
-  name: gpc.json file
+  name: Global Privacy Control (GPC) File Disclosure
   author: MihhailSokolov
   severity: info
-  description: The website defines a Global Privacy Control policy.
-  tags: misc,generic
+  description: |
+    The website defines a Global Privacy Control policy.
+  metadata:
+    verified: "true"
+  tags: misc,generic,gpc
 
 requests:
   - method: GET
@@ -18,13 +21,13 @@ requests:
     max-redirects: 2
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         words:
           - "gpc"
+
+      - type: status
+        status:
+          - 200
 
       - type: dsl
         dsl:

--- a/miscellaneous/gpc-json.yaml
+++ b/miscellaneous/gpc-json.yaml
@@ -1,0 +1,50 @@
+id: gpc-json
+
+info:
+  name: gpc.json file
+  author: MihhailSokolov
+  severity: info
+  description: The website defines a Global Privacy Control policy.
+  tags: misc,generic
+
+requests:
+  - method: GET
+    path:
+      - "{{RootURL}}/.well-known/gpc.json"
+      - "{{RootURL}}/gpc.json"
+
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "gpc"
+
+      - type: dsl
+        dsl:
+          - "len(body) <= 1024 && len(body) > 0"
+
+    extractors:
+      - type: json
+        part: body
+        name: gpc-value
+        json:
+          - ".gpc"
+      
+      - type: json
+        part: body
+        name: gpc-last-update
+        json:
+          - ".lastUpdate?"
+      
+      - type: json
+        part: body
+        name: gpc-version
+        json:
+          - ".version?"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

One possible setting on the website that relates to privacy is the `gpc.json` file that can exist in the `/.well-known/` directory on a website.  If present, it would indicate to visitors whether the website abides by the Global Privacy Control and will not sell or share a client's personal information with third parties if the client has the `Sec-GPC` header in an HTTP request set.

The GPC Support Resource is documented at [Global Privacy Control (GPC)](https://globalprivacycontrol.github.io/gpc-spec/#gpc-support-resource)

Example of `gpc.json`:
```json
{
  "gpc": true,
  "lastUpdate": "1997-03-10"
}
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Testing: `https://www.nytimes.com` has `gpc.json` (see [https://www.nytimes.com/.well-known/gpc.json](https://www.nytimes.com/.well-known/gpc.json)), while `https://google.com` does not (see [https://google.com/.well-known/gpc.json](https://google.com/.well-known/gpc.json)).

Running `nuclei -t gpc-json -u https://www.nytimes.com`:
<img width="1025" alt="Screenshot 2022-12-19 at 16 17 30" src="https://user-images.githubusercontent.com/8766163/208458641-373bc073-118e-4059-b603-d4baa6fd50e2.png">

Running `nuclei -t gpc-json -u https://google.com`:
<img width="1084" alt="Screenshot 2022-12-19 at 16 18 10" src="https://user-images.githubusercontent.com/8766163/208458779-902aad02-ca58-4959-ae70-a8a59288e3d0.png">

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)