### PR TITLE
Update springboot-heapdump.yaml

### DIFF
--- a/http/misconfiguration/springboot/springboot-heapdump.yaml
+++ b/http/misconfiguration/springboot/springboot-heapdump.yaml
@@ -9,34 +9,43 @@ info:
     - https://github.com/pyn3rd/Spring-Boot-Vulnerability
   tags: springboot,exposure
   metadata:
-    max-request: 2
+    max-request: 3
+
+variables:
+  str: "{{rand_base(6)}}"
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/heapdump"
-      - "{{BaseURL}}/actuator/heapdump"
+  - raw:
+      - |
+        GET /{{str}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /heapdump HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /actuator/heapdump HTTP/1.1
+        Host: {{Hostname}}
 
     stop-at-first-match: true
     max-size: 2097152 # 2MB - Max Size to read from server response
     matchers-condition: and
     matchers:
+      - type: dsl
+        dsl:
+          - "!contains(tolower(all_headers_1), 'application/x-gzip')"
 
-      - type: binary
-        part: body
-        binary:
-          - "4a4156412050524f46494c45" # "JAVA PROFILE"
-          - "4850524f46" # "HPROF"
-          - "1f8b080000000000" # Gunzip magic byte
+      - type: dsl
+        dsl:
+          - "contains(hex_encode(body_2), '4a4156412050524f46494c45')"
+          - "contains(hex_encode(body_2), '4850524f46')"
+          - "contains(hex_encode(body_2), '1f8b080000000000')"
         condition: or
 
-      - type: word
-        part: header
-        words:
-          - "Accept-Encoding: gzip"
-        case-insensitive: true
-        negative: true
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "contains(hex_encode(body_3), '4a4156412050524f46494c45')"
+          - "contains(hex_encode(body_3), '4850524f46')"
+          - "contains(hex_encode(body_3), '1f8b080000000000')"
+        condition: or


### PR DESCRIPTION
[INF] [springboot-heapdump] Dumped HTTP request for https://test/iwOPzv

GET /iwOPzv HTTP/1.1
Host: test
User-Agent: Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2225.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [springboot-heapdump] Dumped HTTP response https://test/iwOPzv

HTTP/1.1 200 OK
Connection: close
Content-Length: 23
Content-Type: application/x-gzip
Date: Mon, 29 May 2023 16:40:07 GMT
Eagleeye-Traceid: 2114886416853784079976015e0e83
Server: Tengine/Aserver
Strict-Transport-Security: max-age=31536000
Strict-Transport-Security: max-age=31536000
Timing-Allow-Origin: *
Vary: Origin

���
[INF] [springboot-heapdump] Dumped HTTP request for https://test/heapdump

GET /heapdump HTTP/1.1
Host: test
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [springboot-heapdump] Dumped HTTP response https://test/heapdump

HTTP/1.1 200 OK
Connection: close
Content-Length: 23
Content-Type: application/x-gzip
Date: Mon, 29 May 2023 16:40:08 GMT
Eagleeye-Traceid: 2114885f16853784081887466e573c
Server: Tengine/Aserver
Strict-Transport-Security: max-age=31536000
Strict-Transport-Security: max-age=31536000
Timing-Allow-Origin: *
Vary: Origin

���
[INF] [springboot-heapdump] Dumped HTTP request for https://test/actuator/heapdump

GET /actuator/heapdump HTTP/1.1
Host: test
User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [springboot-heapdump] Dumped HTTP response https://test/actuator/heapdump

HTTP/1.1 200 OK
Connection: close
Content-Length: 23
Content-Type: application/x-gzip
Date: Mon, 29 May 2023 16:40:08 GMT
Eagleeye-Traceid: 2114890a16853784083897113ecf55
Server: Tengine/Aserver
Strict-Transport-Security: max-age=31536000
Strict-Transport-Security: max-age=31536000
Timing-Allow-Origin: *
Vary: Origin

���