### PR TITLE
Fixed - Tableau server build extraction regex

### DIFF
--- a/http/technologies/tableau-server-detect.yaml
+++ b/http/technologies/tableau-server-detect.yaml
@@ -2,7 +2,7 @@ id: tableau-server-detect
 
 info:
   name: Detect Tableau Server
-  author: TechbrunchFR, aringo
+  author: TechbrunchFR,aringo
   severity: info
   description: Detects Tableau Server and extracts the buildid
   metadata:
@@ -36,4 +36,3 @@ http:
         group: 1
         regex:
           - 'data-build[iI]d="([0-9a-z_]*)'
-

--- a/http/technologies/tableau-server-detect.yaml
+++ b/http/technologies/tableau-server-detect.yaml
@@ -2,9 +2,9 @@ id: tableau-server-detect
 
 info:
   name: Detect Tableau Server
-  author: TechbrunchFR
+  author: TechbrunchFR, aringo
   severity: info
-  description: Detects Tableau Server and extract the buildId
+  description: Detects Tableau Server and extracts the buildid
   metadata:
     max-request: 1
   tags: tech,tableau
@@ -35,6 +35,5 @@ http:
         part: body
         group: 1
         regex:
-          - 'data-buildId="([0-9a-z_]*)'
+          - 'data-build[iI]d="([0-9a-z_]*)'
 
-# digest: 4a0a004730450220586755aba4caaac04977ef2f719d43541edab3a28cbeca4f9a9f8cbbbc7d82f3022100a14a17e20d5404fa410d5b8e8e7ead9597d7d685554fb52722fbf90f9277c9a3:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Tableau Servers scanned by me did not return build information. The response bodies all had lowercase `data-buildid` and not `data-buildId` as in the template. The regex was modified to [iI] in case there actually was some that were not all lowercase. 

- Fixed http/technologies/tableau-server-detect.yaml to accept lowercase or uppercase build strings. 


### Template Validation

I've validated this template locally?
- [ x] YES
- [ ] NO


