### PR TITLE
Added avada-fusion-forms-uploads-exposure.yaml (CVE-2024-2340)

### DIFF
--- a/http/cves/2024/CVE-2024-2340.yaml
+++ b/http/cves/2024/CVE-2024-2340.yaml
@@ -1,20 +1,27 @@
-id: avada-fusion-forms-uploads-exposure
+id: CVE-2024-2340
 
 info:
   name: Avada < 7.11.7 - Unauthenticated Sensitive Information Exposure via Form Uploads Directory Listing
   author: t3l3machus
   severity: medium
-  description: The Avada theme for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 7.11.6 via the '/wp-content/uploads/fusion-forms/' directory. This makes it possible for unauthenticated attackers to extract sensitive data uploaded via an Avada created form with a file upload mechanism.
+  description: |
+    The Avada theme for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 7.11.6 via the '/wp-content/uploads/fusion-forms/' directory. This makes it possible for unauthenticated attackers to extract sensitive data uploaded via an Avada created form with a file upload mechanism.
+  remediation: Fixed in 7.11.7
   reference:
     - https://vulners.com/wpvulndb/WPVDB-ID:507E1D07-4953-4A31-81E8-80F01F971E2A
     - https://nvd.nist.gov/vuln/detail/CVE-2024-2340
+    - https://avada.com/documentation/avada-changelog/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/8db8bbc3-43ca-4ef5-a44d-2987c8597961?source=cve
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
+    cve-id: CVE-2024-2340
+    epss-score: 0.00043
+    epss-percentile: 0.08267
   metadata:
     verified: true
     max-request: 1
-  tags: wp-plugin,wp,wordpress,unauthenticated,wpscan
+  tags: cve,cve2024,wp-plugin,wp,wordpress,unauthenticated,wpscan
 
 http:
   - method: GET
@@ -25,8 +32,6 @@ http:
     matchers:
       - type: regex
         part: body
-        # words:
-        #  - "<title>Index of /wp-content/uploads/fusion-forms</title>"
         regex:
           - '<title>Index of [\s\S]*title>'
         condition: and

--- a/http/cves/2024/CVE-2024-2340.yaml
+++ b/http/cves/2024/CVE-2024-2340.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-2340
 
 info:
-  name: Avada < 7.11.7 - Unauthenticated Sensitive Information Exposure via Form Uploads Directory Listing
+  name: Avada < 7.11.7 - Information Disclosure
   author: t3l3machus
   severity: medium
   description: |
@@ -9,9 +9,9 @@ info:
   remediation: Fixed in 7.11.7
   reference:
     - https://vulners.com/wpvulndb/WPVDB-ID:507E1D07-4953-4A31-81E8-80F01F971E2A
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-2340
     - https://avada.com/documentation/avada-changelog/
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/8db8bbc3-43ca-4ef5-a44d-2987c8597961?source=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-2340
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
@@ -21,7 +21,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2024,wp-plugin,wp,wordpress,unauthenticated,wpscan
+  tags: cve,cve2024,wp-theme,wp,wordpress,wpscan,avada,exposure
 
 http:
   - method: GET
@@ -34,6 +34,7 @@ http:
         part: body
         regex:
           - '<title>Index of [\s\S]*title>'
+          - 'fusion'
         condition: and
 
       - type: status

--- a/http/vulnerabilities/wordpress/avada-fusion-forms-uploads-exposure.yaml
+++ b/http/vulnerabilities/wordpress/avada-fusion-forms-uploads-exposure.yaml
@@ -1,0 +1,36 @@
+id: avada-fusion-forms-uploads-exposure
+
+info:
+  name: Avada < 7.11.7 - Unauthenticated Sensitive Information Exposure via Form Uploads Directory Listing
+  author: t3l3machus
+  severity: medium
+  description: The Avada theme for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 7.11.6 via the '/wp-content/uploads/fusion-forms/' directory. This makes it possible for unauthenticated attackers to extract sensitive data uploaded via an Avada created form with a file upload mechanism.
+  reference:
+    - https://vulners.com/wpvulndb/WPVDB-ID:507E1D07-4953-4A31-81E8-80F01F971E2A
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-2340
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+  metadata:
+    verified: true
+    max-request: 1
+  tags: wp-plugin,wp,wordpress,unauthenticated,wpscan
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/uploads/fusion-forms/"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        # words:
+        #  - "<title>Index of /wp-content/uploads/fusion-forms</title>"
+        regex:
+          - '<title>Index of [\s\S]*title>'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

The Avada theme for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 7.11.6 via the '/wp-content/uploads/fusion-forms/' directory. This makes it possible for unauthenticated attackers to extract sensitive data uploaded via an Avada created form with a file upload mechanism.

- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2024-2340
    - https://vulners.com/wpvulndb/WPVDB-ID:507E1D07-4953-4A31-81E8-80F01F971E2A


### Template Validation

I've validated this template locally?
YES

![image](https://github.com/projectdiscovery/nuclei-templates/assets/75489922/f9f2d274-c0a9-4dd5-bb4e-628dfcad9b67)


#### Additional Details 
Vulnerable instances exposing uploaded files via dir listing can be discovered with at least the following google dorks:
`inurl:"uploads/fusion-forms/"`
`intitle:"Index of /wp-content/uploads/fusion-forms"`

![image](https://github.com/projectdiscovery/nuclei-templates/assets/75489922/12c406b5-5fd8-4b49-98b5-e6c421cf6a81)
