### PR TITLE
Supporting translated adminer

### DIFF
--- a/http/exposed-panels/adminer-panel.yaml
+++ b/http/exposed-panels/adminer-panel.yaml
@@ -35,8 +35,8 @@ http:
     matchers:
       - type: word
         words:
-         # We only match the right part of the title as the interface may be translated,
-         # e.g. in Polish there is '<title>Zaloguj się - Adminer</title>'
+          # We only match the right part of the title as the interface may be translated,
+          # e.g. in Polish there is '<title>Zaloguj się - Adminer</title>'
           - "Adminer</title>"
 
       - type: status

--- a/http/exposed-panels/adminer-panel.yaml
+++ b/http/exposed-panels/adminer-panel.yaml
@@ -35,7 +35,9 @@ http:
     matchers:
       - type: word
         words:
-          - "Login - Adminer"
+         # We only match the right part of the title as the interface may be translated,
+         # e.g. in Polish there is '<title>Zaloguj się - Adminer</title>'
+          - "Adminer</title>"
 
       - type: status
         status:

--- a/http/exposed-panels/adminer-panel.yaml
+++ b/http/exposed-panels/adminer-panel.yaml
@@ -1,7 +1,7 @@
 id: adminer-panel
 
 info:
-  name: Adminer Login Panel
+  name: Adminer Login Panel - Detect
   author: random_robbie,meme-lord,ritikchaddha
   severity: info
   description: An Adminer login panel was detected.
@@ -35,9 +35,9 @@ http:
     matchers:
       - type: word
         words:
-          # We only match the right part of the title as the interface may be translated,
-          # e.g. in Polish there is '<title>Zaloguj się - Adminer</title>'
           - "Adminer</title>"
+          - "Adminer</a>"
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

only match the right part of the title as the interface may be translated, e.g. in Polish there is '<title>Zaloguj się - Adminer</title>

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
