### PR TITLE
workflows updates

### DIFF
--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -20,4 +20,3 @@ jobs:
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-#          PURGE_URLS: '["https://version-check.nuclei.sh/versions"]'

--- a/.github/workflows/cve2json.yml
+++ b/.github/workflows/cve2json.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'http/cves/**'
+      - '*/cves/**'
   workflow_dispatch: # allows manual triggering of the workflow
 
 jobs:

--- a/.github/workflows/template-db-indexer.yml
+++ b/.github/workflows/template-db-indexer.yml
@@ -2,10 +2,8 @@ name: 📑 Template-DB Indexer
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - '**.yaml'
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/templateman.yml
+++ b/.github/workflows/templateman.yml
@@ -1,11 +1,6 @@
 name: 🤖 TemplateMan
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '**.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wordpress-plugins-update.yml
+++ b/.github/workflows/wordpress-plugins-update.yml
@@ -1,11 +1,6 @@
 name: ✨ WordPress Plugins - Update
 
 on:
-  schedule:
-    - cron: "0 4 * * *" # every day at 4am UTC
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Template / PR Information

This PR includes changes to few workflow that, previously, were triggered by every yaml update in the ﻿main branch. However, as primarily these templates are made available to users only upon template project release, it is logical to adjust these workflows to run manually before a project release.

The PR covers the following updates:

- Change in the ﻿templateman workflow to trigger manually, ideally before project release.
- Adjustment to the ﻿wordpress plugin update workflow to also run manually, ideally before project release.

With these updates, we address:

- The issue of mismatched template signing.
- The problem of an overly populated commit history that resulted from excessive updates.

Our aim with these improvements is to streamline our workflow, reduce irrelevant commit history, and ensure template signing is accurate during project releases.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)