### PR TITLE
Create CVE-2011-5252.yaml

### DIFF
--- a/http/cves/2011/CVE-2011-5252.yaml
+++ b/http/cves/2011/CVE-2011-5252.yaml
@@ -1,0 +1,46 @@
+id: CVE-2011-5252
+info:
+  name: Orchard 1.0.x before 1.0.21, 1.1.x before 1.1.31, 1.2.x before 1.2.42, and 1.3.x before 1.3.10 - Open Redirect
+  description: | 
+    Open redirect vulnerability in Users/Account/LogOff in Orchard 1.0.x before 1.0.21, 1.1.x before 1.1.31, 1.2.x before 1.2.42, and 1.3.x before 1.3.10 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the ReturnUrl parameter.
+  author: ctflearner
+  severity: medium
+  tags: 
+     - Orchard 
+     - Open redirect
+     - web
+     - cve2011
+  reference:
+    - https://www.exploit-db.com/exploits/36493
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-5252  
+    - https://www.invicti.com/web-applications-advisories/open-redirection-vulnerability-in-orchard/
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/72110
+  classification:
+    cvss-metrics: CVSS:2.0/(AV:N/AC:M/Au:N/C:P/I:P/A:N)
+    cvss-score: 5.8
+    cve-id: CVE-2011-5252
+    cwe-id: CWE-20
+    cpe: cpe:2.3:a:orchardproject:orchard:1.3.10:*:*:*:*:*:*:*
+  
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/orchard/Users/Account/LogOff?ReturnUrl=%2f%2fhttp://www.evil.com%3f"
+    
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+      - type: status
+        status:
+          - 301
+          - 302
+          - 307
+          - 308
+        condition: or


### PR DESCRIPTION
Added a New Nuclei-Template CVE-2011-5252

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei-Template will check for Open redirect vulnerability in Users/Account/LogOff in Orchard 1.0.x before 1.0.21, 1.1.x before 1.1.31, 1.2.x before 1.2.42, and 1.3.x before 1.3.10 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the ReturnUrl parameter.
<!-- Please include any reference to your template if available -->

- Added CVE-2011-5252
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2011-5252 
- https://www.invicti.com/web-applications-advisories/open-redirection-vulnerability-in-orchard/ 
- https://exchange.xforce.ibmcloud.com/vulnerabilities/72110 

![CVE-2011-5252-POC-1](https://github.com/projectdiscovery/nuclei-templates/assets/98345027/b39e6aed-71cd-4ea9-b8a6-d4638a4783ee)


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)