### PR TITLE
Add detection of Mitel MiCollab login panel instances.

### DIFF
--- a/http/exposed-panels/mitel-micollab-panel.yaml
+++ b/http/exposed-panels/mitel-micollab-panel.yaml
@@ -1,0 +1,27 @@
+id: mitel-micollab-panel
+
+info:
+  name: Mitel MiCollab Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Mitel MiCollab login panel was detected.
+  reference:
+    - https://www.mitel.com/products/micollab-miteam-meetings-collaboration-software
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"MiCollab End User Portal"
+    verified: true
+  tags: panel,mitel,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/portal/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "micollab", "mitel_logo", "com.mitel.mas.portal.domain")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Mitel MiCollab** software.

- References: https://www.mitel.com/products/micollab-miteam-meetings-collaboration-software

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/df48398c-a18f-41b0-918b-08180afb4c3b)

Host used for the test found via Shodan:

```text
https://micollab.ferrari.com
https://38.88.253.60
https://71.13.172.243
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22MiCollab+End+User+Portal%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2d23c0e6-ae7c-4840-8412-b66a7e37b8ee)

### Additional References

None