### PR TITLE
Fix FP on open-proxy-external.yaml

### DIFF
--- a/http/misconfiguration/proxy/open-proxy-external.yaml
+++ b/http/misconfiguration/proxy/open-proxy-external.yaml
@@ -39,7 +39,7 @@ http:
         dsl:
           - contains(body_1, "<HostId>") || contains(body_1, "</HostId>")
           - contains(header_2, "X-Interactsh-Version")
-        condition: or
+        condition: and
 
       - type: dsl
         dsl:

--- a/http/misconfiguration/proxy/open-proxy-external.yaml
+++ b/http/misconfiguration/proxy/open-proxy-external.yaml
@@ -37,7 +37,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body_1, "<HostId>") || contains(body_1, "</HostId>")
+          - contains_any(body_1, "<HostId>", "</HostId>")
           - contains(header_2, "X-Interactsh-Version")
         condition: and
 


### PR DESCRIPTION
### Template / PR Information

Fixes cases when amazon bucket returns 403 with hostid html tag. 
Just checking if request to interactsh contains both interactsh header and hostid html tag.

For example on interactsh request server returns:
```
GET http://cmek36kdd6ds739rbjv0xcapy5du78y9x.oast.site HTTP/1.1
Host: cmek36kdd6ds739rbjv09skazfs5cphom.oast.site

[DBG] Http Protocol response variables:
        1. accept_ranges => bytes
        2. accept_ranges_1 => bytes
        3. accept_ranges_2 => bytes
        4. all_headers => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        5. all_headers_1 => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        6. all_headers_2 => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        7. body => <?xml version="1.0" encod .... 71f88448</HostId></Error>
        8. body_1 => <?xml version="1.0" encod .... 71f88448</HostId></Error>
        9. body_2 => <?xml version="1.0" encod .... 71f88448</HostId></Error>
        10. connection => keep-alive
        11. connection_1 => keep-alive
        12. connection_2 => keep-alive
        13. content_length => 226
        14. content_length_1 => 226
        15. content_length_2 => 226
        16. content_security_policy => block-all-mixed-content
        17. content_security_policy_1 => block-all-mixed-content
        18. content_security_policy_2 => block-all-mixed-content
        19. content_type => application/xml
        20. content_type_1 => application/xml
        21. content_type_2 => application/xml
        22. curl-command =>
        23. curl-command_1 =>
        24. curl-command_2 =>
        25. date => Tue, 09 Jan 2024 12:52:43 GMT
        26. date_1 => Tue, 09 Jan 2024 12:52:42 GMT
        27. date_2 => Tue, 09 Jan 2024 12:52:43 GMT
        28. duration => 0.022743771
        29. duration_1 => 0.073749263
        30. duration_2 => 0.022743771
        31. header => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        32. header_1 => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        33. header_2 => HTTP/1.1 403 Forbidden  C .... ection: 1; mode=block
        34. host => https://testhost.com
        35. host_1 => https://testhost.com
        36. host_2 => https://testhost.com
        37. interactsh-id => cmek36kdd6ds739rbjv09skazfs5cphom
        38. interactsh-id_2 => cmek36kdd6ds739rbjv09skazfs5cphom
        39. interactsh-server => oast.site
        40. interactsh-server_1 =>
        41. interactsh-server_2 => oast.site
        42. interactsh-url => cmek36kdd6ds739rbjv09skazfs5cphom.oast.site
        43. interactsh-url_2 => cmek36kdd6ds739rbjv09skazfs5cphom.oast.site
        44. ip => 37.230.181.106
        45. ip_1 => 37.230.181.106
        46. ip_2 => 37.230.181.106
        47. matched => https://testhost.com
        48. matched_1 => https://testhost.com
        49. matched_2 => https://testhost.com
        50. request => GET http://cmek36kdd6ds73 .... kazfs5cphom.oast.site
        51. request_1 => GET https://test.s3.amazo .... test.s3.amazonaws.com
        52. request_2 => GET http://cmek36kdd6ds73 .... kazfs5cphom.oast.site
        53. response => HTTP/1.1 403 Forbidden  C .... 71f88448</HostId></Error>
        54. response_1 => HTTP/1.1 403 Forbidden  C .... 71f88448</HostId></Error>
        55. response_2 => HTTP/1.1 403 Forbidden  C .... 71f88448</HostId></Error>
        56. server => nginx
        57. server_1 => nginx
        58. server_2 => nginx
        59. status_code => 403
        60. status_code_1 => 403
        61. status_code_2 => 403
        62. strict_transport_security => max-age=31536000; includeSubDomains
        63. strict_transport_security_1 => max-age=31536000; includeSubDomains
        64. strict_transport_security_2 => max-age=31536000; includeSubDomains
        65. template-id => open-proxy-external
        66. template-id_1 => open-proxy-external
        67. template-id_2 => open-proxy-external
        68. template-info => {Open Proxy To External N .... to approved hosts/ports.}
        69. template-info_1 => {Open Proxy To External N .... to approved hosts/ports.}
        70. template-info_2 => {Open Proxy To External N .... to approved hosts/ports.}
        71. template-path => /root/nuclei-templates/ht .... /open-proxy-external.yaml
        72. template-path_1 => /root/nuclei-templates/ht .... /open-proxy-external.yaml
        73. template-path_2 => /root/nuclei-templates/ht .... /open-proxy-external.yaml
        74. type => http
        75. type_1 => http
        76. type_2 => http
        77. vary => Origin Accept-Encoding
        78. vary_1 => Origin Accept-Encoding
        79. vary_2 => Origin Accept-Encoding
        80. x_amz_request_id => 17A8AEE663F12A1B
        81. x_amz_request_id_1 => 17A8AEE626C0B2DC
        82. x_amz_request_id_2 => 17A8AEE663F12A1B
        83. x_content_type_options => nosniff
        84. x_content_type_options_1 => nosniff
        85. x_content_type_options_2 => nosniff
        86. x_xss_protection => 1; mode=block
        87. x_xss_protection_1 => 1; mode=block
        88. x_xss_protection_2 => 1; mode=block

[DBG] [open-proxy-external] Dumped HTTP response https://testhost.com

HTTP/1.1 403 Forbidden
Content-Length: 226
Accept-Ranges: bytes
Connection: keep-alive
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Date: Tue, 09 Jan 2024 12:52:43 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
Vary: Accept-Encoding
X-Amz-Request-Id: 17A8123663F12CCC
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied.</Message><Resource>/</Resource><RequestId>17A8123663F12CCC</RequestId><HostId>fafa4b245-7645-4149-84ab-ba9771f78488</HostId></Error>
```
It does contain HostId tag so it will pass current OR check.
By replacing it with AND check we can ensure that we truly managed to get content of interactsh server and not some bucket.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
