### PR TITLE
Break out build to make it more comparable

### DIFF
--- a/http/exposed-panels/teamcity-login-panel.yaml
+++ b/http/exposed-panels/teamcity-login-panel.yaml
@@ -35,7 +35,13 @@ http:
       - type: regex
         part: body
         group: 1
+        name: "version"
         regex:
-          - 'Version<\/span> ([0-9. (a-z)]+)<\/span>'
+          - "Version</span> ([0-9.]+)"
 
-# digest: 4b0a00483046022100a2746f4f6341b76a77014155b342e72ceb2f487f40d48b18a8e7a36d321e6a6e022100ce551750bf4bbd217b3eaf4c764ea0b1cc349b9a4f323fee1558564da63d87d0:922c64590222798bb761d5b6d8e72950
+      - type: regex
+        part: body
+        group: 1
+        name: build
+        regex:
+          - "Version</span> [0-9.]+ \\(build (.*)\\)</span>"

--- a/http/exposed-panels/teamcity-login-panel.yaml
+++ b/http/exposed-panels/teamcity-login-panel.yaml
@@ -35,7 +35,7 @@ http:
       - type: regex
         part: body
         group: 1
-        name: "version"
+        name: version
         regex:
           - "Version</span> ([0-9.]+)"
 

--- a/http/exposed-panels/teamcity-login-panel.yaml
+++ b/http/exposed-panels/teamcity-login-panel.yaml
@@ -13,7 +13,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: http.component:"TeamCity"
-  tags: panel,teamcity,jetbrains
+  tags: panel,teamcity,jetbrains,detect
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information
This breaks out the build into it's own named extraction to make comparisons more easily. 

- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

- Shodan https://www.shodan.io/search?query=teamcity
- Results from first hit:
```
[teamcity-login-panel:version] [http] [info] https://203.76.245.223/login.html [2022.04]
[teamcity-login-panel:build] [http] [info] https://203.76.245.223/login.html [108502]
```
### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)