### PR TITLE
Added CVE-2024-23832 Template

### DIFF
--- a/http/cves/2024/CVE-2024-23832.yaml
+++ b/http/cves/2024/CVE-2024-23832.yaml
@@ -1,0 +1,58 @@
+id: CVE-2024-23832
+
+info:
+  name: Mastodon User Impersonation and Takeover
+  author: yoryio
+  severity: critical
+  description: |
+    Due to insufficient origin validation in all Mastodon, attackers can impersonate and take over any remote account.
+  reference:
+    - https://github.com/mastodon/mastodon/security/advisories/GHSA-3fjr-858r-92rw
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-23832
+    - https://github.com/mastodon/mastodon/commit/1726085db5cd73dd30953da858f9887bcc90b958
+    - https://www.bleepingcomputer.com/news/security/mastodon-vulnerability-allows-attackers-to-take-over-accounts/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H
+    cvss-score: 9.4
+    cve-id: CVE-2024-23832
+    cwe-id: CWE-346
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: 'server: Mastodon'
+  tags: cve, cve-2024-23832, mastodon, origin-validation-error
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+    redirects: true
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "mastodon")'
+          - 'contains(body, "version\":")'
+        condition: and
+
+      - type: regex
+        regex:
+          - \b[0-2]\.(?:[0-9]|1[0-9])\.(?:[0-9]|1[0-9])\b
+          - 3\.(?:[0-4])\.(?:[0-9]|1[0-9])\b
+          - 3\.5\.\b(?:[0-9]|1[0-6])\b
+          - 4\.0\.\b(?:[0-9]|1[0-2])\b
+          - 4\.1\.\b(?:[0-9]|1[0-2])\b
+          - 4\.2\.\b([0-4])\b
+        condition: or
+        part: body
+
+    extractors:
+      - type: regex
+        name: vulnerable
+        part: body_1
+        group: 1
+        regex:
+          - 'version":"(.+?)"'


### PR DESCRIPTION
### Template / PR Information

- Add [CVE-2024-23832](https://github.com/mastodon/mastodon/security/advisories/GHSA-3fjr-858r-92rw)
- References:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-23832
     - https://github.com/mastodon/mastodon/commit/1726085db5cd73dd30953da858f9887bcc90b958

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

**Shodan query**

```
"server: Mastodon"
```

```
http.favicon.hash:-1269979934
```

### Additional References:

- [Mastodon vulnerability allows attackers to take over accounts](https://www.bleepingcomputer.com/news/security/mastodon-vulnerability-allows-attackers-to-take-over-accounts/)
- [CVE-2024-23832: Mastodon: Remote user impersonation and takeover](https://www.openwall.com/lists/oss-security/2024/02/02/4)