### PR TITLE
feat: update fortinet-panel.yaml

### DIFF
--- a/http/exposed-panels/fortinet/fortinet-panel.yaml
+++ b/http/exposed-panels/fortinet/fortinet-panel.yaml
@@ -17,7 +17,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}"
+      - "{{BaseURL}}/login"
 
     matchers-condition: and
     matchers:

--- a/http/exposed-panels/fortinet/fortinet-panel.yaml
+++ b/http/exposed-panels/fortinet/fortinet-panel.yaml
@@ -10,21 +10,25 @@ info:
     cvss-score: 0.0
     cwe-id: CWE-200
   metadata:
-    max-request: 1
+    verified: true
     shodan-query: http.title:"FORTINET LOGIN"
-  tags: panel,fortinet
+  tags: panel,fortinet,login,detect
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}"
       - "{{BaseURL}}/login"
 
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - '<title tiles:fragment="title">FORTINET LOGIN</title>'
+          - 'FORTINET LOGIN</title>'
 
       - type: status
         status:


### PR DESCRIPTION
The default fortinet login endpoint is `/login` but the template check the `/` endpoint

![image](https://github.com/projectdiscovery/nuclei-templates/assets/36522826/9ced32cb-8432-447d-ae3a-58484943fa04)
