### PR TITLE
Added besu-server-detect template

### DIFF
--- a/http/technologies/besu-server-detect.yaml
+++ b/http/technologies/besu-server-detect.yaml
@@ -1,7 +1,7 @@
 id: besu-server-detect
 
 info:
-  name: Besu JSON-RPC HTTP Server Detect
+  name: Besu JSON-RPC HTTP Server - Detect
   author: Nullfuzz
   severity: info
   description: |

--- a/http/technologies/besu-server-detect.yaml
+++ b/http/technologies/besu-server-detect.yaml
@@ -1,0 +1,40 @@
+id: besu-server
+
+info:
+  name: Besu JSON-RPC HTTP Server Detect
+  author: Nullfuzz
+  severity: info
+  description: |
+      Besu is an open source Ethereum client developed under the Apache 2.0 license and written in Java. By default Besu runs a JSON-RPC HTTP server on port 8545/TCP
+  reference:
+    - https://besu.hyperledger.org/
+    - https://besu.hyperledger.org/public-networks/how-to/use-besu-api#service-ports
+  metadata:
+    max-request: 1
+    shodan-query: product:"besu"
+  tags: tech,besu,ethereum,web3,blockchain
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 66
+
+        {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "application/json")'
+          - 'contains(body, "besu")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(v[0-9.]+)'

--- a/http/technologies/besu-server-detect.yaml
+++ b/http/technologies/besu-server-detect.yaml
@@ -1,4 +1,4 @@
-id: besu-server
+id: besu-server-detect
 
 info:
   name: Besu JSON-RPC HTTP Server Detect
@@ -12,6 +12,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: product:"besu"
+    verified: true
   tags: tech,besu,ethereum,web3,blockchain
 
 http:
@@ -20,7 +21,6 @@ http:
         POST / HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 66
 
         {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
 


### PR DESCRIPTION
### Template / PR Information

description:
      Besu is an open source Ethereum client developed under the Apache 2.0 license and written in Java. By default Besu runs a JSON-RPC HTTP server on port 8545/TCP
  reference:
    - https://besu.hyperledger.org/
    - https://besu.hyperledger.org/public-networks/how-to/use-besu-api#service-ports
 
shodan-query: product:"besu"

I've validated this template locally?
- [X] YES
- [ ] NO

