### PR TITLE
Fix shadowd WAF fingerprint

### DIFF
--- a/http/fuzzing/waf-fuzz.yaml
+++ b/http/fuzzing/waf-fuzz.yaml
@@ -133,7 +133,7 @@ http:
         regex:
           - '(?i)<h\d>\d{3}.forbidden<.h\d>'
           - '(?i)request.forbidden.by.administrative.rules.'
-        condition: or
+        condition: and
         part: response
 
       - type: regex

--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -98,7 +98,7 @@ http:
         regex:
           - '(?i)<h\d>\d{3}.forbidden<.h\d>'
           - '(?i)request.forbidden.by.administrative.rules.'
-        condition: or
+        condition: and
         part: response
 
       - type: regex


### PR DESCRIPTION
If condition is "or", the default 403 page will cause false positives.

- References:

https://www.zoomeye.org/searchResult?q=%27request%20forbidden%20by%20administrative%20rules.%27