### PR TITLE
Extracting the app_name from manage.py to know where to look for settings.py

### DIFF
--- a/http/exposures/files/django-secret-key.yaml
+++ b/http/exposures/files/django-secret-key.yaml
@@ -7,24 +7,33 @@ info:
   description: The Django settings.py file containing a secret key was discovered. An attacker may use the secret key to bypass many security mechanisms and potentially obtain other sensitive configuration information (such as database password) from the settings file.
   reference: https://docs.gitguardian.com/secrets-detection/detectors/specifics/django_secret_key
   metadata:
+    max-request: 6
     verified: true
-    max-request: 5
     shodan-query: html:settings.py
   tags: django,exposure,files
 
 http:
   - method: GET
     path:
+      # We download the manage.py file to check whether it contains line such as:
+      #
+      #   os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")
+      #
+      # if it does, we extract the APP_NAME to know in what folder to look for the settings.py file for.
+
+      - "{{BaseURL}}/manage.py"
       - "{{BaseURL}}/settings.py"
       - "{{BaseURL}}/app/settings.py"
       - "{{BaseURL}}/django/settings.py"
       - "{{BaseURL}}/settings/settings.py"
       - "{{BaseURL}}/web/settings/settings.py"
+      - "{{BaseURL}}/{{app_name}}/settings.py"
+
 
     stop-at-first-match: true
-
     matchers-condition: and
     matchers:
+
       - type: word
         part: body
         words:
@@ -46,5 +55,10 @@ http:
         group: 1
         regex:
           - '"DJANGO_SECRET_KEY", "(.*)"'
-
-# digest: 4b0a00483046022100ee698b610a4093e54131c56890fc37e0a997d59e5485ab8450e0370d618019e2022100b70476a9edb09a2f441223350ef9467376345e4f1edd19e27c1e53f1c1566e40:922c64590222798bb761d5b6d8e72950
+      - type: regex
+        part: body
+        internal: true
+        name: app_name
+        group: 1
+        regex:
+          - "os.environ.setdefault\\([\"']DJANGO_SETTINGS_MODULE[\"'],\\s[\"']([a-zA-Z-_0-9]*).settings[\"']\\)"

--- a/http/exposures/files/django-secret-key.yaml
+++ b/http/exposures/files/django-secret-key.yaml
@@ -7,20 +7,15 @@ info:
   description: The Django settings.py file containing a secret key was discovered. An attacker may use the secret key to bypass many security mechanisms and potentially obtain other sensitive configuration information (such as database password) from the settings file.
   reference: https://docs.gitguardian.com/secrets-detection/detectors/specifics/django_secret_key
   metadata:
-    max-request: 6
+    max-request: 7
     verified: true
     shodan-query: html:settings.py
+    comments: 'We download the manage.py file to check whether it contains line such as: `os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")` if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.'
   tags: django,exposure,files
 
 http:
   - method: GET
     path:
-      # We download the manage.py file to check whether it contains line such as:
-      #
-      #   os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")
-      #
-      # if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.
-
       - "{{BaseURL}}/manage.py"
       - "{{BaseURL}}/settings.py"
       - "{{BaseURL}}/app/settings.py"
@@ -29,11 +24,9 @@ http:
       - "{{BaseURL}}/web/settings/settings.py"
       - "{{BaseURL}}/{{app_name}}/settings.py"
 
-
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-
       - type: word
         part: body
         words:
@@ -55,6 +48,7 @@ http:
         group: 1
         regex:
           - '"DJANGO_SECRET_KEY", "(.*)"'
+
       - type: regex
         part: body
         internal: true

--- a/http/exposures/files/django-secret-key.yaml
+++ b/http/exposures/files/django-secret-key.yaml
@@ -4,13 +4,14 @@ info:
   name: Django Secret Key Exposure
   author: geeknik,DhiyaneshDk
   severity: high
-  description: The Django settings.py file containing a secret key was discovered. An attacker may use the secret key to bypass many security mechanisms and potentially obtain other sensitive configuration information (such as database password) from the settings file.
+  description: |
+    The Django settings.py file containing a secret key was discovered. An attacker may use the secret key to bypass many security mechanisms and potentially obtain other sensitive configuration information (such as database password) from the settings file.
   reference: https://docs.gitguardian.com/secrets-detection/detectors/specifics/django_secret_key
   metadata:
     max-request: 7
     verified: true
     shodan-query: html:settings.py
-    comments: 'We download the manage.py file to check whether it contains line such as: `os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")` if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.'
+    comments: 'This template downloads the manage.py file to check whether it contains line such as: `os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")` if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.'
   tags: django,exposure,files
 
 http:

--- a/http/exposures/files/django-secret-key.yaml
+++ b/http/exposures/files/django-secret-key.yaml
@@ -19,7 +19,7 @@ http:
       #
       #   os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")
       #
-      # if it does, we extract the APP_NAME to know in what folder to look for the settings.py file for.
+      # if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.
 
       - "{{BaseURL}}/manage.py"
       - "{{BaseURL}}/settings.py"


### PR DESCRIPTION
### Template / PR Information

We download the manage.py file to check whether it contains line such as:

`os.environ.setdefault("DJANGO_SETTINGS_MODULE", "APP_NAME.settings")`

if it does, we extract the APP_NAME to know in what folder to look for the settings.py file.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
