### PR TITLE
Update to use the JSON extractor for nextcloud-owncloud-detect.yaml 

### DIFF
--- a/http/technologies/nextcloud-owncloud-detect.yaml
+++ b/http/technologies/nextcloud-owncloud-detect.yaml
@@ -2,7 +2,7 @@ id: owncloud-status-page
 
 info:
   name: Owncloud StatusPage detection
-  author: myztique
+  author: myztique,invisiblethreat
   severity: info
   metadata:
     verified: true
@@ -16,15 +16,15 @@ http:
       - "{{BaseURL}}/status.php"
 
     matchers:
-      - type: regex
+      - type: word
         part: body
-        regex:
-          - '"versionstring":"([0-9.]+)"'
+        words:
+          - '"versionstring":'
+          - '"installed":'
+          - '"edition":'
+        condition: and
 
     extractors:
-      - type: regex
-        part: body
-        name: version
-        group: 1
-        regex:
-          - '"versionstring":"([0-9.]+)"'
+      - type: json
+        json:
+          - .version

--- a/http/technologies/nextcloud-owncloud-detect.yaml
+++ b/http/technologies/nextcloud-owncloud-detect.yaml
@@ -16,17 +16,15 @@ http:
       - "{{BaseURL}}/status.php"
 
     matchers:
-      - type: regex
+      - type: word
         part: body
-        regex:
-          - '{"installed":(?:true|false),"maintenance":(?:true|false),"version":"[0-9\.]*","versionstring":"[a-z-A-Z0-9\.]*","edition":"[\d\D]*"}'
+        words:
+          - "version"
 
     extractors:
-      - type: regex
+      - type: json
         part: body
         name: version
-        group: 1
-        regex:
-          - '{[\d\D]*"version":"([0-9\.]+)"'
+        json:
+          - '.version'
 
-# digest: 4a0a00473045022100f3414071ecfd36084121e102dde43f6816d4f5bf9af4653cab8e3f50914aa7d4022002503f4e4f126a0581b1d1731362eaf5b67e9aace6301b608d4a2f24f89d4609:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/nextcloud-owncloud-detect.yaml
+++ b/http/technologies/nextcloud-owncloud-detect.yaml
@@ -16,15 +16,15 @@ http:
       - "{{BaseURL}}/status.php"
 
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - "version"
+        regex:
+          - '"versionstring":"([0-9.]+)"'
 
     extractors:
-      - type: json
+      - type: regex
         part: body
         name: version
-        json:
-          - '.version'
-
+        group: 1
+        regex:
+          - '"versionstring":"([0-9.]+)"'


### PR DESCRIPTION
### PR Information

Fixed detection for brittle regex. Previous regex code failed due to new items being added into the JSON response, which would cause false negatives on newer versions of NextCloud/Owncloud.

### Template Validation

I've validated this template locally?
- [x] YES

#### Additional Details (leave it blank if not applicable)

Old version:

```
$ nuclei -u http://localhost:8080/ -t http/technologies/nextcloud-owncloud-detect.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.4

		projectdiscovery.io

[INF] Current nuclei version: v3.0.4 (latest)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[INF] New templates added in latest release: 73
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] [owncloud-status-page] Dumped HTTP request for http://localhost:8080/status.php

GET /status.php HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (X11; OpenBSD i386) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [owncloud-status-page] Dumped HTTP response http://localhost:8080/status.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 177
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *
Content-Type: application/json
Date: Wed, 29 Nov 2023 15:34:56 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Pragma: no-cache
Server: Apache
Set-Cookie: oc8gdb44o06k=da2fbklfr1jj5la0qm5sr27mbq; path=/; HttpOnly; SameSite=Strict
Set-Cookie: oc_sessionPassphrase=Fyd4F0pAtZVX5z5sO7ctkQog9fS24R8RwvA1ZNC64tyKq0dIMozFGHqtZpNjGHA3CJS%2BKltADxUUOR3mZUlkXebAzU3tDLSvjSzNEKtdmkxETkkSYRhOr%2FKTKXyC%2BNe6; expires=Wed, 29-Nov-2023 15:54:56 GMT; Max-Age=1200; path=/; HttpOnly; SameSite=Strict
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 0

{"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"10.12.2.0","versionstring":"10.12.2","edition":"Community","productname":"ownCloud","product":"ownCloud"}
[INF] No results found. Better luck next time!
```

New version:
```
$ nuclei -u http://localhost:8080/ -t http/technologies/nextcloud-owncloud-detect.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.4

		projectdiscovery.io

[INF] Current nuclei version: v3.0.4 (latest)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[INF] New templates added in latest release: 73
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [owncloud-status-page] Dumped HTTP request for http://localhost:8080/status.php

GET /status.php HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.93 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [owncloud-status-page] Dumped HTTP response http://localhost:8080/status.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 177
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *
Content-Type: application/json
Date: Wed, 29 Nov 2023 15:48:12 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Pragma: no-cache
Server: Apache
Set-Cookie: oc8gdb44o06k=6cl87mrrp2l8dd6nnn7ra85rhm; path=/; HttpOnly; SameSite=Strict
Set-Cookie: oc_sessionPassphrase=AgaY7bFK5J2U9e0URiNroNcW3EOEcHoCz9ICRua%2BlDHX5Ps4VLSKgMVssvPqTx4KYHOrQf9OrvnuT%2BYEFG7IaUNniNZO%2F4NNU9GYJhoj59DHEPFsmoomQEtqCFmQOSAn; expires=Wed, 29-Nov-2023 16:08:12 GMT; Max-Age=1200; path=/; HttpOnly; SameSite=Strict
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 0

{"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"10.12.2.0","versionstring":"10.12.2","edition":"Community","productname":"ownCloud","product":"ownCloud"}
[owncloud-status-page:word-1] [http] [info] http://localhost:8080/status.php [10.12.2.0]
```

Testing against Docker image `owncloud/server:10.12.2-rc.1-amd64`.
