### PR TITLE
Add detection of PrivateBin instances.

### DIFF
--- a/http/technologies/privatebin-detect.yaml
+++ b/http/technologies/privatebin-detect.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-    shodan-query: http.title:"PrivateBin"
+    shodan-query: title:"PrivateBin"
   tags: tech,privatebin,detect
 
 http:
@@ -26,7 +26,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "privatebin.js", "privatebin</title>")'
+          - 'contains_any(to_lower(body), "privatebin.js", "privatebin</title>", "content=\"privatebin")'
         condition: and
 
     extractors:

--- a/http/technologies/privatebin-detect.yaml
+++ b/http/technologies/privatebin-detect.yaml
@@ -1,0 +1,36 @@
+id: privatebin-detect
+
+info:
+  name: PrivateBin - Detect
+  author: righettod
+  severity: info
+  description: |
+    PrivateBin was detected.
+  reference:
+    - https://privatebin.info/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"PrivateBin"
+  tags: tech,privatebin,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "privatebin.js", "privatebin</title>")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'privatebin\.[a-z]{2,3}\?([0-9.]+)'

--- a/http/technologies/privatebin-detect.yaml
+++ b/http/technologies/privatebin-detect.yaml
@@ -21,6 +21,7 @@ http:
 
     redirects: true
     max-redirects: 2
+
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **PrivateBin** software.

- References: https://privatebin.info/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b4939b67-c8ae-4c16-829c-e826797adff4)

Hosts used for the test found via shodan:

```
https://privatebin.lcsb.uni.lu
https://63.224.138.138
http://150.158.161.85:8008
https://51.91.120.87
https://3.23.72.148
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22PrivateBin%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/4e7e0dc6-700f-455f-8345-fbed180d7253)

### Additional References

None