### PR TITLE
Update WP plugin update

### DIFF
--- a/.github/scripts/wordpress-plugins-update.py
+++ b/.github/scripts/wordpress-plugins-update.py
@@ -118,6 +118,7 @@ info:
   reference:
     - https://wordpress.org/plugins/{name}/
   metadata:
+    max-request: 1
     plugin_namespace: {name}
     wpscan: https://wpscan.com/plugin/{name}
   tags: tech,wordpress,wp-plugin,{top_tag}


### PR DESCRIPTION
I saw in this commit ( adc38c9 ) that by default it added the max request to 1

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)