### PR TITLE
Create satis-repository.yaml

### DIFF
--- a/http/exposed-panels/satis-repository.yaml
+++ b/http/exposed-panels/satis-repository.yaml
@@ -1,0 +1,36 @@
+id: satis-repository
+
+info:
+  name: Satis Composer Repository - Detect
+  author: FlorianMaak
+  severity: info
+  description: Satis composer repository was detected
+  reference:
+    - https://github.com/composer/satis
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"<a href=\"https://github.com/composer/satis\">Satis</a>"
+  tags: exposure,composer,satis
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "This is a private Composer repository"
+          - "<a href=\"https://github.com/composer/satis\">Satis</a>"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/satis-repository.yaml
+++ b/http/exposed-panels/satis-repository.yaml
@@ -4,7 +4,8 @@ info:
   name: Satis Composer Repository - Detect
   author: FlorianMaak
   severity: info
-  description: Satis composer repository was detected
+  description: |
+     Satis composer repository was detected
   reference:
     - https://github.com/composer/satis
   classification:
@@ -27,10 +28,16 @@ http:
       - type: word
         part: body
         words:
-          - "This is a private Composer repository"
-          - "<a href=\"https://github.com/composer/satis\">Satis</a>"
+          - 'This is a private repository'
+          - 'https://github.com/composer/satis'
         condition: and
 
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '\d+\.\d+\.\d+-dev'


### PR DESCRIPTION
### Template / PR Information

Create detection to check for satis servers, hosting composer repositories.

- References:
- https://github.com/composer/satis

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)