### PR TITLE
Update IBM Websphere Friendly Path Exposure Template to Reduce False Positives

### DIFF
--- a/http/misconfiguration/ibm-friendly-path-exposure.yaml
+++ b/http/misconfiguration/ibm-friendly-path-exposure.yaml
@@ -39,5 +39,11 @@ http:
       - type: status
         status:
           - 200
+      
+      - type: regex
+        part: header
+        regex:
+          - "Content-Location: .+"
+        negative: true
 
 # digest: 4b0a00483046022100b8ffb455a810ccfda40f96bae3dcea77b4f56ea1d00eb89ba0114e9e3848f86c022100ae09577f1858fdc2203f5e21d548b4032dcf74c4489a6757df180c2361853698:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Summary
This PR addresses an issue with the IBM Websphere Friendly Path Exposure template that leads to false positive detections. The current template incorrectly identifies standard site redirections as potential vulnerabilities, leading to inaccurate results.

### Problem Description
We have observed that the template flags instances where the server responds with a standard landing page (due to redirection) as positive findings. However, these are false positives because the responses are standard behaviors and not indicative of an actual vulnerability. This issue was brought to our attention by a customer experiencing such false positives.

### Proposed Changes
To mitigate this issue, the proposed update includes a negative matcher for the `Content-Location` header in the HTTP response. If this header is present, which is common for standard redirections to a landing page, the response will be marked as non-relevant, reducing false positives.

### Implementation
The update involves adding the following negative matcher to the template:

```yaml
  - type: regex
    part: header
    regex:
      - "Content-Location: .+"
    negative: true

I've validated this template locally?
- [ ] YES
- [X] NO
