### PR TITLE
Fixes #8545 dns/detect-dangling-cname.yaml not working anymore

### DIFF
--- a/dns/detect-dangling-cname.yaml
+++ b/dns/detect-dangling-cname.yaml
@@ -27,8 +27,9 @@ dns:
           - "NXDOMAIN"
 
       - type: regex
+        part: answer
         regex:
-          - "IN\tCNAME\\t(.+)$"
+          - "IN\tCNAME\t(.+)$"
 
     extractors:
       - type: dsl


### PR DESCRIPTION
Fixes #8545.

### Template / PR Information

I've fixed the template to only check the _answer_ section, other parts of the DNS response are not revelant for the regex.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)