### PR TITLE
Add 8 new OSINT templates

### DIFF
--- a/osint/cal.yaml
+++ b/osint/cal.yaml
@@ -1,0 +1,25 @@
+id: cal
+
+info:
+  name: cal
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,cal,caldotcom
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://cal.com/{{user}}"
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/osint/ctflearn.yaml
+++ b/osint/ctflearn.yaml
@@ -1,0 +1,29 @@
+id: CTFLearn
+
+info:
+  name: ctflearn
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,ctflearn
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://ctflearn.com/user/{{user}}"
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Profile -  CTFlearn"

--- a/osint/npmjs.yaml
+++ b/osint/npmjs.yaml
@@ -1,0 +1,24 @@
+id: npmjs
+
+info:
+  name: npmjs
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,npmjs
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://www.npmjs.com/~{{user}}"
+    redirects: true
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/osint/polywork.yaml
+++ b/osint/polywork.yaml
@@ -1,0 +1,29 @@
+id: polywork
+
+info:
+  name: Polywork
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,polywork
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://polywork.com/{{user}}"
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "profile on Polywork"

--- a/osint/postnews.yaml
+++ b/osint/postnews.yaml
@@ -1,0 +1,30 @@
+id: postnews
+
+info:
+  name: Postnews
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,postnews
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://post.news/@/{{user}}"
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "Profile Not Found"

--- a/osint/skillshare.yaml
+++ b/osint/skillshare.yaml
@@ -1,0 +1,24 @@
+id: skillshare
+
+info:
+  name: skillshare
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,skillshare
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://www.skillshare.com/en/user/{{user}}"
+    redirects: true
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/osint/tmdb.yaml
+++ b/osint/tmdb.yaml
@@ -1,0 +1,24 @@
+id: tmdb
+
+info:
+  name: TMDB
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,tmdb
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://www.themoviedb.org/u/{{user}}"
+    redirects: true
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/osint/tryhackme.yaml
+++ b/osint/tryhackme.yaml
@@ -1,0 +1,24 @@
+id: tryhackme
+
+info:
+  name: Tryhackme
+  author: olearycrew
+  description: This OSINT template looks for information about a user name.
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  tags: osint,osint-tech,tryhackme
+
+self-contained: true
+requests:
+  - method: GET
+    path:
+      - "https://tryhackme.com/p/{{user}}"
+    redirects: true
+
+    matchers:
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information
This adds 8 new OSINT templates for identification of user profiles at the following services:

- Cal.com
- CTFlearn
- NPMJS
- Polywork
- Post.news
- SkillShare
- The Movie Database
- Tryhackme

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
N/A

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)