### PR TITLE
[technologies/wso2-apimanager-detect.yaml] Rename the template to made it generic.

### DIFF
--- a/technologies/wso2-products-detect.yaml
+++ b/technologies/wso2-products-detect.yaml
@@ -1,11 +1,11 @@
-id: wso2-apimanager-detect
+id: wso2-products-detect
 
 info:
-  name: WSO2 API Manager detect
+  name: WSO2 Products detect
   author: righettod
   severity: info
-  description: Try to detect the presence of a WSO2 API Manager instance via the version endpoint
-  tags: tech,wso2,api-manager
+  description: Try to detect the presence of a WSO2 products instance via the version endpoint
+  tags: tech,wso2
 
 requests:
   - method: GET

--- a/technologies/wso2-products-detect.yaml
+++ b/technologies/wso2-products-detect.yaml
@@ -1,7 +1,7 @@
 id: wso2-products-detect
 
 info:
-  name: WSO2 Products detect
+  name: WSO2 Products - Detect
   author: righettod
   severity: info
   description: Try to detect the presence of a WSO2 products instance via the version endpoint


### PR DESCRIPTION
### Template / PR Information

I discovered that the endpoint `/services/Version`,  is present on several products from the [WSO2](https://wso2.com) company like for example the **API Manager** or the **ESB**.

So, I proposed a renamed version of the initial template to made it "generic" to the detection of a instance of an WSO2 products.

References: 
- https://wso2.com/integration/
- https://wso2.com/integration/install/docker/community/get-started/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Proof:

![image](https://user-images.githubusercontent.com/1573775/217625725-bd4cda83-ebe9-4589-a20a-5e85042fbe49.png)


### Additional Details (leave it blank if not applicable)

### Additional References:
