### PR TITLE
Create CVE-2008-7269.yaml

### DIFF
--- a/http/cves/2008/CVE-2008-7269.yaml
+++ b/http/cves/2008/CVE-2008-7269.yaml
@@ -1,46 +1,33 @@
 id: CVE-2008-7269
+
 info:
   name: UC Gateway Investment SiteEngine v5.0 - Open Redirect
-  description: | 
-    .Open redirect vulnerability in api.php in SiteEngine 5.x allows user-assisted remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the forward parameter in a logout action.
   author: ctflearner
   severity: medium
-  tags: 
-     - UC Gateway Investment SiteEngine
-     - SiteEngine v5.0
-     - Open redirect
-     - web
-     - cve2008
+  description: |
+    Open redirect vulnerability in api.php in SiteEngine 5.x allows user-assisted remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the forward parameter in a logout action.
   reference:
-    - https://www.exploit-db.com/exploits/32523
     - https://nvd.nist.gov/vuln/detail/CVE-2008-7269
-    
+    - https://www.exploit-db.com/exploits/6823
   classification:
-    cvss-metrics: CVSS:2.0/(AV:N/AC:M/Au:N/C:N/I:P/A:P)
+    cvss-metrics: AV:N/AC:M/Au:N/C:N/I:P/A:P
     cvss-score: 5.8
     cve-id: CVE-2008-7269
     cwe-id: CWE-20
     cpe: cpe:2.3:a:boka:siteengine:5.0:*:*:*:*:*:*:*
-  
   metadata:
     max-request: 1
+    shodan-query: html:"SiteEngine"
+    verified: "true"
+  tags: cve,cve2008,redirect,siteengine
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/api.php?action=logout&forward=http://www.evil.com"
-    
-    stop-at-first-match: true
-    matchers-condition: and
+      - "{{BaseURL}}/api.php?action=logout&forward=http://interact.sh"
+
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
-      - type: status
-        status:
-          - 301
-          - 302
-          - 307
-          - 308
-        condition: or
+          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'

--- a/http/cves/2008/CVE-2008-7269.yaml
+++ b/http/cves/2008/CVE-2008-7269.yaml
@@ -1,0 +1,46 @@
+id: CVE-2008-7269
+info:
+  name: UC Gateway Investment SiteEngine v5.0 - Open Redirect
+  description: | 
+    .Open redirect vulnerability in api.php in SiteEngine 5.x allows user-assisted remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the forward parameter in a logout action.
+  author: ctflearner
+  severity: medium
+  tags: 
+     - UC Gateway Investment SiteEngine
+     - SiteEngine v5.0
+     - Open redirect
+     - web
+     - cve2008
+  reference:
+    - https://www.exploit-db.com/exploits/32523
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-7269
+    
+  classification:
+    cvss-metrics: CVSS:2.0/(AV:N/AC:M/Au:N/C:N/I:P/A:P)
+    cvss-score: 5.8
+    cve-id: CVE-2008-7269
+    cwe-id: CWE-20
+    cpe: cpe:2.3:a:boka:siteengine:5.0:*:*:*:*:*:*:*
+  
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api.php?action=logout&forward=http://www.evil.com"
+    
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+      - type: status
+        status:
+          - 301
+          - 302
+          - 307
+          - 308
+        condition: or


### PR DESCRIPTION
Added a New Nuclei-Template as CVE-2008-7269

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->

This Nuclei Template Will Check for Open redirect vulnerability in api.php in SiteEngine 5.x allows user-assisted remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the forward parameter in a logout action.

<!-- Please include any reference to your template if available -->

- Added CVE-2008-7269
- References: 
- https://nvd.nist.gov/vuln/detail/CVE-2008-7269 
- https://www.exploit-db.com/exploits/32523 

![CVE-2008-7269-POC-1](https://github.com/projectdiscovery/nuclei-templates/assets/98345027/822d850e-b203-4cd1-aa77-28b13ffed623)


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)