### PR TITLE
Add detection of Dokuwiki login panel instances

### DIFF
--- a/http/exposed-panels/dokuwiki-panel.yaml
+++ b/http/exposed-panels/dokuwiki-panel.yaml
@@ -1,0 +1,27 @@
+id: dokuwiki-panel
+
+info:
+  name: Dokuwiki Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+     Dokuwiki login panel was detected.
+  reference:
+    - https://www.dokuwiki.org/dokuwiki
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"/dokuwiki/"
+  tags: panel,dokuwiki,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/doku.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "dokuwiki__header", "content=\"DokuWiki", "/dokuwiki/")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Dokuwiki**wiki.

- References: https://www.dokuwiki.org/dokuwiki

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b49d2fb7-b6a9-4237-a6b7-a3b7118a0088)

Host used for the test found via shodan :

```text
https://190.2.243.198/
https://techniker.post.lu/
https://104.129.129.53/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.html%3A%22%2Fdokuwiki%2F%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/90a16375-45ee-421c-b3e4-23bff6985c35)

### Additional References

None