### PR TITLE
add cve-2024-33575

### DIFF
--- a/http/cves/2024/CVE-2024-33575.yaml
+++ b/http/cves/2024/CVE-2024-33575.yaml
@@ -1,0 +1,37 @@
+id: CVE-2024-33575
+
+info:
+  name: User Meta WP Plugin < 3.1 - Sensitive Information Exposure
+  author: Kazgangap
+  severity: medium
+  description: |
+    The User Meta is vulnerable to Sensitive Information Exposure in all versions up to, and including, 3.0 via the /views/debug.php file. This makes it possible for unauthenticated attackers, with to extract sensitive configuration data.
+  remediation: Fixed in 3.1
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-33575
+    - https://wpscan.com/vulnerability/3b75549c-3fc5-4e6f-84ae-264d8276bfb3/
+    - https://patchstack.com/database/vulnerability/user-meta/wordpress-user-meta-plugin-3-0-sensitive-data-exposure-vulnerability?_s_id=cve
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2024-33575
+    cwe-id: CWE-200
+    epss-score: 0.00043
+    epss-percentile: 0.08268
+  metadata:
+    vendor: User Meta
+    product: User Meta
+    framework: wordpress
+  tags: exposure,wordpress,usermeta,cve2024,wpscan
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/user-meta/views/debug.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+            - 'status_code == 200'
+            - 'contains(content_type, "text/html")'
+        condition: and

--- a/http/cves/2024/CVE-2024-33575.yaml
+++ b/http/cves/2024/CVE-2024-33575.yaml
@@ -22,7 +22,8 @@ info:
     vendor: User Meta
     product: User Meta
     framework: wordpress
-  tags: exposure,wordpress,usermeta,cve2024,wpscan
+    publicwww-query: "/wp-content/plugins/user-meta/"
+  tags: wpscan,cve,cve2024,user-meta,wordpress,wp-plugin,info-leak
 
 http:
   - method: GET
@@ -32,6 +33,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-            - 'status_code == 200'
-            - 'contains(content_type, "text/html")'
+          - 'status_code == 200'
+          - 'contains(body, "um-debug<br/>")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

The related plugin discloses information. It's tagged **CVE-2024-33575.** 

https://wpscan.com/vulnerability/3b75549c-3fc5-4e6f-84ae-264d8276bfb3/

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)