### PR TITLE
Add version detection to vault-panel template

### DIFF
--- a/http/exposed-panels/vault-panel.yaml
+++ b/http/exposed-panels/vault-panel.yaml
@@ -49,7 +49,7 @@ http:
 
       - type: status
         status:
-            - 200
+          - 200
 
     extractors:
       - type: json

--- a/http/exposed-panels/vault-panel.yaml
+++ b/http/exposed-panels/vault-panel.yaml
@@ -1,7 +1,7 @@
 id: vault-panel
 
 info:
-  name: Vault Login Panel - Version Detect
+  name: Vault Login Panel - Detect
   author: DhiyaneshDK
   severity: info
   description: Vault login panel was detected.
@@ -10,14 +10,15 @@ info:
     cvss-score: 0
     cwe-id: CWE-200
   metadata:
+    max-request: 2
     verified: true
-    max-request: 1
     shodan-query: http.favicon.hash:-919788577
-  tags: panel,vault
+  tags: panel,vault,detect
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/v1/sys/health"
       - "{{BaseURL}}/ui/vault/auth?with=oidc%2F"
 
     matchers-condition: and
@@ -28,32 +29,13 @@ http:
           - "vault/"
         condition: and
 
-      - type: word
-        part: header
-        words:
-          - "text/html"
-
-      - type: status
-        status:
-          - 200
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/v1/sys/health"
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        words:
-          - "version"
-
       - type: status
         status:
           - 200
 
     extractors:
       - type: json
-        part: body
+        part: body_1
         name: version
         json:
           - ".version"

--- a/http/exposed-panels/vault-panel.yaml
+++ b/http/exposed-panels/vault-panel.yaml
@@ -1,7 +1,7 @@
 id: vault-panel
 
 info:
-  name: Vault Login Panel - Detect
+  name: Vault Login Panel - Version Detect
   author: DhiyaneshDK
   severity: info
   description: Vault login panel was detected.
@@ -36,5 +36,26 @@ http:
       - type: status
         status:
           - 200
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/v1/sys/health"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "version"
+
+      - type: status
+        status:
+            - 200
+
+    extractors:
+      - type: json
+        part: body
+        name: version
+        json:
+          - ".version"
 
 # digest: 4a0a00473045022043afd1d7f4e370096c6f95b0552fbd75cdfa5cb13cf7e4cbf370a168fb669c85022100c25fe68dcda0228a9aef38c6940c28388b1c59572c90686c633c89a694a5fe5e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

The Vault panel detection could benefit from also detecting the Vault version, so it's easier to detect outdated instances.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

- Vault API documentation for the endpoint: https://developer.hashicorp.com/vault/api-docs/system/health
- Example JSON response from a scanned endpoint:

```json
{"initialized":true,"sealed":false,"standby":false,"performance_standby":false,"replication_performance_mode":"disabled","replication_dr_mode":"disabled","server_time_utc":1705768693,"version":"1.12.1","cluster_name":"vault-cluster-28a893d7","cluster_id":"4e128ce5-ee00-4ab1-aa2f-e233c24c372b"}
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)