### PR TITLE
Fix name for CVE-2018-10093

### DIFF
--- a/http/cves/2018/CVE-2018-10093.yaml
+++ b/http/cves/2018/CVE-2018-10093.yaml
@@ -1,7 +1,7 @@
 id: CVE-2018-10093
 
 info:
-  name: AudioCode 420HD - Remote Code Execution
+  name: AudioCodes 420HD - Remote Code Execution
   author: wisnupramoedya
   severity: high
   description: |


### PR DESCRIPTION
AudioCodes is correct, not AudioCode

### Template / PR Information

- Fixed CVE-2018-10093 info