### PR TITLE
fix jupyter-notebook-rce

### DIFF
--- a/http/vulnerabilities/jupyter-notebook-rce.yaml
+++ b/http/vulnerabilities/jupyter-notebook-rce.yaml
@@ -20,7 +20,7 @@ http:
   - raw:
       - |
         POST /api/terminals HTTP/1.1
-        Host: {Hostname}
+        Host: {{Hostname}}
         X-XSRFToken: 2|7a4faae0|819f5adf7edaef5e74502c9d0c75a604|1653492335
         Cookie: _xsrf=2|7a4faae0|819f5adf7edaef5e74502c9d0c75a604|1653492335
 


### PR DESCRIPTION
### Template / PR Information

Fixed the Hostname error

- Fixed jupyter-notebook-rce
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)