### PR TITLE
Add detection of Pexip instances

### DIFF
--- a/http/technologies/pexip-detect.yaml
+++ b/http/technologies/pexip-detect.yaml
@@ -1,0 +1,30 @@
+id: pexip-detect
+
+info:
+  name: Pexip - Detect
+  author: righettod
+  severity: info
+  description: |
+    Pexip technology was detected.
+  reference:
+    - https://www.pexip.com/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Pexip Connect for Web"
+  tags: tech,pexip,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, " <title>Pexip Connect for Web")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the software **Pexip**.

- References: https://www.pexip.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/7779625a-333f-453e-966c-bed2d248e6a6)

Hosts used for test and found via shodan:

```text
https://acc.vp.tech.ec.europa.eu/
https://80.88.179.26/
https://35.183.32.150/
```

### Additional Details (leave it blank if not applicable)

https://www.shodan.io/search?query=http.title%3A%22Pexip+Connect+for+Web%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/7fa26925-c1cd-435c-b40a-42190c9b7487)


### Additional References

None