### PR TITLE
Lowering threading on memory intensive bruteforce templates

### DIFF
--- a/http/cves/2019/CVE-2019-17382.yaml
+++ b/http/cves/2019/CVE-2019-17382.yaml
@@ -38,7 +38,6 @@ http:
     payloads:
       ids: helpers/wordlists/numbers.txt
     stop-at-first-match: true
-    threads: 50
 
     matchers-condition: and
     matchers:

--- a/http/cves/2023/CVE-2023-24489.yaml
+++ b/http/cves/2023/CVE-2023-24489.yaml
@@ -48,7 +48,6 @@ http:
 
     payloads:
       padding: helpers/payloads/citrix_paddings.txt
-    threads: 30
     stop-at-first-match: true
     matchers:
       - type: dsl

--- a/http/fuzzing/wordpress-weak-credentials.yaml
+++ b/http/fuzzing/wordpress-weak-credentials.yaml
@@ -30,7 +30,6 @@ http:
     payloads:
       users: helpers/wordlists/wp-users.txt
       passwords: helpers/wordlists/wp-passwords.txt
-    threads: 50
     attack: clusterbomb
     stop-at-first-match: true
 


### PR DESCRIPTION
### Template / PR Information
This PR removes high threading from potentially memory intensive templates, allowing the engine to use the default setting of `25` or user specified amount. In the future this will allow adaptive speed (ref: https://github.com/projectdiscovery/nuclei/issues/3072)

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:
- OOM killing nuclei https://github.com/projectdiscovery/nuclei/issues/4756