### PR TITLE
CVE-2023-33405.yaml

### DIFF
--- a/file/keys/twilio-api.yaml
+++ b/file/keys/twilio-api.yaml
@@ -2,7 +2,7 @@ id: twilio-api
 
 info:
   name: Twilio API Key
-  author: gaurang
+  author: gaurang, shankar acharya
   severity: high
   tags: token,file
 
@@ -13,4 +13,4 @@ file:
     extractors:
       - type: regex
         regex:
-          - "(?i)twilio(.{0,20})?SK[0-9a-f]{32}"
+          - "(?i)twilio(.{0,20})?[0-9a-f]{32,34}"

--- a/file/keys/twilio-api.yaml
+++ b/file/keys/twilio-api.yaml
@@ -2,7 +2,7 @@ id: twilio-api
 
 info:
   name: Twilio API Key
-  author: gaurang, shankar acharya
+  author: gaurang
   severity: high
   tags: token,file
 
@@ -13,4 +13,4 @@ file:
     extractors:
       - type: regex
         regex:
-          - "(?i)twilio(.{0,20})?[0-9a-f]{32,34}"
+          - "(?i)twilio(.{0,20})?SK[0-9a-f]{32}"

--- a/http/cves/2023/CVE-2023-33405.yaml
+++ b/http/cves/2023/CVE-2023-33405.yaml
@@ -1,0 +1,35 @@
+id: CVE-2023-33405
+
+info:
+  name: BlogEngine CMS - Open Redirect
+  author: Shankar Acharya
+  severity: medium
+  description: |
+    Blogengine.net 3.3.8.0 and earlier is vulnerable to Open Redirect
+  reference:
+    - https://github.com/hacip/CVE-2023-33405
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-33405
+  remediation: |
+    Update to the latest version of blogengine.net CMS  to fix the open redirect vulnerability.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/Au:N/C:N/I:P/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2023-33405
+    cwe-id: CWE-601
+  metadata:
+    max-request: 1
+    product: blogengine_cms
+    vendor: blogengine
+    verified: true
+  tags: cve,cve2023,Blogengine,cms,redirect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/default.aspx?years=http://oast.pro"
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)oast\.pro.*$'
+        part: header

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -20,4 +20,8 @@ http:
       - type: regex
         part: body
         regex:
+<<<<<<< HEAD
           - '(?i)twilio.{0,20}[a-f0-9]{32,34}'
+=======
+          - '(?i)twilio.{0,20}\b(sk[a-f0-9]{32})\b'
+>>>>>>> parent of e0c79e960 (my template extracts all the keys if the word twilio is present.)

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -20,4 +20,4 @@ http:
       - type: regex
         part: body
         regex:
-          - '(?i)twilio.{0,20}\b[a-f0-9]{32,34})\b'
+          - '(?i)twilio.{0,20}[a-f0-9]{32,34}'

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -20,8 +20,4 @@ http:
       - type: regex
         part: body
         regex:
-<<<<<<< HEAD
-          - '(?i)twilio.{0,20}[a-f0-9]{32,34}'
-=======
           - '(?i)twilio.{0,20}\b(sk[a-f0-9]{32})\b'
->>>>>>> parent of e0c79e960 (my template extracts all the keys if the word twilio is present.)

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -2,7 +2,7 @@ id: twilio-api-key
 
 info:
   name: Twilio API Key
-  author: DhiyaneshDK, Shankar Acharya
+  author: DhiyaneshDK
   severity: info
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/data/default/rules/twilio.yml

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -2,7 +2,7 @@ id: twilio-api-key
 
 info:
   name: Twilio API Key
-  author: DhiyaneshDK
+  author: DhiyaneshDK, Shankar Acharya
   severity: info
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/data/default/rules/twilio.yml

--- a/http/exposures/tokens/twilio/twilio-api-key.yaml
+++ b/http/exposures/tokens/twilio/twilio-api-key.yaml
@@ -20,4 +20,4 @@ http:
       - type: regex
         part: body
         regex:
-          - '(?i)twilio.{0,20}\b(sk[a-f0-9]{32})\b'
+          - '(?i)twilio.{0,20}\b[a-f0-9]{32,34})\b'


### PR DESCRIPTION
### Template / PR Information


Blogengine.net 3.3.8.0 and earlier is vulnerable to Open Redirect.
```
id: CVE-2023-33405

info:
  name: BlogEngine CMS - Open Redirect
  author: Shankar Acharya
  severity: medium
  description: |
    Blogengine.net 3.3.8.0 and earlier is vulnerable to Open Redirect
  reference:
    - https://github.com/hacip/CVE-2023-33405
    - https://nvd.nist.gov/vuln/detail/CVE-2023-33405
  remediation: |
    Update to the latest version of blogengine.net CMS  to fix the open redirect vulnerability.
  classification:
    cvss-metrics: CVSS:3.1/AV:N/AC:L/Au:N/C:N/I:P/A:N
    cvss-score: 6.1
    cve-id: CVE-2023-33405
    cwe-id: CWE-601
  metadata:
    max-request: 1
    product: blogengine_cms
    vendor: blogengine
    verified: true
  tags: cve,cve2023,Blogengine,cms,redirect

http:
  - method: GET
    path:
      - "{{BaseURL}}/default.aspx?years=http://interact.sh"

    matchers:
      - type: regex
        part: header
        regex:
          - '(?m)^(?:Location\s*?:\s*?)(?:http?://|//)(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'
```

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Reference
https://www.opencve.io/cve/CVE-2023-33405
https://cve.report/CVE-2023-33405
