### PR TITLE
Create CVE-2023-3128.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-3128.yaml
+++ b/http/cves/2023/CVE-2023-3128.yaml
@@ -1,0 +1,50 @@
+id: CVE-2023-3128
+
+info:
+  name: Grafana Account Takeover / Authentication Bypass
+  author: bhutch
+  severity: critical
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-3128
+    - https://grafana.com/blog/2023/06/22/grafana-security-release-for-cve-2023-3128/
+  description: Grafana is validating Azure AD accounts based on the email claim. On Azure AD, the profile email field is not unique and can be easily modified. This leads to account takeover and authentication bypass when Azure AD OAuth is configured with a multi-tenant app.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
+    cvss-score: 9.4
+    cve-id: CVE-2023-3128
+    cwe-id: CWE-290
+  metadata:
+    max-request: 1
+    shodan-query: title:"Grafana"
+  tags: cve,cve2023,grafana
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<title>Grafana</title>"
+        part: body
+      - type: dsl
+        dsl:
+          - compare_versions(version, '>= 6.7.0', '< 7.0.0')
+          - compare_versions(version, '>= 8.5.0', '< 8.5.27')
+          - compare_versions(version, '>= 9.2.0', '< 9.2.20')
+          - compare_versions(version, '>= 9.3.0', '< 9.3.16')
+          - compare_versions(version, '>= 9.4.0', '< 9.4.13')
+          - compare_versions(version, '>= 9.5.0', '< 9.5.5')
+          - compare_versions(version, '>= 10.0.0', '< 10.0.1')
+
+    extractors:
+      - type: regex
+        part: body
+        internal: true
+        name: version
+        group: 1
+        regex:
+          - '\"version\"\:\"([0-9.]+)\"}'
+          - '\"subTitle\":\"Grafana v([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Identifies Grafana instances running a version vulnerable to CVE-2023-3128. If the target uses Azure Active Directory for authentication, attackers may be able to bypass authentication and perform account takeover.

- References:
- 
https://nvd.nist.gov/vuln/detail/CVE-2023-3128
https://grafana.com/blog/2023/06/22/grafana-security-release-for-cve-2023-3128
https://www.bleepingcomputer.com/news/security/grafana-warns-of-critical-auth-bypass-due-to-azure-ad-integration/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

This template heavily borrows the excellent work from `http/exposed-panels/grafana-detect.yaml`, so please prepend or append that contributor to `author` if the template is accepted and doing so is customary.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)