### PR TITLE
Add a criteria for detection of Odoo instances

### DIFF
--- a/http/exposed-panels/odoo-panel.yaml
+++ b/http/exposed-panels/odoo-panel.yaml
@@ -31,7 +31,7 @@ http:
           - 'odoo.session_info'
           - 'web.layout.odooscript'
         condition: or
-        
+
       - type: word
         part: body
         words:

--- a/http/exposed-panels/odoo-panel.yaml
+++ b/http/exposed-panels/odoo-panel.yaml
@@ -2,7 +2,7 @@ id: odoo-panel
 
 info:
   name: Odoo - Panel Detect
-  author: DhiyaneshDK
+  author: DhiyaneshDK,righettod
   severity: info
   metadata:
     vendor: odoo
@@ -16,6 +16,11 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/web/login"
+      - "{{BaseURL}}"
+
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
 
     matchers-condition: and
     matchers:
@@ -23,8 +28,14 @@ http:
         part: body
         words:
           - '<title>Odoo</title>'
+          - 'odoo.session_info'
+          - 'web.layout.odooscript'
+        condition: or
+        
+      - type: word
+        part: body
+        words:
           - 'Log in'
-        condition: and
 
       - type: word
         part: header
@@ -34,4 +45,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100a4ee6283d4c0264ea8d9ac9e56e2c948d50afbb650ac84735d4978ada4bfcdf802207a1bf2401f730d11a14cc03bea4d3e2ac98aae9ad05856f7a41359be3b31eda1:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add a detection criteria to the existing template. Indeed, the original template was missing the instance https://portal.netservice.eu/

See the template validation below for an example. I tried to keep the original criteria to not break the template

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a3dfc846-e750-4f9c-917c-e01ca808eaf6)



### Additional Details (leave it blank if not applicable)

None

### Additional References:

None