### PR TITLE
Add template to detect user enumeration in Microsoft Exchange due to a misconfiguration.

### DIFF
--- a/http/misconfiguration/microsoft-exchange-user-enumeration.yaml
+++ b/http/misconfiguration/microsoft-exchange-user-enumeration.yaml
@@ -1,0 +1,37 @@
+id: microsoft-exchange-user-enumeration
+
+info:
+  name: Microsoft Exchange Autodiscover - User Enumeration
+  author: righettod
+  severity: info
+  description: Microsoft Exchange (on premise) is prone to a user enumeration via the ActiveSync protocol using the AutodiscoverV2 endpoint.
+  reference:
+    - https://www.msxfaq.de/exchange/autodiscover/autodiscover_v2.htm
+  classification:
+    cwe-id: CWE-204
+  metadata:
+    max-request: 1
+  tags: exchange,microsoft,misconfig,intrusive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/autodiscover/autodiscover.json?Protocol=ActiveSync&Email={{rand_text_alpha(6)}}%40domain.com&RedirectCount=1"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "/autodiscover/autodiscover.json?Email="
+
+      - type: status
+        status:
+          - 302
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '(?i)Email=([A-Za-z0-9@%.-]+)'

--- a/http/misconfiguration/microsoft-exchange-user-enumeration.yaml
+++ b/http/misconfiguration/microsoft-exchange-user-enumeration.yaml
@@ -1,22 +1,24 @@
-id: microsoft-exchange-user-enumeration
+id: ms-exchange-enum
 
 info:
   name: Microsoft Exchange Autodiscover - User Enumeration
   author: righettod
   severity: info
-  description: Microsoft Exchange (on premise) is prone to a user enumeration via the ActiveSync protocol using the AutodiscoverV2 endpoint.
+  description: |
+    Microsoft Exchange (on premise) is prone to a user enumeration via the ActiveSync protocol using the AutodiscoverV2 endpoint.
   reference:
     - https://www.msxfaq.de/exchange/autodiscover/autodiscover_v2.htm
-  classification:
-    cwe-id: CWE-204
+    - https://github.com/righettod/toolbox-pentest-web/blob/master/docs/4-HINTS_ARCHIVED.md#user-enumeration-techniques-for-microsoft-exchange
   metadata:
     max-request: 1
-  tags: exchange,microsoft,misconfig,intrusive
+    verified: true
+    shodan-query: http.title:outlook exchange
+  tags: ms-exchange,microsoft,misconfig,enum
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/autodiscover/autodiscover.json?Protocol=ActiveSync&Email={{rand_text_alpha(6)}}%40domain.com&RedirectCount=1"
+      - "{{BaseURL}}/autodiscover/autodiscover.json?Protocol=ActiveSync&Email={{rand_text_alpha(6)}}%40oast.pro&RedirectCount=1"
 
     matchers-condition: and
     matchers:

--- a/http/misconfiguration/ms-exchange-user-enum.yaml
+++ b/http/misconfiguration/ms-exchange-user-enum.yaml
@@ -1,4 +1,4 @@
-id: ms-exchange-enum
+id: ms-exchange-user-enum
 
 info:
   name: Microsoft Exchange Autodiscover - User Enumeration


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template that detect, when an instance of Microsoft Exchange, is prone to a User Enumeration via the endpoint **AutodiscoverV2**, in case of a misconfiguration:

 ```text
/autodiscover/autodiscover.json?Protocol=ActiveSync&Email=[RANDOM_STRING]%40domain.com&RedirectCount=1
```

💬 References:

* [Documentation about the endpoint (german)](https://www.msxfaq.de/exchange/autodiscover/autodiscover_v2.htm).
* I documented the behavior [on my cheat sheet](https://github.com/righettod/toolbox-pentest-web/blob/master/docs/4-HINTS_ARCHIVED.md#user-enumeration-techniques-for-microsoft-exchange):
  
![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/5172a0cd-9564-4ba9-a02c-bdbab45c3469)


### Template Validation

I've validated this template locally?
- [x] YES using Nuclei Engine Version v3.0.3
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c51f5551-8a03-4e0f-8342-550f059fd8f1)


### Additional Details (leave it blank if not applicable)

💡 I propose this template, because, when I ran nuclei **latest version** (3.0.3) using **the latest commit on the main branch of the templates repository**, against my target then the user enumeration was not identified.

### Additional References:

None