### PR TITLE
Add detection of LockSelf login panel instances.

### DIFF
--- a/http/exposed-panels/lockself-panel.yaml
+++ b/http/exposed-panels/lockself-panel.yaml
@@ -1,0 +1,27 @@
+id: lockself-panel
+
+info:
+  name: LockSelf Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    LockSelf login panel was detected.
+  reference:
+    - https://www.lockself.com/en/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"LockSelf"
+  tags: panel,lockself,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/application/index.html"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "<title>LockSelf","content=\"LockSelf", "name=\"LockSelf")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **LockSelf** software.

- References: https://www.lockself.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/82d75209-e850-4aed-bf06-f99d0a3975ee)

Hosts used for the test found via shodan:

```
https://m0lcdiees8fjod5l2kzj.aphp.fr
https://171.33.70.4
https://80.247.13.208
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22LockSelf%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/29803402-8e7f-4d7d-8016-9d9231b32912)

### Additional References

None