### PR TITLE
Create CVE-2009-0347.yaml

### DIFF
--- a/http/cves/2009/CVE-2009-0347.yaml
+++ b/http/cves/2009/CVE-2009-0347.yaml
@@ -1,0 +1,34 @@
+id: CVE-2009-0347
+
+info:
+  name: Autonomy Ultraseek- Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+    Open redirect vulnerability in cs.html in the Autonomy (formerly Verity) Ultraseek search engine allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via the url parameter.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2009-0347 
+    - https://www.exploit-db.com/exploits/32766 
+    - https://www.kb.cert.org/vuls/id/202753 
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/48336 
+  classification:
+    cvss-metrics: AV:N/AC:M/Au:N/C:N/I:P/A:P
+    cvss-score: 5.8
+    cve-id: CVE-2009-0347
+    cwe-id: CWE-59
+    cpe: cpe:2.3:a:autonomy:ultraseek:_nil_:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    
+  tags: cve,cve2009,redirect,Autonomy Ultraseek
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cs.html?url=http://www.example2.com"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)example2\.com.*$'

--- a/http/cves/2009/CVE-2009-0347.yaml
+++ b/http/cves/2009/CVE-2009-0347.yaml
@@ -7,19 +7,16 @@ info:
   description: |
     Open redirect vulnerability in cs.html in the Autonomy (formerly Verity) Ultraseek search engine allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via the url parameter.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2009-0347 
-    - https://www.exploit-db.com/exploits/32766 
-    - https://www.kb.cert.org/vuls/id/202753 
-    - https://exchange.xforce.ibmcloud.com/vulnerabilities/48336 
+    - https://nvd.nist.gov/vuln/detail/CVE-2009-0347
+    - https://www.exploit-db.com/exploits/32766
+    - https://www.kb.cert.org/vuls/id/202753
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/48336
   classification:
     cvss-metrics: AV:N/AC:M/Au:N/C:N/I:P/A:P
     cvss-score: 5.8
     cve-id: CVE-2009-0347
     cwe-id: CWE-59
     cpe: cpe:2.3:a:autonomy:ultraseek:_nil_:*:*:*:*:*:*:*
-  metadata:
-    max-request: 1
-    
   tags: cve,cve2009,redirect,Autonomy Ultraseek
 
 http:

--- a/http/cves/2009/CVE-2009-0347.yaml
+++ b/http/cves/2009/CVE-2009-0347.yaml
@@ -1,7 +1,7 @@
 id: CVE-2009-0347
 
 info:
-  name: Autonomy Ultraseek- Open Redirect
+  name: Autonomy Ultraseek - Open Redirect
   author: ctflearner
   severity: medium
   description: |
@@ -17,15 +17,15 @@ info:
     cve-id: CVE-2009-0347
     cwe-id: CWE-59
     cpe: cpe:2.3:a:autonomy:ultraseek:_nil_:*:*:*:*:*:*:*
-  tags: cve,cve2009,redirect,Autonomy Ultraseek
+  tags: cve,cve2009,redirect,autonomy
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/cs.html?url=http://www.example2.com"
+      - "{{BaseURL}}/cs.html?url=http://www.interact.sh"
 
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)example2\.com.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei Template Will check for Open redirect vulnerability in cs.html in the Autonomy (formerly Verity) Ultraseek search engine allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via the url parameter.
<!-- Please include any reference to your template if available -->

-  Added CVE-2009-0347
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2009-0347
- https://www.kb.cert.org/vuls/id/202753
- https://exchange.xforce.ibmcloud.com/vulnerabilities/48336

![CVE-2009-0347-POC-1](https://github.com/projectdiscovery/nuclei-templates/assets/98345027/e7546616-408e-4aa0-892e-8f028f9c52df)


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)