### PR TITLE
Add detection of Sonatype Nexus login panel instances.

### DIFF
--- a/http/exposed-panels/nexus-panel.yaml
+++ b/http/exposed-panels/nexus-panel.yaml
@@ -12,7 +12,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.title:"Sonatype Nexus Repository"
-  tags: panel,nexis,login,detect
+  tags: panel,nexus,login,detect
 
 http:
   - method: GET

--- a/http/exposed-panels/nexus-panel.yaml
+++ b/http/exposed-panels/nexus-panel.yaml
@@ -1,0 +1,34 @@
+id: nexus-panel
+
+info:
+  name: Nexus Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Nexus login panel was detected.
+  reference:
+    - https://www.sonatype.com/products/sonatype-nexus-repository
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Sonatype Nexus Repository"
+  tags: panel,nexis,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>sonatype nexus repository", "content=\"sonatype nexus repository", "nexus-coreui-bundle")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '_v=([0-9\.\-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Sonatype Nexus** software.

- References: https://www.sonatype.com/products/sonatype-nexus-repository

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/506e4efb-41f8-4227-926f-c83f1b1445be)

Hosts used for the test found via shodan:

```
https://nexus.goodyear.eu
https://78.41.241.41
https://91.121.25.138
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Sonatype+Nexus+Repository%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a0cfb074-70df-41db-be6f-fa85475d51f8)

### Additional References

None