### PR TITLE
Additional matcher for security.txt

### DIFF
--- a/http/miscellaneous/security-txt.yaml
+++ b/http/miscellaneous/security-txt.yaml
@@ -32,6 +32,7 @@ http:
       - type: word
         words:
           - "Contact:"
+          - "Expires:"
 
       - type: dsl
         dsl:

--- a/http/miscellaneous/security-txt.yaml
+++ b/http/miscellaneous/security-txt.yaml
@@ -4,12 +4,14 @@ info:
   name: security.txt File
   author: bad5ect0r,noraj
   severity: info
-  description: File similar to robots.txt but intended to be read by humans wishing to contact a website’s owner about security issues. Often defines a security policy and contact details.
+  description: |
+    File similar to robots.txt but intended to be read by humans wishing to contact a website’s owner about security issues. Often defines a security policy and contact details.
   reference:
     - https://securitytxt.org/
     - https://community.turgensec.com/security-txt-progress-in-ethical-security-research/
   metadata:
     max-request: 2
+    verified: true
     shodan-query: http.securitytxt:contact http.status:200
   tags: misc,generic
 
@@ -20,23 +22,23 @@ http:
       - "{{RootURL}}/security.txt"
 
     stop-at-first-match: true
-    host-redirects: true
+    redirects: true
     max-redirects: 2
-
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         words:
           - "Contact:"
           - "Expires:"
+        condition: or
 
       - type: dsl
         dsl:
           - "len(body) <= 4096 && len(body) > 0"
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

According to [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116#name-expires) the field `Expires:` must always be present in the security.txt file. I added a corresponding matcher to increase detection quality.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

:warning: ***Warning*** :warning: This change will result in loss of detection for domains which host an invalid security.txt according to RFC 9116. For example, I noticed that a lot of security.txt instances only consist of the `Contact:` field. 

For example:
```
$ curl https://www.post.ch/.well-known/security.txt
Contact: security@post.ch
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)