### PR TITLE
Added header detection for Adobe Experience Manager in web fingerprint template

### DIFF
--- a/http/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/http/technologies/fingerprinthub-web-fingerprints.yaml
@@ -15058,4 +15058,10 @@ http:
           - <meta name="author" content="Michal Čihař" />
         condition: and
 
+      - type: word
+        name: Adobe Experience Manager (AEM)
+        part: header
+        words:
+          - "x-dispatcher:"
+
 # digest: 4b0a00483046022100b37c245931e34c8af2e40dcfbc6554c2a35726d06530aac15e72b8fdd9ebcc240221009f5c67b8828a107751ebfb7ebb26952d78feb28b0f743f5065aae5f2ce741b7a:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/http/technologies/fingerprinthub-web-fingerprints.yaml
@@ -15063,5 +15063,6 @@ http:
         part: header
         words:
           - "x-dispatcher:"
+        case-insensitive: true
 
 # digest: 4b0a00483046022100b37c245931e34c8af2e40dcfbc6554c2a35726d06530aac15e72b8fdd9ebcc240221009f5c67b8828a107751ebfb7ebb26952d78feb28b0f743f5065aae5f2ce741b7a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Added simple test for AEM in the fingerprinthub-web-fingerprints.yaml template.  There are other AEM related templates but none that used the simple header that this one is.  

- Reference: https://experienceleague.adobe.com/docs/experience-manager-dispatcher/using/configuring/dispatcher-configuration.html?lang=en
- Reference: https://webtechsurvey.com/response-header/x-dispatcher

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)