### PR TITLE
fix(keycloak-cve-2020-27838): Fixing typo in tag

### DIFF
--- a/http/cves/2020/CVE-2020-27838.yaml
+++ b/http/cves/2020/CVE-2020-27838.yaml
@@ -28,7 +28,7 @@ info:
     vendor: redhat
     product: keycloak
     shodan-query: "title:\"keycloak\""
-  tags: cve,cve2020,keyclock,exposure
+  tags: cve,cve2020,keycloak,exposure
 
 http:
   - method: GET


### PR DESCRIPTION
Tag is spelled keyclock and it should be keycloak.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixes a typo in the keycloak tag.