### PR TITLE
Added/apache server status Template

### DIFF
--- a/http/misconfiguration/apache/apache-server-status.yaml
+++ b/http/misconfiguration/apache/apache-server-status.yaml
@@ -1,7 +1,7 @@
 id: apache-server-status
 
 info:
-  name: Apache Server-Status Detected
+  name: Apache Server Status Disclosure
   author: thabisocn
   severity: low
   description: |
@@ -16,7 +16,7 @@ info:
     google-Dork:
       - site:*/server-status intext:"Apache server status for"
       - site:*/server-info intext:"Apache server Information"
-  tags: misconfig,exposure,apache
+  tags: misconfig,exposure,apache,debug
 
 http:
   - method: GET
@@ -25,14 +25,10 @@ http:
       - "{{BaseURL}}/server-status"
 
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "Apache Server Information"
-          - "Apache Server Status"
-        condition: or
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains_any(body, "Apache Server Status", "Apache Server Information")'
+          - 'contains(body, "Server Version")'
+          - 'status_code == 200'
+        condition: and

--- a/http/misconfiguration/apache/apache-server-status.yaml
+++ b/http/misconfiguration/apache/apache-server-status.yaml
@@ -5,45 +5,40 @@ info:
   author: Thabisocn
   severity: medium
   metadata:
-    max-request: 3
+    max-request: 2
     verified: true
-    Description: Apache /server-status displays information about your Apache status. If you are not using this feature, disable it.
-    Google-Dork: 
-     - site:*/server-status intext:"Apache server status for"
-     - site:*/server-info intext:"Apache server Information"
+    Description: Apache /server-status displays information about your Apache
+      status. If you are not using this feature, disable it.
+    Google-Dork:
+      - site:*/server-status intext:"Apache server status for"
+      - site:*/server-info intext:"Apache server Information"
     reference:
-     - https://www.exploit-db.com/ghdb/5548
-     - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
-     - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/
-     
+      - https://www.exploit-db.com/ghdb/5548
+      - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
+      - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/
   tags: exposure,misconfiguration
-  
 
 http:
   - method: GET
     path:
-     - "{{BaseURL}}/server-status"
-     - "{{BaseURL}}/server-info"
-    
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+
     stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - "Srv"
-          - "PID"
-          - "Acc"
-          - "Req"
-          - "Client"
-          - "Request"
-          - "Slot"
-          - "CPU"
-          
+          - Srv
+          - PID
+          - Acc
+          - Req
+          - Client
+          - Request
+          - Slot
+          - CPU
         condition: and
 
       - type: status
         status:
           - 200
-          
-
-

--- a/http/misconfiguration/apache/apache-server-status.yaml
+++ b/http/misconfiguration/apache/apache-server-status.yaml
@@ -1,0 +1,49 @@
+id: apache-server-status
+
+info:
+  name: apache-server-status
+  author: Thabisocn
+  severity: medium
+  metadata:
+    max-request: 3
+    verified: true
+    Description: Apache /server-status displays information about your Apache status. If you are not using this feature, disable it.
+    Google-Dork: 
+     - site:*/server-status intext:"Apache server status for"
+     - site:*/server-info intext:"Apache server Information"
+    reference:
+     - https://www.exploit-db.com/ghdb/5548
+     - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
+     - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/
+     
+  tags: exposure,misconfiguration
+  
+
+http:
+  - method: GET
+    path:
+     - "{{BaseURL}}/server-status"
+     - "{{BaseURL}}/server-info"
+    
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Srv"
+          - "PID"
+          - "Acc"
+          - "Req"
+          - "Client"
+          - "Request"
+          - "Slot"
+          - "CPU"
+          
+        condition: and
+
+      - type: status
+        status:
+          - 200
+          
+
+

--- a/http/misconfiguration/apache/apache-server-status.yaml
+++ b/http/misconfiguration/apache/apache-server-status.yaml
@@ -1,43 +1,37 @@
 id: apache-server-status
 
 info:
-  name: apache-server-status
-  author: Thabisocn
-  severity: medium
+  name: Apache Server-Status Detected
+  author: thabisocn
+  severity: low
+  description: |
+     Apache /server-status displays information about your Apache status. If you are not using this feature, disable it.
+  reference:
+    - https://www.exploit-db.com/ghdb/5548
+    - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
+    - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/
   metadata:
     max-request: 2
     verified: true
-    Description: Apache /server-status displays information about your Apache
-      status. If you are not using this feature, disable it.
-    Google-Dork:
+    google-Dork:
       - site:*/server-status intext:"Apache server status for"
       - site:*/server-info intext:"Apache server Information"
-    reference:
-      - https://www.exploit-db.com/ghdb/5548
-      - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
-      - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/
-  tags: exposure,misconfiguration
+  tags: misconfig,exposure,apache
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/server-status"
       - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/server-status"
 
     stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - Srv
-          - PID
-          - Acc
-          - Req
-          - Client
-          - Request
-          - Slot
-          - CPU
-        condition: and
+          - "Apache Server Information"
+          - "Apache Server Status"
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

A template to use against a list of domains running apache .The template takes a list of domains and checks if they have a server status misconfiguration which  leaks server information . To minimize false positives it picks up words to ensure that the the information exists.

Reference

 - https://www.exploit-db.com/ghdb/5548
 - https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/apache-server-status-detected/
 - https://www.acunetix.com/vulnerabilities/web/apache-server-status-detected/

### Template Validation

I've validated this template locally?
- [ *] YES
- [ ] NO
![Screenshot from 2024-01-05 10-13-42](https://github.com/projectdiscovery/nuclei-templates/assets/55186310/cf07a93b-e86e-4029-bf7a-1451ec968c74)


