### PR TITLE
New plugin for open redirect vulnerability on SAP ICF logout page

### DIFF
--- a/misconfiguration/sap/sap-icf-logoff-open-redirect.yaml
+++ b/misconfiguration/sap/sap-icf-logoff-open-redirect.yaml
@@ -1,0 +1,31 @@
+id: sap-icf-logoff-open-redirect
+
+info:
+  name: SAP ICF logoff Open Redirect
+  author: ndmalc
+  severity: medium
+  description: Detection of open redirect on SAP ICF logoff page
+  reference:
+    - https://userapps.support.sap.com/sap/support/knowledge/en/3143650
+    - https://wiki.scn.sap.com/wiki/display/ABAPConn/The+logoff+parameter+redirecturl+is+marked+as+a+security+vulnerability
+    - https://github.com/ndmalc/SAP-ICF-logoff-Open-Redirect
+    - https://cwe.mitre.org/data/definitions/601.html
+    - https://www.tenable.com/plugins/nessus/121040
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:L/A:N
+    cvss-score: 4.7
+    cwe-id: CWE-601
+  metadata:
+    shodan-query: http.favicon.hash:-266008933
+  tags: sap,redirect,misconfig
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sap/public/bc/icf/logoff?redirecturl=http://interact.sh"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh\/?(\/|[^.].*)?$' # https://regex101.com/r/ZDYhFh/1


### PR DESCRIPTION
### Template / PR Information

- Added open redirect vulnerability on SAP ICF logoff page

### Template Validation

I've validated this template locally?
- [ x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)