### PR TITLE
Update swagger-api.yaml

### DIFF
--- a/exposures/apis/swagger-api.yaml
+++ b/exposures/apis/swagger-api.yaml
@@ -69,6 +69,8 @@ requests:
       - "{{BaseURL}}/api/swagger_doc.json"
       - "{{BaseURL}}/docu"
       - "{{BaseURL}}/docs"
+      - "{{BaseURL}}/swagger"
+      - "{{BaseURL}}/api-doc"
 
     headers:
       Accept: text/html


### PR DESCRIPTION
I encountered two different use cases that are missing in this template.

In my case, the template didn't find these exposed Swagger pages due to a case-sensitive declaration of the page.
So I added two additional endpoints: /swagger and /api-doc.

### Template Validation

I've validated this template locally?
- [v] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)