### PR TITLE
Add detection of AdmiralCloud instances.

### DIFF
--- a/http/technologies/admiralcloud-detect.yaml
+++ b/http/technologies/admiralcloud-detect.yaml
@@ -1,0 +1,34 @@
+id: admiralcloud-detect
+
+info:
+  name: HCP Anywhere - Detect
+  author: righettod
+  severity: info
+  description: |
+    AdmiralCloud was detected.
+  reference:
+    - https://www.admiralcloud.com/en/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"AdmiralCloud"
+  tags: tech,admiralcloud
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "content=\"admiralcloud", "<title>admiralcloud")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '\s+([0-9\.]+)</title>'

--- a/http/technologies/admiralcloud-detect.yaml
+++ b/http/technologies/admiralcloud-detect.yaml
@@ -1,7 +1,7 @@
 id: admiralcloud-detect
 
 info:
-  name: HCP Anywhere - Detect
+  name: AdmiralCloud - Detect
   author: righettod
   severity: info
   description: |

--- a/http/technologies/admiralcloud-detect.yaml
+++ b/http/technologies/admiralcloud-detect.yaml
@@ -12,13 +12,15 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.title:"AdmiralCloud"
-  tags: tech,admiralcloud
+  tags: tech,admiralcloud,detect
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
 
+    redirects: true
+    max-redirects: 2
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **AdmiralCloud** software.

- References: https://www.admiralcloud.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/dd5c6f0d-f3b0-4629-b347-c1f09206ae11)

Hosts used for the test found via shodan:

```
https://dropsite.continental.com
https://video.continental.com
https://3.68.214.8
https://sendy.admiralcloud.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22AdmiralCloud%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a66edf88-ca4b-4ceb-9f18-89bc2c0723d5)

### Additional References

None