### PR TITLE
Add template to detect Blazor WebAssembly app

### DIFF
--- a/http/technologies/blazor-webassembly-detect.yaml
+++ b/http/technologies/blazor-webassembly-detect.yaml
@@ -1,0 +1,43 @@
+id: blazor-webassembly-detect
+
+info:
+  name: Blazor WebAssembly - Detect
+  author: righettod
+  severity: info
+  description: |
+    Blazor WebAssembly application was detected.
+  reference:
+    - https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor
+    - https://github.com/righettod/burp-piper-custom-scripts/issues/1
+  metadata:
+    max-request: 2
+    verified: true
+  tags: blazor,webassembly,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/_framework/blazor.boot.json'
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'dotnet.wasm'
+          - '"entryAssembly"'
+          - '"Microsoft.JSInterop.WebAssembly.dll"'
+        condition: and
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'dotnet.([0-9.]+).[a-z0-9]+.js'

--- a/http/technologies/blazor-webassembly-detect.yaml
+++ b/http/technologies/blazor-webassembly-detect.yaml
@@ -10,8 +10,9 @@ info:
     - https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor
     - https://github.com/righettod/burp-piper-custom-scripts/issues/1
   metadata:
-    max-request: 2
+    max-request: 1
     verified: true
+    shodan-query: html:"blazor.boot.json"
   tags: blazor,webassembly,detect
 
 http:


### PR DESCRIPTION
### Template / PR Information

This PR propose a template to detect when the web app is developed with [Blazor WebAssembly](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor):

`Blazor WebAssembly is a single-page app (SPA) for building interactive client-side web apps with .NET.`

- References: https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![prt](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/fc037e86-dc5b-4925-a7fc-40e643c0c3fe)

I tested the template against an app created with the following [Visual Studio CE](https://visualstudio.microsoft.com/vs/community/) template:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d6b2b90c-1ffc-43ef-bbe5-92f7eb299371)


### Additional Details (leave it blank if not applicable)

None

### Additional References:

None