### PR TITLE
Added gitlab-public-registration template

### DIFF
--- a/http/misconfiguration/gitlab/gitlab-public-registration.yaml
+++ b/http/misconfiguration/gitlab/gitlab-public-registration.yaml
@@ -1,0 +1,35 @@
+id: gitlab-public-registration
+
+info:
+  name: GitLab public registration of new user
+  author: axrk
+  severity: info
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"GitLab"
+  tags: gitlab,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/users/sign_up"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<span class="gl-button-text">Register</span>'
+          - 'data-qa-selector="new_user_register_button"'
+
+      - type: word
+        words:
+          - 'https://about.gitlab.com'
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        negative: true
+        words:
+          - '<meta content="GitLab.com" property="og:description">'

--- a/http/misconfiguration/gitlab/gitlab-public-registration.yaml
+++ b/http/misconfiguration/gitlab/gitlab-public-registration.yaml
@@ -1,7 +1,7 @@
 id: gitlab-public-registration
 
 info:
-  name: GitLab public registration of new user
+  name: GitLab public registration of new user - Detect
   author: axrk
   severity: info
   metadata:
@@ -20,6 +20,7 @@ http:
         words:
           - '<span class="gl-button-text">Register</span>'
           - 'data-qa-selector="new_user_register_button"'
+        condition: or
 
       - type: word
         words:


### PR DESCRIPTION
### Template / PR Information

Another template exists for a similar thing (gitlab-public-signup) but it is detecting the possible registration from the sign-in page whereas it could be interesting to also detect it via the sign-up page (which this template does).
I didn't want to do a fix as the other solution is also useful in some cases, so here is a new template.

- References: https://docs.gitlab.com/ee/administration/settings/sign_up_restrictions.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)