### PR TITLE
fix regex for win.ini

### DIFF
--- a/http/cves/2021/CVE-2021-43798.yaml
+++ b/http/cves/2021/CVE-2021-43798.yaml
@@ -34,7 +34,7 @@ http:
       - type: regex
         regex:
           - 'root:.*:0:0:'
-          - '\\[(font|extension|file)s\\]'
+          - '\[(font|extension|file)s\]'
           - 'socket\s*=\s*\/tmp\/grafana\.sock'
         condition: or
 


### PR DESCRIPTION
### Template / PR Information

during a test, a false positive was triggered by the template. the matcher for the win.ini took effect, although the expected parameters did not apply. on closer inspection, i noticed that the double backslashes seem to cause problems. while the strings `[fonts]`, `[extensions]` and `[files]` were searched for in a win.ini, the double backslashes in the regex caused errors, which ensured that the matcher always applied. however, a single backslash is necessary to map the characters `[` and `]` in regex.

- Fixed CVE-2021-43798

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details

since i unfortunately don't have an actual vulnerable system to test, i tested on an example win.ini file to check if the matcher works correctly according to my understanding.

