### PR TITLE
Add Nemlio API Docs Detection to Swagger Template

### DIFF
--- a/exposures/apis/swagger-api.yaml
+++ b/exposures/apis/swagger-api.yaml
@@ -26,6 +26,7 @@ requests:
       - "{{BaseURL}}/swagger/v1/swagger.json"
       - "{{BaseURL}}/swagger/v1/swagger.yaml"
       - "{{BaseURL}}/api/index.html"
+      - "{{BaseURL}}/api/doc"
       - "{{BaseURL}}/api/docs/"
       - "{{BaseURL}}/api/swagger.json"
       - "{{BaseURL}}/api/swagger.yaml"
@@ -39,6 +40,7 @@ requests:
       - "{{BaseURL}}/api/apidocs/swagger.json"
       - "{{BaseURL}}/api/apidocs/swagger.yaml"
       - "{{BaseURL}}/api/swagger-ui/api-docs"
+      - "{{BaseURL}}/api/doc.json"
       - "{{BaseURL}}/api/api-docs"
       - "{{BaseURL}}/api/apidocs"
       - "{{BaseURL}}/api/swagger"
@@ -56,6 +58,7 @@ requests:
       - "{{BaseURL}}/api/v1/swagger-ui/swagger.yaml"
       - "{{BaseURL}}/swagger-resources/restservices/v2/api-docs"
       - "{{BaseURL}}/api/swagger_doc.json"
+      - "{{BaseURL}}/docu"
 
     stop-at-first-match: true
     matchers-condition: and
@@ -66,6 +69,7 @@ requests:
           - "Swagger 2.0"
           - "\"swagger\":"
           - "Swagger UI"
+          - "loadSwaggerUI"
           - "**token**:"
         condition: or
 

--- a/exposures/apis/swagger-api.yaml
+++ b/exposures/apis/swagger-api.yaml
@@ -59,6 +59,10 @@ requests:
       - "{{BaseURL}}/swagger-resources/restservices/v2/api-docs"
       - "{{BaseURL}}/api/swagger_doc.json"
       - "{{BaseURL}}/docu"
+      - "{{BaseURL}}/docs"
+
+    headers:
+      Accept: text/html
 
     stop-at-first-match: true
     matchers-condition: and
@@ -71,6 +75,7 @@ requests:
           - "Swagger UI"
           - "loadSwaggerUI"
           - "**token**:"
+          - "id=\"swagger-ui"
         condition: or
 
       - type: status


### PR DESCRIPTION
Nemlio is a Symfony PHP Swagger implementation.

It's basically Swagger though. That's why I added it to the swagger template.

Here are the docs: https://symfony.com/bundles/NelmioApiDocBundle/current/index.html#installation There are the "default"/suggested doc routes listed.

I've also added the doc path `/docu` because I've found it several times and I think it fits in there too.

No related issue

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
