### PR TITLE
Removing redirect property - Closes #6431

### DIFF
--- a/.github/scripts/wordpress-plugins-update.py
+++ b/.github/scripts/wordpress-plugins-update.py
@@ -123,8 +123,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
-    max-redirects: 2
+
     path:
       - "{{{{BaseURL}}}}/wp-content/plugins/{name}/readme.txt"
 


### PR DESCRIPTION
### Template / PR Information

- Fixed https://github.com/projectdiscovery/nuclei-templates/issues/6431

The problem is related to the presence of "Stable Tag" word into CSS comments and the redirect property in template.

During scan process the server redirects to root URL when some nonexistent path is requested.

The false matching behavior could be avoided removing the redirect property from template, but this impact http to https redirects as well.

Usually redirects are not included in templates unless it’s mandatory, so the property was removed, cosidering previous probing to detect the correct URL scheme. e.g. using `httpx` tool.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

N/A

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)