### PR TITLE
Detect Open AI plugin manifest

### DIFF
--- a/miscellaneous/openai-plugin-manifest.yaml
+++ b/miscellaneous/openai-plugin-manifest.yaml
@@ -1,4 +1,4 @@
-id: openai-aiplugin-manifest
+id: openai-plugin-manifest
 
 info:
   name: OpenAI AI Plugin Manifest File

--- a/miscellaneous/openai-plugin-manifest.yaml
+++ b/miscellaneous/openai-plugin-manifest.yaml
@@ -1,0 +1,38 @@
+id: openai-aiplugin-manifest
+
+info:
+  name: OpenAI AI Plugin Manifest File
+  author: wunderwuzzi23
+  severity: info
+  tags: misc,generic,tech
+  reference:
+    - https://platform.openai.com/docs/plugins/getting-started/plugin-manifest
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/ai-plugin.json"
+    
+    host-redirects: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "name_for_human"
+          - "name_for_model"
+          - "api"
+        condition: and
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - ".name_for_human"
+          - ".description_for_human"
+          - ".api.url"
+          - ".schema_version"
+     
+        


### PR DESCRIPTION
### Template / PR Information

Recently I started building OpenAI plugins and thought it might be useful to have a plugin detection template. 
The location of the Plugin manifest is at `/.well-known/ai-plugin.json`, which is what this template looks for.

Further documentation for Plugins is located here: 
 - https://platform.openai.com/docs/plugins/getting-started

**Note:** This is my first contribution, so hope it all makes sense. :)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Tests with web servers that hosts a plugin, and one that doesn't.
<img width="1108" alt="plugin-test2" src="https://user-images.githubusercontent.com/35349594/232956702-488952a3-8163-4a4b-8fd8-4820da7bd763.png">

<img width="1108" alt="plugin-test" src="https://user-images.githubusercontent.com/35349594/232956085-dce85699-65c2-4510-b900-8031639bb32b.png">


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)