### PR TITLE
Added bgp-detect template

### DIFF
--- a/network/detection/bgp-detect.yaml
+++ b/network/detection/bgp-detect.yaml
@@ -4,7 +4,6 @@ info:
   name: BGP Detection
   author: danfaizer
   severity: info
-  tags: network,bgp,detect
   description: |
     The remote host is running BGP, a popular routing protocol. This indicates that the remote host is probably a network router.
   impact: |
@@ -16,10 +15,14 @@ info:
   reference:
     - https://www.acunetix.com/vulnerabilities/network/vulnerability/bgp-detection/
     - https://www.tenable.com/plugins/nessus/11907
+  metadata:
+    shodan-query: product:"BGP"
+  tags: network,bgp
 
 tcp:
   - inputs:
       - data: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001D010400FFFF0000B4C0
+        type: hex
         # Source: https://www.rfc-editor.org/rfc/rfc4271.html#section-4.2
         # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF represents the 16-byte marker field.
         # 001D is the total length of the BGP message, including the 19 bytes of the header and the optional parameters.
@@ -28,15 +31,12 @@ tcp:
         # FFFF represents the Autonomous System Number (ASN) in hexadecimal format.
         # 0000 represents the Hold Time.
         # B4C0 represents the BGP Identifier, usually an IP address in hexadecimal format.
-        type: hex
-        name: resp
 
     host:
       - "{{Hostname}}"
-      - "{{Host}}:179"
+    port: 179
 
     read-size: 16
-
     matchers:
       - type: word
         encoding: hex

--- a/network/detection/bgp-detect.yaml
+++ b/network/detection/bgp-detect.yaml
@@ -1,0 +1,44 @@
+id: bgp-detect
+
+info:
+  name: BGP Detection
+  author: danfaizer
+  severity: info
+  tags: network,bgp,detect
+  description: |
+    The remote host is running BGP, a popular routing protocol. This indicates that the remote host is probably a network router.
+  impact: |
+    Following best practices, BGP services should only be accessible to participating BGP neighbors to prevent potential attacks.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  reference:
+    - https://www.acunetix.com/vulnerabilities/network/vulnerability/bgp-detection/
+    - https://www.tenable.com/plugins/nessus/11907
+
+tcp:
+  - inputs:
+      - data: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001D010400FFFF0000B4C0
+        # Source: https://www.rfc-editor.org/rfc/rfc4271.html#section-4.2
+        # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF represents the 16-byte marker field.
+        # 001D is the total length of the BGP message, including the 19 bytes of the header and the optional parameters.
+        # 01 is the BGP message type, which is OPEN (1).
+        # 04 represents the BGP version, which is BGP-4.
+        # FFFF represents the Autonomous System Number (ASN) in hexadecimal format.
+        # 0000 represents the Hold Time.
+        # B4C0 represents the BGP Identifier, usually an IP address in hexadecimal format.
+        type: hex
+        name: resp
+
+    host:
+      - "{{Hostname}}"
+      - "{{Host}}:179"
+
+    read-size: 16
+
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "ffffffffffffffffffffffffffffffff"


### PR DESCRIPTION
### Template / PR Information

- Added bgp-detect template. Following best practices, BGP services should only be accessible to participating BGP neighbors to prevent potential attacks.
- References:
  - https://www.acunetix.com/vulnerabilities/network/vulnerability/bgp-detection/
  - https://www.tenable.com/plugins/nessus/11907
  - https://www.rfc-editor.org/rfc/rfc4271.html

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)