### PR TITLE
Add detection of Syfadis Xperience login panel instances.

### DIFF
--- a/http/exposed-panels/syfadis-xperience-panel.yaml
+++ b/http/exposed-panels/syfadis-xperience-panel.yaml
@@ -1,0 +1,33 @@
+id: syfadis-xperience-panel
+
+info:
+  name: Syfadis Xperience Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Syfadis Xperience login panel was detected.
+  reference:
+    - https://syfadis.fr/xperience
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,syfadis,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Directory/Login/Login.aspx"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "syfadis xperience", "syfadis.supervision.browsersupport") && contains(to_lower(body), "loginpage")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'ajaxz/([0-9.]+)/Common'

--- a/http/exposed-panels/syfadis-xperience-panel.yaml
+++ b/http/exposed-panels/syfadis-xperience-panel.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    fofa-query: title="Syfadis Xperience"
   tags: panel,syfadis,login,detect
 
 http:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Syfadis Xperience** software.

- References: https://syfadis.fr/xperience

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/acd6e034-bca7-4abf-af48-ee19f3de1e48)

Host used for the test found via Google:

```text
https://ifcam.elearning.ca-ifcam.fr
https://lionacademy.delhaize.be
https://digitalcampus-elearning-s.difcam.com
https://academie.astre.fr
```

### Additional Details (leave it blank if not applicable)

I did not find a reliable shodan query.

URL of the favicon: https://ifcam.elearning.ca-ifcam.fr/Files/Themes/360448/4458872832/favicon.png

Google query: `intitle:"Syfadis Xperience"`

https://www.google.com/search?q=intitle%3A%22Syfadis+Xperience%22

### Additional References

None