### PR TITLE
Update redis port to 6379 and 6380

### DIFF
--- a/network/detection/redis-detect.yaml
+++ b/network/detection/redis-detect.yaml
@@ -21,7 +21,7 @@ tcp:
     host:
       - "{{Hostname}}"
       - "tls://{{Hostname}}"
-    port: 6380
+    port: 6379,6380
     read-size: 1024
 
     matchers:

--- a/network/exposures/exposed-redis.yaml
+++ b/network/exposures/exposed-redis.yaml
@@ -22,7 +22,7 @@ tcp:
     host:
       - "{{Hostname}}"
       - "tls://{{Hostname}}"
-    port: 6380
+    port: 6379,6380
     read-size: 2048
 
     matchers-condition: and


### PR DESCRIPTION
### Template / PR Information

Redis default port is 6379 and in some cases 6380 also used so updated port:6379,6380 in the template

- Updated redis ports to 6379 and 6380
- References:
- https://redis.io/docs/install/install-redis/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=redis