### PR TITLE
Fix templates using uppercase WWW-Authenticate matchers instad of Www-Authenticate

### DIFF
--- a/http/technologies/bigip-config-utility-detect.yaml
+++ b/http/technologies/bigip-config-utility-detect.yaml
@@ -29,7 +29,7 @@ http:
     matchers:
       - type: word
         words:
-          - "WWW-Authenticate: Basic realm"
+          - "Www-Authenticate: Basic realm"
           - "Enterprise Manager"
         condition: and
         part: header

--- a/http/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/http/technologies/fingerprinthub-web-fingerprints.yaml
@@ -845,7 +845,7 @@ http:
         part: header
         name: apache-dubbo
         words:
-          - 'WWW-Authenticate: Basic realm="dubbo"'
+          - 'Www-Authenticate: Basic realm="dubbo"'
         case-insensitive: true
 
       - type: word


### PR DESCRIPTION
### Template / PR Information

Header matcher on Www-Authenticate header is case sensitive.
It seems that nuclei normalize WWW-Authenticate to Www-Authenticate.

- References:
see https://github.com/projectdiscovery/nuclei/pull/294 .

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


Fixes [9288](https://github.com/projectdiscovery/nuclei-templates/issues/9288)