### PR TITLE
fix: template for CVE-2021-30151

### DIFF
--- a/http/cves/2021/CVE-2021-30151.yaml
+++ b/http/cves/2021/CVE-2021-30151.yaml
@@ -29,14 +29,14 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/sidekiq/queues/"onmouseover="alert(document.domain)"'
+      - '{{BaseURL}}/sidekiq/queues/"onmouseover="document.write(`averyrandomstring<br>`)"'
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - "onmouseover=\"alert(document.domain)"
+        regex:
+          - "averyrandomstring<br>"
 
       - type: word
         part: header


### PR DESCRIPTION

### Template / PR Information
- Fixed CVE-2021-30151

The template checked only if the payload was present in the response and not if it's actually an XSS. Now, the detection injects a payload that outputs a string, and matches only when the string is found in the page.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO