### PR TITLE
Add detection of Haivision Media Platform login panel instances

### DIFF
--- a/http/exposed-panels/haivision-media-platform-panel.yaml
+++ b/http/exposed-panels/haivision-media-platform-panel.yaml
@@ -1,0 +1,25 @@
+id: haivision-media-platform-panel
+
+info:
+  name: Haivision Media Platform Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Haivision Media Platform login panel was detected.
+  reference:
+    - https://www.haivision.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Haivision Media Platform"
+  tags: panel,haivision,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Haivision Media Platform", "content=\"Haivision Network Video")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Haivision Media Platform** software.

- References: https://www.haivision.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/4ef32d99-b252-4f90-b888-32abe07e81b7)


Host used for the test found via shodan :

```text
https://91.195.79.67/
https://139.104.232.35/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Haivision+Media+Platform%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/097434c2-1a32-4848-8c03-94599ee977e8)

### Additional References

None