### PR TITLE
add cve-2023-6389

### DIFF
--- a/http/cves/2023/ CVE-2023-6389.yaml
+++ b/http/cves/2023/ CVE-2023-6389.yaml
@@ -20,15 +20,14 @@ info:
   metadata:
     vendor: abhinavsingh
     product: wordpress_toolbar
-  tags: wpscan,redirect,wordpress,cve2023,wp-plugin
+    max-request: 1
+  tags: cve,cve2023,wordpress,wp-plugin,wordpress-toolbar,wp
 
-requests:
+http:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/wordpress-toolbar/toolbar.php?wptbto=https://oast.me&wptbhash=acme"
 
-    redirects: true
-    max-redirects: 2
     matchers:
       - type: regex
         part: header

--- a/http/cves/2023/ CVE-2023-6389.yaml
+++ b/http/cves/2023/ CVE-2023-6389.yaml
@@ -7,8 +7,8 @@ info:
   description: |
     The plugin redirects to any URL via the "wptbto" parameter. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-6389
     - https://wpscan.com/vulnerability/04dafc55-3a8d-4dd2-96da-7a8b100e5a81/
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6389
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -18,10 +18,12 @@ info:
     epss-percentile: 0.40297
     cpe: cpe:2.3:a:abhinavsingh:wordpress_toolbar:*:*:*:*:*:*:wordpress:*
   metadata:
+    verified: true
+    max-request: 1
     vendor: abhinavsingh
     product: wordpress_toolbar
-    max-request: 1
-  tags: cve,cve2023,wordpress,wp-plugin,wordpress-toolbar,wp
+    publicwww-query: "/wp-content/plugins/wordpress-toolbar/"
+  tags: cve,cve2023,wordpress,wp-plugin,wordpress-toolbar,wp,redirect
 
 http:
   - method: GET

--- a/http/cves/2023/ CVE-2023-6389.yaml
+++ b/http/cves/2023/ CVE-2023-6389.yaml
@@ -1,0 +1,36 @@
+id: CVE-2023-6389
+
+info:
+  name: WordPress Toolbar <= 2.2.6 - Open Redirect
+  author: Kazgangap
+  severity: medium
+  description: |
+    The plugin redirects to any URL via the "wptbto" parameter. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6389
+    - https://wpscan.com/vulnerability/04dafc55-3a8d-4dd2-96da-7a8b100e5a81/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2023-6389
+    cwe-id: CWE-601
+    epss-score: 0.00097
+    epss-percentile: 0.40297
+    cpe: cpe:2.3:a:abhinavsingh:wordpress_toolbar:*:*:*:*:*:*:wordpress:*
+  metadata:
+    vendor: abhinavsingh
+    product: wordpress_toolbar
+  tags: wpscan,redirect,wordpress,cve2023,wp-plugin
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wordpress-toolbar/toolbar.php?wptbto=https://oast.me&wptbhash=acme"
+
+    redirects: true
+    max-redirects: 2
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)oast\.me.*$'


### PR DESCRIPTION
### Template / PR Information

**_Actually, it's an older plugin and doesn't get updates. I saw a CVE number from 2023 so I wanted to add it._**


**add cve-2023-6389**
The WordPress Toolbar WordPress plugin through 2.2.6 redirects to any URL via the "wptbto" parameter. This makes it possible for unauthenticated attackers to redirect users to potentially malicious sites if they can successfully trick them into performing an action.



References:
https://wpscan.com/vulnerability/04dafc55-3a8d-4dd2-96da-7a8b100e5a81/
https://nvd.nist.gov/vuln/detail/CVE-2023-6389


### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)