### PR TITLE
Create leostream-default-login.yaml

### DIFF
--- a/http/default-logins/leostream/leostream-default-login.yaml
+++ b/http/default-logins/leostream/leostream-default-login.yaml
@@ -4,15 +4,17 @@ info:
   name: Leostream Default Login
   author: bhutch
   severity: high
-  description: Leostream default admin credentials were discovered.
+  description: |
+    Leostream default admin credentials were discovered.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
     cwe-id: CWE-522
-  tags: leostream,default-login
   metadata:
     shodan-query: http.title:"Leostream"
     max-request: 1
+    verified: true
+  tags: leostream,default-login
 
 http:
   - raw:
@@ -31,10 +33,13 @@ http:
 
     matchers-condition: and
     matchers:
+      - type: word
+        part: header
+        words:
+          - "Set-Cookie: lld=%21"
+          - 'server.pl'
+        condition: and
+
       - type: status
         status:
           - 302
-      - type: word
-        words:
-          - "Set-Cookie: lld=%21"
-        part: header

--- a/http/default-logins/leostream/leostream-default-login.yaml
+++ b/http/default-logins/leostream/leostream-default-login.yaml
@@ -1,0 +1,40 @@
+id: leostream-default-login
+
+info:
+  name: Leostream Default Login
+  author: bhutch
+  severity: high
+  description: Leostream default admin credentials were discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-522
+  tags: leostream,default-login
+  metadata:
+    shodan-query: http.title:"Leostream"
+    max-request: 1
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+
+        login_type=0&user={{username}}&password={{password}}&submit=SIGN+IN
+
+    payloads:
+      username:
+        - admin
+      password:
+        - leo
+    attack: pitchfork
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        words:
+          - "Set-Cookie: lld=%21"
+        part: header


### PR DESCRIPTION
### Template / PR Information

Identifies Leostream Connection Broker default credentials.

- References:
https://support.leostream.com/support/solutions/articles/66000480280-changing-the-default-admin-password

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO