### PR TITLE
Add detection of simpleSAMLphp instances.

### DIFF
--- a/http/technologies/simplesamlphp-detect.yaml
+++ b/http/technologies/simplesamlphp-detect.yaml
@@ -12,7 +12,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.title:"SimpleSAMLphp installation page"
-  tags: tech,simplesaml,detect
+  tags: tech,simplesamlphp,detect
 
 http:
   - method: GET

--- a/http/technologies/simplesamlphp-detect.yaml
+++ b/http/technologies/simplesamlphp-detect.yaml
@@ -1,0 +1,30 @@
+id: simplesamlphp-detect
+
+info:
+  name: SimpleSAMLphp - Detect
+  author: righettod
+  severity: info
+  description: |
+    SimpleSAMLphp was detected.
+  reference:
+    - https://simplesamlphp.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"SimpleSAMLphp installation page"
+  tags: tech,simplesaml,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/simplesaml/module.php/core/frontpage_welcome.php"
+      - "{{BaseURL}}/module.php/core/frontpage_welcome.php"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "you have successfully installed simplesamlphp", "simplesamlphp installation page", "/module.php/core/login-admin.php")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **simpleSAMLphp** software.

- References: https://simplesamlphp.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b7d53ae3-bccd-436a-9cbd-b760fbb3cadf)

Hosts used for the test found via shodan:

```
https://148.202.106.110
https://idp.niif.hu
https://www.nedercomweb.nl
https://sso.vgtu.lt
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22SimpleSAMLphp+installation+page%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d980d15c-32ab-4518-8a37-8c1d5bfaa56a)

### Additional References

None