### PR TITLE
Add detection of Blue Coat Telnet Proxy services.

### DIFF
--- a/network/detection/bluecoat-telnet-proxy-detect.yaml
+++ b/network/detection/bluecoat-telnet-proxy-detect.yaml
@@ -1,7 +1,7 @@
-id: bluecoat-telnet-proxy
+id: bluecoat-telnet-proxy-detect
 
 info:
-  name: Blue Coat telnet proxy - Detect
+  name: BlueCoat Telnet Proxy - Detect
   author: righettod
   severity: info
   description: Detects Blue Coat telnet proxy services.
@@ -12,7 +12,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: network,bluecoat,detect
+  tags: network,bluecoat,proxy,detect
 
 tcp:
   - inputs:

--- a/network/detection/bluecoat-telnet-proxy-detect.yaml
+++ b/network/detection/bluecoat-telnet-proxy-detect.yaml
@@ -1,0 +1,31 @@
+id: bluecoat-telnet-proxy
+
+info:
+  name: Blue Coat telnet proxy - Detect
+  author: righettod
+  severity: info
+  description: Detects Blue Coat telnet proxy services.
+  reference:
+    - https://en.wikipedia.org/wiki/Blue_Coat_Systems
+    - https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/about-ssl-proxy.html
+    - https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3.html
+  metadata:
+    max-request: 1
+    verified: true
+  tags: network,bluecoat,detect
+
+tcp:
+  - inputs:
+      - data: "\r\n"
+        read: 1024
+
+    host:
+      - "{{Hostname}}"
+    port: 23
+    read-size: 4096
+
+    matchers:
+      - type: word
+        part: data
+        words:
+          - "Blue Coat telnet proxy"

--- a/network/detection/bluecoat-telnet-proxy-detect.yaml
+++ b/network/detection/bluecoat-telnet-proxy-detect.yaml
@@ -4,7 +4,8 @@ info:
   name: BlueCoat Telnet Proxy - Detect
   author: righettod
   severity: info
-  description: Detects Blue Coat telnet proxy services.
+  description: |
+    Detects Blue Coat telnet proxy services.
   reference:
     - https://en.wikipedia.org/wiki/Blue_Coat_Systems
     - https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/about-ssl-proxy.html


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **Blue Coat Telnet Proxy** services.

References:

- https://en.wikipedia.org/wiki/Blue_Coat_Systems
- https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3/about-ssl-proxy.html
- https://techdocs.broadcom.com/us/en/symantec-security-software/web-and-network-security/edge-swg/7-3.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e6802114-31a3-4759-ad83-1ccd12e777e9)

Such services is not intended to be exposed on Internet or public networks. It is intended to be exposed on internal networks or dedicated management networks.

### Additional Details (leave it blank if not applicable)

None

### Additional References

None