### PR TITLE
Add detection of BeyondTrust Privileged Remote Access login panel instances.

### DIFF
--- a/http/exposed-panels/beyondtrust-priv-panel.yaml
+++ b/http/exposed-panels/beyondtrust-priv-panel.yaml
@@ -1,7 +1,7 @@
-id: beyondtrust-privileged-remote-access-panel
+id: beyondtrust-priv-panel
 
 info:
-  name: BeyondTrust Privileged Remote Access Login Panel - Detect
+  name: BeyondTrust Privileged Remote Access - Panel
   author: righettod
   severity: info
   description: |

--- a/http/exposed-panels/beyondtrust-privileged-remote-access-panel.yaml
+++ b/http/exposed-panels/beyondtrust-privileged-remote-access-panel.yaml
@@ -1,0 +1,30 @@
+id: beyondtrust-privileged-remote-access-panel
+
+info:
+  name: BeyondTrust Privileged Remote Access Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    BeyondTrust Privileged Remote Access login panel was detected.
+  reference:
+    - https://www.beyondtrust.com/products/privileged-remote-access
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"BeyondTrust Privileged Remote Access Login"
+    verified: true
+  tags: panel,beyondtrust,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login/login"
+      - "{{BaseURL}}/login/pre_login_agreement"
+     
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>beyondtrust privileged remote access login", "privileged-remote-access") && contains(to_lower(body), "login")'
+        condition: and

--- a/http/exposed-panels/beyondtrust-privileged-remote-access-panel.yaml
+++ b/http/exposed-panels/beyondtrust-privileged-remote-access-panel.yaml
@@ -19,7 +19,7 @@ http:
     path:
       - "{{BaseURL}}/login/login"
       - "{{BaseURL}}/login/pre_login_agreement"
-     
+
     stop-at-first-match: true
 
     matchers:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **BeyondTrust Privileged Remote Access** software.

- References: https://www.beyondtrust.com/products/privileged-remote-access

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/35d6c297-932b-4270-9b63-3d90000578e2)

Host used for the test found via Shodan:

```text
https://connect.lns.lu
https://194.56.56.13
https://143.244.97.189
https://81.246.14.37
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22BeyondTrust+Privileged+Remote+Access+Login%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/5e93e1a3-a45e-4835-a95d-bef22d2911b4)

### Additional References

None