### PR TITLE
Create CVE-2018-6389.yaml ( Unauthenticated Wordpress DoS Due to load Scripts )

### DIFF
--- a/http/cves/2018/CVE-2018-6389.yaml
+++ b/http/cves/2018/CVE-2018-6389.yaml
@@ -2,7 +2,7 @@ id: CVE-2018-6389
 
 info:
   name: Script-loader WordPress < 4.9.2 - unauthenticated attackers can cause a denial of service
-  author: Chirag & Vikas
+  author: Chirag Agrawal & Vikas Srivastava
   severity: High
   description: In WordPress versions up to 4.9.2, unauthenticated attackers can exploit a vulnerability to perform a denial-of-service attack by sending multiple requests to load a large number of registered .js files from /wp-admin/load-scripts.php.
   reference:

--- a/http/cves/2018/CVE-2018-6389.yaml
+++ b/http/cves/2018/CVE-2018-6389.yaml
@@ -1,0 +1,35 @@
+id: CVE-2018-6389
+
+info:
+  name: Script-loader WordPress < 4.9.2 - unauthenticated attackers can cause a denial of service
+  author: Chirag & Vikas
+  severity: High
+  description: In WordPress versions up to 4.9.2, unauthenticated attackers can exploit a vulnerability to perform a denial-of-service attack by sending multiple requests to load a large number of registered .js files from /wp-admin/load-scripts.php.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-6389
+  classification:
+   cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+   cvss-score: 7.5
+   cve-id: CVE-2018-6389
+  metadata:
+    fofa-query: "/wp-admin/load-scripts.php?load="
+    google-query: inurl:"/wp-admin/load-scripts.php"
+  tags: wordpress-misc,cve,wordpress,wp-plugin,high
+
+http:
+  - method: GET
+    redirects: true
+    max-redirects: 3
+    path:
+      - "{{BaseURL}}/wp-admin/load-scripts.php?load=eutil,set-post-thumbnail,nav-menu,custom-header,custom-background,media-gallery,svg-painter&ver=4.9"
+    matchers:
+      - type: word
+        words:
+          - "custom-header.js"
+          - "svg-painter.js"
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - "\\b(custom-header\\.js|svg-painter\\.js)\\b"


### PR DESCRIPTION
added CVE-2018-6389 nuclei template

### Template Information:

Added nuclei-template for CVE-2018-6389 for nuclei users in the community
Reference: https://nvd.nist.gov/vuln/detail/CVE-2018-6389

Template Validation
I've validated this template locally.

- [x]  YES

- [ ]  NO

![nuclei-preview](https://github.com/projectdiscovery/nuclei-templates/assets/68269472/b28f7071-10f6-43a7-b644-063332866014)


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)