### PR TITLE
non-intrusive template for CVE-2023-7028 GitLab

### DIFF
--- a/http/cves/2023/CVE-2023-7028.yaml
+++ b/http/cves/2023/CVE-2023-7028.yaml
@@ -1,0 +1,36 @@
+id: CVE-2023-7028
+
+info:
+  name: Gitlab CVE-2023-7028 unauthenticated account takeover via password reset
+  author: h4sh5
+  severity: critical
+  description: An issue has been discovered in GitLab CE/EE affecting all versions from 16.1 prior to 16.1.6, 16.2 prior to 16.2.9, 16.3 prior to 16.3.7, 16.4 prior to 16.4.5, 16.5 prior to 16.5.6, 16.6 prior to 16.6.4, and 16.7 prior to 16.7.2 in which user account password reset emails could be delivered to an unverified email address. (patch includes changing the message on the password reset page.)
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10
+    cwe-id: CWE-204
+    cve-id: CVE-2023-7028
+  metadata:
+    max-request: 1
+    shodan-query: product:gitlab
+  tags: cve,cve2023,gitlab
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/users/password/new"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'GitLab'
+          - 'Requires your primary GitLab email address.'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2023-7028
- References:
  - https://www.bleepingcomputer.com/news/security/gitlab-warns-of-critical-zero-click-account-hijacking-vulnerability/
  - https://gitlab.com/gitlab-org/gitlab/-/commit/c571840ba2f0e91ca7ec3c436f796532dbb3c550#27e06e15cfe9583d733619cf7d72629b777f7757_41290_41287
  - https://nvd.nist.gov/vuln/detail/CVE-2023-7028


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

- shodan query: `product:gitlab` (but no version matching available due to GitLab not showing version numbers to unauthed users)
