### PR TITLE
Update url-extension-inspector.yaml (avoid false positive)

### DIFF
--- a/file/url-analyse/url-extension-inspector.yaml
+++ b/file/url-analyse/url-extension-inspector.yaml
@@ -22,227 +22,227 @@ file:
       - type: regex
         name: Backup file
         regex:
-          - "(?i)(\\.bak|\\.backup|\\.bkp|\\._bkp|\\.bk|\\.BAK)"
+          - "(?i)(\\.bak|\\.backup|\\.bkp|\\._bkp|\\.bk|\\.BAK)('|\")"
 
       - type: regex
         name: PHP Source
         regex:
-          - "(?i)(\\.php)(\\.~|\\.bk|\\.bak|\\.bkp|\\.BAK|\\.swp|\\.swo|\\.swn|\\.tmp|\\.save|\\.old|\\.new|\\.orig|\\.dist|\\.txt|\\.disabled|\\.original|\\.backup|\\._back|\\._1\\.bak|~|!|\\.0|\\.1|\\.2|\\.3)"
+          - "(?i)(\\.php)(\\.~|\\.bk|\\.bak|\\.bkp|\\.BAK|\\.swp|\\.swo|\\.swn|\\.tmp|\\.save|\\.old|\\.new|\\.orig|\\.dist|\\.txt|\\.disabled|\\.original|\\.backup|\\._back|\\._1\\.bak|~|!|\\.0|\\.1|\\.2|\\.3)('|\")"
 
       - type: regex
         name: ASP Source
         regex:
-          - "(?i)(\\.asp)(\\.~|\\.bk|\\.bak|\\.bkp|\\.BAK|\\.swp|\\.swo|\\.swn|\\.tmp|\\.save|\\.old|\\.new|\\.orig|\\.dist|\\.txt|\\.disabled|\\.original|\\.backup|\\._back|\\._1\\.bak|~|!|\\.0|\\.1|\\.2|\\.3)"
+          - "(?i)(\\.asp)(\\.~|\\.bk|\\.bak|\\.bkp|\\.BAK|\\.swp|\\.swo|\\.swn|\\.tmp|\\.save|\\.old|\\.new|\\.orig|\\.dist|\\.txt|\\.disabled|\\.original|\\.backup|\\._back|\\._1\\.bak|~|!|\\.0|\\.1|\\.2|\\.3)('|\")"
 
       - type: regex
         name: Database file
         regex:
-          - "(?i)\\.db|\\.sql"
+          - "(?i)\\.db|\\.sql('|\")"
 
       - type: regex
         name: Bash script
         regex:
-          - "(?i)\\.sh|\\.bashrc|\\.zshrc"
+          - "(?i)(\\.sh|\\.bashrc|\\.zshrc)('|\")"
 
       - type: regex
         name: 1Password password manager database file
         regex:
-          - "(?i)\\.agilekeychain"
+          - "(?i)\\.agilekeychain('|\")"
 
       - type: regex
         name: ASP configuration file
         regex:
-          - "(?i)\\.asa"
+          - "(?i)\\.asa('|\")"
 
       - type: regex
         name: Apple Keychain database file
         regex:
-          - "(?i)\\.keychain"
+          - "(?i)\\.keychain('|\")"
 
       - type: regex
         name: Azure service configuration schema file
         regex:
-          - "(?i)\\.cscfg"
+          - "(?i)\\.cscfg('|\")"
 
       - type: regex
         name: Compressed archive file
         regex:
-          - "(?i)(\\.zip|\\.gz|\\.tar|\\.rar|\\.tgz)"
+          - "(?i)(\\.zip|\\.gz|\\.tar|\\.rar|\\.tgz)('|\")"
 
       - type: regex
         name: Configuration file
         regex:
-          - "(?i)(\\.ini|\\.config|\\.conf)"
+          - "(?i)(\\.ini|\\.config|\\.conf)('|\")"
 
       - type: regex
         name: Day One journal file
         regex:
-          - "(?i)\\.dayone"
+          - "(?i)\\.dayone('|\")"
 
       - type: regex
         name: Document file
         regex:
-          - "(?i)(\\.doc|\\.docx|\\.rtf)"
+          - "(?i)(\\.doc|\\.docx|\\.rtf)('|\")"
 
       - type: regex
         name: GnuCash database file
         regex:
-          - "(?i)\\.gnucash"
+          - "(?i)\\.gnucash('|\")"
 
       - type: regex
         name: Include file
         regex:
-          - "(?i)\\.inc"
+          - "(?i)\\.inc('|\")"
 
       - type: regex
         name: XML file
         regex:
-          - "(?i)\\.xml"
+          - "(?i)\\.xml('|\")"
 
       - type: regex
         name: Old file
         regex:
-          - "(?i)\\.old"
+          - "(?i)\\.old('|\")"
 
       - type: regex
         name: Log file
         regex:
-          - "(?i)\\.log"
+          - "(?i)\\.log('|\")"
 
       - type: regex
         name: Java file
         regex:
-          - "(?i)\\.java"
+          - "(?i)\\.java('|\")"
 
       - type: regex
         name: SQL dump file
         regex:
-          - "(?i)\\.sql"
+          - "(?i)\\.sql('|\")"
 
       - type: regex
         name: Excel file
         regex:
-          - "(?i)(\\.xls|\\.xlsx|\\.csv)"
+          - "(?i)(\\.xls|\\.xlsx|\\.csv)('|\")"
 
       - type: regex
         name: Certificate file
         regex:
-          - "(?i)(\\.cer|\\.crt|\\.p7b)"
+          - "(?i)(\\.cer|\\.crt|\\.p7b)('|\")"
 
       - type: regex
         name: Java key storte
         regex:
-          - "(?i)\\.jks"
+          - "(?i)\\.jks('|\")"
 
       - type: regex
         name: KDE Wallet Manager database file
         regex:
-          - "(?i)\\.kwallet"
+          - "(?i)\\.kwallet('|\")"
 
       - type: regex
         name: Little Snitch firewall configuration file
         regex:
-          - "(?i)\\.xpl"
+          - "(?i)\\.xpl('|\")"
 
       - type: regex
         name: Microsoft BitLocker Trusted Platform Module password file
         regex:
-          - "(?i)\\.tpm"
+          - "(?i)\\.tpm('|\")"
 
       - type: regex
         name: Microsoft BitLocker recovery key file
         regex:
-          - "(?i)\\.bek"
+          - "(?i)\\.bek('|\")"
 
       - type: regex
         name: Microsoft SQL database file
         regex:
-          - "(?i)\\.mdf"
+          - "(?i)\\.mdf('|\")"
 
       - type: regex
         name: Microsoft SQL server compact database file
         regex:
-          - "(?i)\\.sdf"
+          - "(?i)\\.sdf('|\")"
 
       - type: regex
         name: Network traffic capture file
         regex:
-          - "(?i)\\.pcap"
+          - "(?i)\\.pcap('|\")"
 
       - type: regex
         name: OpenVPN client configuration file
         regex:
-          - "(?i)\\.ovpn"
+          - "(?i)\\.ovpn('|\")"
 
       - type: regex
         name: PDF file
         regex:
-          - "(?i)\\.pdf"
+          - "(?i)\\.pdf('|\")"
 
       - type: regex
         name: PHP file
         regex:
-          - "(?i)\\.pcap"
+          - "(?i)\\.pcap('|\")"
 
       - type: regex
         name: Password Safe database file
         regex:
-          - "(?i)\\.psafe3"
+          - "(?i)\\.psafe3('|\")"
 
       - type: regex
         name: Potential configuration file
         regex:
-          - "(?i)\\.yml"
+          - "(?i)\\.yml('|\")"
 
       - type: regex
         name: Potential cryptographic key bundle
         regex:
-          - "(?i)(\\.pkcs12|\\.p12|\\.pfx|\\.asc|\\.pem)"
+          - "(?i)(\\.pkcs12|\\.p12|\\.pfx|\\.asc|\\.pem)('|\")"
 
       - type: regex
         name: Potential private key
         regex:
-          - "(?i)otr.private_key"
+          - "(?i)otr.private_key('|\")"
 
       - type: regex
         name: Presentation file
         regex:
-          - "(?i)(\\.ppt|\\.pptx)"
+          - "(?i)(\\.ppt|\\.pptx)('|\")"
 
       - type: regex
         name: Python file
         regex:
-          - "(?i)\\.py"
+          - "(?i)\\.py('|\")"
 
       - type: regex
         name: Remote Desktop connection file
         regex:
-          - "(?i)\\.rdp"
+          - "(?i)\\.rdp('|\")"
 
       - type: regex
         name: Ruby On Rails file
         regex:
-          - "(?i)\\.rb"
+          - "(?i)\\.rb('|\")"
 
       - type: regex
         name: SQLite database file
         regex:
-          - "(?i)\\.sqlite|\\.sqlitedb"
+          - "(?i)\\.sqlite|\\.sqlitedb('|\")"
 
       - type: regex
         name: SQLite3 database file
         regex:
-          - "(?i)\\.sqlite3"
+          - "(?i)\\.sqlite3('|\")"
 
       - type: regex
         name: Sequel Pro MySQL database manager bookmark file
         regex:
-          - "(?i)\\.plist"
+          - "(?i)\\.plist('|\")"
 
       - type: regex
         name: Shell configuration file
         regex:
-          - "(?i)(\\.exports|\\.functions|\\.extra)"
+          - "(?i)(\\.exports|\\.functions|\\.extra)('|\")"
 
       - type: regex
         name: Temporary file
@@ -252,21 +252,21 @@ file:
       - type: regex
         name: Terraform variable config file
         regex:
-          - "(?i)\\.tfvars"
+          - "(?i)\\.tfvars('|\")"
 
       - type: regex
         name: Text file
         regex:
-          - "(?i)\\.txt"
+          - "(?i)\\.txt('|\")"
 
       - type: regex
         name: Tunnelblick VPN configuration file
         regex:
-          - "(?i)\\.tblk"
+          - "(?i)\\.tblk('|\")"
 
       - type: regex
         name: Windows BitLocker full volume encrypted data file
         regex:
-          - "(?i)\\.fve"
+          - "(?i)\\.fve('|\")"
 
 # digest: 490a0046304402203342df27b75080be4762275375e19b63832c89211544474786cce395d13a433302205bfa8b32a8b5f202b6562cc5ac1e8ea50086bca8c54ce36eec20e82d30449b22:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Hi,

The template return many false positives due to matching some functions call, for that i put a quote or double quote to choose only the extensions that end up with ' or "

for example:
`n = n.dblp(u)), o < 0)) break` 

This code is extracted with template as database file which is false.

regards 