### PR TITLE
Update locust-exposure.yaml

### DIFF
--- a/http/misconfiguration/locust-exposure.yaml
+++ b/http/misconfiguration/locust-exposure.yaml
@@ -2,11 +2,11 @@ id: locust-exposure
 
 info:
   name: Locust Exposure
-  author: DhiyaneshDK
+  author: DhiyaneshDK,bhutch
   severity: medium
   metadata:
-    max-request: 1
     verified: true
+    max-request: 1
     shodan-query: title:"Locust"
   tags: exposure,locust,misconfig
 
@@ -17,10 +17,10 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - '<title>Locust</title>'
+        regex:
+          - '<title>Locust(?: for.+)?</title>'
 
       - type: word
         part: body


### PR DESCRIPTION
Hello,

I noticed a false negative in our environment with the current template. The HTTP Title tag for Locust can be either "Locust" or "Locust for $something". For example, there are 147 "Locust for locustfile.py" in Shodan.

Of the ~ 500 indexed in Shodan, about half would be missed by looking for "<title>Locust</title>".

I updated the matcher to use a regex.

- Fixed http/misconfiguration/locust-exposure.yaml

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
