### PR TITLE
content-type also can be set as application/octet-stream + new word

### DIFF
--- a/exposures/logs/error-logs.yaml
+++ b/exposures/logs/error-logs.yaml
@@ -51,11 +51,14 @@ requests:
           - "Array"
           - "Exception"
           - "Fatal"
+          - "FastCGI sent in stderr"
         condition: or
 
       - type: word
+        condition: or
         words:
           - text/plain
+          - application/octet-stream
         part: header
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

The original template contains a match rule for content-type as text/plain, however, it also can be application/octet-stream.
Just tested with nginx/1.18.0 + php8.1-fpm and error.log

Also, added string "FastCGI sent in stderr" wich can be found in the above setup while the other matchers trings might not be present.

### Template Validation

I've validated this template locally?
- [x ] YES
- [ ] NO

