### PR TITLE
Added legit domain to amazon-phish 

### DIFF
--- a/http/osint/phishing/amazon-phish.yaml
+++ b/http/osint/phishing/amazon-phish.yaml
@@ -48,5 +48,6 @@ http:
           - '!contains(host,"amazon.pl")'
           - '!contains(host,"amazon.se")'
           - '!contains(host,"amazon.ae")'
+          - '!contains(host,"amazon.com.tr")'
         condition: and
 # digest: 4a0a0047304502201fd4d7d24929de66852a16f075e85d17adff74989810b1f451c74af789d8da30022100d0e27220b66ad8944944fe23973351e43581c878b9404f1e1faa9876f69cf8c1:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
Amazon has another legit url which services for Turkiye. I added the related domain to type dsl section so a legit website won't be reported as phishing.
<!-- Please include any reference to your template if available -->
Amazon Europe Core S.à r.l. (Responsible for amazon.com.tr website)

- Updated amazon-phish.yaml
- References: [Amazon Turkey](https://www.amazon.com.tr)

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
[Whois response for amazon.com.tr](https://github.com/projectdiscovery/nuclei-templates/assets/79456608/0e96b2d2-8d3a-44a6-b08e-be25724e92e8)

