### PR TITLE
Added local check for CVE-2024-3094

### DIFF
--- a/code/cves/2024/CVE-2024-3094.yaml
+++ b/code/cves/2024/CVE-2024-3094.yaml
@@ -45,8 +45,12 @@ code:
         echo probably not vulnerable
       fi
 
+    matchers:
+      - type: word
+        words:
+          - "probably vulnerable"
+
     extractors:
       - type: dsl
         dsl:
           - response
-# digest: 4a0a00473045022100a77874a0147b7bec600048162bb36b1e05ebeef8632466a877c537337be8ad5702201e1b8f9b3755abec0150d9d93a8a5d46c7a381deafbb97d594262c768d10f3f8:c40a3a04977cdbf9dca31c1002ea8279

--- a/code/cves/2024/CVE-2024-3094.yaml
+++ b/code/cves/2024/CVE-2024-3094.yaml
@@ -1,0 +1,56 @@
+id: CVE-2024-3094
+
+info:
+  name: XZ - Embedded Malicious Code
+  author: pdteam
+  severity: critical
+  description: |
+    Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.
+  reference:
+    - https://www.openwall.com/lists/oss-security/2024/03/29/4
+    - https://access.redhat.com/security/cve/CVE-2024-3094
+    - https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/
+    - https://aws.amazon.com/security/security-bulletins/AWS-2024-002/
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2272210
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2024-3094
+    cwe-id: CWE-506
+    epss-score: 0.00045
+    epss-percentile: 0.13335
+  tags: cve,cve2024,local,code,xz,backdoor
+
+self-contained: true
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      # find path to liblzma used by sshd
+      path="$(ldd $(which sshd) | grep liblzma | grep -o '/[^ ]*')"
+      
+      # does it even exist?
+      if [ "$path" == "" ]
+      then
+        echo probably not vulnerable
+        exit
+      fi
+      
+      # check for function signature
+      if hexdump -ve '1/1 "%.2x"' "$path" | grep -q f30f1efa554889f54c89ce5389fb81e7000000804883ec28488954241848894c2410
+      then
+        echo probably vulnerable
+      else
+        echo probably not vulnerable
+      fi
+
+    matchers:
+      - type: word
+        words:
+          - "probably vulnerable"
+
+    extractors:
+      - type: dsl
+        dsl:
+          - response

--- a/code/cves/2024/CVE-2024-3094.yaml
+++ b/code/cves/2024/CVE-2024-3094.yaml
@@ -17,8 +17,13 @@ info:
     cvss-score: 10
     cve-id: CVE-2024-3094
     cwe-id: CWE-506
-    epss-score: 0.00045
-    epss-percentile: 0.13335
+    epss-score: 0.00079
+    epss-percentile: 0.32887
+    cpe: cpe:2.3:a:tukaani:xz:5.6.0:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    vendor: tukaani
+    product: xz
   tags: cve,cve2024,local,code,xz,backdoor
 
 self-contained: true

--- a/code/cves/2024/CVE-2024-3094.yaml
+++ b/code/cves/2024/CVE-2024-3094.yaml
@@ -29,14 +29,14 @@ code:
     source: |
       # find path to liblzma used by sshd
       path="$(ldd $(which sshd) | grep liblzma | grep -o '/[^ ]*')"
-      
+
       # does it even exist?
       if [ "$path" == "" ]
       then
         echo probably not vulnerable
         exit
       fi
-      
+
       # check for function signature
       if hexdump -ve '1/1 "%.2x"' "$path" | grep -q f30f1efa554889f54c89ce5389fb81e7000000804883ec28488954241848894c2410
       then
@@ -45,12 +45,8 @@ code:
         echo probably not vulnerable
       fi
 
-    matchers:
-      - type: word
-        words:
-          - "probably vulnerable"
-
     extractors:
       - type: dsl
         dsl:
           - response
+# digest: 4a0a00473045022100a77874a0147b7bec600048162bb36b1e05ebeef8632466a877c537337be8ad5702201e1b8f9b3755abec0150d9d93a8a5d46c7a381deafbb97d594262c768d10f3f8:c40a3a04977cdbf9dca31c1002ea8279


### PR DESCRIPTION
### Template / PR Information

```console
nuclei -t code/cves/2024/CVE-2024-3094.yaml -code -itags local 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.2

		projectdiscovery.io

[INF] Current nuclei version: v3.2.2 (latest)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from sandeep
[CVE-2024-3094] [code] [critical]  [probably vulnerable]
```

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)