### PR TITLE
Removing kev tags for CVE-2022-43769 and CVE-2023-25135

### DIFF
--- a/http/cves/2022/CVE-2022-43769.yaml
+++ b/http/cves/2022/CVE-2022-43769.yaml
@@ -27,7 +27,7 @@ info:
     vendor: hitachi
     product: vantara_pentaho_business_analytics_server
     shodan-query: http.favicon.hash:1749354953
-  tags: packetstorm,cve,cve2022,rce,ssti,pentaho,kev,hitachi
+  tags: packetstorm,cve,cve2022,rce,ssti,pentaho,hitachi
 
 http:
   - method: GET

--- a/http/cves/2023/CVE-2023-25135.yaml
+++ b/http/cves/2023/CVE-2023-25135.yaml
@@ -29,7 +29,7 @@ info:
     product: vbulletin
     shodan-query: http.component:"vBulletin"
     google-query: intext:"Powered By vBulletin"
-  tags: cve,cve2023,vbulletin,rce,kev
+  tags: cve,cve2023,vbulletin,rce
 
 http:
   - raw:


### PR DESCRIPTION
These two templates had the tags 'kev' despite not being in kev. I have updated these to address this issue.

- Updated CVE-2022-43769 and CVE-2023-25135
- References:
https://nvd.nist.gov/vuln/detail/CVE-2022-43769
https://nvd.nist.gov/vuln/detail/CVE-2023-25135


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)