### PR TITLE
Update headless-open-redirect.yaml

### DIFF
--- a/headless/headless-open-redirect.yaml
+++ b/headless/headless-open-redirect.yaml
@@ -21,9 +21,6 @@ headless:
       - action: waitload
     payloads:
       redirect:
-        - '%0a/oast.live/'
-        - '%0d/oast.live/'
-        - '%00/oast.live/'
         - '%09/oast.live/'
         - '%5C%5Coast.live/%252e%252e%252f'
         - '%5Coast.live'
@@ -112,6 +109,10 @@ headless:
         - 'cgi-bin/redirect.cgi?oast.live'
         - 'out?oast.live'
         - 'login?to=http://oast.live'
+        - '#/oast.live'
+        - '%0a/oast.live/'
+        - '%0d/oast.live/'
+        - '%00/oast.live/'
     stop-at-first-match: true
     matchers:
       - type: word


### PR DESCRIPTION
### Template / PR Information

While testing this template on this lab: [https://github.com/yeswehack/vulnerable-code-snippets/tree/main/OpenRedirect/open-redirect-url-fragment](https://github.com/yeswehack/vulnerable-code-snippets/tree/main/OpenRedirect/open-redirect-url-fragment), I found that this template did not detect an open redirect. Thus, I added a new payload: `#/oast.live`. There was also another issue. When running this template, it failed to work because it could not fetch HTML, so I moved breaking payloads to the end of the template:

```
PS C:\Users\User\Desktop> nuclei -target http://127.0.0.1:1337/ -t .\headless-open-redirect.yaml -headless -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

                projectdiscovery.io

[WRN] Found 18 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.1.10 (latest)
[INF] Current nuclei-templates version: v9.7.6 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 49
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [headless-open-redirect] Dumped Headless request for http://127.0.0.1:1337/
/oast.live/
[DBG]   navigate => http://127.0.0.1:1337/
/oast.live/
        waitload
[DBG] [headless-open-redirect] Dumped Headless response for http://127.0.0.1:1337/

<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.57 (Debian) Server at 127.0.0.1 Port 1337</address>

</body></html>
/oast.live/less-open-redirect] Dumped Headless request for http://127.0.0.1:1337/
/oast.live/igate => http://127.0.0.1:1337/
        waitload
[DBG] [headless-open-redirect] Dumped Headless response for http://127.0.0.1:1337/

<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.57 (Debian) Server at 127.0.0.1 Port 1337</address>

</body></html>
[WRN] [headless-open-redirect] Could not execute request for http://127.0.0.1:1337/: could get html element: error occurred executing action: [:RUNTIME] could not navigate to url http://127.0.0.1:1337//oast.live/ <- {-32000 Cannot navigate to invalid URL }
[INF] No results found. Better luck next time!
```

Now it works:
```
PS C:\Users\User\Desktop> nuclei -target http://127.0.0.1:1337/ -t .\headless-open-redirect.yaml -headless

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

                projectdiscovery.io

[WRN] Found 18 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.1.10 (latest)
[INF] Current nuclei-templates version: v9.7.6 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 49
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[headless-open-redirect] [headless] [medium] http://127.0.0.1:1337/#/oast.live
```

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)