### PR TITLE
emlog CVE-2021-3293: FPD is not a high-severity vulnerability

### DIFF
--- a/cves/2021/CVE-2021-3293.yaml
+++ b/cves/2021/CVE-2021-3293.yaml
@@ -3,7 +3,7 @@ id: CVE-2021-3293
 info:
   name: emlog 5.3.1 Path Disclosure
   author: h1ei1
-  severity: high
+  severity: low
   description: emlog v5.3.1 is susceptible to full path disclosure via t/index.php, which allows an attacker to see the path to the webroot/file.
   reference:
     - https://github.com/emlog/emlog/issues/62


### PR DESCRIPTION
### Template / PR Information

Decreasing the severity of cves/2021/CVE-2021-3293.yaml as it's a full-path disclosure vulnerability which IMO doesn't deserve to be a high-severity one.

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
