### PR TITLE
Add template for CVE-2022-22733 Apache ShardingSphere ElasticJob-UI p…

### DIFF
--- a/http/cves/2022/CVE-2022-22733.yaml
+++ b/http/cves/2022/CVE-2022-22733.yaml
@@ -1,0 +1,31 @@
+id: CVE-2022-22733
+
+info:
+  name: CVE-2022-22733 Apache ShardingSphere ElasticJob-UI privilege escalation
+  author: Zeyad Azima
+  severity: medium
+  description: CVE-2022-22733 is an Apache ShardingSphere ElasticJob-UI privilege escalation vulnerability and you could achieve Remote Code Execution checkout the Reference URL for full analysis of the vulnerability.
+  reference: https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/login"
+    headers:
+      Host: "192.168.0.162:8888"
+      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0"
+      Accept: "application/json, text/plain, */*"
+      Accept-Language: "en-US,en;q=0.5"
+      Accept-Encoding: "gzip, deflate"
+      Content-Type: "application/json;charset=utf-8"
+      Access-Token: ""
+      Content-Length: "39"
+      Origin: "http://192.168.0.162:8888"
+      DNT: "1"
+      Connection: "close"
+      Referer: "http://192.168.0.162:8888/"
+    body: '{"username":"guest","password":"guest"}'
+    matchers:
+      - type: word
+        words:
+          - '"accessToken":'

--- a/http/cves/2022/CVE-2022-22733.yaml
+++ b/http/cves/2022/CVE-2022-22733.yaml
@@ -10,9 +10,8 @@ info:
 requests:
   - method: POST
     path:
-      - "{{BaseURL}}/api/login"
+      - "{{BaseURL}}:8088/api/login"
     headers:
-      Host: "192.168.0.162:8888"
       User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0"
       Accept: "application/json, text/plain, */*"
       Accept-Language: "en-US,en;q=0.5"
@@ -20,10 +19,10 @@ requests:
       Content-Type: "application/json;charset=utf-8"
       Access-Token: ""
       Content-Length: "39"
-      Origin: "http://192.168.0.162:8888"
+      Origin: "{{BaseURL}}:8088"
       DNT: "1"
       Connection: "close"
-      Referer: "http://192.168.0.162:8888/"
+      Referer: "{{BaseURL}}:8088"
     body: '{"username":"guest","password":"guest"}'
     matchers:
       - type: word

--- a/http/cves/2022/CVE-2022-22733.yaml
+++ b/http/cves/2022/CVE-2022-22733.yaml
@@ -28,7 +28,7 @@ http:
          POST /api/login HTTP/1.1
          Host: {{Hostname}}
          Accept: application/json, text/plain, */*
-         Access-Token: 
+         Access-Token:
          Content-Type: application/json;charset=UTF-8
          Origin: {{RootURL}}
          Referer: {{RootURL}}

--- a/http/cves/2022/CVE-2022-22733.yaml
+++ b/http/cves/2022/CVE-2022-22733.yaml
@@ -18,7 +18,6 @@ requests:
       Accept-Encoding: "gzip, deflate"
       Content-Type: "application/json;charset=utf-8"
       Access-Token: ""
-      Content-Length: "39"
       Origin: "{{BaseURL}}:8088"
       DNT: "1"
       Connection: "close"

--- a/http/cves/2022/CVE-2022-22733.yaml
+++ b/http/cves/2022/CVE-2022-22733.yaml
@@ -1,29 +1,55 @@
 id: CVE-2022-22733
 
 info:
-  name: CVE-2022-22733 Apache ShardingSphere ElasticJob-UI privilege escalation
+  name: Apache ShardingSphere ElasticJob-UI privilege escalation
   author: Zeyad Azima
   severity: medium
-  description: CVE-2022-22733 is an Apache ShardingSphere ElasticJob-UI privilege escalation vulnerability and you could achieve Remote Code Execution checkout the Reference URL for full analysis of the vulnerability.
-  reference: https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation
+  description: |
+    Exposure of Sensitive Information to an Unauthorized Actor vulnerability in Apache ShardingSphere ElasticJob-UI allows an attacker who has guest account to do privilege escalation. This issue affects Apache ShardingSphere ElasticJob-UI Apache ShardingSphere ElasticJob-UI 3.x version 3.0.0 and prior versions.
+  reference:
+    - https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-22733
+    - https://lists.apache.org/thread/qpdsm936n9bhksb0rzn6bq1h7ord2nm6
+    - http://www.openwall.com/lists/oss-security/2022/01/20/2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2022-22733
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: http.favicon.hash:816588900
+    verified: "true"
+  tags: cve,cve2023,exposure,sharingsphere,apache
 
-requests:
-  - method: POST
-    path:
-      - "{{BaseURL}}:8088/api/login"
-    headers:
-      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0"
-      Accept: "application/json, text/plain, */*"
-      Accept-Language: "en-US,en;q=0.5"
-      Accept-Encoding: "gzip, deflate"
-      Content-Type: "application/json;charset=utf-8"
-      Access-Token: ""
-      Origin: "{{BaseURL}}:8088"
-      DNT: "1"
-      Connection: "close"
-      Referer: "{{BaseURL}}:8088"
-    body: '{"username":"guest","password":"guest"}'
+http:
+  - raw:
+      - |
+         POST /api/login HTTP/1.1
+         Host: {{Hostname}}
+         Accept: application/json, text/plain, */*
+         Access-Token: 
+         Content-Type: application/json;charset=UTF-8
+         Origin: {{RootURL}}
+         Referer: {{RootURL}}
+
+         {"username":"guest","password":"guest"}
+
+    matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
+          - '"success":true'
+          - '"isGuest":true'
           - '"accessToken":'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - application/json
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
A vulnerability discovered in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733, The vulnerability lead to exposure of sensitive informatiopns and as a results it allows an attacker who has guest account to do privilege escalation.

### Template / PR Information

- Added CVE-2022-22733 
- References: 
   - https://github.com/apache/shardingsphere-elasticjob-ui/commit/f3afe51221cd2382e59afc4b9544c6c8a4448a99?diff=split
   - https://nvd.nist.gov/vuln/detail/CVE-2022-22733
   - https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation
   - https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO