### PR TITLE
CVE-2023-4911 Looney Tunables Linux Local Privesc

### DIFF
--- a/code-template/CVE-2023-4911.yaml
+++ b/code-template/CVE-2023-4911.yaml
@@ -1,0 +1,35 @@
+id: CVE-2023-4911
+
+info:
+  name: Looney Tunables Linux Local Privilege Escalation
+  author: nybble04
+  severity: high
+  description: |
+    A buffer overflow was discovered in the GNU C Library's dynamic loader ld.so while processing the GLIBC_TUNABLES environment variable. This issue could allow a local attacker to use maliciously crafted GLIBC_TUNABLES environment variables when launching binaries with SUID permission to execute code with elevated privileges.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-4911
+    - https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.txt
+    - https://www.youtube.com/watch?v=1iV-CD9Apn8
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cve-id: CVE-2023-4911
+    cwe-id: CWE-787
+    cpe: cpe:2.3:a:gnu:glibc:-:*:*:*:*:*:*:*
+  metadata:
+    vendor: glibc
+  tags: cve,cve2023,glibc,looneytunables,linux,privesc
+
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      env -i "GLIBC_TUNABLES=glibc.malloc.mxfast=glibc.malloc.mxfast=A" "Z=`printf '%08192x' 1`" /usr/bin/su --help
+      echo $?
+      
+    matchers:
+      - type: word
+        words:
+          - "139"     # Segmentation Fault Exit Code
+# TODO: add final digest after PR review and changes

--- a/code-template/CVE-2023-4911.yaml
+++ b/code-template/CVE-2023-4911.yaml
@@ -27,7 +27,7 @@ code:
     source: |
       env -i "GLIBC_TUNABLES=glibc.malloc.mxfast=glibc.malloc.mxfast=A" "Z=`printf '%08192x' 1`" /usr/bin/su --help
       echo $?
-      
+
     matchers:
       - type: word
         words:

--- a/code/cves/CVE-2023-4911.yaml
+++ b/code/cves/CVE-2023-4911.yaml
@@ -1,7 +1,7 @@
 id: CVE-2023-4911
 
 info:
-  name: Looney Tunables Linux Local Privilege Escalation
+  name: Looney Tunables Linux - Local Privilege Escalation
   author: nybble04
   severity: high
   description: |
@@ -18,7 +18,7 @@ info:
     cpe: cpe:2.3:a:gnu:glibc:-:*:*:*:*:*:*:*
   metadata:
     vendor: glibc
-  tags: cve,cve2023,glibc,looneytunables,linux,privesc
+  tags: cve,cve2023,glibc,looneytunables,linux,privesc,local
 
 code:
   - engine:
@@ -32,4 +32,3 @@ code:
       - type: word
         words:
           - "139"     # Segmentation Fault Exit Code
-# TODO: add final digest after PR review and changes

--- a/code/cves/CVE-2023-4911.yaml
+++ b/code/cves/CVE-2023-4911.yaml
@@ -20,6 +20,7 @@ info:
     vendor: glibc
   tags: cve,cve2023,glibc,looneytunables,linux,privesc,local
 
+self-contained: true
 code:
   - engine:
       - sh


### PR DESCRIPTION
### Template / PR Information
- Added CVE-2023-4911
- References:
    - [Proof of Concept (PoC) by Qualys](https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.txt) - The command used should return a segfault in a vulnerable system.
    - [PoC demo by IppSec](https://www.youtube.com/watch?v=1iV-CD9Apn8) - Timestamp 4:00.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
:warning: FYI
- I am unsure if I should sign this template or if PD will sign it before merging after review. Hence, I have added a `TODO` comment to add the final digest.
- I put it in a folder called `code-template` because I was unable to find a suitable folder for Linux local privesc CVEs.

### Additional References:
- https://nvd.nist.gov/vuln/detail/CVE-2023-4911