### PR TITLE
Detecting Balada Injector malware

### DIFF
--- a/http/miscellaneous/balada-injector-malware.yaml
+++ b/http/miscellaneous/balada-injector-malware.yaml
@@ -1,0 +1,32 @@
+id: balada-injector-malware
+
+info:
+  name: Balada Injector Malware - Detect
+  author: kazet
+  severity: high
+  description: |
+    Checks websites for Balada Injector malware.
+  reference:
+    - https://blog.sucuri.net/2024/01/thousands-of-sites-with-popup-builder-compromised-by-balada-injector.html
+  metadata:
+    max-request: 1
+  tags: malware,balada,misc
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '(?mi)sgpbWillOpen", function\(e\) {if \(e.detail.popupId.{0,100}eval.{0,100}atob'
+
+      - type: word
+        part: header
+        words:
+          - "text/html"


### PR DESCRIPTION
### Template / PR Information

On December 13th, the [Balada Injector](https://blog.sucuri.net/2023/04/balada-injector-synopsis-of-a-massive-ongoing-wordpress-malware-campaign.html) campaign started infecting websites with older versions of the Popup Builder WordPress plugin.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
