### PR TITLE
CVE-2024-1328

### DIFF
--- a/http/cves/2024/CVE-2024-1328.yaml
+++ b/http/cves/2024/CVE-2024-1328.yaml
@@ -1,0 +1,37 @@
+id: CVE-2024-1328
+
+info:
+  name: Newsletter2Go Plugin Detection for CVE-2024-1328
+  author: halilk
+  severity: medium
+  description: The Newsletter2Go plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the ‘style’ parameter in all versions up to, and including, 4.0.13 due to insufficient input sanitization and output escaping.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-1328
+    - https://plugins.trac.wordpress.org/browser/newsletter2go/tags/4.0.13/gui/N2Go_Gui.php#L296
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/766ac399-7280-4186-8972-94da813da85e?source=cve
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 6.4
+    cve-id: CVE-2024-1328
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/newsletter2go/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "gui"
+          - "api"
+          - "lang"
+          - "widget"
+          - "newsletter2go.php"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+          


### PR DESCRIPTION
The Newsletter2Go plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the ‘style’ parameter in all versions up to, and including, 4.0.13 due to insufficient input sanitization and output escaping. This makes it possible for authenticated attackers, with subscriber access and above, to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page.

The template checks whether the vulnerable plugin is installed. Version 4.0.13 and earlier is vulnerable to exploitation without an update.

**The template will be updated when the relevant plugin is updated.**




I've validated this template locally?
- [x] YES
- [ ] NO


