### PR TITLE
Support for detecting Connect Box devices

### DIFF
--- a/exposed-panels/connect-box-login.yaml
+++ b/exposed-panels/connect-box-login.yaml
@@ -1,0 +1,36 @@
+id: connect-box-login
+
+info:
+  name: Connect Box Login Panel - Detect
+  author: fabaff
+  severity: info
+  description: Connect Box login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: tech,panel,connectbox,iot
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "NET-DK/1.0"
+
+      - type: word
+        part: header
+        words:
+          - "../common_page/login.html"
+
+      - type: status
+        status:
+          - 302

--- a/exposed-panels/connect-box-login.yaml
+++ b/exposed-panels/connect-box-login.yaml
@@ -1,15 +1,13 @@
-id: connect-box-login
+id: connectbox-panel
 
 info:
-  name: Connect Box Login Panel - Detect
+  name: Connect Box Login Panel Detect
   author: fabaff
   severity: info
-  description: Connect Box login panel was detected.
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cvss-score: 0.0
-    cwe-id: CWE-200
-  tags: tech,panel,connectbox,iot
+  metadata:
+    verified: true
+    shodan-query: 'NET-DK/1.0'
+  tags: panel,connectbox,iot
 
 requests:
   - method: GET
@@ -18,7 +16,6 @@ requests:
 
     host-redirects: true
     max-redirects: 2
-
     matchers-condition: and
     matchers:
       - type: word
@@ -26,10 +23,10 @@ requests:
         words:
           - "NET-DK/1.0"
 
-      - type: word
+      - type: regex
         part: header
-        words:
-          - "../common_page/login.html"
+        regex:
+          - "../common_page/(.*).html"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Support to detect Connect Box logins. 

The device is a cable modem/router from Compal (Model CH7465LG) which is provided to their customers under different names by various ISP in Europe.

- UPC Connect Box (CH)
- Irish Virgin Media Super Hub 3.0 (IE)
- Ziggo Connectbox (NL)
- Unitymedia Connect Box (DE)

I only have access to a Connect Box to test it. Thus I named it `connect-box-login` even if it's possible to detect other brands.  

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)