### PR TITLE
Allow http/https and www/non-www redirects

### DIFF
--- a/technologies/wordpress-detect.yaml
+++ b/technologies/wordpress-detect.yaml
@@ -11,14 +11,14 @@ info:
 
 requests:
   - method: GET
-    redirects: true
-    max-redirects: 2
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/wp-admin/install.php"
       - "{{BaseURL}}/feed/"
       - "{{BaseURL}}/?feed=rss2" # alternative if /feed/ is blocked
 
+    redirects: true
+    max-redirects: 2
     stop-at-first-match: true
     matchers-condition: and
     matchers:

--- a/technologies/wordpress-detect.yaml
+++ b/technologies/wordpress-detect.yaml
@@ -2,7 +2,7 @@ id: wordpress-detect
 
 info:
   name: WordPress Detect
-  author: pdteam,daffainfo,ricardomaia
+  author: pdteam,daffainfo,ricardomaia,topscoder
   severity: info
   metadata:
     verified: true
@@ -11,6 +11,8 @@ info:
 
 requests:
   - method: GET
+    redirects: true
+    max-redirects: 2
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/wp-admin/install.php"


### PR DESCRIPTION
### Template / PR Information

Many WordPress sites do have redirects implemented for www/non-www and http/https versions of the website in order to prevent from creating duplicate content and insecure content.

By allowing max 2 redirects, this template will definitely match many more WordPress sites.


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- https://websitesetup.org/http-to-https-wordpress/
- https://yoast.com/create-301-redirect-wordpress/