### PR TITLE
Exim Detect template

### DIFF
--- a/network/detection/exim-detect.yaml
+++ b/network/detection/exim-detect.yaml
@@ -1,30 +1,28 @@
 id: exim-detect
 
 info:
-  name: Exim Detect
+  name: Exim - Detect
   author: ricardomaia
   severity: info
   description: |
-    Exim is a message transfer agent (MTA) distributed over GNU General Public License.
+    Exim can accept messages from remote hosts using SMTP over TCP/IP, and as well as from local processes. It handles local deliveries to mailbox files or to pipes attached to commands, as well as remote SMTP deliveries to other hosts.
   reference:
     - https://www.exim.org/docs.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-    max-request: 1
     verified: true
-  tags: network,detect,smtp,mail
+    shodan-query: product:"Exim smtpd"
+  tags: network,detect,smtp,mail,exim
 
 tcp:
   - inputs:
-      - data: ""
+      - data: "\n"
 
     host:
-      - "{{Hostname}}:25"
-      - "{{Hostname}}:2525"
-      - "{{Hostname}}:465"
-      - "{{Hostname}}:587"
+      - "{{Hostname}}"
+    port: 587
 
     matchers:
       - type: word

--- a/network/detection/exim-detect.yaml
+++ b/network/detection/exim-detect.yaml
@@ -1,0 +1,39 @@
+id: exim-detect
+
+info:
+  name: Exim Detect
+  author: ricardomaia
+  severity: info
+  description: |
+    Exim is a message transfer agent (MTA) distributed over GNU General Public License.
+  reference:
+    - https://www.exim.org/docs.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+  tags: network,detect,smtp,mail
+
+tcp:
+  - inputs:
+      - data: ""
+
+    host:
+      - "{{Hostname}}:25"
+      - "{{Hostname}}:2525"
+      - "{{Hostname}}:465"
+      - "{{Hostname}}:587"
+
+    matchers:
+      - type: word
+        words:
+          - "ESMTP Exim"
+
+    extractors:
+      - type: regex
+        group: 1
+        name: version
+        regex:
+          - '(?i)SMTP.Exim\s?([\w.]+)'


### PR DESCRIPTION
### Template / PR Information

Exim is a message transfer agent (MTA) distributed over GNU General Public License. 

This PR adds a template that tries to identify the SMTP service on the most common ports (25, 2525, 465 and 587).

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1353811/4394c9b8-a8b6-4b4f-99b1-e27b0c03dd2d)

- References:
    - https://www.exim.org/docs.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)