### PR TITLE
Added http/cves/2019/CVE-2019-1943.yaml Template

### DIFF
--- a/http/cves/2019/CVE-2019-1943.yaml
+++ b/http/cves/2019/CVE-2019-1943.yaml
@@ -7,18 +7,19 @@ info:
   description: |
     Cisco Small Business 200,300 and 500 Series Switches contain an open redirect vulnerability in the Web UI. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2019-1943
     - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190717-sbss-redirect
     - https://www.exploit-db.com/exploits/47118
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-1943
   classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
-    cvss-score: 6.1
+    cve-id: CVE-2019-1943
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 4.7
     cwe-id: CWE-601
   metadata:
     max-request: 1
     verified: "true"
-    censys-query: "services.http.response.headers.location: /config/log_off_page.htm"
     shodan-query: "/config/log_off_page.htm"
+    censys-query: "services.http.response.headers.location: /config/log_off_page.htm"
   tags: cve,cve2023,redirect,cisco
 
 http:
@@ -35,9 +36,9 @@ http:
           - '(?i)Location:\shttps?:\/\/interact\.sh/cs[\w]+/'
 
       - type: word
-        part: header
+        part: server
         words:
-          - 'Server: GoAhead-Webs'
+          - 'GoAhead-Webs'
 
       - type: status
         status:

--- a/http/cves/2019/CVE-2019-1943.yaml
+++ b/http/cves/2019/CVE-2019-1943.yaml
@@ -1,0 +1,41 @@
+id: CVE-2019-1943
+
+info:
+  name: Cisco Small Business 200, 300, and 500 Series Switches - Open Redirect
+  author: bhutch
+  severity: medium
+  description: |
+    Cisco Small Business 200, 300, and 500 Series Switches contain an open redirect vulnerability in the Web UI. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-1943
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190717-sbss-redirect
+    - https://www.exploit-db.com/exploits/47118
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cwe-id: CWE-601
+  metadata:
+    max-request: 1
+    censys-query: "services.http.response.headers.location: /config/log_off_page.htm"
+    shodan-query: "/config/log_off_page.htm"
+  tags: redirect,cisco,cve
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: interact.sh
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?i)Location:\shttps?:\/\/interact\.sh/cs[\w]+/'
+      - type: word
+        part: header
+        words:
+          - 'Server: GoAhead-Webs'
+      - type: status
+        status:
+          - 302

--- a/http/cves/2019/CVE-2019-1943.yaml
+++ b/http/cves/2019/CVE-2019-1943.yaml
@@ -1,11 +1,11 @@
 id: CVE-2019-1943
 
 info:
-  name: Cisco Small Business 200, 300, and 500 Series Switches - Open Redirect
+  name: Cisco Small Business 200,300 and 500 Series Switches - Open Redirect
   author: bhutch
   severity: medium
   description: |
-    Cisco Small Business 200, 300, and 500 Series Switches contain an open redirect vulnerability in the Web UI. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
+    Cisco Small Business 200,300 and 500 Series Switches contain an open redirect vulnerability in the Web UI. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2019-1943
     - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190717-sbss-redirect
@@ -16,9 +16,10 @@ info:
     cwe-id: CWE-601
   metadata:
     max-request: 1
+    verified: "true"
     censys-query: "services.http.response.headers.location: /config/log_off_page.htm"
     shodan-query: "/config/log_off_page.htm"
-  tags: redirect,cisco,cve
+  tags: cve,cve2023,redirect,cisco
 
 http:
   - raw:
@@ -32,10 +33,12 @@ http:
         part: header
         regex:
           - '(?i)Location:\shttps?:\/\/interact\.sh/cs[\w]+/'
+
       - type: word
         part: header
         words:
           - 'Server: GoAhead-Webs'
+
       - type: status
         status:
           - 302


### PR DESCRIPTION
### Template / PR Information

Template to detect CVE-2019-1943, an open redirect in Cisco Small Business 200, 300, and 500 Series Switches. This template may be helpful in identifying switches potentially vulnerable to more recent CVEs (i.e., CVE-2023-20159, CVE-2023-20610, CVE-2023-20161, CVE-2023-20189).


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)