### PR TITLE
Add more detection criteria for Openx (now Revive Adserver)

### DIFF
--- a/http/exposed-panels/openx-panel.yaml
+++ b/http/exposed-panels/openx-panel.yaml
@@ -1,10 +1,10 @@
 id: openx-panel
 
 info:
-  name: OpenX Login Panel - Detect
+  name: OpenX/Revive Adserver Login Panel - Detect
   author: pikpikcu,righettod
   severity: info
-  description: OpenX login panel was detected. Note that OpenX is now Revive Adserver.
+  description: OpenX login panel was detected. Note that OpenX is now a Revive Adserver.
   reference:
     - https://www.revive-adserver.com/download/
   classification:
@@ -13,7 +13,8 @@ info:
     cwe-id: CWE-200
   metadata:
     max-request: 2
-    shodan-query: http.title:"OpenX"
+    verified: true
+    shodan-query: title:"Revive Adserver"
   tags: panel,openx,revive,adserver,login
 
 http:
@@ -23,7 +24,6 @@ http:
       - "{{BaseURL}}/admin/index.php"
 
     stop-at-first-match: true
-
     matchers-condition: and
     matchers:
       - type: regex
@@ -31,6 +31,7 @@ http:
         regex:
           - '<title>OpenX</title>'
           - '<title>Revive Adserver</title>'
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more detection criteria.

I not modified the shodan query in the template but one for **Revive Adserver** is `http.title:"Revive Adserver"`.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/05902461-0b76-4273-ae10-04c028f1d6bb)

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Revive+Adserver%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/78a2331f-3cae-43d1-a88c-d63d5d69c15a)


### Additional References:

None