### PR TITLE
Add detection of Apigee login panel instances

### DIFF
--- a/http/exposed-panels/apigee-panel.yaml
+++ b/http/exposed-panels/apigee-panel.yaml
@@ -9,8 +9,9 @@ info:
   reference:
     - https://cloud.google.com/apigee?hl=en
   metadata:
+    max-request: 1
     verified: true
-    shodan-query: http.favicon.hash:"1372638959","-839356603","-500010582"
+    shodan-query: http.favicon.hash:"-839356603"
   tags: panel,apigee,login
 
 http:
@@ -22,7 +23,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(body, "Apigee")'
+          - 'contains_any(body, "<title>Apigee", "content=\"Apigee")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/apigee-panel.yaml
+++ b/http/exposed-panels/apigee-panel.yaml
@@ -1,0 +1,33 @@
+id: apigee-panel
+
+info:
+  name: Apigee Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+     Apigee login panel was detected.
+  reference:
+    - https://cloud.google.com/apigee?hl=en
+  metadata:
+    verified: true
+    shodan-query: http.favicon.hash:"1372638959","-839356603","-500010582"
+  tags: panel,apigee,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Apigee")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Version:?\s+([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Apigee** API gateway.

- References: https://cloud.google.com/apigee?hl=en

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0cfaa74f-66d1-4f22-a772-d1cb6ec94d2f)

Host used for the test found via the shodan query from @DhiyaneshGeek :

```text
https://160.92.24.100
https://api-edge-portals-classic.poc.apps.yokogawa.com:9099
```

### Additional Details (leave it blank if not applicable)

Shodan query found by @DhiyaneshGeek :

https://www.shodan.io/search?query=http.favicon.hash%3A%221372638959%22%2C%22-839356603%22%2C%22-500010582%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/dcf634c9-400d-4075-9f6e-d0560e5ca4d7)


### Additional References

Based on exchange coming from the PR #9115 