### PR TITLE
Update wordpress plugins daily

### DIFF
--- a/.github/workflows/wordpress-plugins-update.yml
+++ b/.github/workflows/wordpress-plugins-update.yml
@@ -1,7 +1,8 @@
 name: ✨ WordPress Plugins - Update
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   Update:


### PR DESCRIPTION
### Template / PR Information

ricardomaia has made a github actions workflow to automatically update wordpress plugins templates and versions. Unfortunately, this workflow is manual and a lot of template are out of date. Maybe it can be a good idea to make a daily run to stay up to date. 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:
