### PR TITLE
removed deprecated header syntax with latest one

### DIFF
--- a/http/cves/2018/CVE-2018-18069.yaml
+++ b/http/cves/2018/CVE-2018-18069.yaml
@@ -31,7 +31,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(tolower(all_headers), "text/html")'
+          - 'contains(tolower(header), "text/html")'
           - 'contains(set_cookie, "_icl_current_admin_language")'
           - 'contains(body, "\"><script>alert(0);</script>")'
         condition: and

--- a/http/cves/2018/CVE-2018-19749.yaml
+++ b/http/cves/2018/CVE-2018-19749.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - "contains(body_3, '><script>alert(document.domain)</script></a>')"
         condition: and
 

--- a/http/cves/2018/CVE-2018-19914.yaml
+++ b/http/cves/2018/CVE-2018-19914.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "><script>alert(document.domain)</script></a>")'
         condition: and
 

--- a/http/cves/2018/CVE-2018-19915.yaml
+++ b/http/cves/2018/CVE-2018-19915.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "><script>alert(document.domain)</script></a>")'
         condition: and
 

--- a/http/cves/2018/CVE-2018-20009.yaml
+++ b/http/cves/2018/CVE-2018-20009.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "><script>alert(document.domain)</script></a>")'
         condition: and
 

--- a/http/cves/2018/CVE-2018-20010.yaml
+++ b/http/cves/2018/CVE-2018-20010.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "><script>alert(document.domain)</script></a>")'
         condition: and
 

--- a/http/cves/2018/CVE-2018-20011.yaml
+++ b/http/cves/2018/CVE-2018-20011.yaml
@@ -48,7 +48,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "><script>alert(document.domain)</script></a>")'
         condition: and
 

--- a/http/cves/2019/CVE-2019-11869.yaml
+++ b/http/cves/2019/CVE-2019-11869.yaml
@@ -48,6 +48,6 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers_2), 'text/html')"
+          - "contains(tolower(header_2), 'text/html')"
 
 # Enhanced by mp on 2022/08/11

--- a/http/cves/2019/CVE-2019-12990.yaml
+++ b/http/cves/2019/CVE-2019-12990.yaml
@@ -41,7 +41,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers, "text/html")'
+          - 'contains(header, "text/html")'
           - 'status_code_3 == 200'
           - 'contains(body_1, "<title>Citrix SD-WAN</title>")'
         condition: and

--- a/http/cves/2019/CVE-2019-15811.yaml
+++ b/http/cves/2019/CVE-2019-15811.yaml
@@ -42,7 +42,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "value=\"\"onfocus=\"alert(document.domain)\"autofocus=")'
           - 'contains(body_2, "DomainMOD")'
         condition: and

--- a/http/cves/2020/CVE-2020-11978.yaml
+++ b/http/cves/2020/CVE-2020-11978.yaml
@@ -64,7 +64,7 @@ http:
       - type: dsl
         dsl:
           - 'contains(body_4, "operator":"BashOperator")'
-          - 'contains(all_headers_4, "application/json")'
+          - 'contains(header_4, "application/json")'
         condition: and
 
 # Enhanced by mp on 2022/07/13

--- a/http/cves/2020/CVE-2020-13405.yaml
+++ b/http/cves/2020/CVE-2020-13405.yaml
@@ -46,7 +46,7 @@ http:
           - 'contains(body,"password")'
           - 'contains(body,"password_reset_hash")'
           - 'status_code==200'
-          - 'contains(all_headers,"text/html")'
+          - 'contains(header,"text/html")'
         condition: and
 
 # Enhanced by md on 2023/04/04

--- a/http/cves/2020/CVE-2020-20988.yaml
+++ b/http/cves/2020/CVE-2020-20988.yaml
@@ -44,7 +44,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "value=\"\"/><script>alert(document.domain)</script>")'
           - 'contains(body_2, "DomainMOD")'
         condition: and

--- a/http/cves/2020/CVE-2020-23697.yaml
+++ b/http/cves/2020/CVE-2020-23697.yaml
@@ -53,7 +53,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_4, "text/html")'
+          - 'contains(header_4, "text/html")'
           - 'status_code_4 == 200'
           - 'contains(body_4, "><script>alert(document.domain)</script>") && contains(body_4, "Monstra")'
         condition: and

--- a/http/cves/2020/CVE-2020-9043.yaml
+++ b/http/cves/2020/CVE-2020-9043.yaml
@@ -52,7 +52,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_4, 'text/html')"
+          - "contains(header_4, 'text/html')"
           - "status_code_4 == 200"
           - "contains(body_4, 'wpCentral Connection Key')"
           - contains(body_4, "pagenow = \'dashboard\'")

--- a/http/cves/2021/CVE-2021-24145.yaml
+++ b/http/cves/2021/CVE-2021-24145.yaml
@@ -61,7 +61,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_3, "text/html")
+          - contains(header_3, "text/html")
           - status_code_3 == 200
           - contains(body_3, 'CVE-2021-24145')
         condition: and

--- a/http/cves/2021/CVE-2021-24155.yaml
+++ b/http/cves/2021/CVE-2021-24155.yaml
@@ -66,7 +66,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_4, "text/html")
+          - contains(header_4, "text/html")
           - status_code_4 == 200
           - contains(body_3, '{\"success\":1}')
           - contains(body_4, 'CVE-2021-24155')

--- a/http/cves/2021/CVE-2021-24165.yaml
+++ b/http/cves/2021/CVE-2021-24165.yaml
@@ -43,7 +43,7 @@ http:
         dsl:
           - 'status_code_1 == 302'
           - 'status_code_2 == 302'
-          - "contains(all_headers_2, 'Location: https://interact.sh?client_id=1')"
+          - "contains(header_2, 'Location: https://interact.sh?client_id=1')"
         condition: and
 
 # Enhanced by md on 2022/10/14

--- a/http/cves/2021/CVE-2021-24347.yaml
+++ b/http/cves/2021/CVE-2021-24347.yaml
@@ -88,7 +88,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_4, "text/html")
+          - contains(header_4, "text/html")
           - status_code_4 == 200
           - contains(body_4, "CVE-2021-24347")
         condition: and

--- a/http/cves/2021/CVE-2021-24436.yaml
+++ b/http/cves/2021/CVE-2021-24436.yaml
@@ -43,7 +43,7 @@ http:
         dsl:
           - status_code_2 == 200
           - contains(body_2, '><script>alert(document.domain)</script>&action=view')
-          - contains(all_headers_2, "text/html")
+          - contains(header_2, "text/html")
         condition: and
 
 # Enhanced by md on 2023/03/28

--- a/http/cves/2021/CVE-2021-24452.yaml
+++ b/http/cves/2021/CVE-2021-24452.yaml
@@ -42,7 +42,7 @@ http:
         dsl:
           - status_code_2 == 200
           - contains(body_2, 'extensions/\'-alert(document.domain)-\'') && contains(body_2, 'w3-total-cache')
-          - contains(all_headers_2, "text/html")
+          - contains(header_2, "text/html")
         condition: and
 
 # Enhanced by md on 2023/03/28

--- a/http/cves/2021/CVE-2021-24940.yaml
+++ b/http/cves/2021/CVE-2021-24940.yaml
@@ -40,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_2, "text/html")
+          - contains(header_2, "text/html")
           - status_code_2 == 200
           - contains(body_2, 'accesskey=X onclick=alert(1) test=')
           - contains(body_2, 'woocommerce_persian_translate')

--- a/http/cves/2021/CVE-2021-25078.yaml
+++ b/http/cves/2021/CVE-2021-25078.yaml
@@ -38,7 +38,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200 && status_code_3 == 200'
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'contains(body_3, "<img src onerror=alert(document.domain)>")'
           - 'contains(body_3, "Affiliates Manager Click Tracking")'
         condition: and

--- a/http/cves/2021/CVE-2021-25114.yaml
+++ b/http/cves/2021/CVE-2021-25114.yaml
@@ -38,7 +38,7 @@ http:
       - type: dsl
         dsl:
           - duration_1>=6
-          - contains(all_headers_1, "application/json")
+          - contains(header_1, "application/json")
           - status_code == 200
           - contains(body_2, 'other_discount_code_')
         condition: and

--- a/http/cves/2021/CVE-2021-25299.yaml
+++ b/http/cves/2021/CVE-2021-25299.yaml
@@ -45,7 +45,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "iframe src=\"javascript:alert(document.domain)") && contains(body_3, "SSH Terminal")'
         condition: and

--- a/http/cves/2021/CVE-2021-33851.yaml
+++ b/http/cves/2021/CVE-2021-33851.yaml
@@ -53,7 +53,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_4 == 200'
-          - 'contains(all_headers_4, "text/html")'
+          - 'contains(header_4, "text/html")'
           - 'contains(body_4, "Go to <script>alert(document.domain)</script>")'
         condition: and
 

--- a/http/cves/2021/CVE-2021-36748.yaml
+++ b/http/cves/2021/CVE-2021-36748.yaml
@@ -38,7 +38,7 @@ http:
           - "status_code_1 == 200"
           - "status_code_2 == 404"
           - 'contains(body_1, "prestashop")'
-          - "contains(tolower(all_headers_2), 'index.php?controller=404')"
+          - "contains(tolower(header_2), 'index.php?controller=404')"
           - "len(body_2) == 0"
         condition: and
 

--- a/http/cves/2021/CVE-2021-36873.yaml
+++ b/http/cves/2021/CVE-2021-36873.yaml
@@ -52,7 +52,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_4, "text/html")
+          - contains(header_4, "text/html")
           - status_code_4 == 200
           - contains(body_4, 'blockcountry_blockmessage\">test</textarea><script>alert(document.domain)</script>')
           - contains(body_4, '<h3>Block type</h3>')

--- a/http/cves/2021/CVE-2021-37216.yaml
+++ b/http/cves/2021/CVE-2021-37216.yaml
@@ -41,6 +41,6 @@ http:
 
       - type: dsl
         dsl:
-          - "!contains(tolower(all_headers), 'x-xss-protection')"
+          - "!contains(tolower(header), 'x-xss-protection')"
 
 # Enhanced by mp on 2022/08/28

--- a/http/cves/2021/CVE-2021-38540.yaml
+++ b/http/cves/2021/CVE-2021-38540.yaml
@@ -67,7 +67,7 @@ http:
         dsl:
           - 'contains(body_1, "Sign In")'
           - 'status_code_2 == 302'
-          - 'contains(all_headers_2, "session=.")'
+          - 'contains(header_2, "session=.")'
         condition: and
 
       - type: word

--- a/http/cves/2021/CVE-2021-41432.yaml
+++ b/http/cves/2021/CVE-2021-41432.yaml
@@ -65,7 +65,7 @@ http:
         dsl:
           - "contains(body_4, '<p><script>alert(document.cookie)</script></p>')"
           - "contains(body_4, 'FlatPress')"
-          - "contains(all_headers_4, 'text/html')"
+          - "contains(header_4, 'text/html')"
           - "status_code_4 == 200"
         condition: and
 

--- a/http/cves/2021/CVE-2021-43510.yaml
+++ b/http/cves/2021/CVE-2021-43510.yaml
@@ -41,7 +41,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_1, "text/html")'
+          - 'contains(header_1, "text/html")'
           - 'status_code_1 == 200'
           - 'contains(body_1, "{\"status\":\"success\"}")'
           - 'contains(body_2, "Welcome to Simple Client")'

--- a/http/cves/2021/CVE-2021-46068.yaml
+++ b/http/cves/2021/CVE-2021-46068.yaml
@@ -50,7 +50,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "Administrator\"><script>alert(document.domain)</script> Admin")'
         condition: and

--- a/http/cves/2021/CVE-2021-46069.yaml
+++ b/http/cves/2021/CVE-2021-46069.yaml
@@ -51,7 +51,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "<td>\"><script>alert(document.domain)</script></td>")'
         condition: and

--- a/http/cves/2021/CVE-2021-46071.yaml
+++ b/http/cves/2021/CVE-2021-46071.yaml
@@ -51,7 +51,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "<td>\"><script>alert(document.domain)</script></td>")'
         condition: and

--- a/http/cves/2021/CVE-2021-46072.yaml
+++ b/http/cves/2021/CVE-2021-46072.yaml
@@ -50,7 +50,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "<td>\"><script>alert(document.domain)</script></td>")'
         condition: and

--- a/http/cves/2021/CVE-2021-46073.yaml
+++ b/http/cves/2021/CVE-2021-46073.yaml
@@ -51,7 +51,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_3, 'text/html')"
+          - "contains(header_3, 'text/html')"
           - "status_code_3 == 200"
           - 'contains(body_3, "<script>alert(document.domain)</script> Test</td>")'
         condition: and

--- a/http/cves/2022/CVE-2022-0206.yaml
+++ b/http/cves/2022/CVE-2022-0206.yaml
@@ -41,7 +41,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "onanimationstart=alert(document.domain)")'
           - 'contains(body_2, "newstatpress_page")'
         condition: and

--- a/http/cves/2022/CVE-2022-0220.yaml
+++ b/http/cves/2022/CVE-2022-0220.yaml
@@ -40,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_2, 'text/html')"
+          - "contains(header_2, 'text/html')"
           - "status_code_2 == 200"
           - "contains(body_2, '<body onload=alert(document.domain)>') && contains(body_2, '/wp-content/plugins/')"
         condition: and

--- a/http/cves/2022/CVE-2022-0535.yaml
+++ b/http/cves/2022/CVE-2022-0535.yaml
@@ -54,7 +54,7 @@ http:
       - type: dsl
         dsl:
           - contains(body_4, 'placeholder=\"Developer IPs\" ></textarea><svg/onload=alert(document.domain)>')
-          - contains(all_headers_4, "text/html")
+          - contains(header_4, "text/html")
           - status_code_4 == 200
         condition: and
 

--- a/http/cves/2022/CVE-2022-0599.yaml
+++ b/http/cves/2022/CVE-2022-0599.yaml
@@ -46,7 +46,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
         condition: and
 
 # Enhanced by md on 2022/09/08

--- a/http/cves/2022/CVE-2022-0660.yaml
+++ b/http/cves/2022/CVE-2022-0660.yaml
@@ -48,7 +48,7 @@ http:
           - contains(body_2,'QueryException')
           - contains(body_2,'SQLSTATE')
           - contains(body_2,'runQueryCallback')
-          - 'contains(all_headers_2,"text/html")'
+          - 'contains(header_2,"text/html")'
           - 'status_code_2==500'
         condition: and
 

--- a/http/cves/2022/CVE-2022-0928.yaml
+++ b/http/cves/2022/CVE-2022-0928.yaml
@@ -53,7 +53,7 @@ http:
       - type: dsl
         dsl:
           - 'contains(body_3,"<img src=x onerror=alert(document.domain)></td>")'
-          - 'contains(all_headers_3,"text/html")'
+          - 'contains(header_3,"text/html")'
           - 'status_code_2 == 200 && status_code_3 == 200'
         condition: and
 

--- a/http/cves/2022/CVE-2022-0952.yaml
+++ b/http/cves/2022/CVE-2022-0952.yaml
@@ -48,7 +48,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers, "application/json")'
+          - 'contains(header, "application/json")'
           - "status_code == 200"
           - "contains(body_1, 'users_can_register')"
           - "contains(body_2, 'default_role')"

--- a/http/cves/2022/CVE-2022-0954.yaml
+++ b/http/cves/2022/CVE-2022-0954.yaml
@@ -55,7 +55,7 @@ http:
         dsl:
           - 'contains(body_2,"true")'
           - contains(body_3,'\"><img src=\"x\" onerror=\"alert(document.domain);\">\" placeholder=\"Use default')
-          - 'contains(all_headers_3,"text/html")'
+          - 'contains(header_3,"text/html")'
           - 'status_code_3==200'
         condition: and
 

--- a/http/cves/2022/CVE-2022-0968.yaml
+++ b/http/cves/2022/CVE-2022-0968.yaml
@@ -53,7 +53,7 @@ http:
         dsl:
           - contains(body_3,'\"first_name\":\"{{payload}}\"')
           - 'status_code_3==200'
-          - 'contains(all_headers_3,"application/json")'
+          - 'contains(header_3,"application/json")'
         condition: and
 
     extractors:

--- a/http/cves/2022/CVE-2022-1007.yaml
+++ b/http/cves/2022/CVE-2022-1007.yaml
@@ -43,7 +43,7 @@ http:
         dsl:
           - "contains(body_2, '<script>alert(document.domain)</script>')"
           - "contains(body_2, 'advanced-booking-calendar')"
-          - "contains(all_headers_2, 'text/html')"
+          - "contains(header_2, 'text/html')"
           - "status_code_2 == 200"
         condition: and
 

--- a/http/cves/2022/CVE-2022-1937.yaml
+++ b/http/cves/2022/CVE-2022-1937.yaml
@@ -39,7 +39,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'status_code_2 == 200'
           - contains(body_2, 'colspan=\"2\"><script>alert(document.domain)</script></th>')
         condition: and

--- a/http/cves/2022/CVE-2022-1952.yaml
+++ b/http/cves/2022/CVE-2022-1952.yaml
@@ -63,7 +63,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_3, "text/html")
+          - contains(header_3, "text/html")
           - status_code_3 == 200
           - contains(body_1, 'success\":true')
           - contains(body_3, 'e0d7fcf2c9f63143b6278a3e40f6bea9')

--- a/http/cves/2022/CVE-2022-21371.yaml
+++ b/http/cves/2022/CVE-2022-21371.yaml
@@ -44,8 +44,8 @@ http:
 
       - type: dsl
         dsl:
-          - 'contains(all_headers, "text/xml")'
-          - 'contains(all_headers, "application/xml")'
+          - 'contains(header, "text/xml")'
+          - 'contains(header, "application/xml")'
         condition: or
 
       - type: status

--- a/http/cves/2022/CVE-2022-2219.yaml
+++ b/http/cves/2022/CVE-2022-2219.yaml
@@ -34,7 +34,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "script%3Ealert%28document.domain%29%3C%2Fscript%3")'
           - 'contains(body_2, "Unyson")'
         condition: and

--- a/http/cves/2022/CVE-2022-22536.yaml
+++ b/http/cves/2022/CVE-2022-22536.yaml
@@ -51,7 +51,7 @@ http:
       - type: dsl
         dsl:
           - "contains(tolower(body), 'administration')" # confirms 1st path
-          - "contains(tolower(all_headers), 'content-type: image/png')" # confirms 2nd path
+          - "contains(tolower(header), 'content-type: image/png')" # confirms 2nd path
         condition: or
 
       - type: word

--- a/http/cves/2022/CVE-2022-23131.yaml
+++ b/http/cves/2022/CVE-2022-23131.yaml
@@ -42,6 +42,6 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'location: zabbix.php?action=dashboard.view')"
+          - "contains(tolower(header), 'location: zabbix.php?action=dashboard.view')"
 
 # Enhanced by mp on 2022/03/08

--- a/http/cves/2022/CVE-2022-2546.yaml
+++ b/http/cves/2022/CVE-2022-2546.yaml
@@ -45,7 +45,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_3, "text/html")
+          - contains(header_3, "text/html")
           - status_code_3 == 200
           - contains(body_3, '{\"new_value\":[\"XSSPAYLOAD<svg onload=alert(document.domain)>')
         condition: and

--- a/http/cves/2022/CVE-2022-26134.yaml
+++ b/http/cves/2022/CVE-2022-26134.yaml
@@ -35,7 +35,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(to_lower(all_headers_1), "x-cmd-response:")'
+          - 'contains(to_lower(header_1), "x-cmd-response:")'
 
       - type: dsl
         dsl:

--- a/http/cves/2022/CVE-2022-29005.yaml
+++ b/http/cves/2022/CVE-2022-29005.yaml
@@ -48,7 +48,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_3, "text/html")'
+          - 'contains(header_3, "text/html")'
           - 'status_code_3 == 200'
           - contains(body_3, 'admin-name\">nuclei<script>alert(document.domain);</script>')
         condition: and

--- a/http/cves/2022/CVE-2022-3062.yaml
+++ b/http/cves/2022/CVE-2022-3062.yaml
@@ -38,7 +38,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "ee-simple-file-list")'
           - 'contains(body_2, "onanimationstart=alert(document.domain)//")'
         condition: and

--- a/http/cves/2022/CVE-2022-31499.yaml
+++ b/http/cves/2022/CVE-2022-31499.yaml
@@ -34,7 +34,7 @@ http:
       - type: dsl
         dsl:
           - duration>=7
-          - contains(all_headers, "text/html")
+          - contains(header, "text/html")
           - status_code == 200
           - contains(body, '{\"CardNo\":false')
         condition: and

--- a/http/cves/2022/CVE-2022-33119.yaml
+++ b/http/cves/2022/CVE-2022-33119.yaml
@@ -34,7 +34,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers, "text/html")'
+          - 'contains(header, "text/html")'
           - 'status_code == 200'
           - contains(body,'<script>alert(document.domain)</script><\"?cmd=')
         condition: and

--- a/http/cves/2022/CVE-2022-3506.yaml
+++ b/http/cves/2022/CVE-2022-3506.yaml
@@ -52,7 +52,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_4, 'text/html')"
+          - "contains(header_4, 'text/html')"
           - "status_code_4 == 200"
           - 'contains(body_4, "value=\"\" autofocus onfocus=alert(document.domain)>")'
           - "contains(body_4, 'The amount of automatically')"

--- a/http/cves/2022/CVE-2022-3578.yaml
+++ b/http/cves/2022/CVE-2022-3578.yaml
@@ -40,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'status_code_2 == 200'
           - 'contains(body_2, "Extension Options")'
           - 'contains(body_2, "<script>alert(document.domain)</script>&tab")'

--- a/http/cves/2022/CVE-2022-3933.yaml
+++ b/http/cves/2022/CVE-2022-3933.yaml
@@ -41,7 +41,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "><script>alert(document.domain)</script>")'
           - 'contains(body_2, "ere_property_gallery")'
         condition: and

--- a/http/cves/2022/CVE-2022-3982.yaml
+++ b/http/cves/2022/CVE-2022-3982.yaml
@@ -77,7 +77,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_3, "text/html")
+          - contains(header_3, "text/html")
           - status_code_3 == 200
           - contains(body_3, 'e1bb1e04b786e90b07ebc4f7a2bff37d')
         condition: and

--- a/http/cves/2022/CVE-2022-42095.yaml
+++ b/http/cves/2022/CVE-2022-42095.yaml
@@ -53,7 +53,7 @@ http:
       - type: dsl
         dsl:
           - "status_code_5 == 200"
-          - "contains(all_headers_5, 'text/html')"
+          - "contains(header_5, 'text/html')"
           - 'contains(body_5, "<img src=\"x\" onerror=\"alert(document.domain)\" />")'
           - "contains(body_5, 'Backdrop CMS')"
         condition: and

--- a/http/cves/2022/CVE-2022-4325.yaml
+++ b/http/cves/2022/CVE-2022-4325.yaml
@@ -41,7 +41,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "<script>alert(`document.domain`)</script>")'
           - 'contains(body_2, "Post Status Notifier Lite")'
         condition: and

--- a/http/cves/2023/CVE-2023-0968.yaml
+++ b/http/cves/2023/CVE-2023-0968.yaml
@@ -42,7 +42,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "/onmouseover=alert(document.domain)//")'
           - 'contains(body_2, "Watu Quizzes")'
         condition: and

--- a/http/cves/2023/CVE-2023-1080.yaml
+++ b/http/cves/2023/CVE-2023-1080.yaml
@@ -42,7 +42,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "/ onmouseover=alert(document.domain);//")'
           - 'contains(body_2, "GN Publisher")'
         condition: and

--- a/http/cves/2023/CVE-2023-1362.yaml
+++ b/http/cves/2023/CVE-2023-1362.yaml
@@ -29,6 +29,6 @@ http:
       - type: dsl
         dsl:
           - "status_code_1 == 200"
-          - "!regex('X-Frame-Options', all_headers)"
+          - "!regex('X-Frame-Options', header)"
           - "contains(body, 'BUM</b>Sys</a>')"
         condition: and

--- a/http/default-logins/apache/airflow-default-login.yaml
+++ b/http/default-logins/apache/airflow-default-login.yaml
@@ -54,7 +54,7 @@ http:
       - type: dsl
         dsl:
           - 'contains(body_1, "Sign In - Airflow")'
-          - 'contains(all_headers_2, "session=.")'
+          - 'contains(header_2, "session=.")'
           - 'status_code_2 == 302'
         condition: and
 

--- a/http/default-logins/apollo/apollo-default-login.yaml
+++ b/http/default-logins/apollo/apollo-default-login.yaml
@@ -52,7 +52,7 @@ http:
       - type: dsl
         dsl:
           - "status_code_1 == 302 && status_code_2 == 200"
-          - "contains(tolower(all_headers_2), 'application/json')"
+          - "contains(tolower(header_2), 'application/json')"
         condition: and
 
 # Enhanced by mp on 2022/03/22

--- a/http/default-logins/cobbler/hue-default-credential.yaml
+++ b/http/default-logins/cobbler/hue-default-credential.yaml
@@ -60,8 +60,8 @@ http:
       - type: dsl
         dsl:
           - contains(tolower(body_1), 'welcome to hue')
-          - contains(tolower(all_headers_2), 'csrftoken=')
-          - contains(tolower(all_headers_2), 'sessionid=')
+          - contains(tolower(header_2), 'csrftoken=')
+          - contains(tolower(header_2), 'sessionid=')
         condition: and
 
       - type: status

--- a/http/default-logins/flir/flir-default-login.yaml
+++ b/http/default-logins/flir/flir-default-login.yaml
@@ -39,9 +39,9 @@ http:
 
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'text/html')
-          - contains(tolower(all_headers), 'phpsessid')
-          - contains(tolower(all_headers), 'showcameraid')
+          - contains(tolower(header), 'text/html')
+          - contains(tolower(header), 'phpsessid')
+          - contains(tolower(header), 'showcameraid')
 
         condition: and
 

--- a/http/default-logins/gophish/gophish-default-login.yaml
+++ b/http/default-logins/gophish/gophish-default-login.yaml
@@ -48,9 +48,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "!contains(tolower(all_headers), 'location: /login')"
-          - "contains(tolower(all_headers), 'location: /')"
-          - "contains(tolower(all_headers), 'gophish')"
+          - "!contains(tolower(header), 'location: /login')"
+          - "contains(tolower(header), 'location: /')"
+          - "contains(tolower(header), 'gophish')"
           - "status_code==302"
         condition: and
 

--- a/http/default-logins/jupyterhub/jupyterhub-default-login.yaml
+++ b/http/default-logins/jupyterhub/jupyterhub-default-login.yaml
@@ -38,8 +38,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'jupyterhub-session-id=')
-          - contains(tolower(all_headers), 'jupyterhub-hub-login=')
+          - contains(tolower(header), 'jupyterhub-session-id=')
+          - contains(tolower(header), 'jupyterhub-hub-login=')
         condition: and
 
       - type: status

--- a/http/default-logins/mantisbt/mantisbt-default-credential.yaml
+++ b/http/default-logins/mantisbt/mantisbt-default-credential.yaml
@@ -36,8 +36,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'mantis_secure_session')
-          - contains(tolower(all_headers), 'mantis_string_cookie')
+          - contains(tolower(header), 'mantis_secure_session')
+          - contains(tolower(header), 'mantis_string_cookie')
         condition: and
 
       - type: status

--- a/http/default-logins/nsicg/nsicg-default-login.yaml
+++ b/http/default-logins/nsicg/nsicg-default-login.yaml
@@ -46,7 +46,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_1, "/user/main/")'
+          - 'contains(header_1, "/user/main/")'
           - 'status_code_1 == 302'
           - 'status_code_2 == 200'
           - contains(body_2, "var loguser = \'ns25000")

--- a/http/default-logins/phpmyadmin/phpmyadmin-default-login.yaml
+++ b/http/default-logins/phpmyadmin/phpmyadmin-default-login.yaml
@@ -71,9 +71,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(all_headers_2, "phpMyAdmin=") && contains(all_headers_2, "pmaUser-1=")
+          - contains(header_2, "phpMyAdmin=") && contains(header_2, "pmaUser-1=")
           - status_code_2 == 302
-          - contains(all_headers_2, 'index.php?collation_connection=utf8mb4_unicode_ci') || contains(all_headers_2, '/index.php?route=/&route=%2F')
+          - contains(header_2, 'index.php?collation_connection=utf8mb4_unicode_ci') || contains(header_2, '/index.php?route=/&route=%2F')
         condition: and
 
 # Enhanced by md on 2023/01/09

--- a/http/default-logins/sequoiadb/sequoiadb-default-login.yaml
+++ b/http/default-logins/sequoiadb/sequoiadb-default-login.yaml
@@ -43,7 +43,7 @@ http:
 
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'sdbsessionid')
+          - contains(tolower(header), 'sdbsessionid')
 
       - type: word
         part: body

--- a/http/default-logins/versa/versa-default-login.yaml
+++ b/http/default-logins/versa/versa-default-login.yaml
@@ -43,14 +43,14 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 302'
-          - "contains(tolower(all_headers_2), 'jsessionid')"
-          - "contains(tolower(all_headers_2), 'location: /versa/index.html')"
+          - "contains(tolower(header_2), 'jsessionid')"
+          - "contains(tolower(header_2), 'location: /versa/index.html')"
         condition: and
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers_2), '/login?error=true')"
-          - "contains(tolower(all_headers_2), '/login?tokenmissingerror=true')"
+          - "contains(tolower(header_2), '/login?error=true')"
+          - "contains(tolower(header_2), '/login?tokenmissingerror=true')"
         negative: true
 
 # Enhanced by mp on 2022/04/06

--- a/http/exposed-panels/metersphere-login.yaml
+++ b/http/exposed-panels/metersphere-login.yaml
@@ -39,6 +39,6 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'ms_session_id')"
+          - "contains(tolower(header), 'ms_session_id')"
 
 # Enhanced by md on 2022/11/28

--- a/http/exposed-panels/ms-adcs-detect.yaml
+++ b/http/exposed-panels/ms-adcs-detect.yaml
@@ -28,7 +28,7 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), '/certsrv')"
+          - "contains(tolower(header), '/certsrv')"
 
     extractors:
       - type: kval

--- a/http/exposures/configs/composer-config.yaml
+++ b/http/exposures/configs/composer-config.yaml
@@ -26,11 +26,11 @@ http:
       - type: dsl
         name: composer.lock
         dsl:
-          - "contains(body, 'packages') && contains(tolower(all_headers), 'application/octet-stream') && status_code == 200"
+          - "contains(body, 'packages') && contains(tolower(header), 'application/octet-stream') && status_code == 200"
 
       - type: dsl
         name: composer.json
         dsl:
-          - "contains(body, 'require') && contains(tolower(all_headers), 'application/json') && status_code == 200"
+          - "contains(body, 'require') && contains(tolower(header), 'application/json') && status_code == 200"
 
 # Enhanced by mp on 2023/02/05

--- a/http/exposures/configs/javascript-env.yaml
+++ b/http/exposures/configs/javascript-env.yaml
@@ -28,7 +28,7 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'content-type: application/javascript')"
+          - "contains(tolower(header), 'content-type: application/javascript')"
 
       - type: word
         part: body

--- a/http/exposures/configs/kubernetes-kustomization-disclosure.yaml
+++ b/http/exposures/configs/kubernetes-kustomization-disclosure.yaml
@@ -34,7 +34,7 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'application/yaml')"
+          - "contains(tolower(header), 'application/yaml')"
 
       - type: status
         status:

--- a/http/miscellaneous/ntlm-directories.yaml
+++ b/http/miscellaneous/ntlm-directories.yaml
@@ -72,7 +72,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'www-authenticate: ntlm')"
+          - "contains(tolower(header), 'www-authenticate: ntlm')"
 
       - type: status
         status:

--- a/http/misconfiguration/http-missing-security-headers.yaml
+++ b/http/misconfiguration/http-missing-security-headers.yaml
@@ -22,76 +22,76 @@ http:
       - type: dsl
         name: strict-transport-security
         dsl:
-          - "!regex('(?i)strict-transport-security', all_headers)"
+          - "!regex('(?i)strict-transport-security', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: content-security-policy
         dsl:
-          - "!regex('(?i)content-security-policy', all_headers)"
+          - "!regex('(?i)content-security-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: permissions-policy
         dsl:
-          - "!regex('(?i)permissions-policy', all_headers)"
+          - "!regex('(?i)permissions-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: x-frame-options
         dsl:
-          - "!regex('(?i)x-frame-options', all_headers)"
+          - "!regex('(?i)x-frame-options', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: x-content-type-options
         dsl:
-          - "!regex('(?i)x-content-type-options', all_headers)"
+          - "!regex('(?i)x-content-type-options', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: x-permitted-cross-domain-policies
         dsl:
-          - "!regex('(?i)x-permitted-cross-domain-policies', all_headers)"
+          - "!regex('(?i)x-permitted-cross-domain-policies', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: referrer-policy
         dsl:
-          - "!regex('(?i)referrer-policy', all_headers)"
+          - "!regex('(?i)referrer-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: clear-site-data
         dsl:
-          - "!regex('(?i)clear-site-data', all_headers)"
+          - "!regex('(?i)clear-site-data', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: cross-origin-embedder-policy
         dsl:
-          - "!regex('(?i)cross-origin-embedder-policy', all_headers)"
+          - "!regex('(?i)cross-origin-embedder-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: cross-origin-opener-policy
         dsl:
-          - "!regex('(?i)cross-origin-opener-policy', all_headers)"
+          - "!regex('(?i)cross-origin-opener-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and
 
       - type: dsl
         name: cross-origin-resource-policy
         dsl:
-          - "!regex('(?i)cross-origin-resource-policy', all_headers)"
+          - "!regex('(?i)cross-origin-resource-policy', header)"
           - "status_code != 301 && status_code != 302"
         condition: and

--- a/http/takeovers/aws-bucket-takeover.yaml
+++ b/http/takeovers/aws-bucket-takeover.yaml
@@ -27,7 +27,7 @@ http:
 
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'x-guploader-uploadid')
+          - contains(tolower(header), 'x-guploader-uploadid')
         negative: true
 
       - type: word

--- a/http/technologies/apache/tomcat-detect.yaml
+++ b/http/technologies/apache/tomcat-detect.yaml
@@ -22,7 +22,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(tolower(all_headers), "tomcat")'
+          - 'contains(tolower(header), "tomcat")'
 
       - type: dsl
         dsl:

--- a/http/technologies/aws/aws-bucket-service.yaml
+++ b/http/technologies/aws/aws-bucket-service.yaml
@@ -17,13 +17,13 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'x-amz-bucket')
-          - contains(tolower(all_headers), 'x-amz-request')
-          - contains(tolower(all_headers), 'x-amz-id')
-          - contains(tolower(all_headers), 'amazons3')
+          - contains(tolower(header), 'x-amz-bucket')
+          - contains(tolower(header), 'x-amz-request')
+          - contains(tolower(header), 'x-amz-id')
+          - contains(tolower(header), 'amazons3')
         condition: or
 
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'x-guploader-uploadid')
+          - contains(tolower(header), 'x-guploader-uploadid')
         negative: true

--- a/http/technologies/aws/aws-cloudfront-service.yaml
+++ b/http/technologies/aws/aws-cloudfront-service.yaml
@@ -18,7 +18,7 @@ http:
       - type: dsl
         condition: or
         dsl:
-          - "contains(tolower(all_headers), 'x-cache: hit from cloudfront')"
-          - "contains(tolower(all_headers), 'x-cache: refreshhit from cloudfront')"
-          - "contains(tolower(all_headers), 'x-cache: miss from cloudfront')"
-          - "contains(tolower(all_headers), 'x-cache: error from cloudfront')"
+          - "contains(tolower(header), 'x-cache: hit from cloudfront')"
+          - "contains(tolower(header), 'x-cache: refreshhit from cloudfront')"
+          - "contains(tolower(header), 'x-cache: miss from cloudfront')"
+          - "contains(tolower(header), 'x-cache: error from cloudfront')"

--- a/http/technologies/cloudfoundry-detect.yaml
+++ b/http/technologies/cloudfoundry-detect.yaml
@@ -27,4 +27,4 @@ http:
 
       - type: dsl
         dsl:
-          - 'contains(all_headers, "X-Vcap-Request-Id:") || contains(all_headers, "X-Cf-Routererror:")'
+          - 'contains(header, "X-Vcap-Request-Id:") || contains(header, "X-Cf-Routererror:")'

--- a/http/technologies/google/google-bucket-service.yaml
+++ b/http/technologies/google/google-bucket-service.yaml
@@ -16,11 +16,11 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(tolower(all_headers), 'x-goog-component-count')
-          - contains(tolower(all_headers), 'x-goog-expiration')
-          - contains(tolower(all_headers), 'x-goog-generation')
-          - contains(tolower(all_headers), 'x-goog-metageneration')
-          - contains(tolower(all_headers), 'x-goog-stored-content-encoding')
-          - contains(tolower(all_headers), 'x-goog-stored-content-length')
-          - contains(tolower(all_headers), 'x-guploader-uploadid')
+          - contains(tolower(header), 'x-goog-component-count')
+          - contains(tolower(header), 'x-goog-expiration')
+          - contains(tolower(header), 'x-goog-generation')
+          - contains(tolower(header), 'x-goog-metageneration')
+          - contains(tolower(header), 'x-goog-stored-content-encoding')
+          - contains(tolower(header), 'x-goog-stored-content-length')
+          - contains(tolower(header), 'x-guploader-uploadid')
         condition: or

--- a/http/technologies/magento-detect.yaml
+++ b/http/technologies/magento-detect.yaml
@@ -26,7 +26,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(tolower(all_headers), "x-magento")'
+          - 'contains(tolower(header), "x-magento")'
           - 'status_code == 200'
         condition: and
 

--- a/http/technologies/openethereum-server-detect.yaml
+++ b/http/technologies/openethereum-server-detect.yaml
@@ -28,7 +28,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(all_headers, "application/json")'
+          - 'contains(header, "application/json")'
           - 'contains(body, "OpenEthereum")'
         condition: and
 

--- a/http/technologies/spinnaker-detect.yaml
+++ b/http/technologies/spinnaker-detect.yaml
@@ -23,4 +23,4 @@ http:
 
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'x-spinnaker-priority')"
+          - "contains(tolower(header), 'x-spinnaker-priority')"

--- a/http/vulnerabilities/generic/cors-misconfig.yaml
+++ b/http/vulnerabilities/generic/cors-misconfig.yaml
@@ -39,6 +39,6 @@ http:
       - type: dsl
         name: arbitrary-origin
         dsl:
-          - "contains(tolower(all_headers), 'access-control-allow-origin: {{cors_origin}}')"
-          - "contains(tolower(all_headers), 'access-control-allow-credentials: true')"
+          - "contains(tolower(header), 'access-control-allow-origin: {{cors_origin}}')"
+          - "contains(tolower(header), 'access-control-allow-credentials: true')"
         condition: and

--- a/http/vulnerabilities/magento/magento-2-exposed-api.yaml
+++ b/http/vulnerabilities/magento/magento-2-exposed-api.yaml
@@ -26,14 +26,14 @@ http:
           - 'contains(body, "searchCriteria")'
           - 'contains(body, "parameters")'
           - 'contains(body, "message")'
-          - 'contains(tolower(all_headers), "application/json")'
+          - 'contains(tolower(header), "application/json")'
         condition: and
 
       - type: dsl
         dsl:
           - 'contains(body, "secure_base_link_url")'
           - 'contains(body, "timezone")'
-          - 'contains(tolower(all_headers), "application/json")'
+          - 'contains(tolower(header), "application/json")'
           - 'status_code == 200'
         condition: and
 
@@ -41,6 +41,6 @@ http:
         dsl:
           - 'contains(body, "name")'
           - 'contains(body, "website_id")'
-          - 'contains(tolower(all_headers), "application/json")'
+          - 'contains(tolower(header), "application/json")'
           - 'status_code == 200'
         condition: and

--- a/http/vulnerabilities/magento/magento-unprotected-dev-files.yaml
+++ b/http/vulnerabilities/magento/magento-unprotected-dev-files.yaml
@@ -26,7 +26,7 @@ http:
           - 'contains(body, "Magento")'
           - 'contains(body, "replace xmlns:xsi=")'
           - 'contains(body, "<field path=")'
-          - 'contains(tolower(all_headers), "application/xml") || contains(tolower(all_headers), "application/octet-stream")'
+          - 'contains(tolower(header), "application/xml") || contains(tolower(header), "application/octet-stream")'
           - 'status_code == 200'
         condition: and
 
@@ -36,6 +36,6 @@ http:
           - 'contains(body, "config xmlns:xsi")'
           - 'contains(body, "<application>")'
           - 'contains(body, "<install>")'
-          - 'contains(tolower(all_headers), "application/xml") || contains(tolower(all_headers), "application/octet-stream")'
+          - 'contains(tolower(header), "application/xml") || contains(tolower(header), "application/octet-stream")'
           - 'status_code == 200'
         condition: and

--- a/http/vulnerabilities/other/hospital-management-xss.yaml
+++ b/http/vulnerabilities/other/hospital-management-xss.yaml
@@ -40,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - "status_code_2 == 200"
           - contains(body_2, 'Result against \"<script>alert(document.domain)</script>\" keyword')
         condition: and

--- a/http/vulnerabilities/other/hospital-management-xss2.yaml
+++ b/http/vulnerabilities/other/hospital-management-xss2.yaml
@@ -40,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - "status_code_2 == 200"
           - contains(body_2, 'Result against \"<script>alert(document.domain)</script>\" keyword')
         condition: and

--- a/http/vulnerabilities/other/yeswiki-stored-xss.yaml
+++ b/http/vulnerabilities/other/yeswiki-stored-xss.yaml
@@ -64,7 +64,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_2, 'text/html') && contains(all_headers_2, 'YesWiki')"
+          - "contains(header_2, 'text/html') && contains(header_2, 'YesWiki')"
           - "status_code_2 == 200"
           - contains(body_2, '><img src=x onerror=console.log(123);>')
         condition: and

--- a/http/vulnerabilities/other/zzcms-xss.yaml
+++ b/http/vulnerabilities/other/zzcms-xss.yaml
@@ -34,7 +34,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(all_headers_2, 'text/html')"
+          - "contains(header_2, 'text/html')"
           - "status_code_2 == 200"
           - 'contains(body_2, "参数 1\"+alert(document.domain)+")'
         condition: and

--- a/http/vulnerabilities/wordpress/3dprint-arbitrary-file-upload.yaml
+++ b/http/vulnerabilities/wordpress/3dprint-arbitrary-file-upload.yaml
@@ -46,7 +46,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - "status_code_2 == 200"
           - "contains(body_2, '3DPrint-arbitrary-file-upload')"
         condition: and

--- a/http/vulnerabilities/wordpress/ldap-wp-login-xss.yaml
+++ b/http/vulnerabilities/wordpress/ldap-wp-login-xss.yaml
@@ -32,6 +32,6 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "<script>alert(document_domain)</script>") && contains(body_2, "LDAP-authentication-intergrating-with-AD")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

`header` was added in [nuclei v2.7.2](https://github.com/projectdiscovery/nuclei/releases/tag/v2.7.2)

`header` should be used instead of `all_headers`

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)