### PR TITLE
More effective Roundcube log disclosure template.

### DIFF
--- a/http/exposures/logs/roundcube-log-disclosure.yaml
+++ b/http/exposures/logs/roundcube-log-disclosure.yaml
@@ -8,7 +8,7 @@ info:
     - https://github.com/detectify/ugly-duckling/blob/master/modules/crowdsourced/roundcube-log-disclosure.json
   tags: exposure,logs
   metadata:
-    max-request: 9
+    max-request: 12
 
 http:
   - method: GET
@@ -19,6 +19,9 @@ http:
       - "{{BaseURL}}/webmail/logs/sendmail"
       - "{{BaseURL}}/webmail/logs/errors.log"
       - "{{BaseURL}}/webmail/logs/errors"
+      - "{{BaseURL}}/mail/logs/sendmail"
+      - "{{BaseURL}}/mail/logs/errors.log"
+      - "{{BaseURL}}/mail/logs/errors"
       - "{{BaseURL}}/logs/sendmail"
       - "{{BaseURL}}/logs/errors.log"
       - "{{BaseURL}}/logs/errors"

--- a/http/exposures/logs/roundcube-log-disclosure.yaml
+++ b/http/exposures/logs/roundcube-log-disclosure.yaml
@@ -2,7 +2,7 @@ id: roundcube-log-disclosure
 
 info:
   name: Roundcube Log Disclosure
-  author: dhiyaneshDk
+  author: dhiyaneshDk,kazet
   severity: medium
   reference:
     - https://github.com/detectify/ugly-duckling/blob/master/modules/crowdsourced/roundcube-log-disclosure.json
@@ -13,22 +13,28 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/roundcube/logs/sendmail"
-      - "{{BaseURL}}/roundcube/logs/errors.log"
-      - "{{BaseURL}}/roundcube/logs/errors"
-      - "{{BaseURL}}/webmail/logs/sendmail"
-      - "{{BaseURL}}/webmail/logs/errors.log"
-      - "{{BaseURL}}/webmail/logs/errors"
-      - "{{BaseURL}}/mail/logs/sendmail"
-      - "{{BaseURL}}/mail/logs/errors.log"
-      - "{{BaseURL}}/mail/logs/errors"
-      - "{{BaseURL}}/logs/sendmail"
-      - "{{BaseURL}}/logs/errors.log"
-      - "{{BaseURL}}/logs/errors"
+      - "{{BaseURL}}/{{roundcube_path}}"
 
+    payloads:
+      roundcube_path:
+        - roundcube/logs/sendmail
+        - roundcube/logs/errors.log
+        - roundcube/logs/errors
+        - webmail/logs/sendmail
+        - webmail/logs/errors.log
+        - webmail/logs/errors
+        - mail/logs/sendmail
+        - mail/logs/errors.log
+        - mail/logs/errors
+        - logs/sendmail
+        - logs/errors.log
+        - logs/errors
+
+    max-size: 1000
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "IMAP Error:"
           - "Message for"
@@ -37,8 +43,12 @@ http:
           - "PHP Error:"
           - "PHP Warning:"
         condition: or
-        part: body
 
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: dsl
+        dsl:
+          - content_length

--- a/http/exposures/logs/roundcube-log-disclosure.yaml
+++ b/http/exposures/logs/roundcube-log-disclosure.yaml
@@ -3,24 +3,37 @@ id: roundcube-log-disclosure
 info:
   name: Roundcube Log Disclosure
   author: dhiyaneshDk
-  severity: low
+  severity: medium
   reference:
     - https://github.com/detectify/ugly-duckling/blob/master/modules/crowdsourced/roundcube-log-disclosure.json
   tags: exposure,logs
   metadata:
-    max-request: 2
+    max-request: 9
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/roundcube/logs/sendmail"
       - "{{BaseURL}}/roundcube/logs/errors.log"
+      - "{{BaseURL}}/roundcube/logs/errors"
+      - "{{BaseURL}}/webmail/logs/sendmail"
+      - "{{BaseURL}}/webmail/logs/errors.log"
+      - "{{BaseURL}}/webmail/logs/errors"
+      - "{{BaseURL}}/logs/sendmail"
+      - "{{BaseURL}}/logs/errors.log"
+      - "{{BaseURL}}/logs/errors"
 
     matchers-condition: and
     matchers:
       - type: word
         words:
           - "IMAP Error:"
+          - "Message for"
+          - "DB Error:"
+          - "IMAP Error:"
+          - "PHP Error:"
+          - "PHP Warning:"
+        condition: or
         part: body
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

At CERT PL we have observed many Roundcube instances that:

- are situated in /webmail/ or on the root path
- contain error logs in the /logs/errors, not /logs/errors.log file

Besides, as these logs contain information about senders and recipients of all e-mails in the system, I propose to increase its severity at least to `medium`.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
