### PR TITLE
Add detection of Passbolt login panel instances

### DIFF
--- a/http/exposed-panels/passbolt-panel.yaml
+++ b/http/exposed-panels/passbolt-panel.yaml
@@ -1,0 +1,33 @@
+id: passbolt-panel
+
+info:
+  name: Passbolt Login Panel
+  author: righettod
+  severity: info
+  description: |
+     Passbolt login panel was detected.
+  reference:
+    - https://www.passbolt.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Passbolt | Open source password manager for teams"
+  tags: panel,passbolt,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Passbolt") && contains(body, "Open source password manager for teams")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)v=([0-9a-z.-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the software **Passbolt**.

- References: https://www.passbolt.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/3b8f8a39-da9d-4bcc-ab2f-f98ae07f49d4)

Host used for the test: https://passbolt.vanksen.com/

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Passbolt+%7C+Open+source+password+manager+for+teams%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/120f45c5-865f-4b33-89bc-399cdbdfcd8b)

### Additional References

None