### PR TITLE
Update wordpress-login.yaml

### DIFF
--- a/exposed-panels/wordpress-login.yaml
+++ b/exposed-panels/wordpress-login.yaml
@@ -20,10 +20,8 @@ requests:
       - type: word
         words:
           - "WordPress</title>"
-          - "Log In</title>"
           - '/wp-login.php?action=lostpassword">Lost your password?</a>'
           - '<form name="loginform" id="loginform" action="{{BaseURL}}/wp-login.php" method="post">'
-          - 'input type="password"'
         condition: or
 
 # Enhanced by md on 2023/01/25


### PR DESCRIPTION
Removal of two matchers with a very high false positive probability.

Some pages represent a login page regardless of the url. In this case, there is a high probability that the matches "Log In</title>" or 'input type="password"' are true.