### PR TITLE
Create kanboard-default-login.yaml

### DIFF
--- a/default-logins/kanboard-default-login.yaml
+++ b/default-logins/kanboard-default-login.yaml
@@ -1,0 +1,59 @@
+id: kanboard-default-login
+
+info:
+  name: Kanboard Default Login
+  author: shelled
+  severity: high
+  description: Kanboard default login was discovered.
+  reference:
+    - https://twitter.com/0x_rood/status/1607068644634157059
+    - https://github.com/kanboard/kanboard
+    - https://docs.kanboard.org/v1/admin/installation/
+  metadata:
+    verified: true
+  tags: default-login,kanboard
+
+requests:
+  - raw:
+      - |
+        GET /?controller=AuthController&action=login HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        POST /?controller=AuthController&action=check HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        
+        username={{user}}&password={{pass}}&csrf_token={{token}}
+        
+      - |
+        GET /?controller=DashboardController&action=show HTTP/1.1
+        Host: {{Hostname}}
+        
+    attack: pitchfork
+    payloads:
+      user:
+        - admin
+      pass:
+        - admin
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'kanboard'
+          - 'admin'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: token
+        part: body
+        regex:
+          - '([a-f0-9]{64})'
+        internal: true

--- a/default-logins/kanboard-default-login.yaml
+++ b/default-logins/kanboard-default-login.yaml
@@ -18,18 +18,18 @@ requests:
       - |
         GET /?controller=AuthController&action=login HTTP/1.1
         Host: {{Hostname}}
-        
+
       - |
         POST /?controller=AuthController&action=check HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        
+
         username={{user}}&password={{pass}}&csrf_token={{token}}
-        
+
       - |
         GET /?controller=DashboardController&action=show HTTP/1.1
         Host: {{Hostname}}
-        
+
     attack: pitchfork
     payloads:
       user:

--- a/default-logins/kanboard-default-login.yaml
+++ b/default-logins/kanboard-default-login.yaml
@@ -25,7 +25,7 @@ requests:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        username={{user}}&password={{pass}}&csrf_token={{token}}
+        username={{user}}&password={{pass}}&csrf_token={{csrf_token}}
 
       - |
         GET /?controller=DashboardController&action=show HTTP/1.1
@@ -37,24 +37,25 @@ requests:
         - admin
       pass:
         - admin
-
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - "hidden\" name=\"csrf_token\" value=\"([0-9a-z]+)\""
+          
     cookie-reuse: true
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - 'kanboard'
-          - 'admin'
+          - 'New project'
+          - 'Project management'
         condition: and
+        case-insensitive: true
 
       - type: status
         status:
           - 200
-
-    extractors:
-      - type: regex
-        name: token
-        part: body
-        regex:
-          - '([a-f0-9]{64})'
-        internal: true

--- a/default-logins/kanboard-default-login.yaml
+++ b/default-logins/kanboard-default-login.yaml
@@ -45,7 +45,6 @@ requests:
         group: 1
         regex:
           - "hidden\" name=\"csrf_token\" value=\"([0-9a-z]+)\""
-          
     cookie-reuse: true
     matchers-condition: and
     matchers:

--- a/default-logins/kanboard-default-login.yaml
+++ b/default-logins/kanboard-default-login.yaml
@@ -11,6 +11,7 @@ info:
     - https://docs.kanboard.org/v1/admin/installation/
   metadata:
     verified: true
+    shodan-query: http.favicon.hash:2056442365
   tags: default-login,kanboard
 
 requests:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
Motivation for this template is from this tweet: https://twitter.com/0x_rood/status/1607068644634157059

- References:
    - https://twitter.com/0x_rood/status/1607068644634157059
    - https://github.com/kanboard/kanboard
    - https://docs.kanboard.org/v1/admin/installation/

### Template Validation
It says on the installation page that the default login is admin:admin (https://docs.kanboard.org/v1/admin/installation/)
<img width="908" alt="Screen Shot 2022-12-26 at 5 34 56 PM" src="https://user-images.githubusercontent.com/25315255/209587956-25669907-abc7-45fd-a932-1ad73eb4d015.png">


I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)