### PR TITLE
Add SnapComms Content Manager Panel template

### DIFF
--- a/http/exposed-panels/snapcomms-content-manager-panel.yaml
+++ b/http/exposed-panels/snapcomms-content-manager-panel.yaml
@@ -1,16 +1,15 @@
-id: snapcomms-panel
+id: snapcomms-content-manager-panel
 
 info:
-  name: SnapComms Panel - Detect
+  name: SnapComms Content Manager Panel - Detect
   author: righettod
   severity: info
   description: |
-    SnapComms was detected.
+    SnapComms Content Manager was detected.
   reference:
     - https://www.snapcomms.com/
   metadata:
     max-request: 1
-    shodan-query: title:"Cryptobox"
     verified: true
   tags: panel,snapcomms,login,detect
 

--- a/http/exposed-panels/snapcomms-panel.yaml
+++ b/http/exposed-panels/snapcomms-panel.yaml
@@ -23,7 +23,7 @@ http:
       - type: word
         part: body
         words:
-          - ' <title>SnapComms Content Manager</title>'
+          - '<title>SnapComms Content Manager</title>'
 
       - type: status
         status:

--- a/http/exposed-panels/snapcomms-panel.yaml
+++ b/http/exposed-panels/snapcomms-panel.yaml
@@ -1,4 +1,4 @@
-id: snapcomms-content-manager-panel
+id: snapcomms-panel
 
 info:
   name: SnapComms Content Manager Panel - Detect
@@ -24,7 +24,6 @@ http:
         part: body
         words:
           - ' <title>SnapComms Content Manager</title>'
-        case-insensitive: true
 
       - type: status
         status:

--- a/http/exposed-panels/snapcomms-panel.yaml
+++ b/http/exposed-panels/snapcomms-panel.yaml
@@ -1,0 +1,39 @@
+id: snapcomms-panel
+
+info:
+  name: SnapComms Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    SnapComms was detected.
+  reference:
+    - https://www.snapcomms.com/
+  metadata:
+    max-request: 1
+    shodan-query: title:"Cryptobox"
+    verified: true
+  tags: panel,snapcomms,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/Manager/'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - ' <title>SnapComms Content Manager</title>'
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'version=([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This template propose the detection of the product [SnapComms Content Manager](https://www.snapcomms.com/).

- References: https://www.snapcomms.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/122d884a-84b5-44b4-b806-3e80cfe7065b)


### Additional Details (leave it blank if not applicable)

I did not found a Shodan query but I identity the following Google dork ([Sample](https://www.google.com/search?q=intitle%3A%22Login+%7C+SnapComms+Content+Manager%22+-site%3Ayoutube.com+-site%3A*.snapcomms.com)):

`intitle:"Login | SnapComms Content Manager" -site:youtube.com -site:*.snapcomms.com`


### Additional References:

None