### PR TITLE
Remove MD5 Hashes from the Favicon Detect template

### DIFF
--- a/http/technologies/favicon-detect.yaml
+++ b/http/technologies/favicon-detect.yaml
@@ -35,21 +35,6 @@ http:
           - "status_code==200 && (\"-503480258\" == mmh3(base64_py(body)))"
 
       - type: dsl
-        name: oracle
-        dsl:
-          - "len(body)==1150 && status_code==200 && (\"421e176ae0837bcc6b879ef55adbc897\" == md5(body))"
-
-      - type: dsl
-        name: hitachi
-        dsl:
-          - "len(body)==894 && status_code==200 && (\"41e9c43dc5e994ca7a40f4f92b50d01d\" == md5(body))"
-
-      - type: dsl
-        name: meinberg
-        dsl:
-          - "len(body)==1406 && status_code==200 && (\"4b2524b4f28eac7d0e872b0e1323c02d\" == md5(body))"
-
-      - type: dsl
         name: "slack-instance"
         dsl:
           - "status_code==200 && (\"99395752\" == mmh3(base64_py(body)))"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Removed 3 MD5 hashes from the Favicon Detect template to keep it consistent to mmh3 as mmh3 is more widely supported (such as being used in Shodan)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)