### PR TITLE
Add template to detect instance of Quilium CMS

### DIFF
--- a/http/exposed-panels/quilium-panel.yaml
+++ b/http/exposed-panels/quilium-panel.yaml
@@ -5,7 +5,7 @@ info:
   author: righettod
   severity: info
   description: |
-    Quilium CMS was detected.
+    Quilium CMS Login Panel was detected.
   reference:
     - https://www.quilium.io/
   metadata:
@@ -17,15 +17,23 @@ info:
 http:
   - method: GET
     path:
+      - '{{BaseURL}}'
       - '{{BaseURL}}/en/login'
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - "contains(tolower(body), 'cms quilium')"
-          - "status_code==200"
-        condition: and
+      - type: word
+        part: body
+        words:
+          - 'content="CMS Quilium'
+          - 'Quilium</a>'
+        condition: or
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex

--- a/http/exposed-panels/quilium-panel.yaml
+++ b/http/exposed-panels/quilium-panel.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    shodan-query: http.html:"CMS Quilium"
   tags: panel,quilium,login,detect
 
 http:

--- a/http/exposed-panels/quilium-panel.yaml
+++ b/http/exposed-panels/quilium-panel.yaml
@@ -1,0 +1,34 @@
+id: quilium-panel
+
+info:
+  name: Quilium Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Quilium CMS was detected.
+  reference:
+    - https://www.quilium.io/
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,quilium,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/en/login'
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(tolower(body), 'cms quilium')"
+          - "status_code==200"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'CMS Quilium ([a-f0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect an instance of the [Quilium CMS](https://www.quilium.io/).

- References: https://www.quilium.io/

### Template Validation

I've validated this template locally?
- [x] YES on https://www.valorlux.lu/
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f232553e-7b81-4292-973e-cd35bae8f98b)


### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22CMS+Quilium%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d92d6f82-3ae7-434f-a069-3c096491ec3a)


### Additional References:

None