### PR TITLE
Update CVE-2019-6802.yaml

### DIFF
--- a/http/cves/2019/CVE-2019-6802.yaml
+++ b/http/cves/2019/CVE-2019-6802.yaml
@@ -36,4 +36,5 @@ http:
     matchers:
       - type: regex
         part: header
-        regex: '^Set-Cookie: crlfinjection=1;'
+        regex:
+          - "^Set-Cookie: crlfinjection=1;"

--- a/http/cves/2019/CVE-2019-6802.yaml
+++ b/http/cves/2019/CVE-2019-6802.yaml
@@ -34,7 +34,6 @@ http:
       - "{{BaseURL}}/%0d%0aSet-Cookie:crlfinjection=1;"
 
     matchers:
-      - type: word
+      - type: regex
         part: header
-        words:
-          - 'Set-Cookie: crlfinjection=1;'
+        regex: '^Set-Cookie: crlfinjection=1;'


### PR DESCRIPTION
Updated to remove false positives.
As the previous change matches the words "Set-Cookie: crlfinjection=1" even if the words are present in the Location header too.

The updated code, will match only if the "Set-Cookie: crlfinjection=1" is actually a header, by verifying that it actually starts in the beginning of a response header.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)