### PR TITLE
Add detection of EMQX login panel instances.

### DIFF
--- a/http/exposed-panels/emqx-panel.yaml
+++ b/http/exposed-panels/emqx-panel.yaml
@@ -1,0 +1,34 @@
+id: emqx-panel
+
+info:
+  name: EMQX Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    EMQX login panel was detected.
+  reference:
+    - https://www.emqx.io/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"EMQX Dashboard"
+  tags: panel,emqx,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>emqx dashboard", "emqx-dashboard")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'but\s+(emqx\-dashboard[0-9a-z\-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **EMQX** software.

- References: https://www.emqx.io/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f96d83df-697a-4a05-8ae1-872139535627)

Hosts used for the test found via shodan:

```
https://dev-mqtt-iot.proximus.be
https://101.34.159.13
http://35.157.54.100
http://18.142.205.23
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22EMQX+Dashboard%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/9669a887-5e56-400e-8fe3-46814b65ddf3)

### Additional References

None