### PR TITLE
Fix unauth_psql detection on other protocols

### DIFF
--- a/network/misconfig/unauth-psql.yaml
+++ b/network/misconfig/unauth-psql.yaml
@@ -37,8 +37,10 @@ tcp:
         condition: and
 
       - type: word
+        part: raw
         words:
           - "FTP"
           - "HTTP"
+          - "500"
         condition: or
         negative: true


### PR DESCRIPTION
If the protocol we send the request to reflects our message we detect it as a FP. Excluding a 500 error code should be a more general rule.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed unauth_psql.yaml
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)