### PR TITLE
fix: templates with generic tag should not depend on specific tech

### DIFF
--- a/http/cves/2016/CVE-2016-4975.yaml
+++ b/http/cves/2016/CVE-2016-4975.yaml
@@ -23,7 +23,7 @@ info:
     max-request: 1
     vendor: apache
     product: http_server
-  tags: cve,cve2016,crlf,generic,apache
+  tags: cve,cve2016,crlf,apache
 
 http:
   - method: GET

--- a/http/cves/2019/CVE-2019-6802.yaml
+++ b/http/cves/2019/CVE-2019-6802.yaml
@@ -23,7 +23,7 @@ info:
     verified: true
     vendor: python
     product: pypiserver
-  tags: cve,cve2019,crlf,generic,pypiserver
+  tags: cve,cve2019,crlf,pypiserver
 
 http:
   - method: GET

--- a/http/exposures/configs/cgi-printenv.yaml
+++ b/http/exposures/configs/cgi-printenv.yaml
@@ -11,7 +11,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cwe-id: CWE-200
-  tags: exposure,generic,cgi
+  tags: exposure,cgi
   metadata:
     max-request: 1
 

--- a/http/exposures/configs/msmtp-config.yaml
+++ b/http/exposures/configs/msmtp-config.yaml
@@ -10,7 +10,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: exposure,generic,msmtp
+  tags: exposure,msmtp
 
 http:
   - method: GET

--- a/http/exposures/tokens/amazon/aws-access-secret-key.yaml
+++ b/http/exposures/tokens/amazon/aws-access-secret-key.yaml
@@ -7,7 +7,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: disclosure,aws,generic,exposure,amazon
+  tags: disclosure,aws,exposure,amazon
 
 http:
   - method: GET

--- a/http/exposures/tokens/generic/credentials-disclosure.yaml
+++ b/http/exposures/tokens/generic/credentials-disclosure.yaml
@@ -5,7 +5,7 @@ info:
   author: Sy3Omda,forgedhallpass,geeknik
   severity: unknown
   description: Look for keys/tokens/passwords in HTTP responses, exposed keys/tokens/secrets requires manual verification for impact evaluation.
-  tags: exposure,token,key,api,secret,password
+  tags: exposure,token,key,api,secret,password,generic
   metadata:
     max-request: 1
 

--- a/http/exposures/tokens/generic/jdbc-connection-string.yaml
+++ b/http/exposures/tokens/generic/jdbc-connection-string.yaml
@@ -4,7 +4,7 @@ info:
   name: JDBC Connection String Disclosure
   author: Ice3man
   severity: unknown
-  tags: exposure,token
+  tags: exposure,token,generic
   metadata:
     max-request: 1
 

--- a/http/exposures/tokens/generic/jwt-token.yaml
+++ b/http/exposures/tokens/generic/jwt-token.yaml
@@ -4,7 +4,7 @@ info:
   name: JWT Token Disclosure
   author: Ice3man
   severity: unknown
-  tags: exposure,token
+  tags: exposure,token,generic
   metadata:
     max-request: 1
 

--- a/http/exposures/tokens/generic/shoppable-token.yaml
+++ b/http/exposures/tokens/generic/shoppable-token.yaml
@@ -6,7 +6,7 @@ info:
   severity: unknown
   reference:
     - https://ask.shoppable.com/knowledge/quick-start-api-guide
-  tags: exposure,shoppable,token,auth,service
+  tags: exposure,shoppable,token,auth,service,generic
   metadata:
     max-request: 1
 

--- a/http/miscellaneous/crypto-mining-malware.yaml
+++ b/http/miscellaneous/crypto-mining-malware.yaml
@@ -10,7 +10,7 @@ info:
     - https://github.com/xd4rker/MinerBlock/blob/master/assets/filters.txt
   metadata:
     max-request: 1
-  tags: malware,crypto,mining,misc
+  tags: malware,crypto,mining,misc,generic
 
 http:
   - method: GET

--- a/http/miscellaneous/email-extractor.yaml
+++ b/http/miscellaneous/email-extractor.yaml
@@ -4,7 +4,7 @@ info:
   name: Email Extractor
   author: panch0r3d
   severity: info
-  tags: misc,email
+  tags: misc,email,generic
   metadata:
     max-request: 1
 

--- a/http/miscellaneous/exposed-file-upload-form.yaml
+++ b/http/miscellaneous/exposed-file-upload-form.yaml
@@ -8,7 +8,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.html:"multipart/form-data" html:"file"
-  tags: exposure,upload,form,misc
+  tags: exposure,upload,form,misc,generic
 
 http:
   - method: GET

--- a/http/miscellaneous/old-copyright.yaml
+++ b/http/miscellaneous/old-copyright.yaml
@@ -7,7 +7,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: misc
+  tags: misc,generic
 
 http:
   - method: GET

--- a/http/miscellaneous/x-recruiting-header.yaml
+++ b/http/miscellaneous/x-recruiting-header.yaml
@@ -11,7 +11,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: "X-Recruiting:"
-  tags: misc,hiring,jobs,employment
+  tags: misc,hiring,jobs,employment,generic
 
 http:
   - method: GET

--- a/http/miscellaneous/xml-schema-detect.yaml
+++ b/http/miscellaneous/xml-schema-detect.yaml
@@ -4,7 +4,7 @@ info:
   name: XML Schema Detection
   author: alph4byt3
   severity: info
-  tags: misc
+  tags: misc,generic
   metadata:
     max-request: 1
 

--- a/http/misconfiguration/akamai/akamai-s3-cache-poisoning.yaml
+++ b/http/misconfiguration/akamai/akamai-s3-cache-poisoning.yaml
@@ -15,7 +15,7 @@ info:
   metadata:
     max-request: 204
     verified: true
-  tags: cache,poisoning,generic,xss,akamai,s3,misconfig
+  tags: cache,poisoning,xss,akamai,s3,misconfig
 
 variables:
   rand: "{{rand_base(5)}}"


### PR DESCRIPTION
### Generic tag harmonization

Some templates were wrongfully tag generic.
This small PR removes the generic tag from templates depending on a specific technology like AWS or Akamai.
In the same logic, no CVE should be marked as generic.

Generic tags were also added to certain templates, for example those in http/exposures/tokens/generic/.

### Reproducibility

```bash
nuclei -tags generic -tl
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="611" alt="nuclei_template_validation" src="https://github.com/projectdiscovery/nuclei-templates/assets/35432247/616100a9-89b9-4022-95a0-a5ac5cd644d9">
