### PR TITLE
Add a criteria for detection of Keycloak instances

### DIFF
--- a/http/exposed-panels/keycloak-admin-panel.yaml
+++ b/http/exposed-panels/keycloak-admin-panel.yaml
@@ -37,9 +37,9 @@ http:
           - "alt=\"Keycloak"
           - "kc-form-buttons"
           - "/keycloak/img/favicon.ico"
+          - "/admin/keycloak/"
         condition: or
 
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100ce99a9168d9735401c84081a0b8c389cebe54d781b5616f4d42390b7b920373a02206394e01504f7c25820d9154260d135c341af22fd6e392b37412ecbd99b9403bd:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add a detection criteria to the existing template. Indeed, the original template was missing the instance on the following hosts:

- https://iam-dev.ocpcloud.netservice.eu 
- https://astrea-sso.ocpcloud.netservice.eu

See the template validation below for an example.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/8a498b3d-cb24-458d-9a0a-8e9b68237980)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/110df2cb-28d9-43b6-86a2-87d9f7bbdd6e)


#### Additional Details (leave it blank if not applicable)

None

### Additional References:

None