### PR TITLE
Fix false positives for non-200 status codes.

### DIFF
--- a/http/technologies/nacos-version.yaml
+++ b/http/technologies/nacos-version.yaml
@@ -21,7 +21,12 @@ http:
     path:
       - "{{BaseURL}}/v1/console/server/state?accessToken=&username="
 
+    matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
+
       - type: regex
         regex:
           - '"version":"(\d+\.\d+\.\d+)"'

--- a/http/technologies/nacos-version.yaml
+++ b/http/technologies/nacos-version.yaml
@@ -23,13 +23,13 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: regex
         regex:
           - '"version":"(\d+\.\d+\.\d+)"'
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

An example of a false alarm, Cloudflare added "version" to the 404 error page:

```
$ curl --silent https://www.shellcodes.org/v1/console/server/state\?accessToken\&username | grep version
<script defer src="https://static.cloudflareinsights.com/beacon.min.js/v52afc6f149f6479b8c77fa569edb01181681764108816" integrity="sha512-jGCTpDpBAYDGNYR5ztKt4BQPGef1P0giN6ZGVUi835kFF88FOmmn8jBQWNgrNd8g/Yu421NdgWhwQoaOPFflDw==" data-cf-beacon='{"rayId":"7d5711af49fa4084","version":"2023.4.0","r":1,"b":1,"token":"235041a3dcf149c2bad46aa59c9f9645","si":100}' crossorigin="anonymous"></script>
$ nuclei -t ./technologies/nacos-version.yaml -u https://www.shellcodes.org 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.4

		projectdiscovery.io

[INF] Current nuclei version: v2.9.4 (outdated)
[INF] Current nuclei-templates version: v9.5.2 (latest)
[INF] New templates added in latest release: 50
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[nacos-version] [http] [info] https://www.shellcodes.org/v1/console/server/state?accessToken&username ["version":"2023.4.0"]
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
