### PR TITLE
Fix tiny-file-manager

### DIFF
--- a/http/exposed-panels/tiny-file-manager.yaml
+++ b/http/exposed-panels/tiny-file-manager.yaml
@@ -2,7 +2,7 @@ id: tiny-file-manager
 
 info:
   name: Tiny File Manager Panel - Detect
-  author: DhiyaneshDK
+  author: DhiyaneshDK,HuTa0
   severity: info
   description: Tiny File Manager panel was detected.
   classification:
@@ -13,12 +13,13 @@ info:
     verified: true
     max-request: 1
     shodan-query: title:"Tiny File Manager"
+    zoomeye-query: app:"Tiny File Manager"
   tags: panel,filemanager
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}'
+      - '{{BaseURL}}/index.php'
 
     host-redirects: true
     max-redirects: 2
@@ -26,9 +27,11 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
         words:
-          - 'Tiny File Manager'
+          - "Invert Selection"
+          - "Tiny File Manager"
+          - "Select all"
+        condition: and
 
       - type: status
         status:

--- a/http/exposed-panels/tiny-file-manager.yaml
+++ b/http/exposed-panels/tiny-file-manager.yaml
@@ -14,7 +14,7 @@ info:
     max-request: 1
     shodan-query: title:"Tiny File Manager"
     zoomeye-query: app:"Tiny File Manager"
-  tags: panel,filemanager
+  tags: panel,filemanager,login,detect
 
 http:
   - method: GET
@@ -23,18 +23,13 @@ http:
 
     host-redirects: true
     max-redirects: 2
-
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - "Invert Selection"
-          - "Tiny File Manager"
-          - "Select all"
+          - "<title>Tiny File Manager"
         condition: and
 
       - type: status
         status:
           - 200
-
-# digest: 4b0a00483046022100cae5eddfaf5cf6f9a57d9cc6e278d3e625f348e784b38060131673d2eb3b6f91022100e3facaa0b6f1841829a53f7a4224b414c456d44b0f9974a5db52860ad459abdf:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Update tiny-file-manager

The plugin provides shodan-query to search for web applications with the title Tiny File Manager, but the matcher uses Tiny File Manager as a matching condition, which causes a lot of false positives. No exposed panels were actually found.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)