### PR TITLE
Misc RDAP WHOIS template

### DIFF
--- a/http/miscellaneous/rdap-whois.yaml
+++ b/http/miscellaneous/rdap-whois.yaml
@@ -1,36 +1,30 @@
-id: rdap
+id: rdap-whois
 
 info:
   name: RDAP WHOIS
+  author: ricardomaia
+  severity: info
   description: |
     RDAP (Registration Data Access Protocol) is a standard defined by the IETF to replace the whois protocol
     in queries for information about Internet resource records such as domain names, IP addresses, and ASNs.
-  author: ricardomaia
-  severity: info
+  reference:
+    - https://about.rdap.org/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cvss-score: 0.0
     cwe-id: CWE-200
-  reference:
-    - https://about.rdap.org/
-  tags: misc,dns,domain,whois,rdap
   metadata:
     max-request: 1
+    verified: true
+  tags: misc,dns,domain,whois,rdap
 
 http:
   - method: GET
-    redirects: true
-    max-redirects: 3
-    headers:
-      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36
-      Accept: "*/*"
-      Pragma: no-cache
-      Cache-Control: no-cache
-      sec-fetch-mode: navigate
-      sec-fetch-site: none
-      sec-fetch-dest: document
     path:
       - "https://www.rdap.net/domain/{{Host}}"
+
+    redirects: true
+    max-redirects: 3
 
     extractors:
       - type: json

--- a/http/miscellaneous/rdap-whois.yaml
+++ b/http/miscellaneous/rdap-whois.yaml
@@ -16,7 +16,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: misc,dns,domain,whois,rdap
+  tags: whois,rdap,osint,misc
 
 http:
   - method: GET
@@ -25,7 +25,6 @@ http:
 
     redirects: true
     max-redirects: 3
-
     extractors:
       - type: json
         part: body

--- a/http/miscellaneous/rdap.yaml
+++ b/http/miscellaneous/rdap.yaml
@@ -17,7 +17,6 @@ info:
   metadata:
     max-request: 1
 
-self-contained: true
 http:
   - method: GET
     redirects: true

--- a/http/miscellaneous/rdap.yaml
+++ b/http/miscellaneous/rdap.yaml
@@ -1,0 +1,104 @@
+id: rdap
+
+info:
+  name: RDAP WHOIS
+  description: |
+    RDAP (Registration Data Access Protocol) is a standard defined by the IETF to replace the whois protocol
+    in queries for information about Internet resource records such as domain names, IP addresses, and ASNs.
+  author: ricardomaia
+  severity: info
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  reference:
+    - https://www.rdap.net/
+  tags: misc,dns,domain,whois,rdap
+  metadata:
+    max-request: 1
+
+self-contained: true
+http:
+  - method: GET
+    redirects: true
+    max-redirects: 3
+    headers:
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36
+      Accept: "*/*"
+      Pragma: no-cache
+      Cache-Control: no-cache
+      sec-fetch-mode: navigate
+      sec-fetch-site: none
+      sec-fetch-dest: document
+    path:
+      - "https://www.rdap.net/domain/{{Host}}"
+
+    extractors:
+      - type: json
+        part: body
+        name: raw
+        json:
+          - "."
+
+      - type: regex
+        part: body
+        name: domain
+        group: 1
+        regex:
+          - '^{"objectClassName":"domain","handle":".*?","ldhName":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: legalRepresentative
+        group: 1
+        regex:
+          - 'legalRepresentative":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: identifier
+        group: 1
+        regex:
+          - 'identifier":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: email
+        group: 1
+        regex:
+          - 'email",{},"text","(.*?)"'
+
+      - type: regex
+        part: body
+        name: registrationDate
+        group: 1
+        regex:
+          - '"eventAction":"registration","eventDate":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: lastChangeDate
+        group: 1
+        regex:
+          - '"eventAction":"last changed","eventDate":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: expirationDate
+        group: 1
+        regex:
+          - '"eventAction":"expiration","eventDate":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: nameServers
+        group: 1
+        regex:
+          - 'nameserver","ldhName":"(.*?)"'
+
+      - type: regex
+        part: body
+        name: secureDNS
+        group: 1
+        regex:
+          - '"secureDNS":{"delegationSigned":(.*?)}'

--- a/http/miscellaneous/rdap.yaml
+++ b/http/miscellaneous/rdap.yaml
@@ -12,7 +12,7 @@ info:
     cvss-score: 0.0
     cwe-id: CWE-200
   reference:
-    - https://www.rdap.net/
+    - https://about.rdap.org/
   tags: misc,dns,domain,whois,rdap
   metadata:
     max-request: 1


### PR DESCRIPTION
### Template / PR Information

RDAP (Registration Data Access Protocol) is a standard defined by the IETF to replace the WHOIS protocol in queries for information about Internet resource records such as domain names, IP addresses, and ASNs.

This PR adds a template for extracting domain registration information using the RDAP protocol and can be very useful for OSINT purposes and personal information collection.

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1353811/1f6a349e-e60f-4a40-9bb4-b9fe93ec828a)


- References:

https://about.rdap.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)