### PR TITLE
Fixes incorrect tag in CVE-2020-28185 (TerraMaster TOS User Enum)

### DIFF
--- a/http/cves/2020/CVE-2020-28185.yaml
+++ b/http/cves/2020/CVE-2020-28185.yaml
@@ -14,7 +14,7 @@ info:
     fofa-query: '"TerraMaster" && header="TOS"'
     max-request: 2
     verified: true
-  tags: cve,cve2020,tamronos,enum,tos
+  tags: cve,cve2020,terramaster,enum,tos
 
 http:
   - raw:


### PR DESCRIPTION

### Template / PR Information
Fixes incorrect tag in `CVE-2020-28185.yaml` (TerraMaster TOS < 4.2.06 - User Enumeration). The lack of a `terramaster` tag currently results in this template running outside of the [TerraMaster workflow](https://github.com/projectdiscovery/nuclei-templates/blob/main/workflows/terramaster-workflow.yaml), which has resulted in several false positives for me over the past few days. Outside of the workflow, this template does not adequately verify that the target is a TerraMaster instance and seems to flag on any 200 response whose body contains the strings `username`, `email`, and `status`. Many common sites fit this bill, including cPanel Webmail sign-in pages.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)