### PR TITLE
Create CVE-2022-1970.yaml

### DIFF
--- a/http/cves/2022/CVE-2022-1970.yaml
+++ b/http/cves/2022/CVE-2022-1970.yaml
@@ -6,10 +6,9 @@ info:
   description: |
    keycloak 18.0.0: open redirect in auth endpoint via the redirect_uri parameter.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-1970 
-    - https://bugzilla.redhat.com/show_bug.cgi?id=2092434 
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-1970
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2092434
     - https://github.com/syedsohaibkarim/OpenRedirect-Keycloak18.0.0
-    
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -23,10 +22,10 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/auth/realms/master/protocol/openid-connect/auth?client_id=&redirect_uri=http%3A%2F%2Fwww.evil.com&state=72526a4b-d5b6-4424-90db-cc0f7c2001a7&response_mode=fragment&response_type=code&scope=openid&nonce=33e890be-c19f-463f-bd0e-7fdcd065c0fb"
+      - "{{BaseURL}}/auth/realms/master/protocol/openid-connect/auth?client_id=&redirect_uri=http%3A%2F%2Finteract.sh&state=72526a4b-d5b6-4424-90db-cc0f7c2001a7&response_mode=fragment&response_type=code&scope=openid&nonce=33e890be-c19f-463f-bd0e-7fdcd065c0fb"
 
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh\/?(\/|[^.].*)?$'

--- a/http/cves/2022/CVE-2022-1970.yaml
+++ b/http/cves/2022/CVE-2022-1970.yaml
@@ -1,0 +1,32 @@
+id: CVE-2022-1970
+info:
+  name: keycloak v18.0.0 - Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+   keycloak 18.0.0: open redirect in auth endpoint via the redirect_uri parameter.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-1970 
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2092434 
+    - https://github.com/syedsohaibkarim/OpenRedirect-Keycloak18.0.0
+    
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-1970
+    cwe-id: CWE-601
+    cpe: cpe:2.3:a:redhat:keycloak:18.0.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+  tags: cve,cve2022,redirect,keycloak
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/realms/master/protocol/openid-connect/auth?client_id=&redirect_urihttp%3A%2F%2Fwww.evil.com&state=72526a4b-d5b6-4424-90db-cc0f7c2001a7&response_mode=fragment&response_type=code&scope=openid&nonce=33e890be-c19f-463f-bd0e-7fdcd065c0fb"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'

--- a/http/cves/2022/CVE-2022-1970.yaml
+++ b/http/cves/2022/CVE-2022-1970.yaml
@@ -23,7 +23,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/auth/realms/master/protocol/openid-connect/auth?client_id=&redirect_urihttp%3A%2F%2Fwww.evil.com&state=72526a4b-d5b6-4424-90db-cc0f7c2001a7&response_mode=fragment&response_type=code&scope=openid&nonce=33e890be-c19f-463f-bd0e-7fdcd065c0fb"
+      - "{{BaseURL}}/auth/realms/master/protocol/openid-connect/auth?client_id=&redirect_uri=http%3A%2F%2Fwww.evil.com&state=72526a4b-d5b6-4424-90db-cc0f7c2001a7&response_mode=fragment&response_type=code&scope=openid&nonce=33e890be-c19f-463f-bd0e-7fdcd065c0fb"
 
     matchers:
       - type: regex


### PR DESCRIPTION
Added a New Nuclei Template as CVE-2022-1970

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei Template Will Check for keycloak 18.0.0: open redirect in auth endpoint via the redirect_uri parameter.
<!-- Please include any reference to your template if available -->

-  Added CVE-2022-1970
- References:
- https://nvd.nist.gov/vuln/detail/CVE-2022-1970 
- https://bugzilla.redhat.com/show_bug.cgi?id=2092434 
-  https://github.com/syedsohaibkarim/OpenRedirect-Keycloak18.0.0
### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)