### PR TITLE
Added Integrated Management Module Default Credentials Template

### DIFF
--- a/http/default-logins/imm-default-login.yaml
+++ b/http/default-logins/imm-default-login.yaml
@@ -1,0 +1,35 @@
+id: imm-default-login
+
+info:
+  name: Integrated Management Module - Default Login
+  author: jpg0mez
+  severity: low
+  description: |
+    Integrated Management Module default login credentials were discovered.
+  reference:
+    - https://pubs.lenovo.com/x3650-m4/t_logging_web_interface
+    - https://www.ibm.com/docs/en/tcs-service?topic=oip-logging-imm-web-interface
+  classification:
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 2
+  tags: imm,ibm,lenovo,default-login
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/data/login"
+    cookie-reuse: true
+    body: "user=USERID&password=PASSW0RD"
+    redirects: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<authResult>0</authResult>"
+          - 'authResult":"0'
+        condition: or
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

- Added Integrated Management Module Default Credentials Template

- References:
    - https://pubs.lenovo.com/x3650-m4/t_logging_web_interface
    - https://www.ibm.com/docs/en/tcs-service?topic=oip-logging-imm-web-interface

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)