### PR TITLE
Add detection of Haivision Gateway login panel instances

### DIFF
--- a/http/exposed-panels/haivision-gateway-panel.yaml
+++ b/http/exposed-panels/haivision-gateway-panel.yaml
@@ -1,0 +1,26 @@
+id: haivision-gateway-panel
+
+info:
+  name: Haivision Gateway Login Panel
+  author: righettod
+  severity: info
+  description: |
+     Haivision Gateway login panel was detected.
+  reference:
+    - https://www.haivision.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Haivision Gateway"
+  tags: panel,haivision,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Haivision Gateway", "content=\"Haivision Gateway")'
+        condition: and

--- a/http/exposed-panels/haivision-gateway-panel.yaml
+++ b/http/exposed-panels/haivision-gateway-panel.yaml
@@ -1,17 +1,16 @@
 id: haivision-gateway-panel
 
 info:
-  name: Haivision Gateway Login Panel
+  name: Haivision Gateway Login Panel - Detect
   author: righettod
   severity: info
-  description: |
-     Haivision Gateway login panel was detected.
+  description: Haivision Gateway login panel was detected.
   reference:
     - https://www.haivision.com/
   metadata:
     verified: true
     shodan-query: http.title:"Haivision Gateway"
-  tags: panel,haivision,login
+  tags: panel,haivision,login,detect
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Haivision Gateway** software.

- References: https://www.haivision.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d09bb0d2-ec28-4982-a21d-d8d82ff0a800)


Host used for the test found via shodan :

```text
https://182.169.79.195/
https://34.202.168.72/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Haivision+Gateway%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ca4bb388-ce65-409f-8647-4590657ee5c8)

### Additional References

None