### PR TITLE
Add detection of SafeNet Authentication Service Self Enrollment login panel instances.

### DIFF
--- a/http/exposed-panels/safenet-authentication-panel.yaml
+++ b/http/exposed-panels/safenet-authentication-panel.yaml
@@ -1,7 +1,7 @@
-id: safenet-authenticationservice-panel
+id: safenet-authentication-panel
 
 info:
-  name: SafeNet Authentication Service Self Enrollment Login Panel - Detect
+  name: SafeNet Authentication Login Panel - Detect
   author: righettod
   severity: info
   description: |

--- a/http/exposed-panels/safenet-authenticationservice-panel.yaml
+++ b/http/exposed-panels/safenet-authenticationservice-panel.yaml
@@ -1,0 +1,34 @@
+id: safenet-authenticationservice-panel
+
+info:
+  name: SafeNet Authentication Service Self Enrollment Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    SafeNet Authentication Service Self Enrollment login panel was detected.
+  reference:
+    - https://cpl.thalesgroup.com/access-management/safenet-trusted-access
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Self Enrollment"
+    verified: true
+  tags: panel,safenet,thales,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/selfenrollment/Enrollment.aspx"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "self enrollment") && contains_any(to_lower(body), "safenet", "thales")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'V=([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the Self Enrollment login panel for the **SafeNet Authentication Service** software.

- References: https://cpl.thalesgroup.com/access-management/safenet-trusted-access

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c6e849ce-5ebb-434d-a4fc-d21ee170db08)

Hosts used for the test found via shodan:

```
https://dbg-mtep.deutsche-boerse.com
https://azsr.allianz.com.my
https://token.onlinetreasurysolutions.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Self+Enrollment%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2e0d2041-850a-4671-9303-199f62255068)

### Additional References

None