### PR TITLE
Added Apache Tomcat Stack Trace Detection Template

### DIFF
--- a/http/misconfiguration/tomcat-stacktraces.yaml
+++ b/http/misconfiguration/tomcat-stacktraces.yaml
@@ -1,7 +1,8 @@
 id: tomcat-stacktraces
+
 info:
   name: Tomcat Stack Traces Enabled
-  author: lucky0x0d, PulseSecurity.co.nz
+  author: lucky0x0d
   severity: info
   description: |
     Examine whether Tomcat stack traces are turned on by employing a designated problematic pattern.

--- a/http/misconfiguration/tomcat-stacktraces.yaml
+++ b/http/misconfiguration/tomcat-stacktraces.yaml
@@ -4,8 +4,10 @@ info:
   author: lucky0x0d, PulseSecurity.co.nz
   severity: info
   description: |
-          Check to see if Tomcat stack traces are enabled using a known bad path
+    Examine whether Tomcat stack traces are turned on by employing a designated problematic pattern.
   metadata:
+    verified: true
+    shodan-query: title:"Apache Tomcat"
     max-request: 1
   tags: tech,tomcat,apache
 
@@ -17,7 +19,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(tolower(body), "tomcat")'
-          - 'contains(tolower(body), "org.apache")'
+          - 'contains(body, "tomcat")'
+          - 'contains(body, "org.apache")'
           - status_code == 400
         condition: and

--- a/http/misconfiguration/tomcat-stacktraces.yaml
+++ b/http/misconfiguration/tomcat-stacktraces.yaml
@@ -1,0 +1,23 @@
+id: tomcat-stacktraces
+info:
+  name: Tomcat Stack Traces Enabled
+  author: lucky0x0d, PulseSecurity.co.nz
+  severity: info
+  description: |
+          Check to see if Tomcat stack traces are enabled using a known bad path
+  metadata:
+    max-request: 1
+  tags: tech,tomcat,apache
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/?f=\['
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(tolower(body), "tomcat")'
+          - 'contains(tolower(body), "org.apache")'
+          - status_code == 400
+        condition: and


### PR DESCRIPTION
### Template / PR Information

A template to detect apache tomcat stack traces enabled based on a known bad URI


### Template Validation

I've validated this template locally?
- [x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->

```
$ curl -i "https://...redacted.../?f=\["

HTTP/1.1 400 
Content-Type: text/html;charset=utf-8
Content-Language: pt-BR
Content-Length: 2332
Date: Wed, 08 Nov 2023 03:48:35 GMT
Connection: close

<!doctype html><html lang="pt"><head><title>HTTP Status 400 \u2013 Bad Request</title><style type="text/css">h1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} h2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} h3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} body {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} b {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} p {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;} a {color:black;} a.name {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 \u2013 Bad Request</h1><hr class="line" /><p><b>Type</b> Exception Report</p><p><b>Message</b> Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986</p><p><b>Description</b> The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).</p><p><b>Exception</b></p><pre>java.lang.IllegalArgumentException: Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986
	org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:467)
	org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:294)
	org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:836)
	org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1839)
	org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	java.lang.Thread.run(Thread.java:748)
</pre><p><b>Note</b> A pilha de erros completa da causa principal est\u00e1 dispon\u00edvel nos logs do servidor.</p><hr class="line" /><h3>Apache Tomcat/9.0.20</h3></body></html>
```

<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)