### PR TITLE
Create CVE-2012-6499.yaml

### DIFF
--- a/http/cves/2012/CVE-2012-6499.yaml
+++ b/http/cves/2012/CVE-2012-6499.yaml
@@ -1,0 +1,31 @@
+id: CVE-2012-6499
+info:
+  name: WordPress Plugin Age Verification v0.4 - Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+    Open redirect vulnerability in age-verification.php in the Age Verification plugin 0.4 and earlier for WordPress allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the redirect_to parameter.
+  reference:
+    - https://www.exploit-db.com/exploits/36540 
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-6499 
+    
+  classification:
+    cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N
+    cvss-score: 5.8
+    cve-id: CVE-2012-6499
+    cwe-id: CWE-20
+    cpe: cpe:2.3:a:age_verification_project:age_verification:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+  tags: cve,cve2012,redirect,WordPress Plugin,Age Verification
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/age-verification/age-verification.php?redirect_to=http%3A%2F%2Fwww.evil.com"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'

--- a/http/cves/2012/CVE-2012-6499.yaml
+++ b/http/cves/2012/CVE-2012-6499.yaml
@@ -6,17 +6,14 @@ info:
   description: |
     Open redirect vulnerability in age-verification.php in the Age Verification plugin 0.4 and earlier for WordPress allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the redirect_to parameter.
   reference:
-    - https://www.exploit-db.com/exploits/36540 
-    - https://nvd.nist.gov/vuln/detail/CVE-2012-6499 
-    
+    - https://www.exploit-db.com/exploits/36540
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-6499
   classification:
     cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N
     cvss-score: 5.8
     cve-id: CVE-2012-6499
     cwe-id: CWE-20
     cpe: cpe:2.3:a:age_verification_project:age_verification:*:*:*:*:*:*:*:*
-  metadata:
-    max-request: 1
   tags: cve,cve2012,redirect,WordPress Plugin,Age Verification
 
 http:

--- a/http/cves/2012/CVE-2012-6499.yaml
+++ b/http/cves/2012/CVE-2012-6499.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Open redirect vulnerability in age-verification.php in the Age Verification plugin 0.4 and earlier for WordPress allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the redirect_to parameter.
   reference:
-    - https://www.exploit-db.com/exploits/36540
+    - https://www.exploit-db.com/exploits/18350
     - https://wordpress.org/plugins/age-verification
     - https://nvd.nist.gov/vuln/detail/CVE-2012-6499
   classification:
@@ -19,9 +19,12 @@ info:
   tags: cve,cve2012,wordpress,wp,wp-plugin,redirect,age-verification
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/wp-content/plugins/age-verification/age-verification.php?redirect_to=http%3A%2F%2Fwww.interact.sh"
+  - raw:
+      - |
+        POST /wp-content/plugins/age-verification/age-verification.php HTTP/1.1
+        Host: {{Hostname}}
+
+        redirect_to=http://www.interact.sh&age_day=1&age_month=1&age_year=1970
 
     matchers:
       - type: regex

--- a/http/cves/2012/CVE-2012-6499.yaml
+++ b/http/cves/2012/CVE-2012-6499.yaml
@@ -1,4 +1,5 @@
 id: CVE-2012-6499
+
 info:
   name: WordPress Plugin Age Verification v0.4 - Open Redirect
   author: ctflearner
@@ -7,6 +8,7 @@ info:
     Open redirect vulnerability in age-verification.php in the Age Verification plugin 0.4 and earlier for WordPress allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the redirect_to parameter.
   reference:
     - https://www.exploit-db.com/exploits/36540
+    - https://wordpress.org/plugins/age-verification
     - https://nvd.nist.gov/vuln/detail/CVE-2012-6499
   classification:
     cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N
@@ -14,15 +16,15 @@ info:
     cve-id: CVE-2012-6499
     cwe-id: CWE-20
     cpe: cpe:2.3:a:age_verification_project:age_verification:*:*:*:*:*:*:*:*
-  tags: cve,cve2012,redirect,WordPress Plugin,Age Verification
+  tags: cve,cve2012,wordpress,wp,wp-plugin,redirect,age-verification
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/wp-content/plugins/age-verification/age-verification.php?redirect_to=http%3A%2F%2Fwww.evil.com"
+      - "{{BaseURL}}/wp-content/plugins/age-verification/age-verification.php?redirect_to=http%3A%2F%2Fwww.interact.sh"
 
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh\/?(\/|[^.].*)?$'


### PR DESCRIPTION
Added a New Nuclei Template as CVE-2012-6499

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei Template will check for Open redirect vulnerability in age-verification.php in the Age Verification plugin 0.4 and earlier for WordPress allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via a URL in the redirect_to parameter.
<!-- Please include any reference to your template if available -->

- Added CVE-2012-6499
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2012-6499

![CVE-2012-6499-POC-1](https://github.com/projectdiscovery/nuclei-templates/assets/98345027/b4a9cb4e-c9f5-47d4-a83a-cc0ba7168672)


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)