### PR TITLE
Added templates to identify /.aws/credenitals and /.aws/config

### DIFF
--- a/http/exposures/configs/aws-config.yaml
+++ b/http/exposures/configs/aws-config.yaml
@@ -9,9 +9,9 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cwe-id: CWE-200
-  tags: config,exposure
   metadata:
-    max-request: 1
+    verified: true
+  tags: config,exposure,aws,credential
 
 http:
   - method: GET
@@ -20,15 +20,15 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "[default]"
+      - type: regex
+        regex:
+          - 'aws_access_key_id\s*=\s*'
+          - 'region\s*=\s*'
 
-      - type: dsl
-        dsl:
-          - "!contains(tolower(body), '<html')"
-          - "!contains(tolower(body), '<body')"
-        condition: and
+      - type: word
+        part: body
+        words:
+          - '[default]'
 
       - type: status
         status:

--- a/http/exposures/configs/aws-config.yaml
+++ b/http/exposures/configs/aws-config.yaml
@@ -1,0 +1,36 @@
+id: aws-config
+
+info:
+  name: AWS Configuration - Detect
+  author: m4lwhere
+  severity: medium
+  description: AWS config found via /.aws/config.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  tags: config,exposure
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.aws/config"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "[default]"
+
+      - type: dsl
+        dsl:
+          - "!contains(tolower(body), '<html')"
+          - "!contains(tolower(body), '<body')"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+

--- a/http/exposures/configs/aws-config.yaml
+++ b/http/exposures/configs/aws-config.yaml
@@ -33,4 +33,3 @@ http:
       - type: status
         status:
           - 200
-

--- a/http/exposures/configs/aws-credentials.yaml
+++ b/http/exposures/configs/aws-credentials.yaml
@@ -35,8 +35,8 @@ http:
         status:
           - 200
     extractors:
-     - type: regex
-       part: body
-       regex: 
-         - "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
-         - "([a-zA-Z0-9+/]{40})"
+      - type: regex
+        part: body
+        regex:
+          - "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+          - "([a-zA-Z0-9+/]{40})"

--- a/http/exposures/configs/aws-credentials.yaml
+++ b/http/exposures/configs/aws-credentials.yaml
@@ -5,11 +5,14 @@ info:
   author: m4lwhere
   severity: high
   description: AWS credentials found via /.aws/credentials endpoint.
+  reference:
+    - https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
     cvss-score: 9.4
     cwe-id: CWE-200
-  reference: https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/
+  metadata:
+    verified: true
   tags: config,exposure,aws,credential
 
 http:

--- a/http/exposures/configs/aws-credentials.yaml
+++ b/http/exposures/configs/aws-credentials.yaml
@@ -10,9 +10,7 @@ info:
     cvss-score: 9.4
     cwe-id: CWE-200
   reference: https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/
-  tags: config,exposure
-  metadata:
-    max-request: 1
+  tags: config,exposure,aws,credential
 
 http:
   - method: GET
@@ -21,9 +19,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "aws_access_key_id"
+      - type: regex
+        regex:
+          - 'aws_access_key_id\s*=\s*'
 
       - type: dsl
         dsl:
@@ -34,6 +32,7 @@ http:
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         part: body

--- a/http/exposures/configs/aws-credentials.yaml
+++ b/http/exposures/configs/aws-credentials.yaml
@@ -1,0 +1,42 @@
+id: aws-credentials
+
+info:
+  name: AWS Credentials - Detect
+  author: m4lwhere
+  severity: high
+  description: AWS credentials found via /.aws/credentials endpoint.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
+    cvss-score: 9.4
+    cwe-id: CWE-200
+  reference: https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/
+  tags: config,exposure
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.aws/credentials"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "aws_access_key_id"
+
+      - type: dsl
+        dsl:
+          - "!contains(tolower(body), '<html')"
+          - "!contains(tolower(body), '<body')"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+    extractors:
+     - type: regex
+       part: body
+       regex: 
+         - "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+         - "([a-zA-Z0-9+/]{40})"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Identify exposed `/.aws/credentials` and `/.aws/config` files for a host. These exposed files can leak access keys for AWS.
- References: https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

I've validated these templates across my Internet research as well.

#### Additional Details (leave it blank if not applicable)

Many organizations inadvertently leak their AWS configurations to the Internet. This causes a significant impact through leaked key material and allows attackers to use those keys to authenticate to AWS as that account. 

These templates search for the `/.aws/credentials` and `/.aws/config` files which are used by the AWS CLI to programmatically interface with AWS. 

This PR contains two templates since they are similar.

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)