### PR TITLE
Create CVE-2012-5321.yaml

### DIFF
--- a/http/cves/2012/CVE-2012-5321.yaml
+++ b/http/cves/2012/CVE-2012-5321.yaml
@@ -7,19 +7,16 @@ info:
   description: |
     tiki-featured_link.php in TikiWiki CMS/Groupware 8.3 allows remote attackers to load arbitrary web site pages into frames and conduct phishing attacks via the url parameter, aka "frame injection
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2012-5321 
-    - https://www.exploit-db.com/exploits/36848 
-    - http://st2tea.blogspot.com/2012/02/tiki-wiki-cms-groupware-frame-injection.html  
-    - https://exchange.xforce.ibmcloud.com/vulnerabilities/73403  
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-5321
+    - https://www.exploit-db.com/exploits/36848
+    - http://st2tea.blogspot.com/2012/02/tiki-wiki-cms-groupware-frame-injection.html
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/73403
   classification:
     cvss-metrics: (AV:N/AC:M/Au:N/C:P/I:P/A:N)
     cvss-score: 5.8
     cve-id: CVE-2012-5321
     cwe-id: CWE-20
     cpe: cpe:2.3:a:tiki:tikiwiki_cms\/groupware:8.3:*:*:*:*:*:*:*
-  metadata:
-    max-request: 1
-    
   tags: cve,cve2012,redirect,TikiWiki,CMS/Groupware
 
 http:

--- a/http/cves/2012/CVE-2012-5321.yaml
+++ b/http/cves/2012/CVE-2012-5321.yaml
@@ -1,0 +1,34 @@
+id: CVE-2012-5321
+
+info:
+  name: TikiWiki CMS/Groupware v8.3- Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+    tiki-featured_link.php in TikiWiki CMS/Groupware 8.3 allows remote attackers to load arbitrary web site pages into frames and conduct phishing attacks via the url parameter, aka "frame injection
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-5321 
+    - https://www.exploit-db.com/exploits/36848 
+    - http://st2tea.blogspot.com/2012/02/tiki-wiki-cms-groupware-frame-injection.html  
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/73403  
+  classification:
+    cvss-metrics: (AV:N/AC:M/Au:N/C:P/I:P/A:N)
+    cvss-score: 5.8
+    cve-id: CVE-2012-5321
+    cwe-id: CWE-20
+    cpe: cpe:2.3:a:tiki:tikiwiki_cms\/groupware:8.3:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    
+  tags: cve,cve2012,redirect,TikiWiki,CMS/Groupware
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/tiki-featured_link.php?type=f&url=http://www.example2.com"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)example2\.com.*$'

--- a/http/cves/2012/CVE-2012-5321.yaml
+++ b/http/cves/2012/CVE-2012-5321.yaml
@@ -1,7 +1,7 @@
 id: CVE-2012-5321
 
 info:
-  name: TikiWiki CMS/Groupware v8.3- Open Redirect
+  name: TikiWiki CMS/Groupware v8.3 - Open Redirect
   author: ctflearner
   severity: medium
   description: |
@@ -22,10 +22,10 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/tiki-featured_link.php?type=f&url=http://www.example2.com"
+      - "{{BaseURL}}/tiki-featured_link.php?type=f&url=http://interact.sh"
 
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)example2\.com.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh\/?(\/|[^.].*)?$'

--- a/http/cves/2012/CVE-2012-5321.yaml
+++ b/http/cves/2012/CVE-2012-5321.yaml
@@ -1,7 +1,7 @@
 id: CVE-2012-5321
 
 info:
-  name: TikiWiki CMS/Groupware v8.3 - Open Redirect
+  name: TikiWiki CMS Groupware v8.3 - Open Redirect
   author: ctflearner
   severity: medium
   description: |
@@ -12,17 +12,19 @@ info:
     - http://st2tea.blogspot.com/2012/02/tiki-wiki-cms-groupware-frame-injection.html
     - https://exchange.xforce.ibmcloud.com/vulnerabilities/73403
   classification:
-    cvss-metrics: (AV:N/AC:M/Au:N/C:P/I:P/A:N)
+    cvss-metrics: AV:N/AC:M/Au:N/C:P/I:P/A:N
     cvss-score: 5.8
     cve-id: CVE-2012-5321
     cwe-id: CWE-20
     cpe: cpe:2.3:a:tiki:tikiwiki_cms\/groupware:8.3:*:*:*:*:*:*:*
-  tags: cve,cve2012,redirect,TikiWiki,CMS/Groupware
+  metadata:
+    shodan-query: http.html:"tiki wiki"
+  tags: cve,cve2012,redirect,tikiwiki,groupware
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/tiki-featured_link.php?type=f&url=http://interact.sh"
+      - "{{BaseURL}}/tiki-featured_link.php?type=f&url=https://interact.sh"
 
     matchers:
       - type: regex


### PR DESCRIPTION
Added a New Nuclei Template as CVE-2012-5321

### Template / PR Information
This Template will Check for tiki-featured_link.php in TikiWiki CMS/Groupware 8.3 allows remote attackers to load arbitrary web site pages into frames and conduct phishing attacks via the url parameter, aka "frame injection."

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2012-5321
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2012-5321
- http://st2tea.blogspot.com/2012/02/tiki-wiki-cms-groupware-frame-injection.html
- https://exchange.xforce.ibmcloud.com/vulnerabilities/73403

![CVE-2012-5321-POC-1](https://github.com/projectdiscovery/nuclei-templates/assets/98345027/92a153c4-2afc-4ef5-b4ae-4c8b9b0d4365)


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)