### PR TITLE
enabled external payload file loading

### DIFF
--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Template Validation
         run: |
           cp -r ${{ github.workspace }} $HOME
-          nuclei -duc -validate
-          nuclei -duc -validate -w ./workflows
+          nuclei -duc -validate -allow-local-file-access
+          nuclei -duc -validate -w ./workflows -allow-local-file-access


### PR DESCRIPTION
external payload loading is disabled as default with nuclei v2.9.9

### Template / PR Information

Fixes validate workflow - https://github.com/projectdiscovery/nuclei-templates/actions/runs/5551893150/jobs/10206123624?pr=7693

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)