### PR TITLE
Add detection of Opinio login panel instances

### DIFF
--- a/http/exposed-panels/opinio-panel.yaml
+++ b/http/exposed-panels/opinio-panel.yaml
@@ -15,7 +15,10 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/admin/folder.do"
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl

--- a/http/exposed-panels/opinio-panel.yaml
+++ b/http/exposed-panels/opinio-panel.yaml
@@ -8,6 +8,7 @@ info:
   reference:
     - https://www.objectplanet.com/opinio/
   metadata:
+    max-request: 2
     verified: true
     shodan-query: http.title:"Opinio"
   tags: panel,opinio,login,detect
@@ -15,6 +16,7 @@ info:
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/admin/folder.do"
       - "{{BaseURL}}"
 
     host-redirects: true
@@ -23,13 +25,13 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_any(body, "<title>Opinio", ">Opinio ")'
+          - 'status_code_2 == 200'
+          - 'contains_any(body_2, "<title>Opinio", ">Opinio ")'
         condition: and
 
     extractors:
       - type: regex
-        part: body
+        part: body_1
         group: 1
         regex:
           - 'Opinio\s+([0-9.]+)'

--- a/http/exposed-panels/opinio-panel.yaml
+++ b/http/exposed-panels/opinio-panel.yaml
@@ -1,0 +1,32 @@
+id: opinio-panel
+
+info:
+  name: Opinio Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Opinio login panel was detected.
+  reference:
+    - https://www.objectplanet.com/opinio/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Opinio"
+  tags: panel,opinio,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin/folder.do"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Opinio", ">Opinio ")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Opinio\s+([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Opinio** software.

- References: https://www.objectplanet.com/opinio/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2d0ee112-9e5e-4dc3-acad-731fa293ebb5)

Host used for the test found via shodan :

```text
https://18.198.232.99
https://opinio.europarl.europa.eu
https://3.120.64.102
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Opinio%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0cafe848-490d-498f-b352-9943ab479aa3)

### Additional References

None