### PR TITLE
Add detection of Gotify login panel instances

### DIFF
--- a/http/exposed-panels/gotify-panel.yaml
+++ b/http/exposed-panels/gotify-panel.yaml
@@ -1,0 +1,32 @@
+id: gotify-panel
+
+info:
+  name: Gotify Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Gotify login panel was detected.
+  reference:
+    - https://github.com/gotify/server
+  metadata:
+    verified: true
+    shodan-query: http.title:"Gotify"
+  tags: panel,gotify,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Gotify", "content=\"Gotify")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version":"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Gotify** software.

- References: https://github.com/gotify/server

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1e950f3c-2d3e-44f2-bfb9-0c2bdd4ec5f8)


Host used for the test found via shodan :

```text
https://alpern.hd.free.fr
http://138.201.131.20/
http://125.253.53.249:8888/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Gotify%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b96469b8-f8b5-471c-96fd-3c2e93b14b9c)

### Additional References

None