### PR TITLE
nginx-wrong-resolve

### DIFF
--- a/misconfiguration/nginx/nginx-wrong-resolve.yaml
+++ b/misconfiguration/nginx/nginx-wrong-resolve.yaml
@@ -1,15 +1,16 @@
 id: nginx-wrong-resolve
 
 info:
-  name: Nginx-Wrong-Resolve
+  name: Nginx Wrong Resolve
   author: pwnhxl
   severity: high
-  description: Nginx-Wrong-Resolve
+  description: |
+    Ngnix is a high-performance web server that is widely used. It is not only often used as a reverse proxy, but also supports the operation of PHP very well. When Ngnix encounters %00 null bytes, it is inconsistent with the backend FastCGI processing, so that PHP code can be embedded in the image and then executed by accessing xxx.jpg%00.php.
   reference:
     - https://github.com/vulhub/vulhub/tree/master/nginx/nginx_parsing_vulnerability
     - https://www.cnvd.org.cn/flaw/show/CNVD-2011-3360
     - https://www.cnblogs.com/qmfsun/p/6170175.html
-  tags: misconfiguration,parsing,php
+  tags: misconfig,parsing,php,nginx
 
 requests:
   - raw:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
````

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.9

                projectdiscovery.io

[ERR] Could not read nuclei-ignore file: open C:\Users\LENOVO\.config\nuclei\.nuclei-ignore: The system cannot find the file specified.
[INF] Using Nuclei Engine 2.8.9 (latest)
[INF] Using Nuclei Templates 9.3.9 (latest)
[INF] Templates added in last update: 61
[INF] Templates loaded for scan: 1
[INF] Targets loaded for scan: 1
[INF] [nginx-wrong-resolve] Dumped HTTP request for http://nuclei.projectdiscovery.io/robots.txt

GET /robots.txt HTTP/1.1
Host: nuclei.projectdiscovery.io
User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.3319.102 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [nginx-wrong-resolve] Dumped HTTP response http://nuclei.projectdiscovery.io/robots.txt

HTTP/1.1 200 OK
Connection: close
Content-Length: 4
Accept-Ranges: bytes
Content-Type: text/plain
Date: Thu, 16 Mar 2023 11:00:26 GMT
Etag: "64108854-4"
Last-Modified: Tue, 14 Mar 2023 14:44:36 GMT
Server: nginx/1.15.11

test
[INF] [nginx-wrong-resolve] Dumped HTTP request for http://nuclei.projectdiscovery.io/robots.txt/2N5qjdxmD9LHBzi83yYluef956k.php

GET /robots.txt/2N5qjdxmD9LHBzi83yYluef956k.php HTTP/1.1
Host: nuclei.projectdiscovery.io
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2919.83 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [nginx-wrong-resolve] Dumped HTTP response http://nuclei.projectdiscovery.io/robots.txt/2N5qjdxmD9LHBzi83yYluef956k.php

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/html; charset=UTF-8
Date: Thu, 16 Mar 2023 11:00:26 GMT
Server: nginx/1.15.11
X-Powered-By: PHP/7.3.4

test
[nginx-wrong-resolve:dsl-1] [http] [high] http://nuclei.projectdiscovery.io/robots.txt/2N5qjdxmD9LHBzi83yYluef956k.php
````
<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)