### PR TITLE
Add Template for DNS Rebinding Attack

### DIFF
--- a/dns/dns-rebinding.yaml
+++ b/dns/dns-rebinding.yaml
@@ -1,9 +1,11 @@
 id: dns-rebinding
+
 info:
   name: DNS Rebinding Attack
-  description: Detects DNS Rebinding attacks by checking if the DNS response contains a private IPv4 or IPv6 address.
   author: ricardomaia
   severity: high
+  description: |
+    Detects DNS Rebinding attacks by checking if the DNS response contains a private IPv4 or IPv6 address.
   reference:
     - https://capec.mitre.org/data/definitions/275.html
   metadata:

--- a/dns/dns-rebinding.yaml
+++ b/dns/dns-rebinding.yaml
@@ -1,0 +1,63 @@
+id: dns-rebinding
+info:
+  name: DNS Rebinding Attack
+  description: Detects DNS Rebinding attacks by checking if the DNS response contains a private IPv4 or IPv6 address.
+  author: ricardomaia
+  severity: high
+  reference:
+    - https://capec.mitre.org/data/definitions/275.html
+  metadata:
+    max-request: 3
+  tags: redirect, dns, network
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 8.6
+    cwe-id: CWE-350
+
+dns:
+  - name: "{{FQDN}}"
+    type: A
+    matchers:
+      # IPv4
+      - type: regex
+        part: answer
+        regex:
+          - 'IN.*A.*(127\.0\.0\.1|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})$'
+
+    extractors:
+      - type: regex
+        part: answer
+        name: IPv4
+        group: 1
+        regex:
+          - 'IN.*A.*(127\.0\.0\.1|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})'
+
+  - name: "{{FQDN}}"
+    type: AAAA
+    matchers:
+      # IPv6 Compressed
+      - type: regex
+        part: answer
+        regex:
+          - "IN.+A.+(fd([0-9a-fA-F]{2}):([0-9a-fA-F]{0,4}:){0,5}(:[0-9a-fA-F]{0,4}){1,2}(:)?)$"
+
+      # IPv6
+      - type: regex
+        part: answer
+        regex:
+          - "IN.+A.+(fd([0-9a-fA-F]{2}):([0-9a-fA-F]{1,4}:){0,5}([0-9a-fA-F]{1,4}:){1,2}[0-9a-fA-F]{1,4})$"
+
+    extractors:
+      - type: regex
+        part: answer
+        name: IPv6_Compressed
+        group: 1
+        regex:
+          - "IN.+A.+(fd([0-9a-fA-F]{2}):([0-9a-fA-F]{0,4}:){0,5}(:[0-9a-fA-F]{0,4}){1,2}(:)?)$"
+
+      - type: regex
+        part: answer
+        name: IPv6
+        group: 1
+        regex:
+          - "IN.+A.+(fd([0-9a-fA-F]{2}):([0-9a-fA-F]{1,4}:){0,5}([0-9a-fA-F]{1,4}:){1,2}[0-9a-fA-F]{1,4})$"

--- a/dns/dns-rebinding.yaml
+++ b/dns/dns-rebinding.yaml
@@ -8,13 +8,15 @@ info:
     Detects DNS Rebinding attacks by checking if the DNS response contains a private IPv4 or IPv6 address.
   reference:
     - https://capec.mitre.org/data/definitions/275.html
-  metadata:
-    max-request: 3
-  tags: redirect, dns, network
+    - https://payatu.com/blog/dns-rebinding/
+    - https://heimdalsecurity.com/blog/dns-rebinding/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 8.6
     cwe-id: CWE-350
+  metadata:
+    verified: true
+  tags: redirect,dns,network
 
 dns:
   - name: "{{FQDN}}"


### PR DESCRIPTION
### Template / PR Information

This template search for private IPv4 or IPv6 addresses associated to aimed domain. 

Private IP addresses associated to domains could be used to perform a DNS Rebind attack, bypassing Same-Origin Policy. 

This technique can be used for various malicious purposes. For example, an attacker might exploit this vulnerability to access networked devices such as routers, smart home devices, or even internal corporate systems.

Once identified, extract the IP address into the IPv4, IPv6 and IPv6_Compressed variables.

- References:
  - https://capec.mitre.org/data/definitions/275.html

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1353811/7769df58-d816-4ff5-8505-589fee84b750)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1353811/659fab67-27eb-46c1-baea-9132cc77f6a9)



### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)