### PR TITLE
Create CVE-2024-3094.yaml

### DIFF
--- a/code/cves/2024/CVE-2024-3094.yaml
+++ b/code/cves/2024/CVE-2024-3094.yaml
@@ -1,0 +1,28 @@
+id: CVE-2024-3094
+
+info:
+  name: XZ Backdoor - Detect
+  author: daffainfo
+  severity: critical
+  description: Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.
+  reference: https://github.com/Neo23x0/signature-base/blob/master/yara/bkdr_xz_util_cve_2024_3094.yar
+  tags: cve,cve2024,xz,backdoor
+
+file:
+  - extensions:
+      - all
+
+    matchers-condition: or
+    matchers:
+      - type: word # Detects make file and script
+        part: raw
+        words:
+          - "/bad-3-corrupt_lzma2.xz | tr "
+          - "/tests/files/good-large_compressed.lzma|eval $i|tail -c +31265|"
+          - "eval $zrKcKQ"
+        condition: or
+
+      - type: word # Detects kill switch
+        part: raw
+        words:
+          - "yolAbejyiejuvnup=Evjtgvsh5okmkAvj"


### PR DESCRIPTION
Can't make nuclei-template for `BKDR_XZUtil_Binary_CVE_2024_3094_Mar24_1` because nuclei doesn't support `uint16` keywords or `??` in binary