### PR TITLE
CVE-2023-22515 Passive Template

### DIFF
--- a/http/cves/2023/CVE-2023-22515-passive.yaml
+++ b/http/cves/2023/CVE-2023-22515-passive.yaml
@@ -1,0 +1,69 @@
+id: CVE-2023-22515
+
+info:
+  name: Atlassian Confluence - Privilege Escalation Passive Detection
+  author: rxerium
+  severity: critical
+  description: |
+    Atlassian Confluence Data Center and Server contains a privilege escalation vulnerability that allows an attacker to create unauthorized Confluence administrator accounts and access Confluence.
+  remediation: |
+    Update to the latest version of Confluence
+  reference:
+    - https://attackerkb.com/topics/Q5f0ItSzw5/cve-2023-22515/rapid7-analysis
+    - https://confluence.atlassian.com/security/cve-2023-22515-privilege-escalation-vulnerability-in-confluence-data-center-and-server-1295682276.html
+    - https://confluence.atlassian.com/kb/faq-for-cve-2023-22515-1295682188.html
+    - https://jira.atlassian.com/browse/CONFSERVER-92475
+    - https://www.cisa.gov/news-events/alerts/2023/10/05/cisa-adds-three-known-exploited-vulnerabilities-catalog
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dologin.action"
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/pages"
+      - "{{BaseURL}}/confluence"
+      - "{{BaseURL}}/wiki"
+
+    host-redirects: true
+    stop-at-first-match: true
+
+    matchers:
+
+      - type: word
+        words:
+          - "8.0.0"
+          - "8.0.1"
+          - "8.0.2"
+          - "8.0.3"
+          - "8.0.4"
+          - "8.1.0"
+          - "8.1.1"
+          - "8.1.3"
+          - "8.1.4"
+          - "8.2.0"
+          - "8.2.1"
+          - "8.2.2"
+          - "8.2.3"
+          - "8.3.0"
+          - "8.3.1"
+          - "8.3.2"
+          - "8.4.0"
+          - "8.4.1"
+          - "8.4.2"
+          - "8.5.0"
+          - "8.5.1"
+        part: version
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<meta name="ajs-version-number" content="(.*)">'
+          - 'Atlassian Confluence ([a-z0-9-._]+)'
+        internal: true
+
+      - type: kval
+        kval:
+          - version


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

I understand there is an existing template for CVE-2023-22515 however it is intrusive and will definitely be flagged in firewall logs as exploiting a system. I have taken the opportunity to create a new passive template which will determine whether an instance is vulnerable to CVE-2023-22515 based on the version. However this will of course have lower certainty of being vulnerable compared to the intrusive template. 

References:
- https://confluence.atlassian.com/kb/faq-for-cve-2023-22515-1295682188.html
- https://jira.atlassian.com/browse/CONFSERVER-92475
- https://www.cisa.gov/news-events/alerts/2023/10/05/cisa-adds-three-known-exploited-vulnerabilities-catalog

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)