### PR TITLE
fix  CVE-2022-45917 fp

### DIFF
--- a/http/cves/2022/CVE-2022-45917.yaml
+++ b/http/cves/2022/CVE-2022-45917.yaml
@@ -35,13 +35,13 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/shib_logout.php?action=logout&return=https://evil.com"
-      - "{{BaseURL}}/ilias/shib_logout.php?action=logout&return=https://evil.com"
+      - "{{BaseURL}}/shib_logout.php?action=logout&return=https://oast.me"
+      - "{{BaseURL}}/ilias/shib_logout.php?action=logout&return=https://oast.me"
 
     stop-at-first-match: true
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)oast\.me\/?(\/|[^.].*)?$'
 # digest: 4b0a00483046022100fae3b07ccfdd4ee848d28d943dee2ff6bb4fcb4d42eed3a8a572621d7d69edcd022100d88cff0e5cc31d498edebb952bd682219636cb7af85a1f216e7a124b4e55c19d:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2022/CVE-2022-45917.yaml
+++ b/http/cves/2022/CVE-2022-45917.yaml
@@ -35,13 +35,13 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/shib_logout.php?action=logout&return=https://example.com"
-      - "{{BaseURL}}/ilias/shib_logout.php?action=logout&return=https://example.com"
+      - "{{BaseURL}}/shib_logout.php?action=logout&return=https://evil.com"
+      - "{{BaseURL}}/ilias/shib_logout.php?action=logout&return=https://evil.com"
 
     stop-at-first-match: true
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)example\.com\/?(\/|[^.].*)?$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?:\/\/|\/\/|\/\\\\|\/\\)?(?:[a-zA-Z0-9\-_\.@]*)evil\.com\/?(\/|[^.].*)?$'
 # digest: 4b0a00483046022100fae3b07ccfdd4ee848d28d943dee2ff6bb4fcb4d42eed3a8a572621d7d69edcd022100d88cff0e5cc31d498edebb952bd682219636cb7af85a1f216e7a124b4e55c19d:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION

````


curl -I http://xxxx.xxxxxx.com/
HTTP/1.1 301 Moved Permanently
Server: openresty
Date: Fri, 22 Mar 2024 09:34:01 GMT
Content-Type: text/html
Content-Length: 182
Connection: keep-alive
Location: https://example.com/

nuclei -u http://xxxx.xxxxxx.com/ -id CVE-2022-45917

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.2

                projectdiscovery.io

[WRN] Found 18 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.2.2 (latest)
[INF] Current nuclei-templates version: v9.7.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 126
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[CVE-2022-45917] [http] [medium] http://xxxx.xxxxxx.com/shib_logout.php?action=logout&return=https://example.com

````
