### PR TITLE
Fix false positive for any min.2.1.js file in crypto-mining-malware template

### DIFF
--- a/http/miscellaneous/crypto-mining-malware.yaml
+++ b/http/miscellaneous/crypto-mining-malware.yaml
@@ -24,7 +24,7 @@ http:
         part: body
         regex:
           - '(?mi)cryptonight\.wasm|deepMiner|proxy\=ws|coinhive\.min\.js|wpupdates\.github\.io\/ping|cryptonight\.asm\.js|coin-hive\.com|jsecoin\.com|cryptoloot\.pro'
-          - '(?mi)webassembly\.stream|monero\-miner|wasmminer|cn\-asmjs\.min\.js|aj(\-?)cryptominer|wp\-monero\-miner\-pro|crlt\.js|pool\/direct\.js|n\.2\.1\.(js|l.*)'
+          - '(?mi)webassembly\.stream|monero\-miner|wasmminer|cn\-asmjs\.min\.js|aj(\-?)cryptominer|wp\-monero\-miner\-pro|crlt\.js|pool\/direct\.js|\.n\.2\.1\.(js|l.*)'
           - '(?mi)ppoi\.org|xmrstudio|webmine\.pro|miner\.start|allfontshere\.press|upgraderservices\.cf|vuuwd\.com|gridcash\.js|worker\-asmjs\.min\.js|perfekt\=wss\:'
           - '(?mi)coin\-hive\.com|coinhive|CoinHive|miner\.start|me0w\.js|web(x?)mr(4?)\.js|miner\.js|static\/js\/tpb\.js|lib\/crypta\.js'
           - '(?mi)bitrix\/js\/main\/core\/core\_(tasker|loader)\.js'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- There is a false positive for any min.2.1.js file for example some-script-min.2.1.js would be matched. According to Adguard filters the crypto miner malware is named like .n.2.1.js so we can fix this with adding a necessary point character before n.

- References:
Adguard filters: https://github.com/AdguardTeam/AdguardFilters/blob/master/BaseFilter/sections/cryptominers.txt

### Template Validation

I've validated this template locally?
- [ x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)