### PR TITLE
Add detection of OutSystems Service Center login panel instances.

### DIFF
--- a/http/exposed-panels/outsystems-servicecenter-panel.yaml
+++ b/http/exposed-panels/outsystems-servicecenter-panel.yaml
@@ -1,0 +1,37 @@
+id: outsystems-servicecenter-panel
+
+info:
+  name: OutSystems Service Center Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    OutSystems Service Center login panel was detected.
+  reference:
+    - https://www.outsystems.com/
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"outsystems"
+    verified: true
+  tags: panel,outsystems,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ServiceCenter/Login.aspx"
+      - "{{BaseURL}}/Login.aspx"
+      
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "servicecenter", "outsystems.internal") && contains(to_lower(body), "login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "environmentName:'([a-zA-Z0-9]+)'"


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **OutSystems Service Center** software.

- References: https://www.outsystems.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/03a729fc-ca7d-4dd8-92af-9aa0d7ad581a)

Host used for the test found via Shodan:

```text
https://extapp.dev.ethias.be
https://extapp.tst.ethias.be
```

### Additional Details (leave it blank if not applicable)

🤔 I'm not confident with the Shodan query provided but I did not achieve to find a more accurate one.

Shodan query: https://www.shodan.io/search?query=http.html%3A%22outsystems%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/686d8f47-941a-4e1e-8704-f70346fe61c0)

### Additional References

None