### PR TITLE
Add detection of website specifying the Max-Forwards response headers.

### DIFF
--- a/http/miscellaneous/detect-maxforwards-headers.yaml
+++ b/http/miscellaneous/detect-maxforwards-headers.yaml
@@ -1,0 +1,33 @@
+id: detect-maxforwards-headers
+
+info:
+  name: Max-Forwards header - Detection
+  author: righettod
+  severity: info
+  description: Max-Forwards response header is specified.
+  reference:
+    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Max-Forwards
+    - https://http.dev/max-forwards
+    - https://twitter.com/irsdl/status/1337299267652825088
+  metadata:
+    verified: 'true'
+    max-request: 1
+    shodan-query: "Max-Forwards:"
+    fofa-query: header="max-forwards"
+  tags: miscellaneous,misc
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(to_lower(header), "max-forwards:")'
+
+    extractors:
+      - type: regex
+        part: header
+        regex:
+          - '(?i)max-forwards:\s+([0-9]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect website returning the `Max-Forwards` response headers.

References used:
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Max-Forwards
    - https://http.dev/max-forwards
    - https://twitter.com/irsdl/status/1337299267652825088
    - https://github.com/righettod/toolbox-pentest-web/blob/master/scripts/identify-maxforwards-header-abuse.py

💡 When this header is returned by a site then it can be used, in a requests, to identify the number of hosts between the caller hosts and the destination hosts.

🤔 As it is the first time that I create such type of template, I started from one in the folder `http/miscellaneous`. So, feel free to indicates to me any changes needed.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against https://187.72.61.204:7443/ identified via Fofa:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/6d77dc54-f6ae-47e1-84da-943b5e229123)

### Additional Details (leave it blank if not applicable)

Fofa query: https://en.fofa.info/result?qbase64=aGVhZGVyPSJtYXgtZm9yd2FyZHMi

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1b9b4739-27db-412b-9607-e59d346270ed)

Shodan query: https://www.shodan.io/search?query=%22Max-Forwards%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/15c1cc57-b5cc-4049-8a4c-5b2c4fed4806)

### Additional References:

None