### PR TITLE
Add negative filter for rocketmq unauth

### DIFF
--- a/network/misconfig/apache-rocketmq-broker-unauth.yaml
+++ b/network/misconfig/apache-rocketmq-broker-unauth.yaml
@@ -35,4 +35,5 @@ tcp:
         part: raw
         words:
           - "HTTP/1.1"
+          - "html"
         negative: true

--- a/network/misconfig/apache-rocketmq-broker-unauth.yaml
+++ b/network/misconfig/apache-rocketmq-broker-unauth.yaml
@@ -25,15 +25,11 @@ tcp:
       - "{{Host}}:10911"
     read-size: 2048
 
-    matchers-condition: and
     matchers:
       - type: word
         words:
-          - "serializeTypeCurrentRPC"
-
-      - type: word
-        part: raw
-        words:
-          - "HTTP/1.1"
-          - "html"
-        negative: true
+          - serializeTypeCurrentRPC
+          - language
+          - opaque
+          - version
+        condition: and


### PR DESCRIPTION
### Template / PR Information

This PR reduces the number of false positives in `network/misconfig/apache-rocketmq-broker-unauth.yaml` by adding another negative filter to eliminate all responses that have `html` in them. This does not completely fix the issue but should considerably reduce the number of false positives.

- Fixed network/misconfig/apache-rocketmq-broker-unauth
- References: Fixes #7790

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)