### PR TITLE
Create CVE-2023-3519-timestamp-based.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-3519-timestamp-based.yaml
+++ b/http/cves/2023/CVE-2023-3519-timestamp-based.yaml
@@ -1,0 +1,44 @@
+id: CVE-2023-3519-timestamp-based
+
+info:
+  name: CVE-2023-3519
+  author: vulnspace, gtrrnr
+  severity: High
+  description: CVE-2023-3519 Critical Unauthenticated RCE Vulnerability in Citrix ADC and Citrix Gateway detection based on Last-Modified timestamp
+  reference:
+    - https://support.citrix.com/article/CTX561482/citrix-adc-and-citrix-gateway-security-bulletin-for-cve20233519-cve20233466-cve20233467
+    - https://nvd.nist.gov/vuln/detail/cve-2023-3519
+    - https://github.com/telekom-security/cve-2023-3519-citrix-scanner/blob/main/CVE-2023-3519-checker.py
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-3519
+    cwe-id: CWE-94
+    cpe:  cpe:2.3:a:citrix:netscaler_gateway:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 3
+    verified: "true"
+    vendor: Citrix
+    product: Citrix
+  tags: CVE-2023-3519,citrix
+
+variables:
+  patch_date: '{{to_unix_time("Sun, 01 Jul 2023 00:00:00 GMT", "Mon, 02 Jan 2006 15:04:05 MST")}}'
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{Hostname}}/"
+      - "{{Hostname}}/vpn/index.html"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'Citrix')"
+          - "contains(body, 'gateway') || contains(body, '_ctxstxt_CitrixCopyright')"
+          - "contains(header, 'Last-Modified')"
+          - compare_versions(to_unix_time(last_modified, 'Mon, 02 Jan 2006 15:04:05 MST'), concat("< ", patch_date))
+        condition: and

--- a/http/cves/2023/CVE-2023-3519-timestamp-based.yaml
+++ b/http/cves/2023/CVE-2023-3519-timestamp-based.yaml
@@ -14,7 +14,7 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2023-3519
     cwe-id: CWE-94
-    cpe:  cpe:2.3:a:citrix:netscaler_gateway:*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:citrix:netscaler_gateway:*:*:*:*:*:*:*:*
   metadata:
     max-request: 3
     verified: "true"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
Simple nuclei template that checks Citrix gateway/ADC version based on timestamp, different from https://github.com/projectdiscovery/nuclei-templates/pull/7734
<!-- Please include any reference to your template if available -->
- References:
https://support.citrix.com/article/CTX561482/citrix-adc-and-citrix-gateway-security-bulletin-for-cve20233519-cve20233466-cve20233467
https://nvd.nist.gov/vuln/detail/cve-2023-3519
https://github.com/telekom-security/cve-2023-3519-citrix-scanner/blob/main/CVE-2023-3519-checker.py

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)