### PR TITLE
Add detection for SAP public admin web interface

### DIFF
--- a/http/misconfiguration/sap/sap-public-admin.yaml
+++ b/http/misconfiguration/sap/sap-public-admin.yaml
@@ -1,0 +1,24 @@
+id: sap-public-admin
+
+info:
+  name: SAP ICM Admin Web Interface Set to Public
+  author: t3l3machus
+  severity: medium
+  reference:
+    - https://www.saptechnicalguru.com/information-disclosure-sap-web-administration-interface/
+  description:
+    The SAP ICM (Internet Communication Manager) admin monitor interface is often set to public and can be accessed without authentication. The interface discloses version information about the underlying operating system, a brief SAP patch level overview, running services including their corresponding ports and more.
+  metadata:
+    max-request: 1
+  tags: sap,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sap/admin/public/index.html"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Administration</title>"

--- a/http/misconfiguration/sap/sap-public-admin.yaml
+++ b/http/misconfiguration/sap/sap-public-admin.yaml
@@ -1,7 +1,7 @@
 id: sap-public-admin
 
 info:
-  name: SAP ICM Admin Web Interface Set to Public
+  name: SAP ICM Admin Web Interface
   author: t3l3machus
   severity: low
   description:
@@ -10,19 +10,23 @@ info:
     - https://www.saptechnicalguru.com/information-disclosure-sap-web-administration-interface/
   metadata:
     max-request: 1
+    verified: true
     shodan-query: html:"SAP"
-  tags: sap,misconfig,admin,panel
+  tags: sap,misconfig,admin,dashboard
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/sap/admin/public/index.html"
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "<title>Administration</title>"
+          - "sap.ui"
+        condition: and
 
       - type: status
         status:

--- a/http/misconfiguration/sap/sap-public-admin.yaml
+++ b/http/misconfiguration/sap/sap-public-admin.yaml
@@ -3,14 +3,15 @@ id: sap-public-admin
 info:
   name: SAP ICM Admin Web Interface Set to Public
   author: t3l3machus
-  severity: medium
-  reference:
-    - https://www.saptechnicalguru.com/information-disclosure-sap-web-administration-interface/
+  severity: low
   description:
     The SAP ICM (Internet Communication Manager) admin monitor interface is often set to public and can be accessed without authentication. The interface discloses version information about the underlying operating system, a brief SAP patch level overview, running services including their corresponding ports and more.
+  reference:
+    - https://www.saptechnicalguru.com/information-disclosure-sap-web-administration-interface/
   metadata:
     max-request: 1
-  tags: sap,misconfig
+    shodan-query: html:"SAP"
+  tags: sap,misconfig,admin,panel
 
 http:
   - method: GET
@@ -22,3 +23,7 @@ http:
         part: body
         words:
           - "<title>Administration</title>"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

The SAP ICM (Internet Communication Manager) admin monitor interface is often set to public and can be accessed without authentication. The interface discloses version information about the underlying operating system, a brief SAP patch level overview and version info, running services including hostnames, their corresponding ports and more.


- References:
https://www.saptechnicalguru.com/information-disclosure-sap-web-administration-interface/

### Template Validation

I've validated this template locally?
 YES


![image](https://github.com/projectdiscovery/nuclei-templates/assets/75489922/586f6de7-6a88-423c-8977-03049cc3f506)


#### Additional Details

You can find many vulnerable servers if you search in Shodan "SAP NetWeaver Application Server".
Here's some of the info disclosed by this public interface:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/75489922/dc119644-5ba5-41d5-a7c1-65c30343b401)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/75489922/79e821df-6816-4243-a027-e3a76ee19ad4)




