### PR TITLE
Create  CVE-2022-0869.yaml

### DIFF
--- a/http/cves/2022/CVE-2022-0869.yaml
+++ b/http/cves/2022/CVE-2022-0869.yaml
@@ -1,0 +1,35 @@
+id: CVE-2022-0869
+info:
+  name: nitely/spirit prior to 0.12.3.- Open Redirect
+  author: ctflearner
+  severity: medium
+  description: |
+   Multiple Open Redirect in GitHub repository nitely/spirit prior to 0.12.3.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0869 
+    - https://huntr.dev/bounties/ed335a88-f68c-4e4d-ac85-f29a51b03342/  
+    
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-0869
+    cwe-id: CWE-601
+    cpe: cpe:2.3:a:spirit-project:spirit:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 4
+  tags: cve,cve2022,redirect,nitely/spirit
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/user/login/?next=http%3A%2F%2Fwww.evil.com"
+      - "{{BaseURL}}/user/logout?next=http%3A%2F%2Fwww.evil.com"
+      - "{{BaseURL}}/user/register?next=http%3A%2F%2Fwww.evil.com"
+      - "{{BaseURL}}/user/resend-activation?next=http%3A%2F%2Fwww.evil.com"
+      
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'


### PR DESCRIPTION
Added a New Nuclei Template as CVE-2022-0869

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei Template will check for Multiple Open Redirect in GitHub repository nitely/spirit prior to 0.12.3.
<!-- Please include any reference to your template if available -->

- Added CVE-2022-0869
- References:
- https://huntr.dev/bounties/ed335a88-f68c-4e4d-ac85-f29a51b03342/
- https://nvd.nist.gov/vuln/detail/CVE-2022-0869

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)