### PR TITLE
Add more detection criteria to the "GlassFish Server Default Page" template.

### DIFF
--- a/http/technologies/default-glassfish-server-page.yaml
+++ b/http/technologies/default-glassfish-server-page.yaml
@@ -2,7 +2,7 @@ id: default-glassfish-server-page
 
 info:
   name: GlassFish Server Default Page
-  author: dhiyaneshDk
+  author: dhiyaneshDk,righettod
   severity: info
   metadata:
     max-request: 1
@@ -15,9 +15,15 @@ http:
       - '{{BaseURL}}'
 
     matchers:
-      - type: word
-        words:
-          - "<title>GlassFish Server - Server Running</title>"
-        part: body
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "glassfish server - server running", "glassfish server with premier support", "<b>glassfish server</b>", "glassfish server installation directory")'
+        condition: and
 
-# digest: 4b0a00483046022100b285d702aa78c8a5832e6beb67bec48fc5441e37ed640abc33a1000d933ae729022100f35be40545e34973183d97c7457b0c4e7793827d2e9ddb7dcb7680cd8c2ddb9f:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - 'GlassFish\s+Server\s+([A-Za-z0-9\s.]+)(\n|\r)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more detection criteria to the existing template: 

* Add more matchers.
* Add extraction of the version from headers when available.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/a2abe7da-3c34-41b0-a07c-fc3bbe5ac375)

Tested against hosts found on shodan:

```text
https://booster.bs.fr.atos.net
http://45.4.32.204:9090
http://45.237.45.239:6379
http://145.253.106.219:82
```

### Additional Details (leave it blank if not applicable)

Shodan query used coming from the original template: https://www.shodan.io/search?query=http.title%3A%22GlassFish+Server+-+Server+Running%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/57fcb92a-0d40-4a17-b3a1-3088780cd116)

### Additional References:

None