### PR TITLE
Added extra check for React detection

### DIFF
--- a/http/technologies/tech-detect.yaml
+++ b/http/technologies/tech-detect.yaml
@@ -1653,6 +1653,7 @@ http:
         name: react
         regex:
           - <[^>]+data-react
+          - Web site created using create-react-app
         condition: or
         part: body
 


### PR DESCRIPTION
### Template / PR Information

• Added an extra regex check for React technology detection

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

- "Web site created using create-react-app" is the default meta description on React sites that have used [create-react-app](https://github.com/facebook/create-react-app). This can be seen in the [index.html file in the create-react-app repository](https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/cra-template/template/public/index.html#L10). I have also observed this in the wild.

### Additional References:

- [Create React app GitHub](https://github.com/facebook/create-react-app/)
- [Stack Overflow Post Mentioning this Meta field](https://stackoverflow.com/questions/63927882/how-can-i-change-created-using-create-react-app-in-search-results)