### PR TITLE
Add detection of Friendica instances

### DIFF
--- a/http/exposed-panels/friendica-panel.yaml
+++ b/http/exposed-panels/friendica-panel.yaml
@@ -24,9 +24,10 @@ http:
       - type: word
         part: body
         words:
-          - "friendica.webmanifest"
+          - 'title="Search in Friendica'
+          - 'Welcome to Friendica Social Network'
           - 'content="Friendica'
-        condition: and
+        condition: or
 
       - type: status
         status:

--- a/http/exposed-panels/friendica-panel.yaml
+++ b/http/exposed-panels/friendica-panel.yaml
@@ -1,0 +1,40 @@
+id: friendica-panel
+
+info:
+  name: Friendica Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Friendica was detected.
+  reference:
+    - https://friendi.ca/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Friendica"
+  tags: friendica,panel,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "friendica.webmanifest"
+          - 'content="Friendica'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)v=([a-z0-9.-]+)'

--- a/http/exposed-panels/friendica-panel.yaml
+++ b/http/exposed-panels/friendica-panel.yaml
@@ -5,9 +5,9 @@ info:
   author: righettod
   severity: info
   description: |
-    Friendica was detected.
+    Friendica Login Panel was detected.
   reference:
-    - https://friendi.ca/
+    - https://friendi.ca
   metadata:
     max-request: 1
     verified: true
@@ -17,7 +17,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the software [Friendica](https://friendi.ca/).

- References: https://friendi.ca/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2619e81b-b10e-45d9-b741-ded30e47942d)

Sources used for the test obtained via shodan:

```text
https://85.215.118.198/
https://boerdica.de/
https://86.161.9.119/
http://172.232.173.89:8080/
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Friendica%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e10026ed-9dc2-4efb-8897-c8adf4fa611d)

### Additional References

None