### PR TITLE
fix: network/c2/xtremerat-trojan.yaml replace matcher type

### DIFF
--- a/network/c2/xtremerat-trojan.yaml
+++ b/network/c2/xtremerat-trojan.yaml
@@ -25,8 +25,7 @@ tcp:
     read-size: 1024
 
     matchers:
-      - type: word
-        encoding: hex
-        words:
-          - "58"
+      - type: regex
+        regex:
+          - "^X$"
 # digest: 4a0a0047304502206fa95ec595a2933ca08a0326dbce0d411afd01de4b65c0c060b9d1317264e96e022100a648393498fd3a99b1aec95f74372fc476d2e484933f438b68468bc6efa642d4:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

This PR fixes the false positive described on #9624 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

Using netcat to simulate xtremerat-trojan response:
```shell
$ echo -en 'X' | nc -l 0.0.0.0 10001

$ nuclei -t ./network/c2/xtremerat-trojan.yaml -u 127.0.0.1 --debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

		projectdiscovery.io

[INF] Current nuclei version: v3.1.10 (outdated)
[INF] Current nuclei-templates version: v9.8.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 142
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [xtremerat-trojan] Dumped Network request for 127.0.0.1:10001
00000000  32 45                                             |2E| address=127.0.0.1:10001
[xtremerat-trojan:regex-1] [tcp] [info] 127.0.0.1:10001
[DBG] [xtremerat-trojan] Dumped Network response for 127.0.0.1:10001

00000000  58                                                |X|
```

Prevent FP on `SSH-2.0-X`:
```
$ echo -en 'SSH-2.0-X' | nc -l 0.0.0.0 10001

$ nuclei -t ./network/c2/xtremerat-trojan.yaml -u 127.0.0.1 --debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

		projectdiscovery.io

[INF] Current nuclei version: v3.1.10 (outdated)
[INF] Current nuclei-templates version: v9.8.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 142
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [xtremerat-trojan] Dumped Network request for 127.0.0.1:10001
00000000  32 45                                             |2E| address=127.0.0.1:10001
[DBG] [xtremerat-trojan] Dumped Network response for 127.0.0.1:10001

00000000  53 53 48 2d 32 2e 30 2d  58                       |SSH-2.0-X|
[INF] No results found. Better luck next time!
```