### PR TITLE
Add Lenovo Fan & Power Controller Detection

### DIFF
--- a/exposed-panels/lenovo-fap-controller-detect.yaml
+++ b/exposed-panels/lenovo-fap-controller-detect.yaml
@@ -32,4 +32,3 @@ requests:
       - type: status
         status:
           - 200
-

--- a/exposed-panels/lenovo-fap-controller-detect.yaml
+++ b/exposed-panels/lenovo-fap-controller-detect.yaml
@@ -1,0 +1,35 @@
+id: lenovo-fp-panel-detect
+
+info:
+  name: Lenovo Fan and Power Controller - Detect
+  author: megamansec
+  severity: info
+  description: Lenovo Fan and Power controller was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    shodan-query: http.html:"Avocent Corporation and its affiliates"
+  tags: panel,lenovo
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/login.html"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Avocent Corporation and its affiliates"
+
+      - type: status
+        status:
+          - 200
+

--- a/exposed-panels/lenovo-fp-panel.yaml
+++ b/exposed-panels/lenovo-fp-panel.yaml
@@ -4,12 +4,6 @@ info:
   name: Lenovo Fan and Power Controller Panel
   author: megamansec
   severity: info
-  description: |
-    Lenovo Fan and Power controller was detected.
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cvss-score: 0.0
-    cwe-id: CWE-200
   metadata:
     verified: true
     shodan-query: http.html:"Avocent Corporation and its affiliates"
@@ -19,7 +13,9 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
+      - "{{BaseURL}}/login.html"
 
+    stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
     matchers-condition: and

--- a/exposed-panels/lenovo-fp-panel.yaml
+++ b/exposed-panels/lenovo-fp-panel.yaml
@@ -1,10 +1,11 @@
-id: lenovo-fp-panel-detect
+id: lenovo-fp-panel
 
 info:
-  name: Lenovo Fan and Power Controller - Detect
+  name: Lenovo Fan and Power Controller Panel
   author: megamansec
   severity: info
-  description: Lenovo Fan and Power controller was detected.
+  description: |
+    Lenovo Fan and Power controller was detected.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cvss-score: 0.0
@@ -18,7 +19,6 @@ requests:
   - method: GET
     path:
       - "{{BaseURL}}"
-      - "{{BaseURL}}/login.html"
 
     host-redirects: true
     max-redirects: 2


### PR DESCRIPTION
### Template / PR Information

Detect Lenovo Fan & Power controller panels.
Normally these panels should not be available via the internet, and are password protected, but I have detected otherwise in the past.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
https://download.lenovo.com/servers_pdf/nextscale_system_data_center_planning-v3.0.4.pdf
<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)