### PR TITLE
Fix unauth-psql.yaml false positive

### DIFF
--- a/network/misconfig/unauth-psql.yaml
+++ b/network/misconfig/unauth-psql.yaml
@@ -26,6 +26,7 @@ tcp:
       - "{{Hostname}}"
       - "{{Host}}:5432"
 
+    matchers-condition: and
     matchers:
       - type: word
         part: raw
@@ -34,3 +35,10 @@ tcp:
           - "Locale Provider"
           - "Owner"
         condition: and
+
+      - type: word
+        words:
+          - "FTP"
+          - "HTTP"
+        condition: or
+        negative: true


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed `unauth-psql.yaml` false positive

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Fix unauth-psql.yaml giving false positive results when the request is reflected in the HTTP/FTP response.

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)