### PR TITLE
Add detection of Chemotargets Clarity Vista login panel instances.

### DIFF
--- a/http/exposed-panels/chemotargets-clarityvista-panel.yaml
+++ b/http/exposed-panels/chemotargets-clarityvista-panel.yaml
@@ -1,0 +1,27 @@
+id: chemotargets-clarityvista-panel
+
+info:
+  name: Chemotargets Clarity Vista Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Chemotargets Clarity Vista login panel was detected.
+  reference:
+    - https://chemotargets.com/clarityvista/
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"ClarityVista"
+    verified: true
+  tags: panel,chemotargets,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>clarityvista", "content=\"clarity pharmacovigilance")'
+        condition: and

--- a/http/exposed-panels/chemotargets-clarityvista-panel.yaml
+++ b/http/exposed-panels/chemotargets-clarityvista-panel.yaml
@@ -9,9 +9,9 @@ info:
   reference:
     - https://chemotargets.com/clarityvista/
   metadata:
+    verified: true
     max-request: 1
     shodan-query: http.title:"ClarityVista"
-    verified: true
   tags: panel,chemotargets,login,detect
 
 http:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Chemotargets Clarity Vista** software.

- References: https://chemotargets.com/clarityvista/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c23126fc-a24c-424d-bd33-1a884b1482ee)

Host used for the test found via Shodan and https://crt.sh :

```text
https://34.36.158.111
https://api-java.int.skf.dev.gcp.renault.com
https://clarity-vista.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22ClarityVista%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/23a39ea0-1bb8-4632-b5b5-eef4c785be06)

### Additional References

None