### PR TITLE
Added geth-server-detect template

### DIFF
--- a/http/technologies/geth-server-detect.yaml
+++ b/http/technologies/geth-server-detect.yaml
@@ -1,0 +1,40 @@
+id: geth-server
+
+info:
+  name: Go-ethereum JSON-RPC HTTP Server Detect
+  author: Nullfuzz
+  severity: info
+  description: |
+     Go-ethereum (aka Geth) is an Ethereum client built in Go. Geth runs a JSON-RPC HTTP server on port 8545/TCP
+  reference:
+    - https://geth.ethereum.org/docs
+    - https://github.com/ethereum/go-ethereum
+  metadata:
+    max-request: 1
+    shodan-query: product:"Geth"
+  tags: tech,geth,ethereum,web3,blockchain
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 66
+
+        {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "application/json")'
+          - 'contains(body, "Geth")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(v[0-9a-z-_.]+)'

--- a/http/technologies/geth-server-detect.yaml
+++ b/http/technologies/geth-server-detect.yaml
@@ -1,7 +1,7 @@
-id: geth-server
+id: geth-server-detect
 
 info:
-  name: Go-ethereum JSON-RPC HTTP Server Detect
+  name: Go Ethereum JSON-RPC HTTP Server Detect
   author: Nullfuzz
   severity: info
   description: |
@@ -12,6 +12,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: product:"Geth"
+    verified: true
   tags: tech,geth,ethereum,web3,blockchain
 
 http:
@@ -20,7 +21,6 @@ http:
         POST / HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 66
 
         {"method":"web3_clientVersion","params":[],"id":1,"jsonrpc":"2.0"}
 

--- a/http/technologies/geth-server-detect.yaml
+++ b/http/technologies/geth-server-detect.yaml
@@ -1,7 +1,7 @@
 id: geth-server-detect
 
 info:
-  name: Go Ethereum JSON-RPC HTTP Server Detect
+  name: Go Ethereum JSON-RPC HTTP Server - Detect
   author: Nullfuzz
   severity: info
   description: |


### PR DESCRIPTION
### Template / PR Information
  description: 
     Go-ethereum (aka Geth) is an Ethereum client built in Go. Geth runs a JSON-RPC HTTP server on port 8545/TCP
  reference:
    - https://geth.ethereum.org/docs
    - https://github.com/ethereum/go-ethereum

shodan-query: product:"Geth"

I've validated this template locally?
- [X] YES
- [ ] NO
