### PR TITLE
Adding one more path in prometheus-metrics.yaml

### DIFF
--- a/http/exposures/configs/prometheus-metrics.yaml
+++ b/http/exposures/configs/prometheus-metrics.yaml
@@ -22,6 +22,7 @@ http:
       - "{{BaseURL}}/metrics"
       - "{{BaseURL}}/api/metrics"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word

--- a/http/exposures/configs/prometheus-metrics.yaml
+++ b/http/exposures/configs/prometheus-metrics.yaml
@@ -20,6 +20,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/metrics"
+      - "{{BaseURL}}/api/metrics"
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information

I have seen in multiple places that metric is found under `/api` so adding this path as well in this template so this can find that as well.

- Updated prometheus-metrics.yaml

I've validated this template locally?
- [ ] YES


#### Additional Details 
I have only changed this at one template but it is suggested to add this path `- "{{BaseURL}}/api/metrics"`  in all the templates related to metrics.

