### PR TITLE
Updated aws-bucket-takeover.yaml to reduce false positives

### DIFF
--- a/cves/2018/CVE-2018-20470.yaml
+++ b/cves/2018/CVE-2018-20470.yaml
@@ -11,7 +11,7 @@ info:
     - http://packetstormsecurity.com/files/153330/Sahi-Pro-7.x-8.x-Directory-Traversal.html
     - https://nvd.nist.gov/vuln/detail/CVE-2018-20470
   classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2018-20470
     cwe-id: CWE-22

--- a/cves/2019/CVE-2019-14322.yaml
+++ b/cves/2019/CVE-2019-14322.yaml
@@ -11,7 +11,7 @@ info:
     - http://packetstormsecurity.com/files/163398/Pallets-Werkzeug-0.15.4-Path-Traversal.html
     - https://nvd.nist.gov/vuln/detail/CVE-2019-14322
   classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2019-14322
     cwe-id: CWE-22

--- a/cves/2019/CVE-2019-9922.yaml
+++ b/cves/2019/CVE-2019-9922.yaml
@@ -11,7 +11,7 @@ info:
     - https://extensions.joomla.org/extension/je-messenger/
     - https://nvd.nist.gov/vuln/detail/CVE-2019-9922
   classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2019-9922
     cwe-id: CWE-22

--- a/takeovers/aws-bucket-takeover.yaml
+++ b/takeovers/aws-bucket-takeover.yaml
@@ -27,3 +27,8 @@ requests:
         dsl:
           - contains(tolower(all_headers), 'x-guploader-uploadid')
         negative: true
+
+      - type: word
+        part: host
+        words:
+          - "amazonaws.com"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated template `aws-bucket-takeover` to reduce false positives
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
Certain buckets that has custom domain names are not vulnerable bucket takeover attacks. However, they could return HTTP responses containing the message `Message: The specified bucket does not exist`, and therefore cause false positives.

I've added an additional matcher in the template to match for `amazonaws.com` in the host string.
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)