### PR TITLE
Add template to detect PLESK instances

### DIFF
--- a/http/exposed-panels/plesk-panel.yaml
+++ b/http/exposed-panels/plesk-panel.yaml
@@ -1,0 +1,44 @@
+id: plesk-panel
+
+info:
+  name: Plesk Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Plesk Login Panel was detected.
+  reference:
+    - https://www.plesk.com/
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.html:"plesk-build"
+  tags: panel,plesk,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/login_up.php'
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'plesk-build'
+          - 'plesk-revision'
+          - 'plesk-root'
+        condition: and
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"urlArgs":"([0-9.-]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect an instance of the [PLESK](https://www.plesk.com/) products.

- References: https://www.plesk.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/347edf11-6939-4e94-88e2-a42d931316d4)


Source of test taken from [Shodan](https://www.shodan.io/search?query=http.html%3A%22plesk-build%22):

```text
https://81.169.141.202
https://107.152.46.236:8443/
https://64.91.251.34/
https://144.91.98.225:8443/
https://righettod.eu/
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22plesk-build%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f64480ed-77b9-4b24-8913-d73cc52fe8b2)

### Additional References:

None