### PR TITLE
Fixing false-positive in cves/2020/CVE-2020-35847.yaml

### DIFF
--- a/http/cves/2020/CVE-2020-35847.yaml
+++ b/http/cves/2020/CVE-2020-35847.yaml
@@ -48,3 +48,22 @@ http:
         regex:
           - 'string\([0-9]{1,3}\)(\s)?"(error404)([A-Za-z0-9-.@\s-]+)"'
         negative: true
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/auth/requestreset"
+    headers:
+      Content-Type: application/json
+    body: |
+      {
+        "user": {
+          "$func": "nonexistent_function"
+        }
+      }
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - 'string\([0-9]{1,3}\)(\s)?"([A-Za-z0-9-.@\s-]+)"'
+        negative: true


### PR DESCRIPTION
### Template / PR Information

Some websites always return some var_dump() results in the body. Therefore let's check whether if a function name is different, no var_dump will get called. Therefore we'll eliminate some false positives.

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO

