### PR TITLE
content-type also can be set as application/octet-stream + new word

### DIFF
--- a/cves/2020/CVE-2020-10148.yaml
+++ b/cves/2020/CVE-2020-10148.yaml
@@ -22,8 +22,8 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/web.config.i18n.ashx?l=nuclei&v=nuclei"
-      - "{{BaseURL}}/SWNetPerfMon.db.i18n.ashx?l=nuclei&v=nuclei"
+      - "{{BaseURL}}/web.config.i18n.ashx?l={{rand_text_alphanumeric(4)}}&v={{rand_text_alphanumeric(4)}}"
+      - "{{BaseURL}}/SWNetPerfMon.db.i18n.ashx?l={{rand_text_alphanumeric(4)}}&v={{rand_text_alphanumeric(4)}}"
 
     stop-at-first-match: true
     matchers-condition: and

--- a/cves/2020/CVE-2020-11110.yaml
+++ b/cves/2020/CVE-2020-11110.yaml
@@ -19,7 +19,7 @@ info:
     cwe-id: CWE-79
   metadata:
     shodan-query: title:"Grafana"
-  tags: cve,cve2020,xss,grafana
+  tags: cve2020,xss,grafana,hackerone,cve
 
 requests:
   - raw:

--- a/cves/2020/CVE-2020-35476.yaml
+++ b/cves/2020/CVE-2020-35476.yaml
@@ -14,7 +14,7 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2020-35476
     cwe-id: CWE-78
-  tags: cve,cve2020,opentsdb,rce
+  tags: cve,cve2020,opentsdb,rce,packetstorm
 
 requests:
   - method: GET

--- a/cves/2021/CVE-2021-25099.yaml
+++ b/cves/2021/CVE-2021-25099.yaml
@@ -11,10 +11,13 @@ info:
     - https://wordpress.org/plugins/give/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-25099
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
     cve-id: CVE-2021-25099
+    cwe-id: CWE-79
   metadata:
-    verified: true
-  tags: cve,cve2021,wordpress,wp-plugin,wp,xss,give,unauth
+    verified: "true"
+  tags: wordpress,xss,unauth,wpscan,cve,cve2021,wp-plugin,wp,give
 
 requests:
   - raw:

--- a/cves/2021/CVE-2021-30128.yaml
+++ b/cves/2021/CVE-2021-30128.yaml
@@ -8,11 +8,16 @@ info:
   reference:
     - https://lists.apache.org/thread.html/rbe8439b26a71fc3b429aa793c65dcc4a6e349bc7bb5010746a74fa1d@%3Ccommits.ofbiz.apache.org%3E
     - https://nvd.nist.gov/vuln/detail/CVE-2021-30128
+    - https://lists.apache.org/thread.html/rb3f5cd65f3ddce9b9eb4d6ea6e2919933f0f89b15953769d11003743%40%3Cdev.ofbiz.apache.org%3E
+    - https://lists.apache.org/thread.html/rb3f5cd65f3ddce9b9eb4d6ea6e2919933f0f89b15953769d11003743@%3Cdev.ofbiz.apache.org%3E
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2021-30128
+    cwe-id: CWE-502
   metadata:
-    verified: true
     fofa-query: app="Apache_OFBiz"
+    verified: "true"
   tags: cve,cve2021,apache,ofbiz,deserialization,rce
 
 requests:

--- a/cves/2021/CVE-2021-41773.yaml
+++ b/cves/2021/CVE-2021-41773.yaml
@@ -19,8 +19,8 @@ info:
     cve-id: CVE-2021-41773
     cwe-id: CWE-22
   metadata:
-    verified: "true"
     shodan-query: Apache 2.4.49
+    verified: "true"
   tags: cve,cve2021,lfi,rce,apache,misconfig,traversal,kev
 
 variables:

--- a/cves/2021/CVE-2021-42887.yaml
+++ b/cves/2021/CVE-2021-42887.yaml
@@ -10,7 +10,7 @@ info:
     - https://nvd.nist.gov/vuln/detail/cve-2021-42887
     - https://github.com/p1Kk/vuln/blob/main/totolink_ex1200t_login_bypass.md
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2021-42887
     cwe-id: CWE-287

--- a/cves/2022/CVE-2022-0786.yaml
+++ b/cves/2022/CVE-2022-0786.yaml
@@ -11,10 +11,13 @@ info:
     - https://wordpress.org/plugins/kivicare-clinic-management-system/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-0786
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2022-0786
+    cwe-id: CWE-89
   metadata:
     verified: "true"
-  tags: cve,cve2022,wordpress,wp-plugin,wp,sqli,kivicare-clinic-management-system,unauth
+  tags: cve,cve2022,kivicare-clinic-management-system,wordpress,wp-plugin,wp,sqli,unauth,wpscan
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-1595.yaml
+++ b/cves/2022/CVE-2022-1595.yaml
@@ -11,10 +11,13 @@ info:
     - https://wordpress.org/plugins/hc-custom-wp-admin-url/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-1595
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
     cve-id: CVE-2022-1595
+    cwe-id: CWE-200
   metadata:
     verified: "true"
-  tags: cve,cve2022,wordpress,wp-plugin,wp,hc-custom-wp-admin-url,unauth
+  tags: unauth,wpscan,cve,cve2022,wordpress,wp-plugin,wp,hc-custom-wp-admin-url
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-2314.yaml
+++ b/cves/2022/CVE-2022-2314.yaml
@@ -11,10 +11,12 @@ info:
     - https://wordpress.org/plugins/vr-calendar-sync/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-2314
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2022-2314
   metadata:
-    verified: true
-  tags: cve,cve2022,wordpress,wp-plugin,wp,rce,vr-calendar-sync,unauth
+    verified: "true"
+  tags: cve,cve2022,rce,wpscan,unauth,wordpress,wp-plugin,wp,vr-calendar-sync
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-23854.yaml
+++ b/cves/2022/CVE-2022-23854.yaml
@@ -12,7 +12,10 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23854
     - https://www.cisa.gov/uscert/ics/advisories/icsa-22-342-02
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2022-23854
+    cwe-id: CWE-23
   metadata:
     shodan-query: http.html:"InTouch Access Anywhere"
     verified: "true"

--- a/cves/2022/CVE-2022-33891.yaml
+++ b/cves/2022/CVE-2022-33891.yaml
@@ -8,9 +8,16 @@ info:
   reference:
     - https://github.com/W01fh4cker/cve-2022-33891
     - https://nvd.nist.gov/vuln/detail/CVE-2022-33891
+    - https://lists.apache.org/thread/p847l3kopoo5bjtmxrcwk21xp6tjxqlc
+    - http://packetstormsecurity.com/files/168309/Apache-Spark-Unauthenticated-Command-Injection.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-33891
+    cwe-id: CWE-77
   metadata:
-    verified: "true"
     shodan-query: title:"Spark Master at"
+    verified: "true"
   tags: cve,cve2022,apache,spark,authenticated
 
 variables:

--- a/cves/2022/CVE-2022-3768.yaml
+++ b/cves/2022/CVE-2022-3768.yaml
@@ -6,12 +6,12 @@ info:
   severity: high
   description: |
     The WPSmartContracts WordPress plugin before 1.3.12 does not properly sanitise and escape a parameter before using it in a SQL statement, leading to a SQL injection exploitable by users with a role as low as author
-  remediation: Fixed in version 1.3.12
   reference:
     - https://wpscan.com/vulnerability/1d8bf5bb-5a17-49b7-a5ba-5f2866e1f8a3
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3768
     - https://nvd.nist.gov/vuln/detail/CVE-2022-3768
     - https://cve.report/CVE-2022-3768
+  remediation: Fixed in version 1.3.12
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
@@ -19,7 +19,7 @@ info:
     cwe-id: CWE-89
   metadata:
     verified: "true"
-  tags: cve,cve2022,wordpress,wp-plugin,wp,sqli,wp-smart-contracts,authenticated
+  tags: cve2022,wp-plugin,authenticated,wpscan,wp-smart-contracts,cve,wordpress,wp,sqli
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-4050.yaml
+++ b/cves/2022/CVE-2022-4050.yaml
@@ -11,10 +11,13 @@ info:
     - https://wordpress.org/plugins/joomsport-sports-league-results-management/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-4050
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2022-4050
+    cwe-id: CWE-89
   metadata:
-    verified: true
-  tags: cve,cve2022,wordpress,wp-plugin,wp,sqli,joomsport-sports-league-results-management,unauth
+    verified: "true"
+  tags: cve,wordpress,wp-plugin,sqli,joomsport-sports-league-results-management,cve2022,wp,unauth,wpscan
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-4260.yaml
+++ b/cves/2022/CVE-2022-4260.yaml
@@ -3,20 +3,22 @@ id: CVE-2022-4260
 info:
   name: WP-Ban < 1.69.1 - Admin Stored XSS
   author: Hardik-Solanki
-  severity: high
+  severity: medium
   description: |
     The plugin does not sanitise and escape some of its settings, which could allow high privilege users such as admin to perform Stored Cross-Site Scripting attacks even when the unfiltered_html capability is disallowed (for example in multisite setup).
-  remediation: Fixed in version 1.69.1
   reference:
     - https://wpscan.com/vulnerability/d0cf24be-df87-4e1f-aae7-e9684c88e7db
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4260
     - https://drive.google.com/file/d/11nQ21cQ9irajYqNqsQtNrLJOkeRcwCXn/view?usp=drivesdk
+  remediation: Fixed in version 1.69.1
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 4.8
     cve-id: CVE-2022-4260
     cwe-id: CWE-79
   metadata:
     verified: "true"
-  tags: cve,cve2022,wordpress,wp-plugin,wp,xss,wp-ban,authenticated
+  tags: cve2022,xss,authenticated,wpscan,wp-ban,cve,wordpress,wp-plugin,wp
 
 requests:
   - raw:

--- a/cves/2022/CVE-2022-42746.yaml
+++ b/cves/2022/CVE-2022-42746.yaml
@@ -9,14 +9,15 @@ info:
   reference:
     - https://fluidattacks.com/advisories/modestep/
     - https://nvd.nist.gov/vuln/detail/CVE-2022-42746
+    - https://candidats.net/
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
-    cvss-score: 5.4
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
     cve-id: CVE-2022-42746
-    cwe-id: CWE-80
+    cwe-id: CWE-79
   metadata:
-    verified: true
     shodan-query: http.html:"CandidATS"
+    verified: "true"
   tags: cve,cve2022,candidats,xss
 
 requests:

--- a/cves/2022/CVE-2022-45917.yaml
+++ b/cves/2022/CVE-2022-45917.yaml
@@ -11,10 +11,15 @@ info:
     - https://seclists.org/fulldisclosure/2022/Dec/7
     - https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-ilias-elearning-platform/
     - https://github.com/advisories/GHSA-hf6q-rx44-fh6j
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-45917
+    cwe-id: CWE-601
   metadata:
-    verified: true
     shodan-query: http.html:"ILIAS"
-  tags: cve,cve2022,ilias,redirect
+    verified: "true"
+  tags: cve,cve2022,ilias,redirect,packetstorm,seclists
 
 requests:
   - method: GET

--- a/cves/2022/CVE-2022-46381.yaml
+++ b/cves/2022/CVE-2022-46381.yaml
@@ -9,9 +9,14 @@ info:
   reference:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-46381
     - https://github.com/omarhashem123/Security-Research/blob/main/CVE-2022-46381/CVE-2022-46381.txt
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-46381
+    cwe-id: CWE-79
   metadata:
-    verified: "true"
     shodan-query: http.html:"Linear eMerge"
+    verified: "true"
   tags: cve,cve2022,xss,emerge,linear
 
 requests:

--- a/exposures/files/svn-wc-db.yaml
+++ b/exposures/files/svn-wc-db.yaml
@@ -10,7 +10,7 @@ info:
   metadata:
     verified: true
     google-query: intitle:"index of" "wc.db"
-  tags: exposure,svn,config,files
+  tags: exposure,svn,config,files,msf
 
 requests:
   - method: GET

--- a/exposures/logs/error-logs.yaml
+++ b/exposures/logs/error-logs.yaml
@@ -51,6 +51,7 @@ requests:
           - "Array"
           - "Exception"
           - "Fatal"
+          - "FastCGI sent in stderr"
         condition: or
 
       - type: word

--- a/exposures/logs/error-logs.yaml
+++ b/exposures/logs/error-logs.yaml
@@ -54,8 +54,10 @@ requests:
         condition: or
 
       - type: word
+        condition: or
         words:
           - text/plain
+          - application/octet-stream
         part: header
 
       - type: status

--- a/vulnerabilities/vmware/vmware-nsx-stream-rce.yaml
+++ b/vulnerabilities/vmware/vmware-nsx-stream-rce.yaml
@@ -21,7 +21,7 @@ info:
     verified: true
     shodan-query: title:"VMware Appliance Management"
     fofa-query: title="VMware Appliance Management"
-  tags: vmware,xstream,rce
+  tags: vmware,xstream,rce,msf
 
 variables:
   lowerrstr: "{{to_lower(rand_text_alpha(6))}}"

--- a/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
+++ b/vulnerabilities/zyxel/unauth-lfd-zhttpd.yaml
@@ -13,7 +13,7 @@ info:
   metadata:
     verified: "true"
     shodan-query: http.html:"VMG1312-B10D"
-  tags: misconfig,unauth,zyxel,lfi
+  tags: zyxel,lfi,msf,misconfig,unauth
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

The original template contains a match rule for content-type as text/plain, however, it also can be application/octet-stream.
Just tested with nginx/1.18.0 + php8.1-fpm and error.log

Also, added string "FastCGI sent in stderr" wich can be found in the above setup while the other matchers trings might not be present.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

