### PR TITLE
Add detection of CleanWeb login panel instances. 

### DIFF
--- a/http/exposed-panels/cleanweb-panel.yaml
+++ b/http/exposed-panels/cleanweb-panel.yaml
@@ -1,0 +1,36 @@
+id: cleanweb-panel
+
+info:
+  name: CleanWeb Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    CleanWeb login panel was detected.
+  reference:
+    - https://tentelemed.com/
+  metadata:
+    verified: true
+    shodan-query: http.title:"CleanWeb"
+  tags: panel,cleanweb,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+    max-redirects: 4
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>cleanweb","logo cleanweb", "-cleanweb-")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'title="version\s+([0-9A-Za-z\s\.\-]+)"'

--- a/http/exposed-panels/cleanweb-panel.yaml
+++ b/http/exposed-panels/cleanweb-panel.yaml
@@ -9,6 +9,7 @@ info:
   reference:
     - https://tentelemed.com/
   metadata:
+    max-request: 1
     verified: true
     shodan-query: http.title:"CleanWeb"
   tags: panel,cleanweb,login,detect


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **CleanWeb** medical software.

- References: https://tentelemed.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0652d1a0-7e50-4c1b-bb76-fa0ce676688e)

Hosts used for the test found via shodan :

```text
https://cleanweb-production1.aphp.fr
https://cleanweb-production2.aphp.fr
https://cleanweb-production3.aphp.fr
https://cleanweb-production4.aphp.fr
https://cleanweb-production5.aphp.fr
https://141.94.5.121
https://164.132.86.195/
```

📍 The number of redirects is wanted because the software made a lot of them from the root context path and the final context path is proper to the instance.

### Additional Details (leave it blank if not applicable)

Shodan query:

https://www.shodan.io/search?query=http.title%3A%22CleanWeb%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ebf8b170-5c49-48fc-bb34-c89ae67385fd)


### Additional References

None