### PR TITLE
FIX: Matcher Updated for Kubecost

### DIFF
--- a/http/misconfiguration/unauth-kubecost.yaml
+++ b/http/misconfiguration/unauth-kubecost.yaml
@@ -21,6 +21,7 @@ http:
         words:
           - "<title>Cluster Overview | Kubecost</title>"
           - "<title>Kubecost</title>"
+        condition: or
 
       - type: word
         part: header

--- a/http/misconfiguration/unauth-kubecost.yaml
+++ b/http/misconfiguration/unauth-kubecost.yaml
@@ -19,7 +19,8 @@ http:
     matchers:
       - type: word
         words:
-          - '<title>Cluster Overview | Kubecost</title>'
+          - "<title>Cluster Overview | Kubecost</title>"
+          - "<title>Kubecost</title>"
 
       - type: word
         part: header


### PR DESCRIPTION
### Template / PR Information

Fixed matcher for unauthenticated Kubecost

Expected Result
<img width="776" alt="Screenshot 2023-06-13 at 7 55 37 PM" src="https://github.com/projectdiscovery/nuclei-templates/assets/43168803/c84aad8d-f5d8-404a-8ca1-cc6db27e512f">


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)