### PR TITLE
Add detection of Bynder login panel instances.

### DIFF
--- a/http/exposed-panels/bynder-panel.yaml
+++ b/http/exposed-panels/bynder-panel.yaml
@@ -10,8 +10,8 @@ info:
     - https://www.bynder.com/en/
   metadata:
     max-request: 1
-    shodan-query: http.html:"Bynder"
     verified: true
+    shodan-query: http.favicon.hash:1017650009
   tags: panel,bynder,login,detect
 
 http:
@@ -23,7 +23,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "bynder.") && contains(to_lower(body), "login")'
+          - 'contains_any(to_lower(body), "bynder.", "bynder brand portal", "bynder login")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/bynder-panel.yaml
+++ b/http/exposed-panels/bynder-panel.yaml
@@ -1,0 +1,34 @@
+id: bynder-panel
+
+info:
+  name: Bynder Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Bynder login panel was detected.
+  reference:
+    - https://www.bynder.com/en/
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"Bynder"
+    verified: true
+  tags: panel,bynder,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "bynder.") && contains(to_lower(body), "login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'http-equiv="version"\s+content="([0-9\.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Bynder** software.

- References: https://www.bynder.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/97391613-4f56-4f9b-9794-855073415b46)

Hosts used for the test found via shodan:

```
https://brand.napoleon.com
https://dam.ag2rlamondiale.fr
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Bynder%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/80ea20e1-476a-4e47-acd5-f23a3f80bfbe)

### Additional References

None