### PR TITLE
exposed ftpsync.settings files are high severity, as their may contain passwords

### DIFF
--- a/exposures/configs/ftp-credentials-exposure.yaml
+++ b/exposures/configs/ftp-credentials-exposure.yaml
@@ -3,11 +3,11 @@ id: ftp-credentials-exposure
 info:
   name: FTP Credentials - Detect
   author: pikpikcu
-  severity: medium
+  severity: high
   description: FTP credentials were detected.
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-    cvss-score: 5.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cwe-id: CWE-200
   tags: config,ftp,exposure
 

--- a/exposures/configs/ftp-credentials-exposure.yaml
+++ b/exposures/configs/ftp-credentials-exposure.yaml
@@ -1,7 +1,7 @@
 id: ftp-credentials-exposure
 
 info:
-  name: FTP Credentials - Detect
+  name: FTP Credentials Exposure
   author: pikpikcu
   severity: high
   description: FTP credentials were detected.

--- a/exposures/configs/ftp-credentials-exposure.yaml
+++ b/exposures/configs/ftp-credentials-exposure.yaml
@@ -9,6 +9,9 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cwe-id: CWE-200
+  metadata:
+    verified: "true"
+    google-query: inurl:"/ftpsync.settings"
   tags: config,ftp,exposure
 
 requests:
@@ -19,11 +22,11 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
-        words:
-          - FTPSync
-          - overwrite_newer_prevention
-          - default_folder_permissions
         part: body
+        words:
+          - "FTPSync"
+          - "overwrite_newer_prevention"
+          - "default_folder_permissions"
         condition: and
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

ftpsync.settings files may contain FTP passwords, which has a significant impact
on confidentiality (as it may allow an attacker to download website code including configuration files).

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
