### PR TITLE
Add detection of Kopano WebApp login panel instances

### DIFF
--- a/http/exposed-panels/kopano-webapp-panel.yaml
+++ b/http/exposed-panels/kopano-webapp-panel.yaml
@@ -1,0 +1,35 @@
+id: kopano-webapp-panel
+
+info:
+  name: Kopano WebApp Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Kopano WebApp login panel was detected.
+  reference:
+    - https://kopano.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Kopano WebApp"
+  tags: panel,kopano,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/webapp/"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Kopano WebApp", "content=\"Kopano WebApp")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '\?kv([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Kopano WebApp** software.

- References: https://kopano.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1dbc3703-c17d-4193-9e0c-d152bac25eda)

Host used for the test found via shodan :

```text
https://93.240.31.66/
https://groupware.triag-int.ch/
https://83.64.17.222/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Kopano+WebApp%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c6a726d3-fe1e-4f5f-a8ea-be78ac3dc2cd)

### Additional References

None