### PR TITLE
osnexus-quantastor-manager-panel

### DIFF
--- a/http/exposed-panels/osnexus-login-panel.yaml
+++ b/http/exposed-panels/osnexus-login-panel.yaml
@@ -27,4 +27,4 @@ http:
 
       - type: status
         status:
-          - 200  
+          - 200

--- a/http/exposed-panels/osnexus-login-panel.yaml
+++ b/http/exposed-panels/osnexus-login-panel.yaml
@@ -1,0 +1,30 @@
+id: osnexus-quantastor-manager-panel
+
+info:
+  name: OSNEXUS QuantaStor Manager Login Panel - Detect
+  author: Charles D.
+  severity: info
+  description: OSNEXUS QuantaStor Manager login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"OSNEXUS QuantaStor Manager"
+  tags: panel,osnexus,login
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>OSNEXUS QuantaStor Manager</title>'
+
+      - type: status
+        status:
+          - 200  

--- a/http/exposed-panels/osnexus-panel.yaml
+++ b/http/exposed-panels/osnexus-panel.yaml
@@ -1,10 +1,11 @@
-id: osnexus-quantastor-manager-panel
+id: osnexus-panel
 
 info:
-  name: OSNEXUS QuantaStor Manager Login Panel - Detect
+  name: OSNEXUS QuantaStor Manager Panel - Detect
   author: Charles D.
   severity: info
-  description: OSNEXUS QuantaStor Manager login panel was detected.
+  description: |
+    OSNEXUS QuantaStor Manager login panel was detected.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cvss-score: 0


### PR DESCRIPTION
Doing a pull request to add a new nuclei template for the OSNexus QuantaStor Manager Panel, as I noticed there wasn't an existing template for it. After encountering the panel, I decided it would be beneficial to include it in the repository. This template is designed to identify the login page for the service.

Regarding the Shodan query, I conducted tests using both http.title and http.favicon.hash. Interestingly, both methods provide identical results.