### PR TITLE
Update ftp-anonymous-login to reject HTTP false positives

### DIFF
--- a/network/ftp-anonymous-login.yaml
+++ b/network/ftp-anonymous-login.yaml
@@ -34,7 +34,5 @@ network:
       - type: word
         part: raw
         words:
-          - "Bad Request"
           - "HTTP/1.1"
         negative: true
-        condition: or

--- a/network/ftp-anonymous-login.yaml
+++ b/network/ftp-anonymous-login.yaml
@@ -21,6 +21,7 @@ network:
       - "{{Host}}:21"
       - "{{Hostname}}"
 
+    matchers-condition: and
     matchers:
       - type: word
         part: raw
@@ -29,3 +30,8 @@ network:
           - "Logged in anonymously"
           - "230"
         condition: or
+      - type: word
+        part: raw
+        words:
+          - "Bad Request"
+        negative: true  

--- a/network/ftp-anonymous-login.yaml
+++ b/network/ftp-anonymous-login.yaml
@@ -35,4 +35,5 @@ network:
         part: raw
         words:
           - "Bad Request"
+          - "HTTP/1.1"
         negative: true

--- a/network/ftp-anonymous-login.yaml
+++ b/network/ftp-anonymous-login.yaml
@@ -37,3 +37,4 @@ network:
           - "Bad Request"
           - "HTTP/1.1"
         negative: true
+        condition: or

--- a/network/ftp-anonymous-login.yaml
+++ b/network/ftp-anonymous-login.yaml
@@ -30,8 +30,9 @@ network:
           - "Logged in anonymously"
           - "230"
         condition: or
+
       - type: word
         part: raw
         words:
           - "Bad Request"
-        negative: true  
+        negative: true


### PR DESCRIPTION


### Template / PR Information

The `ftp-anonymous-login` template will generate false positive reports for some hosts. This occurs because targets hosting web servers will sometimes reply with an HTTP 400 response that contains text matching the template's existing conditional check for a 230 response code (image).

This PR adds a matcher to ignore responses containing the text "Bad Request", which appears in all false positive responses we have observed.

![image](https://user-images.githubusercontent.com/45573235/210875650-575945ab-6076-434c-be6a-e53ac9b7aa93.png)




### Template Validation

I've validated this template locally?
- [ x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)