### PR TITLE
Add detection of Atlassian Bamboo login panel instances.

### DIFF
--- a/http/exposed-panels/atlassian-bamboo-panel.yaml
+++ b/http/exposed-panels/atlassian-bamboo-panel.yaml
@@ -19,12 +19,20 @@ http:
     path:
       - "{{BaseURL}}/userlogin!doDefault.action?os_destination=%2Fstart.action"
 
+    matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>log in as a bamboo user", "com.atlassian.bamboo")'
-        condition: and
+      - type: word
+        part: body
+        words:
+          - '<title>Log in as a Bamboo user'
+          - 'content="Bamboo'
+          - 'atlassian.bamboo.plugins'
+          - 'Atlassian Bamboo</a>'
+        condition: or
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex
@@ -32,3 +40,4 @@ http:
         group: 1
         regex:
           - 'version\s+([0-9A-Za-z\s\.]+)\s+-'
+          - 'pvpVersion = "([a-z0-9.]+)";'

--- a/http/exposed-panels/atlassian-bamboo-panel.yaml
+++ b/http/exposed-panels/atlassian-bamboo-panel.yaml
@@ -1,0 +1,34 @@
+id: atlassian-bamboo-panel
+
+info:
+  name: Atlassian Bamboo Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Atlassian Bamboo login panel was detected.
+  reference:
+    - https://www.atlassian.com/software/bamboo
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Bamboo"
+  tags: panel,bamboo,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/userlogin!doDefault.action?os_destination=%2Fstart.action"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>log in as a bamboo user", "com.atlassian.bamboo")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'version\s+([0-9A-Za-z\s\.]+)\s+-'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Atlassian Bamboo** software.

- References: https://www.atlassian.com/software/bamboo

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/83f55167-9088-4e17-8af9-3c4edd5f34e6)


Hosts used for the test found via shodan:

```
https://88.99.96.8
https://174.138.65.163
https://52.16.6.207
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Bamboo%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1ee521c1-6b98-4ded-a927-0ef6f97a622f)


### Additional References

None