### PR TITLE
Update svn-wc-db.yaml

### DIFF
--- a/exposures/files/svn-wc-db.yaml
+++ b/exposures/files/svn-wc-db.yaml
@@ -2,8 +2,8 @@ id: svn-wc-db
 
 info:
   name: SVN wc.db File Exposure
-  author: Hardik-Solanki, R12W4N
-  severity: High
+  author: Hardik-Solanki,R12W4N
+  severity: medium
   reference:
     - https://github.com/maurosoria/dirsearch/blob/master/db/dicc.txt
     - https://github.com/rapid7/metasploit-framework/blob/master//modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
@@ -17,8 +17,10 @@ requests:
   - method: HEAD
     path:
       - "{{BaseURL}}/.svn/wc.db"
-      - "{{RootURL}}/.svn/wc.db"
+      - "{{BaseURL}}/wc.db"
 
+    stop-at-first-match: true
+    max-size: 10000
     matchers:
       - type: status
         status:

--- a/exposures/files/svn-wc-db.yaml
+++ b/exposures/files/svn-wc-db.yaml
@@ -2,30 +2,23 @@ id: svn-wc-db
 
 info:
   name: SVN wc.db File Exposure
-  author: Hardik-Solanki
-  severity: medium
+  author: Hardik-Solanki, R12W4N
+  severity: High
   reference:
     - https://github.com/maurosoria/dirsearch/blob/master/db/dicc.txt
     - https://github.com/rapid7/metasploit-framework/blob/master//modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
+    - https://infosecwriteups.com/indias-aadhar-card-source-code-disclosure-via-exposed-svn-wc-db-c05519ea7761
   metadata:
     verified: true
     google-query: intitle:"index of" "wc.db"
   tags: msf,exposure,svn,config,files
 
 requests:
-  - method: GET
+  - method: HEAD
     path:
       - "{{BaseURL}}/.svn/wc.db"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - 'SQLite format'
-          - 'WCROOT'
-        condition: and
-
       - type: status
         status:
           - 200

--- a/exposures/files/svn-wc-db.yaml
+++ b/exposures/files/svn-wc-db.yaml
@@ -17,6 +17,7 @@ requests:
   - method: HEAD
     path:
       - "{{BaseURL}}/.svn/wc.db"
+      - "{{RootURL}}/.svn/wc.db"
 
     matchers:
       - type: status


### PR DESCRIPTION
### Template / PR Information

Most of the time wc.db file is big in size, response from the web server may take time, could lead to content deadline exceeded error, even if the wc.db file exist. So I change the HTTP Method to HEAD
Also, I change the rating to High because it could lead to source code disclosure. I cross verified with one of my target, current template does not work, so here is the revised one.

- References: https://infosecwriteups.com/indias-aadhar-card-source-code-disclosure-via-exposed-svn-wc-db-c05519ea7761

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
