### PR TITLE
Solve Issue - #6811

### DIFF
--- a/http/default-logins/geoserver/geoserver-default-login.yaml
+++ b/http/default-logins/geoserver/geoserver-default-login.yaml
@@ -1,7 +1,8 @@
 id: geoserver-default-login
+
 info:
-  name: Geoserver Default Admin Login
-  author: For3stCo1d
+  name: Geoserver Admin - Default Login
+  author: For3stCo1d,professorabhay,ritikchaddha
   severity: high
   description: Geoserver default admin credentials were discovered.
   reference:
@@ -10,10 +11,11 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
     cwe-id: CWE-522
-metadata:
-  max-request: 1
-  fofa-query: app="GeoServer"
-tags: geoserver,default-login
+  metadata:
+    max-request: 1
+    verified: true
+    fofa-query: app="GeoServer"
+  tags: geoserver,default-login
 
 http:
   - raw:
@@ -24,6 +26,10 @@ http:
 
         username={{user}}&password={{pass}}
 
+      - |
+        GET /geoserver/web/ HTTP/1.1
+        Host: {{Hostname}}
+
     attack: pitchfork
     payloads:
       user:
@@ -31,18 +37,13 @@ http:
       pass:
         - geoserver
 
-    matchers-condition: and
+    host-redirects: true
+    max-redirects: 2
+    cookie-reuse: true
     matchers:
       - type: dsl
         dsl:
-          - "contains(tolower(location), '/geoserver/web')"
-          - "!contains(tolower(location), 'error=true')"
+          - "contains(tolower(location_1), '/geoserver/web') && contains(body_2, '<span>admin</span>')"
+          - "!contains(tolower(location_1), 'error=true')"
+          - 'status_code_1 == 302'
         condition: and
-
-      - type: status
-        status:
-          - 302
-
-      - type: status
-        status:
-          - 200


### PR DESCRIPTION
### Template / PR Information

As mentioned in issue #6811 - A target where it was redirecting to /org.geoserver.web.GeoServerLoginPage?error=false which gave 302 redirection but it was 404 - Not found after the redirection.

In this updated version, a new matcher condition checks for a status code of 200. 

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)