### PR TITLE
Add detection of SOAP-based ASP.NET web services ASMX.

### DIFF
--- a/http/exposures/apis/aspnet-soap-webservices-asmx.yaml
+++ b/http/exposures/apis/aspnet-soap-webservices-asmx.yaml
@@ -1,4 +1,4 @@
-id: exposed-aspnet-soap-webservices-asmx
+id: aspnet-soap-webservices-asmx
 
 info:
   name: SOAP-based ASP.NET web services ASMX - Detect
@@ -21,11 +21,11 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - ".asmx?op="
           - ".asmx?WSDL"
           - ".asmx?disco"
-        part: body
         condition: and
 
       - type: status

--- a/http/exposures/apis/aspnet-soap-webservices-asmx.yaml
+++ b/http/exposures/apis/aspnet-soap-webservices-asmx.yaml
@@ -4,7 +4,8 @@ info:
   name: SOAP-based ASP.NET web services ASMX - Detect
   author: righettod
   severity: info
-  description: SOAP-based ASP.NET web services collection was detected.
+  description: |
+    SOAP-based ASP.NET web services collection was detected.
   reference:
     - https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/csharp/language-compilers/write-web-service
   metadata:

--- a/http/exposures/apis/exposed-aspnet-soap-webservices-asmx.yaml
+++ b/http/exposures/apis/exposed-aspnet-soap-webservices-asmx.yaml
@@ -1,0 +1,40 @@
+id: exposed-aspnet-soap-webservices-asmx
+
+info:
+  name: SOAP-based ASP.NET web services ASMX - Detect
+  author: righettod
+  severity: info
+  description: SOAP-based ASP.NET web services collection was detected.
+  reference:
+    - https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/csharp/language-compilers/write-web-service
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:".asmx?WSDL"
+  tags: config,exposure,asmx,soap
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - ".asmx?op="
+          - ".asmx?WSDL"
+          - ".asmx?disco"
+        part: body
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<p class="heading1">([A-Za-z0-9\s_\-\.]+)<\/p>'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect when **SOAP-based ASP.NET web services** (ASMX) are exposed via the collection page:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f30dc07e-3a09-44dd-a05b-ff740f23f332)

References: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/csharp/language-compilers/write-web-service

I used this [template](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposures/configs/exposed-authentication-asmx.yaml) as base.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e38a038f-23ab-4531-bc03-44308aab5973)

Host used for the test found via Shodan:

```text
http://112.74.108.249:89
https://gold.ursservice.fiat.com
http://175.139.218.19:8080
http://190.104.194.115
http://200.71.203.195:82
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22.asmx%3FWSDL%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ce522c50-cdde-4b5f-b131-fffd152e896b)

### Additional References

None