### PR TITLE
Update weak-cipher-suites.yaml

### DIFF
--- a/ssl/weak-cipher-suites.yaml
+++ b/ssl/weak-cipher-suites.yaml
@@ -3,7 +3,7 @@ id: weak-cipher-suites
 info:
   name: Weak Cipher Suites Detection
   author: pussycat0x
-  severity: medium
+  severity: low
   reference:
     - https://www.acunetix.com/vulnerabilities/web/tls-ssl-weak-cipher-suites/
     - http://ciphersuite.info


### PR DESCRIPTION
### Template / PR Information

While weak cipher suites are not advisable, their ease of exploitation is limited in many real-world scenarios. And when performing external testing, it's difficult to determine the true impact. Given these factors, lowering the severity rating seems reasonable compared to other more serious remote bugs. But organizations should still look to phase out weak ciphers in a responsible manner.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

