### PR TITLE
Add template for Kubernetes Fake Certificates

### DIFF
--- a/ssl/kubernetes-fake-certificate.yaml
+++ b/ssl/kubernetes-fake-certificate.yaml
@@ -1,0 +1,31 @@
+id: kubernetes-fake-certificate
+
+info:
+  name: Kubernetes Fake Ingress Certificate
+  author: kchason
+  severity: low
+  reference:
+    - https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
+  description: |
+    Kubernetes Ingress controllers use a default self-signed certificate when no certificate is specified. 
+    This certificate is not trusted by any browser and should be replaced with a proper certificate.
+  remediation: |
+    Purchase or generate a proper SSL certificate for this service.
+    https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
+  tags: ssl,kubernetes,tls
+
+ssl:
+  - address: "{{Host}}:{{Port}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'subject_cn == "Kubernetes Ingress Controller Fake Certificate"'
+          - 'issuer_cn == "Kubernetes Ingress Controller Fake Certificate"'
+        condition: or
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Subject: " + subject_cn'
+          - '"Issuer: " + issuer_cn'

--- a/ssl/kubernetes-fake-certificate.yaml
+++ b/ssl/kubernetes-fake-certificate.yaml
@@ -6,10 +6,9 @@ info:
   severity: low
   description: |
     Kubernetes Fake Ingress Certificate is a feature in Kubernetes that allows users to create and use fake or self-signed SSL/TLS certificates for testing purposes without having to obtain a real SSL/TLS certificate from a trusted Certificate Authority (CA).
+  remediation: Purchase or generate a proper SSL certificate for this service.
   reference:
     - https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
-  remediation: |
-    Purchase or generate a proper SSL certificate for this service.
   metadata:
     verified: "true"
     shodan-query: ssl:"Kubernetes Ingress Controller Fake Certificate"

--- a/ssl/kubernetes-fake-certificate.yaml
+++ b/ssl/kubernetes-fake-certificate.yaml
@@ -7,7 +7,7 @@ info:
   reference:
     - https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
   description: |
-    Kubernetes Ingress controllers use a default self-signed certificate when no certificate is specified. 
+    Kubernetes Ingress controllers use a default self-signed certificate when no certificate is specified.
     This certificate is not trusted by any browser and should be replaced with a proper certificate.
   remediation: |
     Purchase or generate a proper SSL certificate for this service.

--- a/ssl/kubernetes-fake-certificate.yaml
+++ b/ssl/kubernetes-fake-certificate.yaml
@@ -1,18 +1,19 @@
 id: kubernetes-fake-certificate
 
 info:
-  name: Kubernetes Fake Ingress Certificate
+  name: Kubernetes Fake Ingress Certificate - Detect
   author: kchason
   severity: low
+  description: |
+    Kubernetes Fake Ingress Certificate is a feature in Kubernetes that allows users to create and use fake or self-signed SSL/TLS certificates for testing purposes without having to obtain a real SSL/TLS certificate from a trusted Certificate Authority (CA).
   reference:
     - https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
-  description: |
-    Kubernetes Ingress controllers use a default self-signed certificate when no certificate is specified.
-    This certificate is not trusted by any browser and should be replaced with a proper certificate.
   remediation: |
     Purchase or generate a proper SSL certificate for this service.
-    https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/
-  tags: ssl,kubernetes,tls
+  metadata:
+    verified: "true"
+    shodan-query: ssl:"Kubernetes Ingress Controller Fake Certificate"
+  tags: ssl,kubernetes,tls,self-signed
 
 ssl:
   - address: "{{Host}}:{{Port}}"
@@ -27,5 +28,4 @@ ssl:
     extractors:
       - type: dsl
         dsl:
-          - '"Subject: " + subject_cn'
           - '"Issuer: " + issuer_cn'


### PR DESCRIPTION
### Template / PR Information

Kubernetes Ingress controllers use a default self-signed certificate when no certificate is specified. This certificate is not trusted by any browser and should be replaced with a proper certificate. This is similar to the self-signed certificate template at `ssl/self-signed-ssl.yaml` but provides more specific information as to the infrastructure, issuer, and remediation.

- References: https://snyk.io/blog/setting-up-ssl-tls-for-kubernetes-ingress/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
![image](https://user-images.githubusercontent.com/1111099/227735353-979f1e7d-859b-4f19-9f68-a61520aefb7a.png)
