### PR TITLE
Add version extraction for Element Web

### DIFF
--- a/http/technologies/element-version.yaml
+++ b/http/technologies/element-version.yaml
@@ -36,4 +36,3 @@ http:
         # Get only the first word to avoid self denial of service in case of false positives
         regex:
           - '[^\s]+'
-

--- a/http/technologies/element-version.yaml
+++ b/http/technologies/element-version.yaml
@@ -1,0 +1,39 @@
+id: element-detect
+
+info:
+  name: Detect Element Web
+  author: Davide Girardi
+  severity: info
+  description: Identify if a web application is vanilla Element Web and return the version
+  metadata:
+    max-request: 2
+  tags: tech,matrix,element
+
+http:
+
+  - method: GET
+    redirects: true
+    max-redirects: 2
+    path:
+      - "{{BaseURL}}/manifest.json"
+      - "{{BaseURL}}/version"
+
+    req-condition: true
+
+    matchers:
+
+      - type: dsl
+        dsl:
+          - status_code_1 == 200
+          - 'contains(content_type_1, "application/json")'
+          - 'contains(json_minify(body_1), "\"name\":\"Element\"")'
+          - status_code_2 == 200
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        # Get only the first word to avoid self denial of service in case of false positives
+        regex:
+          - '[^\s]+'
+

--- a/http/technologies/element-web-detect.yaml
+++ b/http/technologies/element-web-detect.yaml
@@ -1,38 +1,35 @@
-id: element-detect
+id: element-web-detect
 
 info:
-  name: Detect Element Web
-  author: Davide Girardi
+  name: Element Web - Detect
+  author: davidegirardi
   severity: info
   description: Identify if a web application is vanilla Element Web and return the version
   metadata:
     max-request: 2
-  tags: tech,matrix,element
+    verified: true
+    shodan-query: html:"manifest.json"
+  tags: tech,matrix,element,detect
 
 http:
-
   - method: GET
-    redirects: true
-    max-redirects: 2
     path:
       - "{{BaseURL}}/manifest.json"
       - "{{BaseURL}}/version"
 
-    req-condition: true
-
+    host-redirects: true
+    max-redirects: 2
     matchers:
-
       - type: dsl
         dsl:
-          - status_code_1 == 200
+          - 'status_code_1 == 200'
           - 'contains(content_type_1, "application/json")'
           - 'contains(json_minify(body_1), "\"name\":\"Element\"")'
-          - status_code_2 == 200
+          - 'status_code_2 == 200'
         condition: and
 
     extractors:
       - type: regex
         part: body
-        # Get only the first word to avoid self denial of service in case of false positives
         regex:
           - '[^\s]+'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Identify if an HTTP server is hosting the Element Web Matrix client and extract the version
- References:
  - PR detecting the Matrix homeserver software and version: https://github.com/projectdiscovery/nuclei-templates/pull/8721
  - https://matrix.org/ecosystem/clients/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Snippet of the HTTP response body for detecting Element:
```json
{
  "name": "Element",
  "short_name": "Element",
  "display": "standalone",
  "theme_color": "#76CFA6",
  "start_url": "index.html",
  "icons": [
    {
...
```

HTTP response body for the version:
```
1.11.50
```
### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)