### PR TITLE
Add detection of IBM AIX Web-based System Manager services.

### DIFF
--- a/network/detection/aix-websm-detect.yaml
+++ b/network/detection/aix-websm-detect.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    shodan-query: "/websm/"
   tags: network,aix,detect
 
 tcp:
@@ -29,4 +30,4 @@ tcp:
         words:
           - "/var/websm/"
           - "startNewWServer"
-          - "WServer.HANDSHAKING"
+        condition: and

--- a/network/detection/aix-websm-detect.yaml
+++ b/network/detection/aix-websm-detect.yaml
@@ -4,7 +4,8 @@ info:
   name: AIX WebSM - Detect
   author: righettod
   severity: info
-  description: Detects IBM AIX Web-based System Manager services.
+  description: |
+    Detects IBM AIX Web-based System Manager services.
   reference:
     - https://en.wikipedia.org/wiki/IBM_Web-based_System_Manager
     - https://www.filibeto.org/unix/aix/lib/rel/5.2/wsmadmn.pdf

--- a/network/detection/aix-websm-detect.yaml
+++ b/network/detection/aix-websm-detect.yaml
@@ -1,0 +1,31 @@
+id: aix-websm-detect
+
+info:
+  name: AIX WebSM - Detect
+  author: righettod
+  severity: info
+  description: Detects IBM AIX Web-based System Manager services.
+  reference:
+    - https://en.wikipedia.org/wiki/IBM_Web-based_System_Manager
+    - https://www.filibeto.org/unix/aix/lib/rel/5.2/wsmadmn.pdf
+  metadata:
+    max-request: 1
+    verified: true
+  tags: network,aix,detect
+
+tcp:
+  - inputs:
+      - data: "en_US\r\n"
+
+    host:
+      - "{{Hostname}}"
+    port: 9090
+    read-size: 4096
+
+    matchers:
+      - type: word
+        part: data
+        words:
+          - "/var/websm/"
+          - "startNewWServer"
+          - "WServer.HANDSHAKING"

--- a/network/detection/aix-websm-detect.yaml
+++ b/network/detection/aix-websm-detect.yaml
@@ -16,6 +16,7 @@ info:
 tcp:
   - inputs:
       - data: "en_US\r\n"
+        read: 1024
 
     host:
       - "{{Hostname}}"


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **IBM AIX Web-based System Manager** services.

References:

- https://en.wikipedia.org/wiki/IBM_Web-based_System_Manager
- https://www.filibeto.org/unix/aix/lib/rel/5.2/wsmadmn.pdf

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/9a9eb399-13ca-44e7-8430-2f7ad15dc920)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/9050505c-494f-4090-99f5-54ddfeb9a5bc)

Such services is not intended to be exposed on Internet or public networks. It is intended to be exposed on internal networks or dedicated management networks.

### Additional Details (leave it blank if not applicable)

None

### Additional References

None