### PR TITLE
Update fingerprinthub-web-fingerprints.yaml

### DIFF
--- a/http/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/http/technologies/fingerprinthub-web-fingerprints.yaml
@@ -11440,6 +11440,7 @@ http:
         name: softether-vpn
         words:
           - <li>manage this vpn server or vpn bridge<ul>
+        case-insensitive: true
 
       - type: word
         name: softnext-spam


### PR DESCRIPTION
### Template / PR Information

The matcher for `softether-vpn` in `fingerprinthub-web-fingerprints.yaml` needs to be case-insensitive.

All instances I've seen need to match this:
`<li>Manage this VPN Server or VPN Bridge<ul>`

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO