### PR TITLE
Update sonarqube-login.yaml

### DIFF
--- a/http/exposed-panels/sonarqube-login.yaml
+++ b/http/exposed-panels/sonarqube-login.yaml
@@ -17,9 +17,16 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/sessions/new"
-
+      
+    matchers-condition: and
     matchers:
       - type: word
         words:
-          - "<title>SonarQube</title>"
+          - "SonarQube"
         part: body
+
+      - type: status
+        status:
+          - 200
+    
+# Enhanced by Ep1cSage 10/10/2013

--- a/http/exposed-panels/sonarqube-login.yaml
+++ b/http/exposed-panels/sonarqube-login.yaml
@@ -17,16 +17,14 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/sessions/new"
-      
+
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "SonarQube"
-        part: body
 
       - type: status
         status:
           - 200
-    
-# Enhanced by Ep1cSage 10/10/2013


### PR DESCRIPTION
The original template was causing too many false positives.  It seems that it was only picking off the BaseURL endpoint.  Meaning if any other service like Fortinet had a similar endpoint then it would show up as a Sonarqube result.

I've added matchers-condition as well as the HTTP status to 200 which eliminated the false positives in my case during testing.

I've also went ahead and removed the title tags as it wasn't necessary and populated results for me on SonarQube services