### PR TITLE
Fix the naming and tagging on the internal ip disclosure template

### DIFF
--- a/http/misconfiguration/internal-ip-disclosure.yaml
+++ b/http/misconfiguration/internal-ip-disclosure.yaml
@@ -1,12 +1,12 @@
-id: iis-internal-ip-disclosure
+id: internal-ip-disclosure
 
 info:
-  name: IIS Internal IP Disclosure Template
+  name: Internal IP Disclosure Template
   author: WillD96
   severity: info
   reference:
     - https://support.kemptechnologies.com/hc/en-us/articles/203522429-How-to-Mitigate-Against-Internal-IP-Address-Domain-Name-Disclosure-In-Real-Server-Redirect
-  tags: iis,misconfig,disclosure
+  tags: misconfig,disclosure
   metadata:
     max-request: 2
 

--- a/http/misconfiguration/internal-ip-disclosure.yaml
+++ b/http/misconfiguration/internal-ip-disclosure.yaml
@@ -1,7 +1,7 @@
 id: internal-ip-disclosure
 
 info:
-  name: Internal IP Disclosure Template
+  name: Internal IP Disclosure
   author: WillD96
   severity: info
   reference:


### PR DESCRIPTION
### Template / PR Information

The `iis-internal-ip-disclosure` template really has nothing to do with `iis`. There is no checking that the affected hosts are running `iis`, it is simply a check for internal IP disclosure. I am submitting this PR to rename the template, template-id, description, and remove `iis` from the tags.

- Fixed `iis-internal-ip-disclosure`. Renamed to `internal-ip-disclosure`
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)