### PR TITLE
Fewer false positives in generic-env.yaml

### DIFF
--- a/http/vulnerabilities/generic/generic-env.yaml
+++ b/http/vulnerabilities/generic/generic-env.yaml
@@ -40,8 +40,15 @@ http:
       - "{{BaseURL}}/.env.{{SD}}"
       - "{{BaseURL}}/api/.env"
 
+    matchers-condition: and
     matchers:
       - type: regex
         part: body
         regex:
           - "(?mi)^[a-z_]*(KEY|TOKEN|PASS|SECRET|DB_URL|DATABASE_URL|MAILER_URL)[a-z_]*="
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "<html"


### PR DESCRIPTION
### Template / PR Information

Some websites have HTML that match this template, e.g. where HTML accesskey= property is at the beginning
of line because of HTML wrapping.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

