### PR TITLE
build: update yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -19,3 +19,7 @@ rules:
     min-spaces-from-content: 1
   empty-lines:
     max: 5
+  braces:
+    forbid: true
+  brackets:
+    forbid: true


### PR DESCRIPTION
This commit updates the `.yamllint` configuration file by forbid the usage of `braces` and `brackets` in the template file which coincidentally was introduced in the commit 249ad821ec85c3bd2dc503a35a9a79e542800c7a.

These changes aim to enhance the overall template syntax quality and maintain a consistent style throughout the Nuclei template files.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)