### PR TITLE
Fix - exposed-panels/server-backup-manager-se.yaml

### DIFF
--- a/exposed-panels/server-backup-manager-se.yaml
+++ b/exposed-panels/server-backup-manager-se.yaml
@@ -22,7 +22,7 @@ requests:
     matchers:
       - type: word
         words:
-          - '<title>Server Backup Manager SE  </title>'
+          - '<title>Server Backup Manager SE'
       - type: status
         status:
           - 200

--- a/exposed-panels/server-backup-manager-se.yaml
+++ b/exposed-panels/server-backup-manager-se.yaml
@@ -1,7 +1,7 @@
 id: server-backup-manager-se
 
 info:
-  name: Server Backup Manager SE Login Panel - Detect
+  name: Server Backup Manager SE Panel - Detect
   author: dhiyaneshDK
   severity: info
   description: Server Backup Manager SE login panel was detected.
@@ -11,7 +11,7 @@ info:
     cwe-id: CWE-200
   metadata:
     shodan-query: http.title:"Server Backup Manager SE"
-  tags: panel
+  tags: panel,server,backup,manager
 
 requests:
   - method: GET
@@ -20,9 +20,11 @@ requests:
 
     matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - '<title>Server Backup Manager SE'
+      - type: regex
+        part: body
+        regex:
+          - "<title>.*(Server Backup Manager SE).*</title>"
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information

- Fixed exposed-panels/server-backup-manager-se.yaml

The current template matcher is set to  `'<title>Server Backup Manager SE  </title>'` 

Using the Shodan query included in the template __http.title:"Server Backup Manager SE"__  will show many results with title response ``<title>Server Backup Manager SE  -my.hostname</title>``.  

This PR just removes the end of the title match `'<title>Server Backup Manager SE'` this detects more and matches the Shodan query. 



### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


