### PR TITLE
Add detection for API Gateway APIGEE

### DIFF
--- a/http/technologies/apigee-detect.yaml
+++ b/http/technologies/apigee-detect.yaml
@@ -1,0 +1,30 @@
+id: apigee-detect
+
+info:
+  name: Apigee Detect
+  author: righettod
+  severity: info
+  reference:
+    - https://docs.apigee.com/api-platform/troubleshoot/runtime/502-bad-gateway-response-405-without-allow-header
+  metadata:
+    max-request: 1
+  tags: tech,apigee
+
+http:
+  - method: TRACE
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "protocol.http.Response405WithoutAllowHeader"
+
+      - type: status
+        status:
+          - 502


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect the presence of the API gateway software named **Apigee**.

References: 
- https://docs.apigee.com/ 
- https://docs.apigee.com/api-platform/troubleshoot/runtime/502-bad-gateway-response-405-without-allow-header

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a135143f-51a4-433a-9204-e323f1aa9717)

Host used for the test: https://api-prod.unified-patent-court.org/upc/public/api

Sources used to find the test host:
- https://www.unified-patent-court.org/en/news/unified-patent-court-provides-update-regarding-case-management-system-api-opt-out-process
- https://www.unified-patent-court.org/sites/default/files/upc_documents/upc-cms-public-api-documentation_v1_4.pdf

### Additional Details (leave it blank if not applicable)

No Shodan query found

### Additional References:

None