### PR TITLE
Fewer FPs in mixed content Nuclei template

### DIFF
--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -22,31 +22,17 @@ http:
 
     host-redirects: true
     max-redirects: 3
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: regex
         part: body
-        name: script
         regex:
           - "<script[^>]*src=['\"]http://[^'\">]+['\"]"
-
-      - type: regex
-        part: body
-        name: iframe
-        regex:
           - "<iframe[^>]*src=['\"]http://[^'\">]+['\"]"
-
-      - type: regex
-        part: body
-        name: object
-        regex:
           - "<object[^>]*data=['\"]http://[^'\">]+['\"]"
-
-      - type: regex
-        part: body
-        name: link
-        regex:
-          - "<link[^>]*href=['\"]http://[^'\">]+['\"]"
+      - type: dsl
+        dsl: 
+          - 'startswith(tostring(BaseURL), "https://")'
 
     extractors:
       - type: regex
@@ -56,5 +42,4 @@ http:
           - "<script[^>]*src=['\"](http[^s'\">][^'\">]*)['\"]"
           - "<iframe[^>]*src=['\"](http[^s'\">][^'\">]*)['\"]"
           - "<object[^>]*data=['\"](http[^s'\">][^'\">]*)['\"]"
-          - "<link[^>]*href=['\"](http[^s'\">][^'\">]*)['\"]"
 # digest: 4a0a0047304502204149676bab57d4abe400adafd2797ae56c8c4ac9dff90db9d8a3e657299914bf022100e2dcd183a9dd2feaba62be499b43008f0662acfb53f93f4677972eea51c1a945:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

It's not interesting if a website is served under http:// -  an attacker controlling the network may replace
the whole source, not loaded scripts. Therefore a check whether the URL starts with HTTPS got added.

Besides, I observed a lot of FPs where e.g. styles, preloads etc were misinterpreted as active content - therefore
`<link` got removed as well.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
