### PR TITLE
Add detection of "BMC Remedy Single Sign-On domain data entry" login panel instances.

### DIFF
--- a/http/exposed-panels/bmc/bmc-remedy-sso-panel.yaml
+++ b/http/exposed-panels/bmc/bmc-remedy-sso-panel.yaml
@@ -1,0 +1,30 @@
+id: bmc-remedy-sso-panel
+
+info:
+  name: BMC Remedy Single Sign-On domain data entry Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    BMC Remedy Single Sign-On domain data entry login panel was detected.
+  reference:
+    - https://www.bmc.com/it-solutions/remedy-itsm.html
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"BMC Remedy Single Sign-On domain data entry"
+  tags: panel,bmc,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/arsys/"
+      - "{{BaseURL}}/webUI/userHome.do"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>bmc remedy single sign-on domain data entry")'
+        condition: and

--- a/http/exposed-panels/bmc/bmc-remedy-sso-panel.yaml
+++ b/http/exposed-panels/bmc/bmc-remedy-sso-panel.yaml
@@ -1,7 +1,7 @@
 id: bmc-remedy-sso-panel
 
 info:
-  name: BMC Remedy Single Sign-On domain data entry Login Panel - Detect
+  name: BMC Remedy SSO Login Panel - Detect
   author: righettod
   severity: info
   description: |
@@ -10,7 +10,7 @@ info:
     - https://www.bmc.com/it-solutions/remedy-itsm.html
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     shodan-query: http.title:"BMC Remedy Single Sign-On domain data entry"
   tags: panel,bmc,login,detect
 


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **BMC Remedy Single Sign-On domain data entry** software.

References:

- https://www.bmc.com/it-solutions/remedy-itsm.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/875e0ff3-8baa-45f5-8ca0-f281f82047cf)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://approvalportaluat.cgi.com
https://supportportaluat.cgi.com
https://165.233.59.132
https://64.254.18.26
https://165.233.59.205
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22BMC+Remedy+Single+Sign-On+domain+data+entry%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/400b6bdd-4575-47ea-9c02-9c4b019b41de)

### Additional References

None