### PR TITLE
Add detection of Mitric Checker login panel instances. 

### DIFF
--- a/http/exposed-panels/mitric-checker-panel.yaml
+++ b/http/exposed-panels/mitric-checker-panel.yaml
@@ -1,0 +1,29 @@
+id: mitric-checker-panel
+
+info:
+  name: Mitric Checker Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Mitric Checker login panel was detected.
+  reference:
+    - https://www.mitric.com/en/audit-with-checker/
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,mitric,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/QSA/Login.aspx"
+      - "{{BaseURL}}/API/External/GetPrivacy"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "/checker/", "bg-blue-checker", "checker platform")'
+        condition: and

--- a/http/exposed-panels/mitric-checker-panel.yaml
+++ b/http/exposed-panels/mitric-checker-panel.yaml
@@ -9,7 +9,7 @@ info:
   reference:
     - https://www.mitric.com/en/audit-with-checker/
   metadata:
-    max-request: 1
+    max-request: 2
     verified: true
   tags: panel,mitric,login,detect
 


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Mitric Checker** software.

- References: https://www.mitric.com/en/audit-with-checker/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b2532058-4c95-4515-ae64-a7124eaf4a7d)

Tested against host https://audit-test.ferrari.com that was found via [crt.sh](https://crt.sh): 

https://crt.sh/?q=ferrari.com

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d5c6c351-069b-4f76-bc27-d46ccce01ac3)

### Additional Details (leave it blank if not applicable)

I did not achieve to find a accurate Shodan query.

### Additional References

None