### PR TITLE
Add detection of Progress Web Transfer Client login panel instances

### DIFF
--- a/http/exposed-panels/webtransfer-client-panel.yaml
+++ b/http/exposed-panels/webtransfer-client-panel.yaml
@@ -1,4 +1,4 @@
-id: webtransferclient-panel
+id: webtransfer-client-panel
 
 info:
   name: Web Transfer Client Login Panel - Detect
@@ -8,6 +8,7 @@ info:
   reference:
     - https://www.progress.com/ftp-server/web-transfer
   metadata:
+    max-request: 1
     verified: true
     shodan-query: http.title:"Web Transfer Client"
   tags: panel,webtransferclient,login,detect

--- a/http/exposed-panels/webtransferclient-panel.yaml
+++ b/http/exposed-panels/webtransferclient-panel.yaml
@@ -1,0 +1,25 @@
+id: webtransferclient-panel
+
+info:
+  name: Web Transfer Client Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Progress Web Transfer Client login panel was detected.
+  reference:
+    - https://www.progress.com/ftp-server/web-transfer
+  metadata:
+    verified: true
+    shodan-query: http.title:"Web Transfer Client"
+  tags: panel,webtransferclient,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ThinClient/WTM/public/index.html"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>Web Transfer Client")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Web Transfer Client** software from **Progress**.

- References: https://www.progress.com/ftp-server/web-transfer

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/fbdbaf66-39c9-49f0-b56e-05fb1641f4ab)

Hosts used for the test found via shodan :

```text
https://sftp.ecdc.europa.eu/
https://xfer.vudu.com/
https://213.121.201.84/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Web+Transfer+Client%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/482d71e7-daf0-485f-b3bd-5de00a18ff4c)

### Additional References

None