### PR TITLE
Add detection of Vista Web login panel instances

### DIFF
--- a/http/exposed-panels/vistaweb-panel.yaml
+++ b/http/exposed-panels/vistaweb-panel.yaml
@@ -1,0 +1,32 @@
+id: vistaweb-panel
+
+info:
+  name: Vista Web Login Panel
+  author: righettod
+  severity: info
+  description: |
+     Vista Web login panel was detected.
+  reference:
+    - https://resa.aero/solutions-operations-facturation/vista-web/
+  metadata:
+    verified: true
+  tags: panel,vistaweb,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/account/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "login") && contains(body, "/lib/@resa/identityserver/") && contains(body, "resa.aero")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'v=([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the software **Vista Web**.

- References: https://resa.aero/solutions-operations-facturation/vista-web/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/3127c237-6514-4ea8-b936-1b859d0bed22)

Host used for the test: https://vistaweb.lux-airport.lu/

### Additional Details (leave it blank if not applicable)

No shodan query found.

### Additional References

None