### PR TITLE
Fixed incorrect description in tilda-takeover.yaml

### DIFF
--- a/http/takeovers/tilda-takeover.yaml
+++ b/http/takeovers/tilda-takeover.yaml
@@ -4,7 +4,7 @@ info:
   name: tilda takeover detection
   author: pdteam
   severity: high
-  description: Bigcartel takeover was detected.
+  description: Tilda takeover was detected.
   reference:
     - https://github.com/EdOverflow/can-i-take-over-xyz/issues/155
   metadata:


### PR DESCRIPTION
Following commit added incorrect description for tilda-takeover.yaml: https://github.com/projectdiscovery/nuclei-templates/commit/ee9c12c9519c9a65b97b7e0716cc20d5dc027ca4