### PR TITLE
Fix error in WordPress Plugin Update workflow

### DIFF
--- a/.github/scripts/wordpress-plugins-update.py
+++ b/.github/scripts/wordpress-plugins-update.py
@@ -123,8 +123,7 @@ info:
 
 requests:
   - method: GET
-    redirects: true
-    max-redirects: 2
+
     path:
       - "{{{{BaseURL}}}}/wp-content/plugins/{name}/readme.txt"
 

--- a/.github/scripts/wordpress-plugins-update.py
+++ b/.github/scripts/wordpress-plugins-update.py
@@ -160,13 +160,13 @@ requests:
           - '(?i)Stable.tag:\s?([\w.]+)'
 '''
         version_file = open(
-            f"./nuclei-templates/helpers/wordpress/plugins/{name}.txt", "w")
+            f"helpers/wordpress/plugins/{name}.txt", "w")
         version_file.write(version)
         version_file.close()
 
         # print(template)
         template_file = open(
-            f"./nuclei-templates/technologies/wordpress/plugins/{name}.yaml", "w")
+            f"technologies/wordpress/plugins/{name}.yaml", "w")
         template_file.write(template)
         template_file.close()
 

--- a/.github/scripts/wordpress-plugins-update.py
+++ b/.github/scripts/wordpress-plugins-update.py
@@ -19,6 +19,7 @@ from bs4 import BeautifulSoup
 import requests
 import re
 from markdown import markdown
+import os
 from termcolor import colored, cprint
 
 # Regex to extract the name of th plugin from the URL
@@ -158,14 +159,25 @@ requests:
         regex:
           - '(?i)Stable.tag:\s?([\w.]+)'
 '''
-        version_file = open(
-            f"helpers/wordpress/plugins/{name}.txt", "w")
+
+        work_dir = os.getcwd()
+        print(f"Current working directory: {work_dir}")
+        helper_dir = f"{work_dir}/helpers/wordpress/plugins"
+        template_dir = f"{work_dir}/technologies/wordpress/plugins"
+
+        if not os.path.exists(helper_dir):
+            os.makedirs(helper_dir)
+
+        if not os.path.exists(template_dir):
+            os.makedirs(template_dir)
+
+        helper_path = f"helpers/wordpress/plugins/{name}.txt"
+        version_file = open(helper_path, "w")
         version_file.write(version)
         version_file.close()
 
-        # print(template)
-        template_file = open(
-            f"technologies/wordpress/plugins/{name}.yaml", "w")
+        template_path = f"technologies/wordpress/plugins/{name}.yaml"
+        template_file = open(template_path, "w")  # Dev environment
         template_file.write(template)
         template_file.close()
 

--- a/.github/workflows/wordpress-plugins-update.yml
+++ b/.github/workflows/wordpress-plugins-update.yml
@@ -1,4 +1,4 @@
-name: ✨ Update WordPress Plugin Templates
+name: ✨ WordPress Plugins - Update
 on:
   schedule:
     - cron: "0 4 * * *" # every day at 4am UTC
@@ -24,7 +24,7 @@ jobs:
       - name: Update Templates
         id: update-templates
         run: |
-          python3 .github/scripts/update-wordpress-plugin-templates.py
+          python3 .github/scripts/wordpress-plugins-update.py
           git status -s | wc -l | xargs -I {} echo CHANGES={} >> $GITHUB_OUTPUT
 
       - name: Commit files
@@ -36,7 +36,7 @@ jobs:
           git commit -m "Auto WordPress Plugins Update [$(date)] :robot:"
 
       - name: Push changes
-        if: steps.update-templates.CHANGES > 0
+        if: steps.update-templates.outputs.CHANGES > 0
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.TOKEN }}

--- a/.github/workflows/wordpress-plugins-update.yml
+++ b/.github/workflows/wordpress-plugins-update.yml
@@ -1,4 +1,4 @@
-name: ✨ WordPress Plugins - Update
+name: ✨ Update WordPress Plugin Templates
 on:
   schedule:
     - cron: "0 4 * * *" # every day at 4am UTC
@@ -7,9 +7,6 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-      - name: Install tree
-        run: sudo apt-get install tree -y
-
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
@@ -25,19 +22,21 @@ jobs:
           pip install -r .github/scripts/wordpress-plugins-update-requirements.txt
 
       - name: Update Templates
+        id: update-templates
         run: |
-          python3 .github/scripts/wordpress-plugins-update.py
+          python3 .github/scripts/update-wordpress-plugin-templates.py
           git status -s | wc -l | xargs -I {} echo CHANGES={} >> $GITHUB_OUTPUT
 
       - name: Commit files
-        if: steps.readme-update.outputs.CHANGES > 0
+        if: steps.update-templates.outputs.CHANGES > 0
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git commit -m "Auto WordPress Plugins Update [$(date)] :robot:" -a
+          git add --all
+          git commit -m "Auto WordPress Plugins Update [$(date)] :robot:"
 
       - name: Push changes
-        if: steps.readme-update.outputs.CHANGES > 0
+        if: steps.update-templates.CHANGES > 0
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
### Template / PR Information

An error was introduced in the workflow when I used `readme-update.yml` as an example. I didn't correctly set the step ID (`id: update-templates`) and the conditional tests (`if: steps.update-templates.outputs.CHANGES > 0`), so the following steps don't work properly and no one changes are commited or pushed to repository.

As we can see below, the commit and push steps were not executed.

![image](https://user-images.githubusercontent.com/1353811/209762358-b6aee6e5-22f6-4972-aa9c-cb2b2b3cd825.png)

#### Additional Details (leave it blank if not applicable)

N/A

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)