### PR TITLE
fix nginx-module-vts-xss false-positive 

### DIFF
--- a/.nuclei-ignore
+++ b/.nuclei-ignore
@@ -28,4 +28,3 @@ files:
   - http/cves/2020/CVE-2020-2036.yaml
   - http/cves/2020/CVE-2020-28351.yaml
   - http/vulnerabilities/oracle/oracle-ebs-xss.yaml
-  - http/vulnerabilities/other/nginx-module-vts-xss.yaml

--- a/http/vulnerabilities/other/nginx-module-vts-xss.yaml
+++ b/http/vulnerabilities/other/nginx-module-vts-xss.yaml
@@ -2,7 +2,7 @@ id: nginx-module-vts-xss
 
 info:
   name: Nginx Virtual Host Traffic Status Module - Cross-Site Scripting
-  author: madrobot
+  author: madrobot,j4vaovo
   severity: high
   description: Nginx Virtual Host Traffic Status Module contains a cross-site scripting vulnerability. An attacker can execute arbitrary script and thus steal cookie-based authentication credentials and launch other attacks.
   reference:
@@ -13,25 +13,28 @@ info:
     cwe-id: CWE-79
   tags: nginx,xss,status
   metadata:
-    max-request: 1
+    max-request: 2
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/status%3E%3Cscript%3Ealert(31337)%3C%2Fscript%3E"
+  - raw:
+      - |
+        GET /_404_%3E%3Cscript%3Ealert(1337)%3C%2Fscript%3E HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /status%3E%3Cscript%3Ealert(7331)%3C%2Fscript%3E HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "status_code_2 == 200"
+          - "contains(header_2, 'text/html')"
+          - "contains(tolower(body_2), '<script>alert(7331)</script>')"
+        condition: and
 
-      - type: word
-        words:
-          - "<script>alert(31337)</script>"
-        part: body
-
-      - type: word
-        words:
-          - "text/html"
-        part: header
+      - type: dsl
+        dsl:
+          - "!contains(tolower(body_1), '<script>alert(1337)</script>')"
+        condition: and


### PR DESCRIPTION
````
nuclei -u http://hydass.be -id nginx-module-vts-xss

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.6

                projectdiscovery.io

[WRN] Found 22 template[s] loaded with deprecated paths, update before v2.9.5 for continued support.
[INF] Current nuclei version: v2.9.6 (outdated)
[INF] Current nuclei-templates version: v9.6.0 (latest)
[INF] New templates added in latest release: 33
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time
````