### PR TITLE
Add detection of Graylog login panel instances.

### DIFF
--- a/http/exposed-panels/graylog-panel.yaml
+++ b/http/exposed-panels/graylog-panel.yaml
@@ -1,0 +1,26 @@
+id: graylog-panel
+
+info:
+  name: Graylog Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Graylog login panel was detected.
+  reference:
+    - https://graylog.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Graylog Web Interface"
+  tags: panel,graylog,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>Graylog Web Interface")'
+        condition: and

--- a/http/exposed-panels/graylog-panel.yaml
+++ b/http/exposed-panels/graylog-panel.yaml
@@ -4,7 +4,8 @@ info:
   name: Graylog Login Panel - Detect
   author: righettod
   severity: info
-  description: Graylog login panel was detected.
+  description: |
+    Graylog login panel was detected.
   reference:
     - https://graylog.org/
   metadata:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Gaylog** software.

- References: https://graylog.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0ed694d9-f309-400a-84d9-ba7247524ba6)

Hosts used for the test found via shodan :

```text
https://98.159.223.36/
https://167.235.246.216/
https://gra1.logs.ovh.com/
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22Graylog+Web+Interface%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0da2905b-9cb5-4672-ac70-ceab3cf39812)

### Additional References

None