### PR TITLE
Updated the payload list and attack type of the Tomcat default login detection template

### DIFF
--- a/http/default-logins/apache/tomcat-default-login.yaml
+++ b/http/default-logins/apache/tomcat-default-login.yaml
@@ -2,11 +2,12 @@ id: tomcat-default-login
 
 info:
   name: Apache Tomcat Manager Default Login
-  author: pdteam,sinKettu
+  author: pdteam,sinKettu,nybble04
   severity: high
   description: Apache Tomcat Manager default login credentials were discovered. This template checks for multiple variations.
   reference:
     - https://www.rapid7.com/db/vulnerabilities/apache-tomcat-default-ovwebusr-password/
+    - https://github.com/danielmiessler/SecLists/blob/master/Passwords/Default-Credentials/tomcat-betterdefaultpasslist.txt
   metadata:
     max-request: 18
     shodan-query: title:"Apache Tomcat"
@@ -21,46 +22,52 @@ http:
 
     payloads:
       username:
-        - tomcat
-        - admin
-        - ovwebusr
-        - j2deployer
-        - cxsdk
         - ADMIN
-        - xampp
-        - tomcat
         - QCC
         - admin
-        - root
-        - role1
-        - role
-        - tomcat
-        - admin
-        - role1
         - both
-        - admin
+        - cxsdk
+        - demo
+        - j2deployer
+        - manager
+        - ovwebusr
+        - role
+        - role1
+        - root
+        - server_admin
+        - tomcat
+        - xampp
 
       password:
-        - tomcat
-        - admin
+        - ADMIN
         - OvW*busr1
+        - Password1
+        - QLogic66
+        - admanager
+        - admin
+        - adrole1
+        - adroot
+        - ads3cret
+        - adtomcat
+        - advagrant
+        - changethis
+        - demo
         - j2deployer
         - kdsxc
-        - ADMIN
-        - xampp
-        - s3cret
-        - QLogic66
-        - tomcat
-        - root
+        - manager
+        - owaspbwa
+        - password
+        - password1
+        - r00t
         - role1
-        - changethis
-        - changethis
-        - j5Brn9
+        - root
+        - s3cret
         - tomcat
-        - tomcat
-        - 123456
+        - toor
+        - vagrant
+        - xampp
 
-    attack: pitchfork  # Available options: sniper, pitchfork and clusterbomb
+    attack: clusterbomb  # Available options: sniper, pitchfork and clusterbomb
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information
The following changes were made to the existing template:
 - Updated the wordlist with [SecList's tomcat-betterdefaultpasslist.txt](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Default-Credentials/tomcat-betterdefaultpasslist.txt) 
 - Updated attack type from `pitchfork` to `clusterbomb` for more attack variations. This also prevents the need for having duplicate entries in the payload list.