### PR TITLE
Add detection of iparapheur instance

### DIFF
--- a/http/technologies/iparapheur-detect.yaml
+++ b/http/technologies/iparapheur-detect.yaml
@@ -4,19 +4,20 @@ info:
   name: iparapheur Detection
   author: righettod
   severity: info
-  description: iparapheur technology was detected.
+  description: |
+    iparapheur technology was detected.
   reference:
     - https://www.libriciel.fr/logiciels/iparapheur/
   metadata:
     max-request: 1
     verified: true
-    shodan-query: http.title:"iparapheur"
+    shodan-query: http.favicon.hash:-1383463717
   tags: iparapheur,detect,tech
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     host-redirects: true
     max-redirects: 2

--- a/http/technologies/iparapheur-detect.yaml
+++ b/http/technologies/iparapheur-detect.yaml
@@ -32,4 +32,3 @@ http:
       - type: status
         status:
           - 200
-

--- a/http/technologies/iparapheur-detect.yaml
+++ b/http/technologies/iparapheur-detect.yaml
@@ -1,0 +1,35 @@
+id: iparapheur-detect
+
+info:
+  name: iparapheur Detection
+  author: righettod
+  severity: info
+  description: iparapheur technology was detected.
+  reference:
+    - https://www.libriciel.fr/logiciels/iparapheur/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"iparapheur"
+  tags: iparapheur,detect,tech
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>iparapheur</title>"
+          - "Libriciel SCOP"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+

--- a/http/technologies/iparapheur-detect.yaml
+++ b/http/technologies/iparapheur-detect.yaml
@@ -1,7 +1,7 @@
 id: iparapheur-detect
 
 info:
-  name: iparapheur Detection
+  name: Iparapheur - Detect
   author: righettod
   severity: info
   description: |


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the software [iparapheur](https://www.libriciel.fr/logiciels/iparapheur/).

- References: https://www.libriciel.fr/logiciels/iparapheur/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/8c7ba651-222b-4f7d-8d75-6137515f785e)

📝 Source used for the validation, obtained via [Shodan](https://www.shodan.io/search?query=http.title%3A%22iparapheur%22):

```text
https://57.128.115.109/
https://194.167.248.27/
https://194.199.94.171/
https://87.252.4.36/
https://righettod.eu
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22iparapheur%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/395573cd-dd86-406a-980b-e2ba33612aa5)

### Additional References

None