### PR TITLE
Template to detect "Kiteworks PCN" instances

### DIFF
--- a/http/exposed-panels/kiteworks-pcn-panel.yaml
+++ b/http/exposed-panels/kiteworks-pcn-panel.yaml
@@ -24,11 +24,15 @@ http:
       - type: word
         part: body
         words:
-          - 'Go to Kiteworks.com'
-          - 'Already a kiteworks user'
-          - 'Protected by Kiteworks-enabled Private Content Network'
+          - 'Secured by Kiteworks'
+          - 'Return to sign in'
         condition: and
         case-insensitive: true
+
+      - type: word
+        part: header
+        words:
+          - 'application/octet-stream'
 
       - type: status
         status:

--- a/http/exposed-panels/kiteworks-pcn-panel.yaml
+++ b/http/exposed-panels/kiteworks-pcn-panel.yaml
@@ -1,0 +1,35 @@
+id: kiteworks-pcn-panel
+
+info:
+  name: Kiteworks PCN Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Kiteworks PCN Login Panel was detected.
+  reference:
+    - https://www.kiteworks.com/platform/private-content-network/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.favicon.hash:-1215318992
+  tags: panel,kiteworks,login,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/login/locales/login_en.json'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Go to Kiteworks.com'
+          - 'Already a kiteworks user'
+          - 'Protected by Kiteworks-enabled Private Content Network'
+        condition: and
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instances of [Kiteworks PCN](https://www.kiteworks.com/platform/private-content-network/) products.

- References: https://www.kiteworks.com/platform/private-content-network/

### Template Validation

I've validated this template locally?
- [x] YES via https://safebox.deloitte.lu/
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/bc63c96d-639c-4d63-a615-dfdc7f2c951c)

Command used to get the favicon hash:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/9cfc612a-1af6-47c5-bc99-062db9522c03)


### Additional Details (leave it blank if not applicable)

Shodan query: ` shodan search http.favicon.hash:-1215318992`

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/167d646b-2e40-410d-9ab3-77a5284784e6)


### Additional References:

None