### PR TITLE
Added more words to microsoft-azure-error template

### DIFF
--- a/http/miscellaneous/microsoft-azure-error.yaml
+++ b/http/miscellaneous/microsoft-azure-error.yaml
@@ -7,7 +7,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: title:"Microsoft Azure Web App - Error 404"
-  tags: error,azure,microsoft,misc
+  tags: error,azure,microsoft,misc,takeover
 
 http:
   - method: GET
@@ -23,5 +23,7 @@ http:
       - type: word
         words:
           - "<title>Microsoft Azure Web App - Error 404</title>"
+          - "Custom domain has not been configured inside Azure. See how to map an existing domain to resolve this."
+        condition: or
 
 # digest: 490a0046304402207f40d1e02b49c5a20b36bf6b47cf97a9eb871de346e70bb6d000e964c1e1dfbb02203dbac21b899cfc64285966fbc015627ff3f57693f3604fcb8da8caa4718b27f0:922c64590222798bb761d5b6d8e72950

--- a/http/miscellaneous/microsoft-azure-error.yaml
+++ b/http/miscellaneous/microsoft-azure-error.yaml
@@ -16,14 +16,14 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 404
-
       - type: word
         words:
           - "<title>Microsoft Azure Web App - Error 404</title>"
           - "Custom domain has not been configured inside Azure. See how to map an existing domain to resolve this."
         condition: or
+
+      - type: status
+        status:
+          - 404
 
 # digest: 490a0046304402207f40d1e02b49c5a20b36bf6b47cf97a9eb871de346e70bb6d000e964c1e1dfbb02203dbac21b899cfc64285966fbc015627ff3f57693f3604fcb8da8caa4718b27f0:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
I was doing some testing in my organisation using Nuclei and found some assets which were previously hosting something which was hosted on Azure, now that has been removed, that's why these assets are dangling entries. I found the repeated description in the websites. As far as I could understood, this could be a possible subdomain takeover.

### Template Validation

I've validated this template locally?
- [x] YES ☑️
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)