### PR TITLE
CVE-2024-1328

### DIFF
--- a/http/cves/2024/CVE-2024-1328.yaml
+++ b/http/cves/2024/CVE-2024-1328.yaml
@@ -1,0 +1,35 @@
+id: CVE-2024-1328
+
+info:
+  name: Newsletter2Go Plugin Version Detection for CVE-2024-1328
+  author: halilk
+  severity: medium
+  description: The Newsletter2Go plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the ‘style’ parameter in all versions up to, and including, 4.0.13 due to insufficient input sanitization and output escaping.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-1328
+    - https://plugins.trac.wordpress.org/browser/newsletter2go/tags/4.0.13/gui/N2Go_Gui.php#L296
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/766ac399-7280-4186-8972-94da813da85e?source=cve
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 6.4
+    cve-id: CVE-2024-1328
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/newsletter2go/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Stable tag: 4.0.13"
+          - "Stable tag: 4.0.12"
+          - "Stable tag: 4.0.8"
+          - "Stable tag: trunk"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
**Newsletter2Go Plugin Version Detection for CVE-2024-1328**
Related code performs plugin version scanning for CVE-2024-1328 vulnerability. Warns if vulnerable versions of the plugin are in use.
Checks plugin version information for CVE-2024-1328 vulnerability. It uses the readme.txt file to get version information.


I've validated this template locally?
- [x] YES
- [ ] NO

Example vulnerable version:

<img width="962" alt="old1" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/64625f4e-f6ed-473d-9530-4689fee61782">


