### PR TITLE
QLIK Server - NTLM Endpoint

### DIFF
--- a/miscellaneous/ntlm-directories.yaml
+++ b/miscellaneous/ntlm-directories.yaml
@@ -64,7 +64,8 @@ requests:
         - /webticket/webticketservice.svc
         - /webticket/webticketservice.svcabs/
         - /adfs/services/trust/2005/windowstransport
-
+        - /internal_windows_authentication/
+        
     matchers-condition: and
     matchers:
       - type: dsl


### PR DESCRIPTION
### Template / PR Information

- Extended NTLM directories endpoints list to include QLIK Server


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Unable to share vulnerable example server details. 
QLIK servers expose `/internal_windows_authentication/` when NTLM authentication is enabled.
![Screenshot 2023-06-01 at 11 15 49](https://github.com/projectdiscovery/nuclei-templates/assets/62152036/197e3c65-abe9-4a70-b14b-49f19816fbc7)

