### PR TITLE
fix(template): Improve joomla-com-booking-component.yaml rules.

### DIFF
--- a/http/vulnerabilities/joomla/joomla-com-booking-component.yaml
+++ b/http/vulnerabilities/joomla/joomla-com-booking-component.yaml
@@ -33,6 +33,11 @@ http:
           - '"email":'
         condition: and
 
+      - type: regex
+        part: body
+        regex:
+          - '^{.*}$'
+
       - type: word
         part: header
         words:
@@ -42,4 +47,9 @@ http:
         status:
           - 200
 
-# digest: 4a0a004730450220201101df01d1b5a291f4b5acf1391eb2b92e20ebd5770d3f542a9eb51d30f718022100b92ff63a1cad5633e2d2dbf81eaaa44cf30cedac05164515bbf31d2eceae04e5:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: json
+        name: keys
+        part: body
+        json:
+          - 'keys'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

I had some false positive with this template. I wanted to find a way to improve it. 
By looking at the [exploit in reference](https://www.exploit-db.com/exploits/51595) with the following code:

```
try:
    jsondocument = response.json()
    if jsondocument["name"] != None:
        print(jsondocument)
except requests.exceptions.JSONDecodeError:
    raise
```
I understand that the content of the body returned by the server should be a json (even if the header should be `text/html`)

I could confirm it by setting up a local vulnerable server:

![Content of the body is a json. Local vulnerable setup.](https://github.com/projectdiscovery/nuclei-templates/assets/42201667/b65335d0-cb2d-49bc-a118-e09349a7daba)

Unfortunately, I didn't find a proper way to check that the content of the body is a `json` (there is no `json` matcher contrary to the extractor): I just added the following regex: `'^{.*}$'`

If you have a better way to check that the body is a json or a better regex, I am open to suggestion. 

- Fixed `joomla-com-booking-component.yaml`
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

I could validate that the template matches locally 

![Template matches locally](https://github.com/projectdiscovery/nuclei-templates/assets/42201667/af30789c-0fb3-4f29-9def-71ea222fba36)



#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)