### PR TITLE
Update wordpress-debug-log.yaml

### DIFF
--- a/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
@@ -2,7 +2,7 @@ id: wp-debug-log
 
 info:
   name: WordPress debug log
-  author: geraldino2,dwisiswant0
+  author: geraldino2,dwisiswant0,philippedelteil
   severity: low
   metadata:
     max-request: 1
@@ -12,7 +12,12 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/debug.log"
-
+      - "{{BaseURL}}/wordpress/wp-content/debug.log"
+      
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 3
+    max-size: 5000
     matchers-condition: and
     matchers:
       - type: word
@@ -30,5 +35,11 @@ http:
       - type: status
         status:
           - 200
+    
+    extractors:
+      - type: dsl
+        dsl:
+          - to_string(content_length)+ " bytes"
+
 
 # digest: 4b0a0048304602210088508540400171b7789ff615fc799433d70f773a308c8d2e42b180fe62ed400f022100b2b045d2694a75337ccdc3cd7259ecb012a37786663dbeba923b350c1d9ba968:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
@@ -13,7 +13,7 @@ http:
     path:
       - "{{BaseURL}}/wp-content/debug.log"
       - "{{BaseURL}}/wordpress/wp-content/debug.log"
-      
+
     stop-at-first-match: true
     host-redirects: true
     max-redirects: 3
@@ -35,7 +35,7 @@ http:
       - type: status
         status:
           - 200
-    
+
     extractors:
       - type: dsl
         dsl:

--- a/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
@@ -1,18 +1,24 @@
 id: wp-debug-log
 
 info:
-  name: WordPress debug log
+  name: WordPress Debug Log - Exposure
   author: geraldino2,dwisiswant0,philippedelteil
   severity: low
   metadata:
-    max-request: 1
-  tags: wordpress,log
+    max-request: 4
+  tags: wp,wordpress,log,exposure
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/wp-content/debug.log"
-      - "{{BaseURL}}/wordpress/wp-content/debug.log"
+      - "{{BaseURL}}/{{paths}}/debug.log"
+
+    payloads:
+      paths:
+        - 'wp-content'
+        - 'wordpress'
+        - 'wp'
+        - 'blog'
 
     stop-at-first-match: true
     host-redirects: true
@@ -21,16 +27,16 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: header
         words:
           - octet-stream
           - text/plain
-        part: header
         condition: or
 
       - type: regex
+        part: body
         regex:
           - "[[0-9]{2}-[a-zA-Z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3}] PHP"
-        part: body
 
       - type: status
         status:
@@ -40,6 +46,5 @@ http:
       - type: dsl
         dsl:
           - to_string(content_length)+ " bytes"
-
 
 # digest: 4b0a0048304602210088508540400171b7789ff615fc799433d70f773a308c8d2e42b180fe62ed400f022100b2b045d2694a75337ccdc3cd7259ecb012a37786663dbeba923b350c1d9ba968:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
1-. Added another path
2. Added redirects and max size (sometimes it tries to download the entire file, but this flag it will only download the first 5,000 bytes).
3. Added extractor to show the size of the log.


### Template Validation

I've validated this template locally?
- [ x ] YES
- [ ] NO


