### PR TITLE
Create camunda-default-credential.yaml

### DIFF
--- a/http/default-logins/camunda/camunda-default-credential.yaml
+++ b/http/default-logins/camunda/camunda-default-credential.yaml
@@ -1,0 +1,55 @@
+id: camunda-default-credential
+
+info:
+  name: Camunda Login Panel - Default Login
+  author: bhutch
+  severity: high
+  description: Camunda login panel contains a default login vulnerability.
+  reference:
+    - https://github.com/camunda/camunda-docs-manual/blob/master/content/webapps/admin/user-management.md
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-522
+  metadata:
+    verified: true
+    max-request: 4
+    shodan-query: http.html:"Camunda Welcome"
+  tags: default-login,camunda
+
+http:
+  - raw:
+      - |
+        GET /camunda/app/welcome/default/ HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /camunda/api/admin/auth/user/default/login/welcome HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+        Accept: application/json, text/plain, */*
+        X-Xsrf-Token: {{xsrf_token}}
+
+        username=demo&password=demo
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"userId"'
+          - '"authorizedApps"'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: xsrf_token
+        group: 1
+        internal: true
+        part: header
+        regex:
+          - '(?i)Set-Cookie: XSRF-TOKEN=([A-Za-z0-9_.-]+)'

--- a/http/default-logins/camunda/camunda-default-login.yaml
+++ b/http/default-logins/camunda/camunda-default-login.yaml
@@ -1,10 +1,11 @@
-id: camunda-default-credential
+id: camunda-default-login
 
 info:
-  name: Camunda Login Panel - Default Login
+  name: Camunda - Default Login
   author: bhutch
   severity: high
-  description: Camunda login panel contains a default login vulnerability.
+  description: |
+    Camunda login panel contains a default login vulnerability.
   reference:
     - https://github.com/camunda/camunda-docs-manual/blob/master/content/webapps/admin/user-management.md
   classification:
@@ -13,7 +14,6 @@ info:
     cwe-id: CWE-522
   metadata:
     verified: true
-    max-request: 4
     shodan-query: http.html:"Camunda Welcome"
   tags: default-login,camunda
 
@@ -22,6 +22,7 @@ http:
       - |
         GET /camunda/app/welcome/default/ HTTP/1.1
         Host: {{Hostname}}
+
       - |
         POST /camunda/api/admin/auth/user/default/login/welcome HTTP/1.1
         Host: {{Hostname}}
@@ -29,9 +30,14 @@ http:
         Accept: application/json, text/plain, */*
         X-Xsrf-Token: {{xsrf_token}}
 
-        username=demo&password=demo
+        username={{username}}&password={{password}}
 
-    cookie-reuse: true
+    attack: pitchfork
+    payloads:
+      username:
+        - demo
+      password:
+        - demo
 
     matchers-condition: and
     matchers:
@@ -40,6 +46,7 @@ http:
         words:
           - '"userId"'
           - '"authorizedApps"'
+        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
The Camunda process automation and orchestration platform has a documented default admin credential. This template checks for that default credential.

It complements `camunda-login-panel` and could be run as part of a workflow.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO