### PR TITLE
updated templates with outdated syntax

### DIFF
--- a/http/cves/2023/CVE-2023-0448.yaml
+++ b/http/cves/2023/CVE-2023-0448.yaml
@@ -27,7 +27,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(all_headers, "text/html")'
+          - 'contains(header, "text/html")'
           - 'contains(body, "><svg onload=alert(document.domain)>")'
           - 'contains(body, "params\":{\"action")'
         condition: and

--- a/http/cves/2023/CVE-2023-23491.yaml
+++ b/http/cves/2023/CVE-2023-23491.yaml
@@ -27,7 +27,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(all_headers, "text/html")'
+          - 'contains(header, "text/html")'
           - 'contains(body, "<script>alert(document.domain)</script>")'
           - 'contains(body, "qem_calendar")'
         condition: and

--- a/http/cves/2023/CVE-2023-28665.yaml
+++ b/http/cves/2023/CVE-2023-28665.yaml
@@ -35,7 +35,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code_2 == 200'
-          - 'contains(all_headers_2, "text/html")'
+          - 'contains(header_2, "text/html")'
           - 'contains(body_2, "<svg onload=alert(document.domain)>")'
           - 'contains(body_2, "pagination\":")'
         condition: and

--- a/http/miscellaneous/spnego.yaml
+++ b/http/miscellaneous/spnego.yaml
@@ -26,7 +26,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(tolower(all_headers), 'www-authenticate: negotiate')"
+          - "contains(tolower(header), 'www-authenticate: negotiate')"
 
     extractors:
       - type: kval

--- a/http/technologies/graylog/graylog-endpoints-exposure.yaml
+++ b/http/technologies/graylog/graylog-endpoints-exposure.yaml
@@ -76,7 +76,7 @@ http:
       - type: dsl
         dsl:
           - "status_code == 200"
-          - "contains_any(all_headers, 'X-Graylog-Node-Id', 'Graylog', 'graylog')"
+          - "contains_any(header, 'X-Graylog-Node-Id', 'Graylog', 'graylog')"
           - "contains_any(body, 'X-Graylog-Node-Id', 'Graylog', 'graylog')"
           - "contains_any(body, 'swagger')"
         condition: and
@@ -85,5 +85,5 @@ http:
         name: unauthorized-graylog-header
         dsl:
           - "status_code == 401"
-          - "contains(all_headers, 'X-Graylog-Node-Id') || contains(all_headers, 'Graylog Server')"
+          - "contains(header, 'X-Graylog-Node-Id') || contains(header, 'Graylog Server')"
         condition: and


### PR DESCRIPTION
### Template / PR Information
`all_headers` is deprecated long back, instead `header` can be used.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)