### PR TITLE
Fixed wildcard TLS reference

### DIFF
--- a/ssl/wildcard-tls.yaml
+++ b/ssl/wildcard-tls.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Checks a sites certificate to see if there are wildcard CN or SAN entries.
   reference:
-    - https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html#carefully-consider-the-use-of-wildcard-certificates
+    - https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html#carefully-consider-the-use-of-wildcard-certificates
   metadata:
     max-request: 1
   tags: ssl,tls,wildcard


### PR DESCRIPTION
### Template / PR Information

The given reference is deprecated by OWASP:

> The Transport Layer Protection Cheat Sheet has been deprecated.
Please visit the [Transport Layer Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html) instead.

This is my first contribution to the project, and just opening a PR is okay?

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)