### PR TITLE
Add detection of Algonomia Leaf Platform login panel instances.

### DIFF
--- a/http/exposed-panels/algonomia-leaf-platform-panel.yaml
+++ b/http/exposed-panels/algonomia-leaf-platform-panel.yaml
@@ -1,0 +1,26 @@
+id: algonomia-leaf-platform-panel
+
+info:
+  name: Algonomia Leaf Platform Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Algonomia Leaf Platform login panel was detected.
+  reference:
+    - https://algonomia.com/
+  metadata:
+    max-request: 1
+    verified: true
+  tags: tech,algonomia,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/assets/i18n/en.json"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "logincomponent") && contains_any(to_lower(body), "leafplatform", "leaf platform")'
+        condition: and

--- a/http/exposed-panels/algonomia-panel.yaml
+++ b/http/exposed-panels/algonomia-panel.yaml
@@ -22,6 +22,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "logincomponent") && contains_any(to_lower(body), "leafplatform", "leaf platform")'
+          - 'contains(to_lower(body), "logincomponent\":")'
+          - 'contains_any(to_lower(body), "leafplatform", "leaf platform")'
           - 'contains(header, "application/json")'
         condition: and

--- a/http/exposed-panels/algonomia-panel.yaml
+++ b/http/exposed-panels/algonomia-panel.yaml
@@ -1,7 +1,7 @@
-id: algonomia-leaf-platform-panel
+id: algonomia-panel
 
 info:
-  name: Algonomia Leaf Platform Login Panel - Detect
+  name: Algonomia Leaf Platform Panel - Detect
   author: righettod
   severity: info
   description: |
@@ -23,4 +23,5 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(to_lower(body), "logincomponent") && contains_any(to_lower(body), "leafplatform", "leaf platform")'
+          - 'contains(header, "application/json")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Algonomia Leaf Platform** software.

References:

- https://algonomia.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c66ff504-2789-40b8-b5f1-5ba5e0d9b210)

Hosts used for the test found via https://crt.sh :

```text
https://tax-vision.renault.com
```

### Additional Details (leave it blank if not applicable)

No shodan query found.

### Additional References

None