### PR TITLE
password-policy.yaml: tags consistency

### DIFF
--- a/file/audit/fortigate/password-policy.yaml
+++ b/file/audit/fortigate/password-policy.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   description: The Administrative Password Policy is not set. Use the password policy feature to ensure all administrators use secure passwords that meet your organization's requirements.
   reference: https://docs.fortinet.com/document/fortigate/6.2.0/hardening-your-fortigate/582009/system-administrator-best-practices
-  tags: fortigate,config,audit,firewall
+  tags: fortigate,config,audit,file,firewall
 
 file:
   - extensions:


### PR DESCRIPTION
Missing `file` tag to be consistent with other file based templates

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)