### PR TITLE
Add detection of TIXEO login panel instances.

### DIFF
--- a/http/exposed-panels/tixeo-panel.yaml
+++ b/http/exposed-panels/tixeo-panel.yaml
@@ -26,9 +26,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_any(to_lower(body), "tixeo", "tixeoclient")'
-        condition: and
+          - 'contains(header, "Tixeo")'
+          - 'contains_any(to_lower(body), "tixeo-button", "tixeoclient")'
+        condition: or
 
     extractors:
       - type: regex

--- a/http/exposed-panels/tixeo-panel.yaml
+++ b/http/exposed-panels/tixeo-panel.yaml
@@ -1,0 +1,38 @@
+id: tixeo-panel
+
+info:
+  name: Tixeo Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Tixeo login panel was detected.
+  reference:
+    - https://www.tixeo.com/en/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"tixeo"
+  tags: panel,tixeo,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/meet/services/json/v1/settings"
+      - "{{BaseURL}}/meet/login.html"
+      - "{{BaseURL}}/meet/"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "tixeo", "tixeoclient")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"applicationVersion"\s*:\s*"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **TIXEO** software.

References:

- https://www.tixeo.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b1472b0e-8845-4e9b-a3cc-6b94edb0eda6)


Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://pp-secuvisio.edf.fr
https://51.255.98.213
https://51.210.52.152
https://143.196.255.44
https://51.210.52.139
https://51.255.221.3
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22tixeo%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f8df2dfa-5d74-46b5-9ffa-f2709fcf80ee)

### Additional References

None