### PR TITLE
Fix variable value in emcecom-default-login.yaml

### DIFF
--- a/http/default-logins/dell/emcecom-default-login.yaml
+++ b/http/default-logins/dell/emcecom-default-login.yaml
@@ -1,7 +1,7 @@
-id: dell-emc-ecom-default-login
+id: emcecom-default-login
 
 info:
-  name: Dell EMC ECOM Default Login
+  name: Dell EMC ECOM - Default Login
   author: Techryptic (@Tech)
   severity: high
   description: Dell EMC ECOM default login information "(admin:#1Password)" was discovered.
@@ -24,9 +24,9 @@ http:
 
     payloads:
       username:
-        - admin
+        - 'admin'
       password:
-        - #1Password
+        - '#1Password'
     attack: pitchfork
 
     matchers-condition: and


### PR DESCRIPTION
### Template / PR Information
Previously, the password variable value was considered as a comment in the template due to the '#', resulting in the password value not being passed through the request.

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO
