### PR TITLE
Add detection of Redfish API.

### DIFF
--- a/http/exposures/apis/redfish-api.yaml
+++ b/http/exposures/apis/redfish-api.yaml
@@ -1,0 +1,42 @@
+id: redfish-api
+
+info:
+  name: Redfish API - Detect
+  author: righettod
+  severity: info
+  description: |
+    Redfish API was detected.
+  reference:
+    - https://en.wikipedia.org/wiki/Redfish_(specification)
+    - https://www.dmtf.org/standards/redfish
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"/redfish/v1"
+  tags: config,exposure,redfish,api
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/redfish/v1/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/redfish/v1/"
+          - "@odata.type"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+          - 502
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '[a-z]+\.v?([0-9_\.]+)\.'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect when **Redfish API** are exposed:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/3a24de77-a8fe-4668-9ede-f54ed8076f34)

References:
* https://en.wikipedia.org/wiki/Redfish_(specification)
* https://www.dmtf.org/standards/redfish

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c62094a2-2dda-4521-8ffe-e5d97ecf468e)

Host used for the test found via Shodan:

```text
http://199.19.74.175:5000
https://46.234.105.33
http://91.123.202.96:8000
http://135.148.34.84:8000
http://51.81.67.134:8000
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22%2Fredfish%2Fv1%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/bbb4a3ad-1fdb-460b-9224-9484d835ed36)

### Additional References

None