### PR TITLE
Added default-lighttpd-placeholder-page.yaml

### DIFF
--- a/technologies/default-lighttpd-placeholder-page.yaml
+++ b/technologies/default-lighttpd-placeholder-page.yaml
@@ -1,0 +1,25 @@
+id: lighttpd-placeholder-page
+
+info:
+  name: lighttpd Placeholder Page
+  author: idealphase
+  severity: info
+  metadata:
+    shodan-query: "If you find a bug in this Lighttpd package, or in Lighttpd itself"
+  tags: tech,lighttpd
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "If you find a bug in this Lighttpd package, or in Lighttpd itself"
+          - "<h1> Placeholder page </h1>"
+
+      - type: status
+        status:
+          - 200

--- a/technologies/default-lighttpd-placeholder-page.yaml
+++ b/technologies/default-lighttpd-placeholder-page.yaml
@@ -1,7 +1,7 @@
 id: lighttpd-placeholder-page
 
 info:
-  name: lighttpd Placeholder Page
+  name: Lighttpd Placeholder Page
   author: idealphase
   severity: info
   metadata:
@@ -20,6 +20,7 @@ requests:
           - "If you find a bug in this Lighttpd package, or in Lighttpd itself"
           - "<h1> Placeholder page </h1>"
         condition: and
+
       - type: status
         status:
           - 200

--- a/technologies/default-lighttpd-placeholder-page.yaml
+++ b/technologies/default-lighttpd-placeholder-page.yaml
@@ -19,7 +19,8 @@ requests:
         words:
           - "If you find a bug in this Lighttpd package, or in Lighttpd itself"
           - "<h1> Placeholder page </h1>"
-
+        condition: and
+        
       - type: status
         status:
           - 200

--- a/technologies/default-lighttpd-placeholder-page.yaml
+++ b/technologies/default-lighttpd-placeholder-page.yaml
@@ -20,7 +20,6 @@ requests:
           - "If you find a bug in this Lighttpd package, or in Lighttpd itself"
           - "<h1> Placeholder page </h1>"
         condition: and
-        
       - type: status
         status:
           - 200


### PR DESCRIPTION
Added default-lighttpd-placeholder-page.yaml

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![default-lighttpd-placeholder-page-shodan](https://user-images.githubusercontent.com/12832679/214473538-aa02f6de-783a-49f6-a876-116e7f2384cd.png)
![default-lighttpd-placeholder-page-UI](https://user-images.githubusercontent.com/12832679/214473476-5d2e0888-f76a-4abe-b05f-22d1dbf59ba5.png)
![default-lighttpd-placeholder-page-nuclei](https://user-images.githubusercontent.com/12832679/214473483-98affd26-dd00-4c3d-8a93-3fa6574f2b47.png)

### Additional References:


- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)