### PR TITLE
Add detection of Moodle Workplace login panel instances.

### DIFF
--- a/http/exposed-panels/moodle-workplace-panel.yaml
+++ b/http/exposed-panels/moodle-workplace-panel.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-    shodan-query: http.html:"moodle,"
+    shodan-query: http.html:"moodle"
   tags: panel,moodle,login,detect
 
 http:

--- a/http/exposed-panels/moodle-workplace-panel.yaml
+++ b/http/exposed-panels/moodle-workplace-panel.yaml
@@ -1,0 +1,27 @@
+id: moodle-workplace-panel
+
+info:
+  name: Moodle Workplace Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Moodle workplace login panel was detected.
+  reference:
+    - https://moodle.com/solutions/workplace/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"moodle,"
+  tags: panel,moodle,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login/index.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "content=\"moodle", "\"name\":\"moodle\"") && contains(body, "workplace")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Moodle Workplace** software.

- References: https://moodle.com/solutions/workplace/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2bd30c69-fd17-4b76-87a2-045e44ba9e76)

Hosts used for the test found via shodan :

```text
https://tmcella.themedicalcity.com
https://www.formaphp.fr
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.html%3A%22moodle%2C%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c309aa15-50b2-4b24-b5ce-b992896aede4)

### Additional References

None