### PR TITLE
Add Akamai cache detection template

### DIFF
--- a/technologies/akamai-cache-detect.yaml
+++ b/technologies/akamai-cache-detect.yaml
@@ -14,7 +14,7 @@ info:
 
 requests:
   - method: HEAD
-    path: 
+    path:
       - "{{BaseURL}}"
     headers:
       Pragma: akamai-x-cache-on

--- a/technologies/akamai-cache-detect.yaml
+++ b/technologies/akamai-cache-detect.yaml
@@ -1,0 +1,26 @@
+id: akamai-cache-detect
+
+info:
+  name: Akamai Cache Detection Template
+  author: nybble04
+  severity: info
+  description: Sends a HEAD request with a Pragma header value of "akamai-x-cache-on" and looks for an akamai-specific response header value.
+  reference:
+    - https://community.akamai.com/customers/s/article/Using-Akamai-Pragma-headers-to-investigate-or-troubleshoot-Akamai-content-delivery?language=en_US
+    - https://spyclub.tech/2022/12/14/unusual-cache-poisoning-akamai-s3/
+  metadata:
+    verified: true
+  tags: cache,akamai
+
+requests:
+  - method: HEAD
+    path: 
+      - "{{BaseURL}}"
+    headers:
+      Pragma: akamai-x-cache-on
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?:TCP_HIT|TCP_MISS).*deploy\.akamaitechnologies\.com'

--- a/technologies/akamai-cache-detect.yaml
+++ b/technologies/akamai-cache-detect.yaml
@@ -1,16 +1,17 @@
 id: akamai-cache-detect
 
 info:
-  name: Akamai Cache Detection Template
+  name: Akamai Cache Detection
   author: nybble04
   severity: info
-  description: Sends a HEAD request with a Pragma header value of "akamai-x-cache-on" and looks for an akamai-specific response header value.
+  description: |
+     Sends a HEAD request with a Pragma header value of "akamai-x-cache-on" and looks for an akamai-specific response header value.
   reference:
     - https://community.akamai.com/customers/s/article/Using-Akamai-Pragma-headers-to-investigate-or-troubleshoot-Akamai-content-delivery?language=en_US
     - https://spyclub.tech/2022/12/14/unusual-cache-poisoning-akamai-s3/
   metadata:
     verified: true
-  tags: cache,akamai
+  tags: cache,akamai,tech
 
 requests:
   - method: HEAD


### PR DESCRIPTION
### Template / PR Information

This template checks if a URL target uses Akamai caching. A request is sent with the Pragma header set to "akamai-x-cache-on" and the response headers are examined for an Akamai cache-specific value. Since the name of the response header could vary, a regex is used to match the header value. 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
N/A

### Additional References:

- [Using Pragma headers to investigate Akamai content delivery](https://community.akamai.com/customers/s/article/Using-Akamai-Pragma-headers-to-investigate-or-troubleshoot-Akamai-content-delivery?language=en_US)
- [Usage with a Python script that does the same](https://spyclub.tech/2022/12/14/unusual-cache-poisoning-akamai-s3/)