### PR TITLE
Add detection of TIBCO Spotfire login panel instances.

### DIFF
--- a/http/exposed-panels/tibco-spotfire-panel.yaml
+++ b/http/exposed-panels/tibco-spotfire-panel.yaml
@@ -1,0 +1,27 @@
+id: tibco-spotfire-panel
+
+info:
+  name: TIBCO Spotfire Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    TIBCO Spotfire login panel was detected.
+  reference:
+    - https://www.tibco.com/products/tibco-spotfire
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"TIBCO Spotfire"
+    verified: true
+  tags: panel,tibco,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/spotfire/login.html"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "content=\"tibco spotfire", "/spotfire/")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **TIBCO Spotfire** software.

- References: https://www.tibco.com/products/tibco-spotfire

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ec58258a-9e85-4f18-90b2-611a8598ca69)

Host used for the test found via Shodan and https://crt.sh :

```text
https://162.44.167.197
https://34.214.248.233
https://spotfire-m8.abi.poc.gcp.renault.com
https://spotfire-m8.abi.int.gcp.renault.com
https://spotfire-m8.abi.ope.gcp.renault.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22TIBCO+Spotfire%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/6bd3574a-ce79-427b-bf72-1507b11ef172)

### Additional References

None