### PR TITLE
Add Seafile API detection template

### DIFF
--- a/http/exposures/apis/seafile-api.yaml
+++ b/http/exposures/apis/seafile-api.yaml
@@ -1,0 +1,41 @@
+id: seafile-api
+
+info:
+  name: Seafile API - Detect
+  author: righettod
+  severity: info
+  description: |
+    Seafile API was detected.
+  reference:
+    - https://download.seafile.com/published/web-api/home.md
+    - https://manual.seafile.com/
+    - https://www.seafile.com/en/home/
+  metadata:
+    max-request: 1
+    verified: true
+  tags: exposure,api
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/api2/server-info/'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'seafile-basic'
+          - 'seafile-pro'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version":\s*"([0-9.]+)"'

--- a/http/exposures/apis/seafile-api.yaml
+++ b/http/exposures/apis/seafile-api.yaml
@@ -13,6 +13,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    shodan-query: http.html:"seafile"
   tags: exposure,api
 
 http:
@@ -28,6 +29,11 @@ http:
           - 'seafile-basic'
           - 'seafile-pro'
         condition: or
+
+      - type: word
+        part: header
+        words:
+          - 'application/json'
 
       - type: status
         status:

--- a/http/exposures/apis/seafile-api.yaml
+++ b/http/exposures/apis/seafile-api.yaml
@@ -14,7 +14,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.html:"seafile"
-  tags: exposure,api
+  tags: exposure,api,detect
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose the detection of the web API of the [Seafile product](https://www.seafile.com/en/home/).

- References:
    - https://download.seafile.com/published/web-api/home.md
    - https://manual.seafile.com/
    - https://www.seafile.com/en/home/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/3fbae20f-c3e9-4df1-8e8b-268cf9b3223e)


### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22seafile%22

### Additional References:

None