### PR TITLE
Update cacti-weathermap-file-write.yaml removing broken reference

### DIFF
--- a/http/vulnerabilities/other/cacti-weathermap-file-write.yaml
+++ b/http/vulnerabilities/other/cacti-weathermap-file-write.yaml
@@ -4,8 +4,6 @@ info:
   name: Cacti Weathermap File Write
   author: pikpikcu
   severity: medium
-  reference:
-    - https://www.freebuf.com/articles/system/125177.html
   tags: injection,cacti
   metadata:
     max-request: 2


### PR DESCRIPTION
Reference does not exist on website anymore, no cached version found and I also couldn't find a good replacement reference.
### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO - no change in logic

