### PR TITLE
Add template for ManageEngine "Network Configuration Manager"

### DIFF
--- a/exposed-panels/zoho/manageengine-network-config.yaml
+++ b/exposed-panels/zoho/manageengine-network-config.yaml
@@ -1,11 +1,11 @@
-id: manageengine-networkconfigurationmanager
+id: manageengine-network-config
 
 info:
-  name: ZOHO ManageEngine Network Configuration Manager
+  name: Zoho Manage Engine Network Configuration Manager
   author: righettod
   severity: info
   metadata:
-    verified: true
+    verified: "true"
     shodan-query: http.title:"Network Configuration Manager"
   tags: panel,zoho,manageengine
 
@@ -20,7 +20,7 @@ requests:
         part: body
         words:
           - 'Network Configuration Manager'
-          - '"https://www.manageengine.com'
+          - 'https://www.manageengine.com'
         condition: and
 
       - type: status

--- a/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
+++ b/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
@@ -13,7 +13,6 @@ requests:
   - method: GET
     path:
       - '{{BaseURL}}/apiclient/ember/Login.jsp'
-      - "{{BaseURL}}/servlet/GetProductVersion"
 
     matchers-condition: and
     matchers:

--- a/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
+++ b/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
@@ -26,4 +26,3 @@ requests:
       - type: status
         status:
           - 200
-

--- a/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
+++ b/exposed-panels/zoho/manageengine-networkconfigurationmanager.yaml
@@ -1,0 +1,30 @@
+id: manageengine-networkconfigurationmanager
+
+info:
+  name: ZOHO ManageEngine Network Configuration Manager
+  author: righettod
+  severity: info
+  metadata:
+    verified: true
+    shodan-query: http.title:"Network Configuration Manager"
+  tags: panel,zoho,manageengine
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/apiclient/ember/Login.jsp'
+      - "{{BaseURL}}/servlet/GetProductVersion"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Network Configuration Manager'
+          - '"https://www.manageengine.com'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect the presence of the login panel of the [ManageEngine Network Configuration Manager](https://www.manageengine.com/network-configuration-manager/) software.

- References: https://www.manageengine.com/network-configuration-manager/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof:

![image](https://user-images.githubusercontent.com/1573775/209908579-37f64971-1a41-4617-8e48-4d9e74609522.png)




#### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Network+Configuration+Manager%22

![image](https://user-images.githubusercontent.com/1573775/209908642-d8d579d4-b974-445e-93fc-6bfd0294e5ba.png)


### Additional References:

None