### PR TITLE
Add detection for DXPlanning

### DIFF
--- a/http/exposed-panels/dxplanning-panel.yaml
+++ b/http/exposed-panels/dxplanning-panel.yaml
@@ -1,0 +1,36 @@
+id: dxplanning-panel
+
+info:
+  name: DXPlanning Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    DXPlanning was detected.
+  reference:
+    - https://www.dedalus.com/fr/wp-content/uploads/sites/13/2022/05/Catalogue-formations-DxCare-2022.pdf
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,dxplanning,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/'
+      - '{{BaseURL}}/DxPlanning/WebBooking/Version'
+    
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(tolower(body), 'dxplanning/webbooking/') && status_code==200"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<td>([0-9.]+)</td>'

--- a/http/exposed-panels/dxplanning-panel.yaml
+++ b/http/exposed-panels/dxplanning-panel.yaml
@@ -18,7 +18,7 @@ http:
     path:
       - '{{BaseURL}}/'
       - '{{BaseURL}}/DxPlanning/WebBooking/Version'
-    
+
     host-redirects: true
     max-redirects: 2
     matchers-condition: and

--- a/http/exposed-panels/dxplanning-panel.yaml
+++ b/http/exposed-panels/dxplanning-panel.yaml
@@ -16,16 +16,14 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/'
       - '{{BaseURL}}/DxPlanning/WebBooking/Version'
 
-    host-redirects: true
-    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - "contains(tolower(body), 'dxplanning/webbooking/') && status_code==200"
+          - "contains(tolower(body), 'dxplanning/webbooking/')"
+          - "status_code==200"
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect an instance of the **DXPlanning** product.

- References: https://www.dedalus.com/fr/wp-content/uploads/sites/13/2022/05/Catalogue-formations-DxCare-2022.pdf

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![prt](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/91a6b02d-f93a-4462-b92c-09739f5451f5)


### Additional Details (leave it blank if not applicable)

I did not found a viable Shodan query as the product is a very specific one.

However, this Google dork can help: `https://www.google.com/search?q=intext%3A%22dxplanning%22` 

### Additional References:

None