### PR TITLE
ci(cve2json): add branch restriction & minor changes

### DIFF
--- a/.github/workflows/cve2json.yml
+++ b/.github/workflows/cve2json.yml
@@ -2,11 +2,13 @@ name: Generate JSON Metadata of CVE Templates
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'cves/**'
 
 jobs:
-  build:
+  cve2json:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -20,7 +22,7 @@ jobs:
         run: |
            go env -w GO111MODULE=off
            go get gopkg.in/yaml.v3
-           go run .github/scripts/yaml2json.go /home/runner/work/nuclei-templates/nuclei-templates/cves/ cves.json
+           go run .github/scripts/yaml2json.go $GITHUB_WORKSPACE/cves/ cves.json
           
       - name: Commit files
         run: |
@@ -34,4 +36,3 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main


### PR DESCRIPTION
This commit updates the cve2json GitHub workflow to add a branch restriction for `main` branch, thus we don't need to spesify `branch` input for `ad-m/github-push-action` step & change the filepath for the `yaml2json.go` script.

The changes ensure that the workflow only runs on the `main` branch & simply use `$GITHUB_WORKSPACE` variable as a filepath for generating the JSON metadata of CVE templates.

It is not advisable for bot(s) to push changes while creating a PR that does not target the default branch (`main`).