### PR TITLE
Add detection of PAHTool login panel instances.

### DIFF
--- a/http/exposed-panels/pahtool-panel.yaml
+++ b/http/exposed-panels/pahtool-panel.yaml
@@ -1,0 +1,34 @@
+id: pahtool-panel
+
+info:
+  name: PAHTool Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    PAHTool login panel was detected.
+  reference:
+    - http://www.inovultus.com/index.html
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"PAHTool"
+  tags: panel,pahtool,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, ">PAHTool")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'id="appVersion"\s+value="([0-9\.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **PAHTool** software.

- References: http://www.inovultus.com/index.html (no english version available)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/add35b40-53f8-4ea2-b488-0a7fce3ffec4)

Hosts used for the test found via shodan :

```text
https://registre-htap.aphp.fr
http://155.207.200.132
```

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22PAHTool%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/473f6b7a-ad90-471d-a5a2-2bc7209fbd4d)

### Additional References

None