### PR TITLE
Add detection of LinShare login panel instances

### DIFF
--- a/http/exposed-panels/linshare-panel.yaml
+++ b/http/exposed-panels/linshare-panel.yaml
@@ -1,0 +1,30 @@
+id: linshare-panel
+
+info:
+  name: LinShare Login Panel - Detect
+  author: righettod
+  severity: info
+  description: LinShare login panel was detected.
+  reference:
+    - https://www.linshare.org/
+    - https://github.com/linagora/linshare
+  metadata:
+    verified: true
+    shodan-query: http.title:"LinShare"
+  tags: panel,linshare,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/login"
+      - "{{BaseURL}}/new/login"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>LinShare")'
+        condition: and

--- a/http/exposed-panels/linshare-panel.yaml
+++ b/http/exposed-panels/linshare-panel.yaml
@@ -21,10 +21,12 @@ http:
       - "{{BaseURL}}/new/login"
 
     stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(body, "<title>LinShare")'
+          - 'contains_any(body, "<title>LinShare", "x-ng-app=\"linshareAdminApp")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **LinShare** software.

- References: https://www.linshare.org/ and https://github.com/linagora/linshare

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/93ef6718-58ac-4550-aeeb-3c42347aa7a6)


Host used for the test found via shodan :

```text
https://143.196.250.2/
https://cofile-admin.europarl.europa.eu/new/login
https://demo.linshare.org/login
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22LinShare%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/58358361-80ee-4ff2-876a-b3316a32111c)

### Additional References

None