### PR TITLE
Update dom-xss.yaml

### DIFF
--- a/file/xss/dom-xss.yaml
+++ b/file/xss/dom-xss.yaml
@@ -18,6 +18,7 @@ file:
       - js
       - ts
       - html
+      - htm
       - php
       - cs
       - rb


### PR DESCRIPTION
'htm' is a valid extension for HTML files and should be scanned

### Template / PR Information

As said above it happens that files that intuitively should be scanned are otherwise skipped because of atypical extensions

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [X ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)