### PR TITLE
Fixed 8 templates in misconfiguration/proxy/ -  added newlines at the end of raw requests

### DIFF
--- a/misconfiguration/proxy/metadata-aws.yaml
+++ b/misconfiguration/proxy/metadata-aws.yaml
@@ -29,6 +29,7 @@ requests:
       - |+
         GET http://{{hostval}}/latest/meta-data/ HTTP/1.1
         Host: {{hostval}}
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-azure.yaml
+++ b/misconfiguration/proxy/metadata-azure.yaml
@@ -30,6 +30,7 @@ requests:
         GET http://{{hostval}}/metadata/instance?api-version=2021-02-01 HTTP/1.1
         Host: {{hostval}}
         Metadata: true
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-digitalocean.yaml
+++ b/misconfiguration/proxy/metadata-digitalocean.yaml
@@ -29,6 +29,7 @@ requests:
       - |+
         GET http://{{hostval}}/metadata/v1.json HTTP/1.1
         Host: {{hostval}}
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-google.yaml
+++ b/misconfiguration/proxy/metadata-google.yaml
@@ -30,6 +30,7 @@ requests:
         GET http://{{hostval}}/computeMetadata/v1/project/ HTTP/1.1
         Host: {{hostval}}
         Metadata-Flavor: Google
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-hetzner.yaml
+++ b/misconfiguration/proxy/metadata-hetzner.yaml
@@ -29,6 +29,7 @@ requests:
       - |+
         GET http://{{hostval}}/v1/metadata/private-networks HTTP/1.1
         Host: {{hostval}}
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-openstack.yaml
+++ b/misconfiguration/proxy/metadata-openstack.yaml
@@ -29,6 +29,7 @@ requests:
       - |+
         GET http://{{hostval}}/openstack/latest HTTP/1.1
         Host: {{hostval}}
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/metadata-oracle.yaml
+++ b/misconfiguration/proxy/metadata-oracle.yaml
@@ -30,6 +30,7 @@ requests:
         GET http://{{hostval}}/opc/v1/instance HTTP/1.1
         Host: {{hostval}}
         Metadata: true
+
     payloads:
       hostval:
         - aws.oast.online

--- a/misconfiguration/proxy/open-proxy-internal.yaml
+++ b/misconfiguration/proxy/open-proxy-internal.yaml
@@ -21,78 +21,103 @@ requests:
       - |+
          GET / HTTP/1.1
          Host: {{Hostname}}
+
       - |+
         GET http://192.168.0.1/ HTTP/1.1
         Host: 192.168.0.1
+
       - |+
         GET https://192.168.0.1/ HTTP/1.1
         Host: 192.168.0.1
+
       - |+
         GET http://192.168.0.1:22/ HTTP/1.1
         Host: 192.168.0.1
+
       - |+
         GET http://192.168.1.1/ HTTP/1.1
         Host: 192.168.1.1
+
       - |+
         GET https://192.168.1.1/ HTTP/1.1
         Host: 192.168.1.1
+
       - |+
         GET http://192.168.1.1:22/ HTTP/1.1
         Host: 192.168.1.1
+
       - |+
         GET http://192.168.2.1/ HTTP/1.1
         Host: 192.168.2.1
+
       - |+
         GET https://192.168.2.1/ HTTP/1.1
         Host: 192.168.2.1
+
       - |+
         GET http://192.168.2.1:22/ HTTP/1.1
         Host: 192.168.2.1
+
       - |+
         GET http:/10.0.0.1/ HTTP/1.1
         Host: 10.0.0.1
+
       - |+
         GET https://10.0.0.1/ HTTP/1.1
         Host: 10.0.0.1
+
       - |+
         GET http://10.0.0.1:22/ HTTP/1.1
         Host: 10.0.0.1
+
       - |+
         GET http:/172.16.0.1/ HTTP/1.1
         Host: 172.16.0.1
+
       - |+
         GET https://172.16.0.1/ HTTP/1.1
         Host: 172.16.0.1
+
       - |+
         GET http://172.16.0.1:22/ HTTP/1.1
         Host: 172.16.0.1
+
       - |+
         GET http:/intranet/ HTTP/1.1
         Host: intranet
+
       - |+
         GET https://intranet/ HTTP/1.1
         Host: intranet
+
       - |+
         GET http://intranet:22/ HTTP/1.1
         Host: intranet
+
       - |+
         GET http:/mail/ HTTP/1.1
         Host: mail
+
       - |+
         GET https://mail/ HTTP/1.1
         Host: mail
+
       - |+
         GET http://mail:22/ HTTP/1.1
         Host: mail
+
       - |+
         GET http:/ntp/ HTTP/1.1
         Host: ntp
+
       - |+
         GET https://ntp/ HTTP/1.1
         Host: ntp
+
       - |+
         GET http://ntp:22/ HTTP/1.1
         Host: ntp
+
     unsafe: true
     matchers:
       - type: dsl


### PR DESCRIPTION

### Template / PR Information

The following templates contained a bug, there was no newline at the end of raw request. Because of that, the requests were hanging and causing timeouts, and also the detections themselves did not work.

misconfiguration/proxy/metadata-aws.yaml
misconfiguration/proxy/metadata-azure.yaml
misconfiguration/proxy/metadata-digitalocean.yaml
misconfiguration/proxy/metadata-google.yaml
misconfiguration/proxy/metadata-hetzner.yaml
misconfiguration/proxy/metadata-openstack.yaml
misconfiguration/proxy/metadata-oracle.yaml
misconfiguration/proxy/open-proxy-internal.yaml

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)