### PR TITLE
fix: update matcher to match vuln 2.0.x versions for airflow CVE-2021-38540

### DIFF
--- a/cves/2021/CVE-2021-38540.yaml
+++ b/cves/2021/CVE-2021-38540.yaml
@@ -62,7 +62,7 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_1, "Sign In - Airflow")'
+          - 'contains(body_1, "Sign In")'
           - 'status_code_2 == 302'
           - 'contains(all_headers_2, "session=.")'
         condition: and


### PR DESCRIPTION
Signed-off-by: ludo <controlplane@spiarh.fr>

### Template / PR Information

Versions `2.0.x` only have `Sign In` in the body so the current matcher does not work for the vulnerable versions. This has been tested with the following versions: 2.0.0, 2.0.1, 2.0.2, 2.1.1, 2.1.2

- Fixed CVE-2021-38540

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)