### PR TITLE
fix: typo in CNVD-2023-76801 tags

### DIFF
--- a/http/cnvd/2023/CNVD-C-2023-76801.yaml
+++ b/http/cnvd/2023/CNVD-C-2023-76801.yaml
@@ -7,7 +7,7 @@ info:
   description: There is an arbitrary method calling vulnerability in UFIDA NC and NCC systems. By exploiting the vulnerability through uapjs (jsinvoke), dangerous methods can be called to cause attacks.
   metadata:
     max-request: 2
-  tags: cvnd,cvnd2023,yonyou,rce
+  tags: cnvd,cnvd2023,yonyou,rce
 
 http:
   - raw:


### PR DESCRIPTION
In the tags of this CNVD, "cnvd" was misspelled as "cvnd".

### Template / PR Information

In the tags of this CNVD, "cnvd" was misspelled as "cvnd".