### PR TITLE
Update swagger-api.yaml for detecting springfox swagger

### DIFF
--- a/http/exposures/apis/swagger-api.yaml
+++ b/http/exposures/apis/swagger-api.yaml
@@ -72,7 +72,10 @@ http:
       - "{{BaseURL}}/swagger"
       - "{{BaseURL}}/api-doc"
       - "{{BaseURL}}/doc/"
-
+      - "{{BaseURL}}/swagger-ui/springfox.js"
+      - "{{BaseURL}}/swagger-ui/swagger-ui-standalone-preset.js"
+      - "{{BaseURL}}/swagger-ui/swagger-ui/swagger-ui-bundle.js"
+      
     headers:
       Accept: text/html
     stop-at-first-match: true


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
- Title: Added detection for springfox Swagger
- Description: This PR adds a new nuclei template for detecting the Springfox Swagger web interface(version 3.0.0). The need for this PR arises from the fact that the current template is unable to detect Springfox Swagger(3.0.0) instances effectively, and adding this new template will enhance the detection capability of nuclei.
- Changes: The following URLs have been added to the swagger-api template to enable the detection of springfox Swagger:
  - "{{BaseURL}}/swagger-ui/springfox.js"
  - "{{BaseURL}}/swagger-ui/swagger-ui-standalone-preset.js"
  -"{{BaseURL}}/swagger-ui/swagger-ui/swagger-ui-bundle.js"
- References: N/A

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)