### PR TITLE
Mixed-active-content: fewer FPs

### DIFF
--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -26,6 +26,18 @@ http:
     matchers:
       - type: regex
         part: body
+        negative: true
+        regex:
+         # There are some sites which download scripts using an unencrypted connection (e.g. http://html5shiv.googlecode.com/svn/trunk/html5.js)
+         # to the users of old browsers.
+         #
+         # This rule filters such sites (even if the site contains other scripts downloaded using an unencrypted connection) to decrease the number
+         # of false positives. If you have an idea how to filter out only such scripts (and detect if the same site serves another script using
+         # http:// to all users) feel free to replace the rule.
+         - "(?mi)<!--\\[if lt IE [0-9]*\\]>\\s*<script src=\"http://"
+
+      - type: regex
+        part: body
         regex:
           - "<script[^>]*src=['\"]http://[^'\">]+['\"]"
           - "<iframe[^>]*src=['\"]http://[^'\">]+['\"]"

--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -28,13 +28,13 @@ http:
         part: body
         negative: true
         regex:
-         # There are some sites which download scripts using an unencrypted connection (e.g. http://html5shiv.googlecode.com/svn/trunk/html5.js)
-         # to the users of old browsers.
-         #
-         # This rule filters such sites (even if the site contains other scripts downloaded using an unencrypted connection) to decrease the number
-         # of false positives. If you have an idea how to filter out only such scripts (and detect if the same site serves another script using
-         # http:// to all users) feel free to replace the rule.
-         - "(?mi)<!--\\[if lt IE [0-9]*\\]>\\s*<script src=\"http://"
+          # There are some sites which download scripts using an unencrypted connection (e.g. http://html5shiv.googlecode.com/svn/trunk/html5.js)
+          # to the users of old browsers.
+          #
+          # This rule filters such sites (even if the site contains other scripts downloaded using an unencrypted connection) to decrease the number
+          # of false positives. If you have an idea how to filter out only such scripts (and detect if the same site serves another script using
+          # http:// to all users) feel free to replace the rule.
+          - "(?mi)<!--\\[if lt IE [0-9]*\\]>\\s*<script src=\"http://"
 
       - type: regex
         part: body

--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -28,12 +28,6 @@ http:
         part: body
         negative: true
         regex:
-          # There are some sites which download scripts using an unencrypted connection (e.g. http://html5shiv.googlecode.com/svn/trunk/html5.js)
-          # to the users of old browsers.
-          #
-          # This rule filters such sites (even if the site contains other scripts downloaded using an unencrypted connection) to decrease the number
-          # of false positives. If you have an idea how to filter out only such scripts (and detect if the same site serves another script using
-          # http:// to all users) feel free to replace the rule.
           - "(?mi)<!--\\[if lt IE [0-9]*\\]>\\s*<script src=\"http://"
 
       - type: regex


### PR DESCRIPTION
### Template / PR Information

There are some sites which download scripts using an unencrypted connection (e.g. http://html5shiv.googlecode.com/svn/trunk/html5.js) to the users of old browsers.

This rule filters such sites so they aren't matched.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

