### PR TITLE
Improve CVE-2017-12149 template

### DIFF
--- a/cves/2017/CVE-2017-12149.yaml
+++ b/cves/2017/CVE-2017-12149.yaml
@@ -2,7 +2,7 @@ id: CVE-2017-12149
 
 info:
   name: Jboss Application Server - Remote Code Execution
-  author: fopina
+  author: fopina,s0obi
   severity: critical
   description: Jboss Application Server as shipped with Red Hat Enterprise Application Platform 5.2 is susceptible to a remote code execution vulnerability because  the doFilter method in the ReadOnlyAccessFilter of the HTTP Invoker does not restrict classes for which it performs deserialization, thus allowing an attacker to execute arbitrary code via crafted serialized data.
   reference:
@@ -33,16 +33,22 @@ requests:
 
         {{ base64_decode("rO0ABXNyABNqYXZhLnV0aWwuQXJyYXlMaXN0eIHSHZnHYZ0DAAFJAARzaXpleHAAAAACdwQAAAACdAAJZWxlbWVudCAxdAAJZWxlbWVudCAyeA==") }}
 
+      - |
+        POST /invoker/readonly HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/octet-stream
+
+        {{ base64_decode("rO0ABXNyABNqYXZhLnV0aWwuQXJyYXlMaXN0eIHSHZnHYZ0DAAFJAARzaXpleHAAAAACdwQAAAACdAAJZWxlbWVudCAxdAAJZWxlbWVudCAyeA==") }}
+
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "ClassCastException"
-
-      - type: word
-        part: header
-        words:
-          - "application/x-java-serialized-object"
+      - type: status
+        status:
+          - 200
+          - 500
 
 # Enhanced by mp on 2022/05/11

--- a/cves/2017/CVE-2017-12149.yaml
+++ b/cves/2017/CVE-2017-12149.yaml
@@ -46,6 +46,7 @@ requests:
         part: body
         words:
           - "ClassCastException"
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information

This commit will fix two issues with CVE-2017-12149 template : 

- matchers were too restrictives, multiple installations of JBoss will actually send "text/html;charset=utf-8" as Content-Type, having an 200 or 500 http error in addition of the `ClassCastException` keyword feel like a reasonable balance
- `/invoker/readonly` endpoint can also be used to achieve RCE, surprisingly jexboss doesn't support it, more details in the references part

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

### Additional References:

- [CVE-2017-12149 Exploited in Wild](https://praveenp13.wordpress.com/2018/01/20/cve-2017-12149-exploited-in-wild/)
- [CVE_2017_12149.pl](https://github.com/gottburgm/Exploits/blob/master/CVE-2017-12149/CVE_2017_12149.pl)