### PR TITLE
Add detection of Sentry login panel instances

### DIFF
--- a/http/exposed-panels/sentry-panel.yaml
+++ b/http/exposed-panels/sentry-panel.yaml
@@ -1,0 +1,36 @@
+id: sentry-panel
+
+info:
+  name: Sentry Login Panel
+  author: righettod
+  severity: info
+  description: |
+     Sentry login panel was detected.
+  reference:
+    - https://sentry.io/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Login | Sentry"
+  tags: panel,sentry,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "/sentry/")'
+          - 'contains(body, "Login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"current":\s*"([0-9a-z.-]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the software **Sentry**.

- References: https://sentry.io/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d8d5c86c-bf84-4514-a88f-f0046cdbf47d)

Host used for the test and found via Shodan:

```text
3.106.9.234
54.169.86.118
44.230.152.182
34.192.74.99
104.209.196.177
sentry.data.public.lu
righettod.eu
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Login+%7C+Sentry%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/4a5b8f77-41bb-467b-a146-33a6f86a880e)

### Additional References

None