### PR TITLE
added besu-server-detect template 

### DIFF
--- a/http/technologies/besu-server-detect.yaml
+++ b/http/technologies/besu-server-detect.yaml
@@ -1,0 +1,40 @@
+id: besu-server
+
+info:
+  name: Besu JSON-RPC HTTP Server Detect
+  author: Nullfuzz
+  severity: info
+  description: |
+      Besu is an open source Ethereum client developed under the Apache 2.0 license and written in Java. By default Besu runs a JSON-RPC HTTP server on port 8545/TCP
+  reference:
+    - https://besu.hyperledger.org/
+    - https://besu.hyperledger.org/public-networks/how-to/use-besu-api#service-ports
+  metadata:
+    max-request: 1
+    shodan-query: product:"besu"
+  tags: tech,besu,ethereum,web3,blockchain
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 66
+
+        {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "application/json")'
+          - 'contains(body, "besu")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(v[0-9.]+)'

--- a/http/technologies/erigon-server-detect.yaml
+++ b/http/technologies/erigon-server-detect.yaml
@@ -1,0 +1,39 @@
+id: erigon-server
+
+info:
+  name: Erigon JSON-RPC HTTP Server Detect
+  author: Nullfuzz
+  severity: info
+  description: |
+    Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer). By default Erigon runs a JSON-RPC HTTP server on port 8545/TCP
+  reference:
+    - https://github.com/ledgerwatch/erigon
+  metadata:
+    max-request: 1
+    shodan-query: product:"Erigon"
+  tags: tech,erigon,ethereum,web3,blockchain
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 66
+
+        {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "application/json")'
+          - 'contains(body, "erigon")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(erigon/[0-9_.]+)'


### PR DESCRIPTION
### Template / PR Information

description: 
      Besu is an open source Ethereum client developed under the Apache 2.0 license and written in Java. By default Besu runs a JSON-RPC HTTP server on port 8545/TCP
  reference:
    - https://besu.hyperledger.org/
    - https://besu.hyperledger.org/public-networks/how-to/use-besu-api#service-ports
  
shodan-query: product:"besu"

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

