### PR TITLE
chore: add conditional exec for cve2json workflow

### DIFF
--- a/.github/workflows/cve2json.yml
+++ b/.github/workflows/cve2json.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   cve2json:
     runs-on: ubuntu-latest
+    if: github.repository == 'projectdiscovery/nuclei-templates'
     steps:
       - uses: actions/checkout@master
       - name: Set up Go


### PR DESCRIPTION
This commit adds a condition to the cve2json workflow. The workflow will now only run if the repository is not a forked repository. This change ensures that the workflow is executed only in the specified repository.