### PR TITLE
Added template for Citrix XenMobile technology and version detection …

### DIFF
--- a/http/technologies/citrix-xenmobile-version.yaml
+++ b/http/technologies/citrix-xenmobile-version.yaml
@@ -1,0 +1,44 @@
+id: citrix-xenmobile-version
+
+info:
+  name: Citrix XenMobile Version
+  description: Template for XenMobile-detection (even if login-page is deactivated) and the specific version and rolling patch from js/app/init.js endpoint
+  author: Puben
+  severity: info
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'len(body) == 0'
+          - 'contains(header, "Location: /zdm/login_xdm_uc.jsp")'
+        condition: and
+
+  - method: GET
+    path:
+      - '{{BaseURL}}/js/app/init.js'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - 'v=([^"]+)'
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'v=([^"]+)'

--- a/http/technologies/citrix-xenmobile-version.yaml
+++ b/http/technologies/citrix-xenmobile-version.yaml
@@ -1,10 +1,16 @@
 id: citrix-xenmobile-version
 
 info:
-  name: Citrix XenMobile Version
-  description: Template for XenMobile-detection (even if login-page is deactivated) and the specific version and rolling patch from js/app/init.js endpoint
+  name: Citrix XenMobile Version - Detect
   author: Puben
   severity: info
+  description: |
+    Template for XenMobile-detection (even if login-page is deactivated) and the specific version and rolling patch from js/app/init.js endpoint
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"XenMobile - Console"
+  tags: tech,edb,citrix,version,detect
 
 flow: http(1) && http(2)
 
@@ -17,9 +23,9 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 302'
-          - 'len(body) == 0'
           - 'contains(header, "Location: /zdm/login_xdm_uc.jsp")'
         condition: and
+        internal: true
 
   - method: GET
     path:
@@ -27,18 +33,19 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: regex
         name: version
         part: body
         regex:
           - 'v=([^"]+)'
 
+      - type: status
+        status:
+          - 200
+
     extractors:
       - type: regex
         part: body
+        group: 1
         regex:
           - 'v=([^"]+)'


### PR DESCRIPTION
### Template / PR Information

This template will detect XenMobile technology even if no login panel is exposed (as opposed to nuclei-templates/http/exposed-panels/xenmobile-login.yaml) and grab version and rolling patch from {{BaseURL}}/js/app/init.js


add citrix-xenmobile-version

References:
- https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposed-panels/xenmobile-login.yaml
- https://docs.citrix.com/en-us/xenmobile/server.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)