### PR TITLE
Update waf-detect.yaml

### DIFF
--- a/technologies/waf-detect.yaml
+++ b/technologies/waf-detect.yaml
@@ -18,8 +18,43 @@ requests:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        _=<script>alert(1)</script>
+        _={{whatwaf-payloads}}
+      - |
+        GET /?_={{whatwaf-payloads}} HTTP/1.1
+        Host: {{Hostname}}
 
+    payloads:
+      whatwaf-payloads:
+        - 484029\") AS xDKy WHERE 5427=5427 UNION ALL SELECT NULL,NULL
+        - \' AND 1=1 \'
+        - \'))) AND \'1\'=\'1\' (((\'
+        - AND 1=1
+        - \' AND 1=1 \' OR 10=11,<script>alert(\'\');</script>
+        - \"\"\' AND 1=1 \" OR 1=10 \'\"\"
+        - \' AND 1=1 OR 2=2
+        - \' AND 1=1 OR 2=2 \'
+        - \' )) AND 1=1 \' OR \'2\'=\'3 --\'
+        - \' AND 1=1 OR 24=25 \'
+        - \' AND 1=1 OR 9=10 ORDERBY(1,2,3,4,5)
+        - \' AND 1=1 ORDERBY(1,2,3,4,5) \'; asdf
+        - AND 1=1,<script>alert(\"1,2,3,4,5);</script>
+        - AND 1=1,<script>alert(\\"test\\");</script>
+        - \' AND 1=1;SELECT * FROM information_schema.tables \'
+        - AS start WHERE 1601=1601 UNION ALL SELECT NULL,NULL
+        - /bin/cat /etc/passwd
+        - <img src=x onerror=\\"input\\">
+        - r\"\"\"&\lt\' AND 1=1 \',<script>alert(\"test\");</script>\"\"\"
+        - <script>alert(\'1\');</script>
+        - <script>alert(1);</script>
+        - <script>alert(\"\");</script>
+        - <script>alert(\"test\");</script>
+        - <script>alert(\'test\');</script>
+        - \'/><script>alert(\'whatwaf\');</script>
+        - <script>alert(\\"XSS\\");</script>
+        - SELECT * FROM information_schema.tables
+        - SELECT user FROM information_schema.tables AND user = \'test user\';
+        - UNION SELECT * FROM users WHERE user = \'admin\';
+    stop-at-first-match: true
     matchers:
       - type: regex
         name: instart
@@ -754,4 +789,4 @@ requests:
           - 'Server: CloudWAF'
           - 'Set-Cookie: HWWAFSESID='
 
-# Enhanced by mp on 2022/03/21
+# Enhanced by myztique on 2023/04/19


### PR DESCRIPTION
This commit extends the existing nuclei template for detecting WAFs. The original payload was matched with the reference payloads of the WhatWaf tool and all payloads used by this tool were added to the template. Additionally, a GET request was added, but to prevent a huge load on the tested web service, the option "stop-at-first-match: true" was added. This ensures that only the minimum number of requests are made until a WAF is detected.

As a pentester, I have noticed that the Nuclei template is not always able to detect WAFs, although the template and the tool it is based on are generally good. Therefore, I made these changes to improve the template's detection capability, which already provides me more impact.

In a second point, I would like to initiate a discussion. In my daily work I noticed that often generic WAFs are detected, which often don't have much impact, in this case you wouldn't find an additional waf like modsecurity. To solve this problem, I split the script into "waf-detect.yaml" and "waf-detect-generic.yaml" for myself. The "waf-detect-generic.yaml" file contains only matchers named "apachegeneric", "aspgeneric" and "nginxgeneric", while the corresponding matchers have been removed from "waf-detect.yaml". I welcome discussion of this approach as a suggestion.


- References: https://github.com/Ekultek/WhatWaf

### Template Validation

I've validated this template on a lagre list of live systems.