### PR TITLE
Added Teampass LDAP template

### DIFF
--- a/http/exposures/logs/teampass-ldap.yaml
+++ b/http/exposures/logs/teampass-ldap.yaml
@@ -3,8 +3,9 @@ id: teampass-ldap
 info:
   name: Teampass LDAP Debug Config - Detect
   author: josecosta
-  severity: high
-  description: Teampass ldap.debug.txt config was detected. This file is generated on "/files/ldap.debug.txt" for versions earlier than 3.0.0.0 when utilizing the "Test current configuration" in LDAP settings.
+  severity: medium
+  description: |
+    Teampass ldap.debug.txt config was detected. This file is generated on "/files/ldap.debug.txt" for versions earlier than 3.0.0.0 when utilizing the "Test current configuration" in LDAP settings.
   reference:
     - https://github.com/nilsteampassnet/TeamPass/commit/ea9838481a58879cdf3def31046955efcff5a546#diff-61809be6a8fff101e3748a0c7dfad90bR16
   classification:
@@ -13,7 +14,9 @@ info:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-  tags: exposure,cgi
+    verified: true
+    fofa-query: app="TEAMPASS"
+  tags: exposure,teampass,ldap,logs
 
 http:
   - method: GET
@@ -23,12 +26,18 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: header
         words:
           - 'base_dn'
           - 'search_base'
           - 'bind_dn'
           - 'bind_passwd'
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - 'text/plain'
 
       - type: status
         status:

--- a/http/exposures/logs/teampass-ldap.yaml
+++ b/http/exposures/logs/teampass-ldap.yaml
@@ -1,0 +1,35 @@
+id: teampass-ldap
+
+info:
+  name: Teampass LDAP Debug Config - Detect
+  author: josecosta
+  severity: high
+  description: Teampass ldap.debug.txt config was detected. This file is generated on "/files/ldap.debug.txt" for versions earlier than 3.0.0.0 when utilizing the "Test current configuration" in LDAP settings.
+  reference:
+    - https://github.com/nilsteampassnet/TeamPass/commit/ea9838481a58879cdf3def31046955efcff5a546#diff-61809be6a8fff101e3748a0c7dfad90bR16
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+  tags: exposure,cgi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/files/ldap.debug.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'base_dn'
+          - 'search_base'
+          - 'bind_dn'
+          - 'bind_passwd'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

This template searches for the "/files/ldap.debug.txt" is present on TeamPass versions earlier than 3.0.0.0 when utilizing the "Test current configuration" in LDAP settings.

- Added Teampass LDAP template
- References:
https://github.com/nilsteampassnet/TeamPass/commit/ea9838481a58879cdf3def31046955efcff5a546#diff-61809be6a8fff101e3748a0c7dfad90bR16

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)