### PR TITLE
Add detection of CISCO Expressway login panel instances.

### DIFF
--- a/http/exposed-panels/cisco/cisco-expressway-panel.yaml
+++ b/http/exposed-panels/cisco/cisco-expressway-panel.yaml
@@ -1,0 +1,34 @@
+id: cisco-expressway-panel
+
+info:
+  name: CISCO Expressway Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    CISCO Expressway login panel was detected.
+  reference:
+    - https://www.cisco.com/c/en/us/products/unified-communications/expressway-series/index.html
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"Cisco Expressway"
+    verified: true
+  tags: panel,cisco,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "cisco expressway", "cisco expway") && contains(to_lower(body), "login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Cisco\s+(?:Expressway|Expway)\s+([A-Za-z\s]+)<\/legend>'

--- a/http/exposed-panels/cisco/cisco-expressway-panel.yaml
+++ b/http/exposed-panels/cisco/cisco-expressway-panel.yaml
@@ -9,9 +9,9 @@ info:
   reference:
     - https://www.cisco.com/c/en/us/products/unified-communications/expressway-series/index.html
   metadata:
-    max-request: 1
-    shodan-query: http.html:"Cisco Expressway"
     verified: true
+    max-request: 1
+    shodan-query: html:"Cisco Expressway"
   tags: panel,cisco,login,detect
 
 http:
@@ -23,7 +23,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "cisco expressway", "cisco expway") && contains(to_lower(body), "login")'
+          - 'contains_any(to_lower(body), "cisco expressway", "cisco expway")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **CISCO Expressway** software.

- References: https://www.cisco.com/c/en/us/products/unified-communications/expressway-series/index.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e2f9b4c0-f55e-4993-a936-4be15f428c6f)

Hosts used for the test found via shodan:

```
https://80.246.97.153
https://expe1.foyer.lu
https://expe2.foyer.lu
https://200.178.17.61
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Cisco+Expressway%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2fc5b726-8993-40b9-aabf-ae863e0c1f85)

### Additional References

None