### PR TITLE
Update aws-bucket-takeover.yaml

### DIFF
--- a/http/takeovers/aws-bucket-takeover.yaml
+++ b/http/takeovers/aws-bucket-takeover.yaml
@@ -35,3 +35,11 @@ http:
         words:
           - "amazonaws.com"
         negative: true
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<li>BucketName: (.*?)</li>'
+          - '<BucketName>(.*?)</BucketName>'


### PR DESCRIPTION
### Template / PR Information

Added an extractor to pull the hijackable S3 bucket name. I've found this useful during remediation and for demonstrating impact; in some cases, multiple URIs point to the same bucket.

There are two regexes, as I've seen different output when the HTTP Server is "AmazonS3" vs. "cloudflare". This extractor has worked against every target I've tried.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
