### PR TITLE
Create CVE-2019-10098.yaml

### DIFF
--- a/http/cves/2019/CVE-2019-10098.yaml
+++ b/http/cves/2019/CVE-2019-10098.yaml
@@ -1,4 +1,5 @@
 id: CVE-2019-10098
+
 info:
   name: Apache HTTP server v2.4.0 to v2.4.39 - Open Redirect
   author: ctflearner
@@ -8,19 +9,16 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/47689
     - https://nvd.nist.gov/vuln/detail/CVE-2019-10098
-    -  https://www.openwall.com/lists/oss-security/2020/04/01/4
+    - https://www.openwall.com/lists/oss-security/2020/04/01/4
     - https://httpd.apache.org/security/vulnerabilities_24.html
     - https://www.oracle.com/security-alerts/cpuapr2021.html
     - https://www.oracle.com/security-alerts/cpuoct2019.html
-    
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
     cve-id: CVE-2019-10098
     cwe-id: CWE-601
     cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
-  metadata:
-    max-request: 1
   tags: cve,cve2019,redirect,Apache HTTP server
 
 http:

--- a/http/cves/2019/CVE-2019-10098.yaml
+++ b/http/cves/2019/CVE-2019-10098.yaml
@@ -5,7 +5,7 @@ info:
   author: ctflearner
   severity: medium
   description: |
-   In Apache HTTP server 2.4.0 to 2.4.39, Redirects configured with mod_rewrite that were intended to be self-referential might be fooled by encoded newlines and redirect instead to an unexpected URL within the request URL.
+    In Apache HTTP server 2.4.0 to 2.4.39, Redirects configured with mod_rewrite that were intended to be self-referential might be fooled by encoded newlines and redirect instead to an unexpected URL within the request URL.
   reference:
     - https://www.exploit-db.com/exploits/47689
     - https://nvd.nist.gov/vuln/detail/CVE-2019-10098
@@ -19,15 +19,15 @@ info:
     cve-id: CVE-2019-10098
     cwe-id: CWE-601
     cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
-  tags: cve,cve2019,redirect,Apache HTTP server
+  tags: cve,cve2019,redirect,apache,server
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/http%3A%2F%2Fwww.evil.com"
+      - "{{BaseURL}}/http%3A%2F%2Fwww.interact.sh"
 
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh\/?(\/|[^.].*)?$'

--- a/http/cves/2019/CVE-2019-10098.yaml
+++ b/http/cves/2019/CVE-2019-10098.yaml
@@ -1,0 +1,35 @@
+id: CVE-2019-10098
+info:
+  name: Apache HTTP server v2.4.0 to v2.4.39 - Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+   In Apache HTTP server 2.4.0 to 2.4.39, Redirects configured with mod_rewrite that were intended to be self-referential might be fooled by encoded newlines and redirect instead to an unexpected URL within the request URL.
+  reference:
+    - https://www.exploit-db.com/exploits/47689
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-10098
+    -  https://www.openwall.com/lists/oss-security/2020/04/01/4
+    - https://httpd.apache.org/security/vulnerabilities_24.html
+    - https://www.oracle.com/security-alerts/cpuapr2021.html
+    - https://www.oracle.com/security-alerts/cpuoct2019.html
+    
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2019-10098
+    cwe-id: CWE-601
+    cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+  tags: cve,cve2019,redirect,Apache HTTP server
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/http%3A%2F%2Fwww.evil.com"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'


### PR DESCRIPTION
Added a New Nuclei Template as CVE-2019-10098

### Template / PR Information
This Nuclei Template Will Check  In Apache HTTP server 2.4.0 to 2.4.39, Redirects configured with mod_rewrite that were intended to be self-referential might be fooled by encoded newlines and redirect instead to an unexpected URL within the request URL.
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2019-10098
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2019-10098
- https://www.openwall.com/lists/oss-security/2020/04/01/4
- https://httpd.apache.org/security/vulnerabilities_24.html
- https://www.oracle.com/security-alerts/cpuapr2021.html
- https://www.oracle.com/security-alerts/cpuoct2019.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)