### PR TITLE
One more way of detecting Symfony Profiler

### DIFF
--- a/http/exposures/configs/symfony-profiler.yaml
+++ b/http/exposures/configs/symfony-profiler.yaml
@@ -28,5 +28,6 @@ http:
         part: body
         words:
           - "Symfony Profiler"
+          - "<title>Profiler</title>"
 
 # digest: 490a00463044022016ad2dd56b7facbd00ce5afe393fde84b71ca9098e2591d6766ce2b15184e66e022073396c3b2f5aee3fb02f19cc58f4b4df76bfc1e886fcbb2322ff1439094b40ea:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

When performing scannings as CERT PL I observed some Symfony Profiler instances that don't have the words Symfony Profiler inside, but can be detected differently (e.g. via `<title>Profiler</title>`)


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
