### PR TITLE
TXT Service Detector

### DIFF
--- a/dns/txt-service-detect.yaml
+++ b/dns/txt-service-detect.yaml
@@ -1,14 +1,16 @@
-id: txt-service-detector
+id: txt-service-detect
 
 info:
-  name: DNS TXT Service Detector
+  name: DNS TXT Service - Detect
   author: rxerium
   severity: info
-  description: Template to detect services associated with a domain through TXT records.
+  description: |
+    Finding the services companies use via their TXT records.
   reference:
-    - https://www.abenezer.ca/blog/services-companies-use-txt-records?ref=upstract.com
+    - https://www.abenezer.ca/blog/services-companies-use-txt-records
   metadata:
     max-request: 1
+    verified: true
   tags: dns,txt
 
 dns:
@@ -18,127 +20,127 @@ dns:
     matchers-condition: or
     matchers:
       - type: word
-        name: "Keybase"
+        name: "keybase"
         words:
           - "keybase-site-verification"
 
       - type: word
-        name: "Proton Mail"
+        name: "proton-mail"
         words:
           - "protonmail-verification"
 
       - type: word
-        name: "Webex"
+        name: "webex"
         words:
           - "webexdomainverification"
 
       - type: word
-        name: "Apple"
+        name: "apple"
         words:
           - "apple-domain-verification"
 
       - type: word
-        name: "Facebook"
+        name: "facebook"
         words:
           - "facebook-domain-verification"
 
       - type: word
-        name: "Autodesk"
+        name: "autodesk"
         words:
           - "autodesk-domain-verification"
 
       - type: word
-        name: "Stripe"
+        name: "stripe"
         words:
           - "stripe-verification"
 
       - type: word
-        name: "Atlassian"
+        name: "atlassian"
         words:
           - "atlassian-domain-verification"
 
       - type: word
-        name: "Adobe Sign"
+        name: "adobe-sign"
         words:
           - "adobe-sign-verification"
 
       - type: word
-        name: "Zoho"
+        name: "zoho"
         words:
           - "zoho-verification"
 
       - type: word
-        name: "Have I been Pwned"
+        name: "have-i-been-pwned"
         words:
           - "have-i-been-pwned-verification"
 
       - type: word
-        name: "KnowBe4"
+        name: "knowbe4"
         words:
           - "knowbe4-site-verification"
 
       - type: word
-        name: "Jamf"
+        name: "jamf"
         words:
           - "jamf-site-verification"
 
       - type: word
-        name: "Parallels"
+        name: "parallels"
         words:
           - "parallels-domain-verification"
 
       - type: word
-        name: "Dropbox"
+        name: "dropbox"
         words:
           - "dropbox-domain-verification"
 
       - type: word
-        name: "VMWare Cloud"
+        name: "vmware-cloud"
         words:
           - "vmware-cloud-verification"
 
       - type: word
-        name: "Canva"
+        name: "canva"
         words:
           - "canva-site-verification"
 
       - type: word
-        name: "MongoDB"
+        name: "mongodb"
         words:
           - "mongodb-site-verification"
 
       - type: word
-        name: "Slack"
+        name: "slack"
         words:
           - "slack-domain-verification"
 
       - type: word
-        name: "TeamViewer"
+        name: "teamViewer"
         words:
           - "teamviewer-sso-verification"
 
       - type: word
-        name: "Bugcrowd"
+        name: "bugcrowd"
         words:
           - "bugcrowd-verification"
 
       - type: word
-        name: "Cisco"
+        name: "cisco"
         words:
           - "cisco-site-verification"
 
       - type: word
-        name: "Palo Alto Networks"
+        name: "palo-alto-networks"
         words:
           - "paloaltonetworks-site-verification"
 
       - type: word
-        name: "Twilio"
+        name: "twilio"
         words:
           - "twilio-domain-verification"
 
       - type: word
-        name: "Dell Technologies"
+        name: "dell-technologies"
         words:
           - "dell-technologies-domain-verification"
 
@@ -148,71 +150,71 @@ dns:
           - "1password-site-verification"
 
       - type: word
-        name: "Duo"
+        name: "duo"
         words:
           - "duo_sso_verification"
 
       - type: word
-        name: "Sophos"
+        name: "sophos"
         words:
           - "sophos-domain-verification"
 
       - type: word
-        name: "Pinterest"
+        name: "pinterest"
         words:
           - "pinterest-site-verification"
 
       - type: word
-        name: "Citrix"
+        name: "citrix"
         words:
           - "citrix-verification-code"
 
       - type: word
-        name: "Zapier"
+        name: "zapier"
         words:
           - "zapier-domain-verification-challenge"
 
       - type: word
-        name: "Uber"
+        name: "uber"
         words:
           - "uber-domain-verification"
 
       - type: word
-        name: "Zoom"
+        name: "zoom"
         words:
           - "zoom-domain-verification"
 
       - type: word
-        name: "Lastpass"
+        name: "lastpass"
         words:
           - "lastpass-verification-code"
 
       - type: word
-        name: "Google Workspace"
+        name: "google-workspace"
         words:
           - "google-site-verification"
 
       - type: word
-        name: "Flexera"
+        name: "flexera"
         words:
           - "flexera-domain-verification"
 
       - type: word
-        name: "Yandex"
+        name: "yandex"
         words:
           - "yandex-verification"
 
       - type: word
-        name: "Calendly"
+        name: "calendly"
         words:
           - "calendly-site-verification"
 
       - type: word
-        name: "Docusign"
+        name: "docusign"
         words:
           - "docusign"
 
       - type: word
-        name: "Whimsical"
+        name: "whimsical"
         words:
           - "whimsical"

--- a/dns/txt-service-detector.yaml
+++ b/dns/txt-service-detector.yaml
@@ -101,7 +101,7 @@ dns:
         name: "Canva"
         words:
           - "canva-site-verification"
-        
+
       - type: word
         name: "MongoDB"
         words:
@@ -151,7 +151,7 @@ dns:
         name: "Duo"
         words:
           - "duo_sso_verification"
-        
+
       - type: word
         name: "Sophos"
         words:
@@ -201,7 +201,7 @@ dns:
         name: "Yandex"
         words:
           - "yandex-verification"
-        
+
       - type: word
         name: "Calendly"
         words:

--- a/dns/txt-service-detector.yaml
+++ b/dns/txt-service-detector.yaml
@@ -4,7 +4,7 @@ info:
   name: DNS TXT Service Detector
   author: rxerium
   severity: info
-  description: Template to detect services associated with a domain through TXT records. 
+  description: Template to detect services associated with a domain through TXT records.
   reference:
     - https://www.abenezer.ca/blog/services-companies-use-txt-records?ref=upstract.com
   metadata:

--- a/dns/txt-service-detector.yaml
+++ b/dns/txt-service-detector.yaml
@@ -1,0 +1,218 @@
+id: txt-service-detector
+
+info:
+  name: DNS TXT Service Detector
+  author: rxerium
+  severity: info
+  description: Template to detect services associated with a domain through TXT records. 
+  reference:
+    - https://www.abenezer.ca/blog/services-companies-use-txt-records?ref=upstract.com
+  metadata:
+    max-request: 1
+  tags: dns,txt
+
+dns:
+  - name: "{{FQDN}}"
+    type: TXT
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        name: "Keybase"
+        words:
+          - "keybase-site-verification"
+
+      - type: word
+        name: "Proton Mail"
+        words:
+          - "protonmail-verification"
+
+      - type: word
+        name: "Webex"
+        words:
+          - "webexdomainverification"
+
+      - type: word
+        name: "Apple"
+        words:
+          - "apple-domain-verification"
+
+      - type: word
+        name: "Facebook"
+        words:
+          - "facebook-domain-verification"
+
+      - type: word
+        name: "Autodesk"
+        words:
+          - "autodesk-domain-verification"
+
+      - type: word
+        name: "Stripe"
+        words:
+          - "stripe-verification"
+
+      - type: word
+        name: "Atlassian"
+        words:
+          - "atlassian-domain-verification"
+
+      - type: word
+        name: "Adobe Sign"
+        words:
+          - "adobe-sign-verification"
+
+      - type: word
+        name: "Zoho"
+        words:
+          - "zoho-verification"
+
+      - type: word
+        name: "Have I been Pwned"
+        words:
+          - "have-i-been-pwned-verification"
+
+      - type: word
+        name: "KnowBe4"
+        words:
+          - "knowbe4-site-verification"
+
+      - type: word
+        name: "Jamf"
+        words:
+          - "jamf-site-verification"
+
+      - type: word
+        name: "Parallels"
+        words:
+          - "parallels-domain-verification"
+
+      - type: word
+        name: "Dropbox"
+        words:
+          - "dropbox-domain-verification"
+
+      - type: word
+        name: "VMWare Cloud"
+        words:
+          - "vmware-cloud-verification"
+
+      - type: word
+        name: "Canva"
+        words:
+          - "canva-site-verification"
+        
+      - type: word
+        name: "MongoDB"
+        words:
+          - "mongodb-site-verification"
+
+      - type: word
+        name: "Slack"
+        words:
+          - "slack-domain-verification"
+
+      - type: word
+        name: "TeamViewer"
+        words:
+          - "teamviewer-sso-verification"
+
+      - type: word
+        name: "Bugcrowd"
+        words:
+          - "bugcrowd-verification"
+
+      - type: word
+        name: "Cisco"
+        words:
+          - "cisco-site-verification"
+
+      - type: word
+        name: "Palo Alto Networks"
+        words:
+          - "paloaltonetworks-site-verification"
+
+      - type: word
+        name: "Twilio"
+        words:
+          - "twilio-domain-verification"
+
+      - type: word
+        name: "Dell Technologies"
+        words:
+          - "dell-technologies-domain-verification"
+
+      - type: word
+        name: "1password"
+        words:
+          - "1password-site-verification"
+
+      - type: word
+        name: "Duo"
+        words:
+          - "duo_sso_verification"
+        
+      - type: word
+        name: "Sophos"
+        words:
+          - "sophos-domain-verification"
+
+      - type: word
+        name: "Pinterest"
+        words:
+          - "pinterest-site-verification"
+
+      - type: word
+        name: "Citrix"
+        words:
+          - "citrix-verification-code"
+
+      - type: word
+        name: "Zapier"
+        words:
+          - "zapier-domain-verification-challenge"
+
+      - type: word
+        name: "Uber"
+        words:
+          - "uber-domain-verification"
+
+      - type: word
+        name: "Zoom"
+        words:
+          - "zoom-domain-verification"
+
+      - type: word
+        name: "Lastpass"
+        words:
+          - "lastpass-verification-code"
+
+      - type: word
+        name: "Google Workspace"
+        words:
+          - "google-site-verification"
+
+      - type: word
+        name: "Flexera"
+        words:
+          - "flexera-domain-verification"
+
+      - type: word
+        name: "Yandex"
+        words:
+          - "yandex-verification"
+        
+      - type: word
+        name: "Calendly"
+        words:
+          - "calendly-site-verification"
+
+      - type: word
+        name: "Docusign"
+        words:
+          - "docusign"
+
+      - type: word
+        name: "Whimsical"
+        words:
+          - "whimsical"


### PR DESCRIPTION
Hi there,
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Similar to the mx-service-detector template this template will detect services that are associated with a domain through TXT records. 

To gather an initial set of verification txt records I used to the following command:
```
cat txt-service-input.txt | dnsx -txt -resp -silent | grep "verification" > output.txt
```

While I've listed the most common services in the template, it can be expanded as I'm sure I'm missing quite a few. 


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


Many thanks,

Rishi