### PR TITLE
Added description fields where missing in the ssl templates

### DIFF
--- a/ssl/detect-ssl-issuer.yaml
+++ b/ssl/detect-ssl-issuer.yaml
@@ -4,6 +4,8 @@ info:
   name: Detect SSL Certificate Issuer
   author: Lingtren
   severity: info
+  description: |
+    Extract the issuer's organization from the target's certificate. Issuers are entities which sign and distribute certificates.
   tags: ssl
   metadata:
     max-request: 1

--- a/ssl/mismatched-ssl-certificate.yaml
+++ b/ssl/mismatched-ssl-certificate.yaml
@@ -6,6 +6,8 @@ info:
   severity: low
   reference:
     - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/ssl-certificate-name-hostname-mismatch/
+  description: |
+    Mismatched certificates occur when there is inconsistency between the common name to which the certificate was issued and the domain name in the URL. This issue impacts the trust value of the affected website.
   tags: ssl,mismatched,tls
   metadata:
     max-request: 1

--- a/ssl/ssl-dns-names.yaml
+++ b/ssl/ssl-dns-names.yaml
@@ -4,6 +4,8 @@ info:
   name: SSL DNS Names
   author: pdteam
   severity: info
+  description: |
+    Extract the Subject Alternative Name (SAN) from the target's certificate. SAN facilitates the usage of additional hostnames with the same certificate.
   tags: ssl
   metadata:
     max-request: 1


### PR DESCRIPTION
### Template / PR Information

- Updated `ssl/detect-ssl-issuer.yaml`, `ssl/mismatched-ssl-certificate.yaml`, `ssl/ssl-dns-names.yaml`

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO

#### Additional Details (leave it blank if not applicable)

Added description fields where missing in the ssl templates.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
