### PR TITLE
Added erigon-server-detect template

### DIFF
--- a/http/technologies/erigon-server-detect.yaml
+++ b/http/technologies/erigon-server-detect.yaml
@@ -1,4 +1,4 @@
-id: erigon-server
+id: erigon-server-detect
 
 info:
   name: Erigon JSON-RPC HTTP Server Detect
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: product:"Erigon"
+    verified: true
   tags: tech,erigon,ethereum,web3,blockchain
 
 http:
@@ -19,7 +20,6 @@ http:
         POST / HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 66
 
         {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
 

--- a/http/technologies/erigon-server-detect.yaml
+++ b/http/technologies/erigon-server-detect.yaml
@@ -1,7 +1,7 @@
 id: erigon-server-detect
 
 info:
-  name: Erigon JSON-RPC HTTP Server Detect
+  name: Erigon JSON-RPC HTTP Server - Detect
   author: Nullfuzz
   severity: info
   description: |

--- a/http/technologies/erigon-server-detect.yaml
+++ b/http/technologies/erigon-server-detect.yaml
@@ -1,0 +1,39 @@
+id: erigon-server
+
+info:
+  name: Erigon JSON-RPC HTTP Server Detect
+  author: Nullfuzz
+  severity: info
+  description: |
+    Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer). By default Erigon runs a JSON-RPC HTTP server on port 8545/TCP
+  reference:
+    - https://github.com/ledgerwatch/erigon
+  metadata:
+    max-request: 1
+    shodan-query: product:"Erigon"
+  tags: tech,erigon,ethereum,web3,blockchain
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 66
+
+        {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "application/json")'
+          - 'contains(body, "erigon")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(erigon/[0-9_.]+)'


### PR DESCRIPTION
### Template / PR Information

description: 
    Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer). By default Erigon runs a JSON-RPC HTTP server on port 8545/TCP
  reference:
    - https://github.com/ledgerwatch/erigon
   
shodan-query: product:"Erigon"


I've validated this template locally?
- [X] YES
- [ ] NO
