### PR TITLE
Update gitlab-detect.yaml

### DIFF
--- a/http/exposed-panels/gitlab-detect.yaml
+++ b/http/exposed-panels/gitlab-detect.yaml
@@ -24,6 +24,7 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        condition: and
         words:
           - 'GitLab'
           - 'https://about.gitlab.com'

--- a/http/exposed-panels/gitlab-detect.yaml
+++ b/http/exposed-panels/gitlab-detect.yaml
@@ -24,10 +24,10 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        condition: and
         words:
           - 'GitLab'
           - 'https://about.gitlab.com'
+        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
Fix false positive #8239 

### Template / PR Information

After this fix:

```
 echo https://public-metrics-grafana-customer-front-qa-9145.aivencloud.com | nuclei -duc -t http/exposed-panels/gitlab-detect.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.15

                projectdiscovery.io

[WRN] Found 11 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v2.9.15 (outdated)
[INF] Current nuclei-templates version: v9.6.4 (latest)
[INF] New templates added in latest release: 121
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!
```

Gitlab sites are still detected:
```
 echo https://dev.gitlab.org/ | nuclei -duc -t http/exposed-panels/gitlab-detect.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.15

                projectdiscovery.io

[WRN] Found 11 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v2.9.15 (outdated)
[INF] Current nuclei-templates version: v9.6.4 (latest)
[INF] New templates added in latest release: 121
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[gitlab-detect] [http] [info] https://dev.gitlab.org/users/sign_in
```

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
