### PR TITLE
Update leostream-default-login.yaml

### DIFF
--- a/http/default-logins/leostream/leostream-default-login.yaml
+++ b/http/default-logins/leostream/leostream-default-login.yaml
@@ -37,8 +37,14 @@ http:
         part: header
         words:
           - "Set-Cookie: lld=%21"
+
+      - type: word
+        part: header
+        words:
+          - 'index.pl'
           - 'server.pl'
-        condition: and
+          - 'status.pl'
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Hi Team,

To meet PD template standards, the matcher was modified before the initial PR was merged. The template checks for `server.pl` in the HTTP redirect. This will result in False Negatives, as redirections to `index.pl` and `status.pl` are more common.

A redirection to `server.pl` or `status.pl` means the credential worked and the target is licensed.

A redirection to `index.pl` means the credential worked and the target is not licensed.

I modified the template to check for the other two `.pl` files. These are the only three I have seen in my testing.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO