### PR TITLE
Add detection of Amprion Grid Loss login panel instances.

### DIFF
--- a/http/exposed-panels/amprion-gridloss-panel.yaml
+++ b/http/exposed-panels/amprion-gridloss-panel.yaml
@@ -1,0 +1,33 @@
+id: amprion-gridloss-panel
+
+info:
+  name: Amprion Grid Loss Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Amprion Grid Loss login panel was detected.
+  reference:
+    - https://www.amprion.net/index-2.html
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,amprion,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/config/public"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "amprion") && contains(to_lower(body), "grid loss")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"envTitle":"([A-Z0-9a-z]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Amprion Grid Loss** software.

- References: https://www.amprion.net/index-2.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e925bce0-925a-4ca1-a9bd-5a2daa0b20ff)

Host used for the test: https://prod1.gridloss.deutsche-boerse.com

### Additional Details (leave it blank if not applicable)

I did not find a reliable shodan query.

I think that this soft is really specific but I propose a template in case in which you think that it is still interesting 😃 

### Additional References

None