### PR TITLE
frp-default-login: more precise body match

### DIFF
--- a/http/default-logins/frps/frp-default-login.yaml
+++ b/http/default-logins/frps/frp-default-login.yaml
@@ -32,7 +32,7 @@ http:
 
       - type: word
         words:
-          - "proxies"
+          - '"proxies":'
         part: body
         condition: and
 


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

This PR tightens the word matcher for the `frp-default-login` template to reduce false positives. 

The `/api/proxy/tcp` endpoint in `frps` returns JSON:

```
curl http://admin:admin@localhost:7500/api/proxy/tcp
{"proxies":[]}⏎                               
```

This PR was motivated by a false positive we saw in the wild with a host that returned 200 for any URL, and happened to mention "proxies" in the body.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Before PR (localhost is a real frps endpoint):

```
[VER] [frp-default-login] Sent HTTP request to http://localhost:7500/api/proxy/tcp
[frp-default-login] [http] [high] http://localhost:7500/api/proxy/tcp [password="admin",username="admin"]
[VER] [frp-default-login] Sent HTTP request to https:///false-positive.a.run.app/api/proxy/tcp
[frp-default-login] [http] [high] https://false-positive.a.run.app/api/proxy/tcp [username="admin",password="admin"]
```

After PR:

```
[VER] [frp-default-login] Sent HTTP request to http://localhost:7500/api/proxy/tcp
[frp-default-login] [http] [high] http://localhost:7500/api/proxy/tcp [password="admin",username="admin"]
[VER] [frp-default-login] Sent HTTP request to https:///false-positive.a.run.app/api/proxy/tcp
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)