### PR TITLE
Using interactsh to detect open HTTP proxies

### DIFF
--- a/http/misconfiguration/proxy/open-proxy-interactsh.yaml
+++ b/http/misconfiguration/proxy/open-proxy-interactsh.yaml
@@ -1,0 +1,23 @@
+id: open-proxy-interactsh
+
+info:
+  name: Open Proxy Check
+  author: kazet
+  severity: low
+  description: The HTTP server is configured as a proxy and allows to perform arbitrary HTTP requests.
+  tags: proxy,http,misconfig
+  metadata:
+    max-request: 1
+
+http:
+  - raw:
+      - |+
+        GET http://{{interactsh-url}}/ HTTP/1.1
+        Host: {{interactsh-url}}
+
+    unsafe: true
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"


### PR DESCRIPTION
### Template / PR Information

From what I see, Nuclei doesn't have a template that detects generic HTTP proxies - it is able to check whether a proxy allows access to AWS metadata, localhost etc., but not arbitrary outside addresses.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


