### PR TITLE
Add detection of Skeepers login panel instances.

### DIFF
--- a/http/exposed-panels/skeepers-panel.yaml
+++ b/http/exposed-panels/skeepers-panel.yaml
@@ -28,7 +28,7 @@ http:
           - 'status_code == 200'
           - 'contains(to_lower(body), "skeepers") && contains(to_lower(body), "login")'
         condition: and
-        
+
     extractors:
       - type: regex
         part: body

--- a/http/exposed-panels/skeepers-panel.yaml
+++ b/http/exposed-panels/skeepers-panel.yaml
@@ -10,7 +10,7 @@ info:
     - https://skeepers.io
   metadata:
     max-request: 1
-    shodan-query: http.title:"Skeepers cx | Room"
+    shodan-query: http.title:"Skeepers"
     verified: true
   tags: panel,skeepers,login,detect
 
@@ -18,6 +18,9 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/backend/login"
+      - "{{BaseURL}}"
+
+    stop-at-first-match: true
 
     matchers:
       - type: dsl
@@ -25,3 +28,10 @@ http:
           - 'status_code == 200'
           - 'contains(to_lower(body), "skeepers") && contains(to_lower(body), "login")'
         condition: and
+        
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Version\s+([0-9\.]+)\s+-'

--- a/http/exposed-panels/skeepers-panel.yaml
+++ b/http/exposed-panels/skeepers-panel.yaml
@@ -1,0 +1,27 @@
+id: skeepers-panel
+
+info:
+  name: Skeepers Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Skeepers login panel was detected.
+  reference:
+    - https://skeepers.io
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Skeepers cx | Room"
+    verified: true
+  tags: panel,skeepers,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/backend/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "skeepers") && contains(to_lower(body), "login")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Skeepers** software.

- References: https://skeepers.io

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ba025a6f-0cfa-4264-b0ef-cd3d670ccb96)

Hosts used for the test found via shodan:

```
https://52.210.110.224
https://preprod.cem.mediatech-cx.com
https://149.202.166.5
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Skeepers%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/bbc3e16e-fec5-473a-8cf4-9df22fb0a3f4)

### Additional References

None