### PR TITLE
Add detection of Redmine login panel instances

### DIFF
--- a/http/exposed-panels/redmine-panel.yaml
+++ b/http/exposed-panels/redmine-panel.yaml
@@ -1,0 +1,25 @@
+id: redmine-panel
+
+info:
+  name: Redmine Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Redmine login panel was detected.
+  reference:
+    - https://www.redmine.org/
+  metadata:
+    verified: true
+    shodan-query: http.html:'content="Redmine'
+  tags: panel,redmine,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "content=\"Redmine")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Redmine** software.

- References: https://www.redmine.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/31628ed7-76d2-45d2-b88a-2f6d8a6e408c)


Hosts used for the test found via shodan :

```text
https://helpdesk.flosslab.com/
http://92.222.98.171/
https://168.90.175.228/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.html%3A%27content%3D%22Redmine%27

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a727a85c-6a67-4449-a369-60fa04c0e8d6)


### Additional References

None