### PR TITLE
Add Netman Default Login

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1378,6 +1378,16 @@
             "website": "https://the-empire.systems",
             "email": ""
         }
+    },
+    {
+        "author": "mabdullah22",
+        "links": {
+            "github": "https://www.github.com/maabdullah22",
+            "twitter": "https://twitter.com/0x416264",
+            "linkedin": "",
+            "website": "",
+            "email": ""
+        }
     }
 
 ]

--- a/http/default-logins/Riello/netman204-default-login.yaml
+++ b/http/default-logins/Riello/netman204-default-login.yaml
@@ -1,0 +1,46 @@
+id: Netman204-default-login
+
+info:
+  name: Riello UPS NetMan 204 Network Card - Default Login
+  author: mabdullah22
+  severity: high
+  description: Default logins on Riello UPS NetMan 204 is used. Attacker can access to UPS and attacker can manipulate the UPS settings to disrupt the onsite systems.
+  reference:
+    - https://www.riello-ups.com/
+  metadata:
+    verified: true
+    shodan-query: title:"Netman"
+    censys-query: services.http.response.body:"Netman204"
+  tags: default-login,Netman-204-login
+
+requests:
+  - raw:
+      - |
+        GET /cgi-bin/login.cgi?username={{username}}&password={{password}} HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36
+        X-Requested-With: XMLHttpRequest
+        Accept-Encoding: gzip, deflate
+        Accept-Language: en-US,en;q=0.9
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+
+    matchers-condition: and
+    matchers:
+
+      - type: word
+        part: body
+        words:
+          - '"response": "ok",'
+          - '"message": "Welcome."'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+


### PR DESCRIPTION
Add a template for default login on Riello UPS NetMan 204. 

### Template / PR Information

During a Penetration testing I found multiple instances of Netman204 UPS instances with default logins, I wrote a template to test the logins.


### Template Validation

I've validated this template locally?
- [*] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Shodan Query Result
![image](https://github.com/projectdiscovery/nuclei-templates/assets/31371789/d4292027-d3ef-47e3-bd25-f13c43303d45)
