### PR TITLE
Add template to detect RCDevs WebADM instances

### DIFF
--- a/http/exposed-panels/rcdevs-webadm-panel.yaml
+++ b/http/exposed-panels/rcdevs-webadm-panel.yaml
@@ -17,7 +17,7 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/'
+      - '{{BaseURL}}'
       - '{{BaseURL}}/webapps/index.php'
       - '{{BaseURL}}/websrvs/index.php'
       - '{{BaseURL}}/admin/login_uid.php'

--- a/http/exposed-panels/rcdevs-webadm-panel.yaml
+++ b/http/exposed-panels/rcdevs-webadm-panel.yaml
@@ -1,0 +1,47 @@
+id: rcdevs-webadm-panel
+
+info:
+  name: RCDevs WebADM Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    RCDevs WebADM Login Panel was detected.
+  reference:
+    - https://www.rcdevs.com/solutions/
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.html:"WebADM"
+  tags: panel,rcdevs,webadm,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/'
+      - '{{BaseURL}}/webapps/index.php'
+      - '{{BaseURL}}/websrvs/index.php'
+      - '{{BaseURL}}/admin/login_uid.php'
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'WebADM'
+          - 'RCDevs Security'
+          - 'www.rcdevs.com'
+        condition: and
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)webadm\s+(free|enterprise)\s+edition'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect an instance of the [RCDevs WebADM](https://www.rcdevs.com/solutions/) products.

- References: https://www.rcdevs.com/solutions/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/471f6e06-5247-497c-8ebb-d7428093b0d0)

Source of test taken from [Shodan](https://www.shodan.io/search?query=http.html%3A%22WebADM%22):

```text
https://194.151.115.179
https://5.180.164.143
https://195.46.255.68
https://194.14.245.40
https://righettod.eu
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22WebADM%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f0c2fc56-91e7-4901-87d0-c3b5dc248690)


### Additional References:

None