### PR TITLE
Add detection of Neocase HR Portal login panel instances.

### DIFF
--- a/http/exposed-panels/neocase-hrportal-panel.yaml
+++ b/http/exposed-panels/neocase-hrportal-panel.yaml
@@ -1,0 +1,34 @@
+id: neocase-hrportal-panel
+
+info:
+  name: Neocase HR Portal Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Neocase HR Portal login panel was detected.
+  reference:
+    - https://www.neocasesoftware.com/neocase-hr-solution/
+    - https://www.neocasesoftware.com/self-service-portal-module/
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,neocase,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "neocase") && contains(to_lower(body), "hr portal") && contains(to_lower(body), "login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'name="version"\s+content="([0-9\.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Neocase HR Portal** software.

References:
- https://www.neocasesoftware.com/neocase-hr-solution/
- https://www.neocasesoftware.com/self-service-portal-module/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ed62610f-6653-445f-bad7-f35acace4e18)

Host used for the test, found via https://crt.sh , on **proximus.be** domain (Belgian ICT provider): 
- https://hrm.proximus.be


### Additional Details (leave it blank if not applicable)

No valid shodan query found.

### Additional References

None