### PR TITLE
Add CVE-2019-1579

### DIFF
--- a/cves/2019/CVE-2019-1579.yaml
+++ b/cves/2019/CVE-2019-1579.yaml
@@ -1,0 +1,32 @@
+id: CVE-2019-1579
+
+info:
+  name: CVE-2019-1579
+  author: seqrity
+  severity: high
+  description: PreAuth RCE on Palo Alto GlobalProtect
+  reference:
+    - https://nvd.nist.gov/vuln/detail/cve-2019-1579
+    - https://https://blog.orange.tw/2019/07/attacking-ssl-vpn-part-1-preauth-rce-on-palo-alto.html
+    - https://github.com/securifera/CVE-2019-1579/blob/master/CVE-2019-1579_8.0.7_mips.py
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2019-1579
+    cwe-id: CWE-134
+  tags: paloalto
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sslmgr"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - <msg>Invalid parameters</msg>
+      - type: status
+        status:
+          - 200

--- a/cves/2019/CVE-2019-1579.yaml
+++ b/cves/2019/CVE-2019-1579.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://nvd.nist.gov/vuln/detail/cve-2019-1579
     - https://https://blog.orange.tw/2019/07/attacking-ssl-vpn-part-1-preauth-rce-on-palo-alto.html
-    - https://github.com/securifera/CVE-2019-1579/blob/master/CVE-2019-1579_8.0.7_mips.py
+    - https://github.com/seqrity/CVE-2019-1579/blob/master/CVE-2019-1579_8.0.7_mips.py
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.1

--- a/http/cves/2019/CVE-2019-1579.yaml
+++ b/http/cves/2019/CVE-2019-1579.yaml
@@ -1,22 +1,27 @@
 id: CVE-2019-1579
 
 info:
-  name: CVE-2019-1579
+  name: Palo Alto GlobalProtect - PreAuth RCE
   author: seqrity
   severity: high
-  description: PreAuth RCE on Palo Alto GlobalProtect
+  description: |
+    Remote Code Execution in PAN-OS 7.1.18 and earlier, PAN-OS 8.0.11-h1 and earlier, and PAN-OS 8.1.2 and earlier with GlobalProtect Portal or GlobalProtect Gateway Interface enabled may allow an unauthenticated remote attacker to execute arbitrary code.
   reference:
-    - https://nvd.nist.gov/vuln/detail/cve-2019-1579
     - https://https://blog.orange.tw/2019/07/attacking-ssl-vpn-part-1-preauth-rce-on-palo-alto.html
     - https://github.com/seqrity/CVE-2019-1579/blob/master/CVE-2019-1579_8.0.7_mips.py
+    - https://nvd.nist.gov/vuln/detail/cve-2019-1579
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.1
     cve-id: CVE-2019-1579
     cwe-id: CWE-134
-  tags: paloalto
+  metadata:
+    max-request: 1
+    verified: "true"
+    shodan-query: title:"GlobalProtect Portal"
+  tags: cve,cve2019,pan-os,rce
 
-requests:
+http:
   - method: GET
     path:
       - "{{BaseURL}}/sslmgr"
@@ -26,7 +31,10 @@ requests:
       - type: word
         part: body
         words:
-          - <msg>Invalid parameters</msg>
+          - "<msg>Invalid parameters</msg>"
+          - "error</status>"
+        condition: and
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
PreAuth RCE on Palo Alto GlobalProtect

### Template / PR Information

This template inspired by an [article](https://blog.orange.tw/2019/07/attacking-ssl-vpn-part-1-preauth-rce-on-palo-alto.html) from [orange_8361](https://twitter.com/orange_8361) PreAuth RCE on Palo Alto GlobalProtect 


- References:
    - https://nvd.nist.gov/vuln/detail/cve-2019-1579
    - https://https://blog.orange.tw/2019/07/attacking-ssl-vpn-part-1-preauth-rce-on-palo-alto.html
    - https://github.com/seqrity/CVE-2019-1579/blob/master/CVE-2019-1579_8.0.7_mips.py

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO