### PR TITLE
Adds missing 'tags' attributes to 3 templates

### DIFF
--- a/http/fuzzing/valid-gmail-check.yaml
+++ b/http/fuzzing/valid-gmail-check.yaml
@@ -6,6 +6,7 @@ info:
   severity: info
   reference:
     - https://github.com/dievus/geeMailUserFinder
+  tags: fuzz,gmail
   metadata:
     max-request: 1
 

--- a/http/miscellaneous/robots-txt-endpoint.yaml
+++ b/http/miscellaneous/robots-txt-endpoint.yaml
@@ -4,6 +4,7 @@ info:
   name: robots.txt endpoint prober
   author: CasperGN,pdteam
   severity: info
+  tags: misc,generic
   metadata:
     max-request: 2
 

--- a/http/vulnerabilities/ransomware/deadbolt-ransomware.yaml
+++ b/http/vulnerabilities/ransomware/deadbolt-ransomware.yaml
@@ -4,6 +4,7 @@ info:
   name: Deadbolt Ransomware Detection
   author: pdteam
   severity: info
+  tags: ransomware,deadbolt
   metadata:
     max-request: 1
 


### PR DESCRIPTION
### Template / PR Information

This change adds the 'tags' attribute to the info block of three templates that are currently missing it.

### Template Validation

I've validated this template locally?
- [ X ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)