### PR TITLE
Add detection of Rocket.Chat login panel instances

### DIFF
--- a/http/exposed-panels/rocketchat-panel.yaml
+++ b/http/exposed-panels/rocketchat-panel.yaml
@@ -19,7 +19,6 @@ http:
 
     host-redirects: true
     max-redirects: 2
-
     matchers:
       - type: dsl
         dsl:

--- a/http/exposed-panels/rocketchat-panel.yaml
+++ b/http/exposed-panels/rocketchat-panel.yaml
@@ -1,0 +1,28 @@
+id: rocketchat-panel
+
+info:
+  name: RocketChat Login Panel - Detect
+  author: righettod
+  severity: info
+  description: RocketChat login panel was detected.
+  reference:
+    - https://www.rocket.chat/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Rocket.Chat"
+  tags: panel,rocketchat,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>Rocket.Chat", "content=\"Rocket.Chat")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Rocket.Chat** software.

- References: https://www.rocket.chat/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/77a452d6-6928-4914-b38e-5701d42aff92)


Host used for the test found via shodan :

```text
https://99.81.234.245/
https://chat.webconference.fpfis.tech.ec.europa.eu/
http://5.78.89.232:9000/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Rocket.Chat%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/92edb635-a129-4ede-ba1f-674279333b01)


### Additional References

None