### PR TITLE
updated the fingerprint for Caddy

### DIFF
--- a/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/technologies/fingerprinthub-web-fingerprints.yaml
@@ -885,7 +885,7 @@ requests:
         part: header
         name: apilayer-caddy
         words:
-          - "Server: caddy"
+          - "Server: Caddy"
 
       - type: word
         name: appcms


### PR DESCRIPTION
### Template / PR Information

- Fixed fingerprinthub-web-fingerprints.yaml to detect Caddy web server
- The original template tried detecting Caddy based on the server header "Server: caddy"
- I updated the matcher since it is case sensitive to be "Server: Caddy"
- References:https://caddyserver.com/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Details to replicate locally:

```bash
# Start Caddy docker container with basic index file
docker pull caddy
echo "hello world" > index.html
docker run --rm -p 8000:80 -v $PWD/index.html:/usr/share/caddy/index.html caddy

# Curl command to view the server header
$ curl http://localhost:8000 -v
*   Trying 127.0.0.1:8000...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Length: 12
< Content-Type: text/html; charset=utf-8
< Etag: "rtkkrnc"
< Last-Modified: Sun, 23 Apr 2023 13:14:11 GMT
< Server: Caddy
< Date: Sun, 23 Apr 2023 13:25:45 GMT
< 
hello world
* Connection #0 to host localhost left intact

# Test the old template and see it doesn't detect caddy is running
$ nuclei -u http://localhost:8000 -t fingerprinthub-web-fingerprints.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.2

		projectdiscovery.io

[INF] Current nuclei version: v2.9.2 (latest)
[INF] Current nuclei-templates version: 9.4.2 (latest)
[INF] New templates added in latest release: 78
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!

# After updating the server header in the template, it now detects Caddy
$ nuclei -u http://localhost:8000 -t fingerprinthub-web-fingerprints.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.2

		projectdiscovery.io

[INF] Current nuclei version: v2.9.2 (latest)
[INF] Current nuclei-templates version: 9.4.2 (latest)
[INF] New templates added in latest release: 78
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[fingerprinthub-web-fingerprints:apilayer-caddy] [http] [info] http://localhost:8000

```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)