### PR TITLE
Create sunbird-dcim-panel.yaml

### DIFF
--- a/http/exposed-panels/sunbird-dcim-panel.yaml
+++ b/http/exposed-panels/sunbird-dcim-panel.yaml
@@ -1,0 +1,35 @@
+id: sunbird-dcim-panel
+
+info:
+  name: Sunbird DCIM - Detect
+  author: bhutch
+  severity: info
+  description: Sunbird DCIM login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: html.title:"dcTrack - Operations"
+  tags: sunbird,panel,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/dcim/"
+
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>dcTrack - Operations</title>'
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/sunbird-dcim-panel.yaml
+++ b/http/exposed-panels/sunbird-dcim-panel.yaml
@@ -11,7 +11,8 @@ info:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-    shodan-query: html.title:"dcTrack - Operations"
+    shodan-query: http.favicon.hash:781922099
+    verified: true
   tags: sunbird,panel,login
 
 http:


### PR DESCRIPTION
### Template / PR Information

Template to detect Sunbird DCIM (a.k.a., Sunbird dcTrack) login panels. It's uncommon to see these publicly-exposed. It may be worth checking for a default credential (`admin:sunbird`) against any results.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO