### PR TITLE
Add a `CWE-` prefix for cwe-id

### DIFF
--- a/http/cves/2015/CVE-2015-20067.yaml
+++ b/http/cves/2015/CVE-2015-20067.yaml
@@ -17,7 +17,7 @@ info:
     cve-id: CVE-2015-20067
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: 862
+    cwe-id: CWE-862
   metadata:
     max-request: 2
     verified: true


### PR DESCRIPTION
### Template / PR Information

The cwe-id in the other templates has the `CWE-` prefix, but not in CVE-2015-20067, so I added it.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)