### PR TITLE
Downgrading CVE-2022-0165 to medium, as it's Open Redirect

### DIFF
--- a/cves/2022/CVE-2022-0165.yaml
+++ b/cves/2022/CVE-2022-0165.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-0165
 info:
   name: WordPress Page Builder KingComposer <=2.9.6 - Open Redirect
   author: akincibor
-  severity: high
+  severity: medium
   description: WordPress Page Builder KingComposer 2.9.6 and prior does not validate the id parameter before redirecting the user to it via the kc_get_thumbn AJAX action (which is available to both unauthenticated and authenticated users).
   reference:
     - https://wpscan.com/vulnerability/906d0c31-370e-46b4-af1f-e52fbddd00cb


### PR DESCRIPTION
### Template / PR Information

Looks like the consensus in `nuclei-templates`  is that Open Redirects are of medium severity:

```
$ grep "severity:" `grep -r "Open Red"|cut -d: -f1|grep yaml`|cut -d: -f3|sort|uniq -c
      1  critical
      1  high
      5  low
     92  medium
```

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO

#### Additional Details (leave it blank if not applicable)

### Additional References:
