### PR TITLE
Add detection of UiPath Orchestrator login panel instances.

### DIFF
--- a/http/exposed-panels/uipath-orchestrator-panel.yaml
+++ b/http/exposed-panels/uipath-orchestrator-panel.yaml
@@ -1,0 +1,34 @@
+id: uipath-orchestrator-panel
+
+info:
+  name: UiPath Orchestrator Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    UiPath Orchestrator login panel was detected.
+  reference:
+    - https://www.uipath.com/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"UiPath Orchestrator"
+  tags: panel,uipath,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Account/Login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>uipath orchestrator")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '\?(?:version|v)=([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **UiPath Orchestrator** software.

References:

- https://www.uipath.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/456e1eac-c550-46bd-bf38-7931ccf16d6d)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://34.243.8.247
https://52.255.194.51
https://3.132.116.224
https://164.68.123.152
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22UiPath+Orchestrator%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/9a8baa04-eb2e-4604-8fc0-1e14f2d33bf5)

### Additional References

None