### PR TITLE
add docker daemon exposed via http

### DIFF
--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -40,8 +40,6 @@ http:
         part: body_2
         words:
           - '[]'
-          - '"ImageID":'
-          - '"HostConfig":'
         condition: and
 
     extractors:

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -18,7 +18,7 @@ http:
       - |
         GET /version HTTP/1.1
         Host: {{Hostname}}
-    
+
       - |
         GET /v{{version}}/containers/json HTTP/1.1
         Host: {{Hostname}}
@@ -40,7 +40,6 @@ http:
         words:
           - '[]'
 
-
     extractors:
       - type: regex
         name: version
@@ -48,4 +47,3 @@ http:
         regex:
           - '"ApiVersion":"(.*?)"'
         internal: true
-

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -40,7 +40,7 @@ http:
         part: body_2
         words:
           - '[]'
-          - '"ImageID":
+          - '"ImageID":'
           - '"HostConfig":'
         condition: and
         

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -11,7 +11,7 @@ info:
     shodan-query: port:2375 product:"docker"
     fofa-query: app="docker-Daemon" && port="2375"
     verified: true
-  tags: docker,exposure
+  tags: docker,exposure,misconfig
 
 http:
   - raw:
@@ -23,10 +23,10 @@ http:
         GET /v{{version}}/containers/json HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_2
         words:
           - "Id"
           - "Names"
@@ -35,10 +35,6 @@ http:
           - "PrivatePort"
           - "PublicPort"
         condition: and
-      - type: word
-        part: body
-        words:
-          - '[]'
 
     extractors:
       - type: regex

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -43,7 +43,7 @@ http:
           - '"ImageID":'
           - '"HostConfig":'
         condition: and
-        
+
     extractors:
       - type: regex
         name: version

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -23,7 +23,7 @@ http:
         GET /v{{version}}/containers/json HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
+    matchers-condition: or
     matchers:
       - type: word
         part: body_2
@@ -36,6 +36,14 @@ http:
           - "PublicPort"
         condition: and
 
+      - type: word
+        part: body_2
+        words:
+          - '[]'
+          - '"ImageID":
+          - '"HostConfig":'
+        condition: and
+        
     extractors:
       - type: regex
         name: version

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -23,23 +23,12 @@ http:
         GET /v{{version}}/containers/json HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: or
     matchers:
-      - type: word
-        part: body_2
-        words:
-          - "Id"
-          - "Names"
-          - "Image"
-          - "Command"
-          - "PrivatePort"
-          - "PublicPort"
-        condition: and
-
-      - type: word
-        part: body_2
-        words:
-          - '[]'
+      - type: dsl
+        dsl:
+          - 'status_code_2 == 200'
+          - 'contains(body_1, "ApiVersion") && contains(body_1, "GitCommit") && contains(body_1, "GoVersion")  && contains(body_1, "KernelVersion")'
+          - 'contains(body_2, "Id") && contains(body_2, "Names") && contains(body_2, "Image") && contains(body_2, "Command") && contains(body_2, "PrivatePort") && contains(body_2, "PublicPort") || contains(body_2, "[]")'
         condition: and
 
     extractors:

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -1,0 +1,51 @@
+id: docker-daemon-exposed
+
+info:
+  name: Docker Daemon Exposed
+  author: Arm!tage
+  severity: critical
+  description: |
+    Docker Daemon exposed on the network map can help remote attacker to gain access to the Docker containers and potentially the host system.
+  metadata:
+    max-request: 1
+    shodan-query: port:2375 product:"docker"
+    fofa-query: app="docker-Daemon" && port="2375"
+    verified: true
+  tags: docker,exposure
+
+http:
+  - raw:
+    - |
+      GET /version HTTP/1.1
+      Host: {{Hostname}}
+    
+    - |
+      GET /v{{version}}/containers/json HTTP/1.1
+      Host: {{Hostname}}
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Id"
+          - "Names"
+          - "Image"
+          - "Command"
+          - "PrivatePort"
+          - "PublicPort"
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '[]'
+
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '"ApiVersion":"(.*?)"'
+        internal: true
+

--- a/http/exposures/docker-daemon-exposed.yaml
+++ b/http/exposures/docker-daemon-exposed.yaml
@@ -15,13 +15,13 @@ info:
 
 http:
   - raw:
-    - |
-      GET /version HTTP/1.1
-      Host: {{Hostname}}
+      - |
+        GET /version HTTP/1.1
+        Host: {{Hostname}}
     
-    - |
-      GET /v{{version}}/containers/json HTTP/1.1
-      Host: {{Hostname}}
+      - |
+        GET /v{{version}}/containers/json HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: or
     matchers:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

-  Added docker-daemon-exposed
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="1109" alt="image" src="https://github.com/projectdiscovery/nuclei-templates/assets/48816467/e46c8f98-9bee-45da-9239-f1f7e7afdff7">

#### Additional Details (leave it blank if not applicable)

The exposed-dockerd.yaml always can't detect vulnerability. So I write a template via http method. 


<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)