### PR TITLE
Create CVE-2012-4982.yaml

### DIFF
--- a/http/cves/2012/CVE-2012-4982.yaml
+++ b/http/cves/2012/CVE-2012-4982.yaml
@@ -3,11 +3,11 @@ info:
   name: Forescout CounterACT 6.3.4.1 - Open Redirect
   author: ctflearner
   severity: medium
-  description: | 
+  description: |
     Open redirect vulnerability in assets/login on the Forescout CounterACT NAC device before 7.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the 'a' parameter.
   reference:
     - https://www.exploit-db.com/exploits/38062
-    - https://www.reactionpenetrationtesting.co.uk/forescout-cross-site-redirection.html 
+    - https://www.reactionpenetrationtesting.co.uk/forescout-cross-site-redirection.html
     - https://nvd.nist.gov/vuln/detail/CVE-2012-4982
   classification:
     cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N

--- a/http/cves/2012/CVE-2012-4982.yaml
+++ b/http/cves/2012/CVE-2012-4982.yaml
@@ -1,0 +1,45 @@
+id: CVE-2012-4982
+info:
+  name: Forescout CounterACT 6.3.4.1 - Open Redirect
+  description: | 
+    Open redirect vulnerability in assets/login on the Forescout CounterACT NAC device before 7.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the 'a' parameter.
+  author: ctflearner
+  severity: medium
+  tags: 
+     - Forescout NAC
+     - Open redirect
+     - web
+     - cve2012
+  reference:
+    - https://www.exploit-db.com/exploits/38062
+    - https://www.reactionpenetrationtesting.co.uk/forescout-cross-site-redirection.html 
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-4982
+  classification:
+    cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N
+    cvss-score: 5.8
+    cve-id: CVE-2012-4982
+    cwe-id: CWE-20
+    cpe: cpe:2.3:a:forescout:counteract:6.3.4.10:*:*:*:*:*:*:*
+  
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/assets/login?a=http://www.evil.com"
+    
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+      - type: status
+        status:
+          - 301
+          - 302
+          - 307
+          - 308
+        condition: or

--- a/http/cves/2012/CVE-2012-4982.yaml
+++ b/http/cves/2012/CVE-2012-4982.yaml
@@ -1,15 +1,10 @@
 id: CVE-2012-4982
 info:
   name: Forescout CounterACT 6.3.4.1 - Open Redirect
-  description: | 
-    Open redirect vulnerability in assets/login on the Forescout CounterACT NAC device before 7.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the 'a' parameter.
   author: ctflearner
   severity: medium
-  tags: 
-     - Forescout NAC
-     - Open redirect
-     - web
-     - cve2012
+  description: | 
+    Open redirect vulnerability in assets/login on the Forescout CounterACT NAC device before 7.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the 'a' parameter.
   reference:
     - https://www.exploit-db.com/exploits/38062
     - https://www.reactionpenetrationtesting.co.uk/forescout-cross-site-redirection.html 
@@ -20,26 +15,17 @@ info:
     cve-id: CVE-2012-4982
     cwe-id: CWE-20
     cpe: cpe:2.3:a:forescout:counteract:6.3.4.10:*:*:*:*:*:*:*
-  
   metadata:
     max-request: 1
+  tags: cve,cve2012,redirect,forescout,counteract
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/assets/login?a=http://www.evil.com"
-    
-    stop-at-first-match: true
-    matchers-condition: and
+      - "{{BaseURL}}/assets/login?a=https://interact.sh"
+
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
-      - type: status
-        status:
-          - 301
-          - 302
-          - 307
-          - 308
-        condition: or
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'


### PR DESCRIPTION
Added a New  Nuclei Template CVE-2012-4982.yaml

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
-   This Template will Check for Open redirect vulnerability in assets/login on the Forescout CounterACT NAC device before 7.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the 'a' parameter.
<!-- Please include any reference to your template if available -->




-  Added CVE-2012-4982
- References: 
 - https://nvd.nist.gov/vuln/detail/CVE-2012-4982 
- https://www.reactionpenetrationtesting.co.uk/forescout-cross-site-redirection.html
- https://www.exploit-db.com/exploits/38062

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)