### PR TITLE
Fixed 3x invalid cvss strings within templates

### DIFF
--- a/http/vulnerabilities/other/huawei-router-auth-bypass.yaml
+++ b/http/vulnerabilities/other/huawei-router-auth-bypass.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/48310
   classification:
-    cvss-metrics: CVSS:10.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cwe-id: CWE-288
   metadata:

--- a/http/vulnerabilities/other/watchguard-credentials-disclosure.yaml
+++ b/http/vulnerabilities/other/watchguard-credentials-disclosure.yaml
@@ -9,7 +9,7 @@ info:
     - https://www.exploit-db.com/exploits/48203
     - https://www.watchguard.com/wgrd-blog/tdr-ad-helper-credential-disclosure-vulnerability
   classification:
-    cvss-metrics: CVSS:10.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cwe-id: CWE-288
   metadata:

--- a/http/vulnerabilities/wordpress/wp-woocommerce-email-verification.yaml
+++ b/http/vulnerabilities/wordpress/wp-woocommerce-email-verification.yaml
@@ -10,7 +10,7 @@ info:
     - https://wpvulndb.com/vulnerabilities/10318
     - https://wpscan.com/vulnerability/0c93832c-83db-4053-8a11-70de966bb3a8
   classification:
-    cvss-metrics: CVSS:10.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cwe-id: CWE-288
   metadata:


### PR DESCRIPTION
### Template / PR Information

3x templates had invalid CVSS strings, have made a small commit to correct them.

- http/vulnerabilities/other/huawei-router-auth-bypass.yaml 
- http/vulnerabilities/other/watchguard-credentials-disclosure.yaml 
- http/vulnerabilities/wordpress/wp-woocommerce-email-verification.yaml


Rest of PR template is N/A


---

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)