### PR TITLE
Fixed path on drupal-install template

### DIFF
--- a/http/exposures/files/drupal-install.yaml
+++ b/http/exposures/files/drupal-install.yaml
@@ -15,6 +15,7 @@ http:
       - "{{BaseURL}}/install.php?profile=default"
       - "{{BaseURL}}/core/install.php"
 
+    stop-at-first-match: true
     host-redirects: true
     max-redirects: 1
     matchers:

--- a/http/exposures/files/drupal-install.yaml
+++ b/http/exposures/files/drupal-install.yaml
@@ -13,6 +13,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/install.php?profile=default"
+      - "{{BaseURL}}/core/install.php"
 
     host-redirects: true
     max-redirects: 1


### PR DESCRIPTION
### Template / PR Information

Drupal install URL has been modified on some versions from /install.php to /core/install.php so an update was needed in order to better detect this weakness.

- References : https://api.drupal.org/api/drupal/core%21install.php/8.1.x

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)