### PR TITLE
Fix - azure-takeover-detection.yaml 

### DIFF
--- a/dns/azure-takeover-detection.yaml
+++ b/dns/azure-takeover-detection.yaml
@@ -40,6 +40,7 @@ dns:
           - "redis.cache.windows.net"
           - "search.windows.net"
           - "servicebus.windows.net"
+          - "trafficmanager.net"
           - "visualstudio.com"
 
       - type: word


### PR DESCRIPTION
### Template / PR Information

Traffic Manager was removed from the template as being no longer possible. At my work we took over quite a few this week and I did a couple myself 23 Jan 2023. Maybe something changed to make it vulnerable again or there are edge cases but to say it's not possible is very inaccurate.

- Fixed dns/azure-takeover-detection.yaml 
- Added back Traffic Manager

I've validated this template locally?
- [X ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
