### PR TITLE
entend seen-in-the-wild locations for sendmail

### DIFF
--- a/http/exposures/logs/roundcube-log-disclosure.yaml
+++ b/http/exposures/logs/roundcube-log-disclosure.yaml
@@ -19,15 +19,19 @@ http:
     payloads:
       roundcube_path:
         - roundcube/logs/sendmail
+        - roundcube/logs/sendmail.log
         - roundcube/logs/errors.log
         - roundcube/logs/errors
         - webmail/logs/sendmail
+        - webmail/logs/sendmail.log
         - webmail/logs/errors.log
         - webmail/logs/errors
         - mail/logs/sendmail
+        - mail/logs/sendmail.log
         - mail/logs/errors.log
         - mail/logs/errors
         - logs/sendmail
+        - logs/sendmail.log
         - logs/errors.log
         - logs/errors
     max-size: 1000


### PR DESCRIPTION
I have found several instances where the sendmail log had the the .log filename extension and nuclei did not found it because this widely used location is not present

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- extends widely used location for the sendmail log (with .log extension)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
