### PR TITLE
Update AWS Bucket Takeover

### DIFF
--- a/http/takeovers/aws-bucket-takeover.yaml
+++ b/http/takeovers/aws-bucket-takeover.yaml
@@ -2,7 +2,7 @@ id: aws-bucket-takeover
 
 info:
   name: AWS Bucket Takeover Detection
-  author: pdteam,pwnhxl
+  author: pdteam,pwnhxl,zy9ard3
   severity: high
   reference:
     - https://github.com/EdOverflow/can-i-take-over-xyz/issues/36
@@ -24,6 +24,8 @@ http:
       - type: word
         words:
           - "The specified bucket does not exist"
+          - "BucketName"
+        condition: and
 
       - type: dsl
         dsl:


### PR DESCRIPTION
BucketName is the main part for S3 Takeovers and as well as to avoid false positives with other similar services ( eg: Acronis )

### Template / PR Information :

Added word matcher `BucketName` to avoid false positives with other similar services

### References :

Too Many False Positives on https://baas-fes-jp2.acronis.com and other similar domains

### Template Validation :

I've validated this template locally?
- [x] YES
- [ ] NO
