### PR TITLE
New directory listing template

### DIFF
--- a/http/miscellaneous/directory-listing.yaml
+++ b/http/miscellaneous/directory-listing.yaml
@@ -1,0 +1,90 @@
+id: directory-listing
+
+info:
+  name: Directory Listing Enabled
+  author: theMiddle
+  severity: low
+  description: Directory Indexing is a web server feature that allows the contents of a directory to be displayed when no index file is present. This can be a security risk as it can expose sensitive files, old backup or unreferenced files.
+  reference:
+    - https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
+    - https://portswigger.net/kb/issues/00600100_directory-listing
+  tags: miscellaneous,misc,generic,misconfguration,web
+
+flow: |
+  function target_is_in_scope(url) {
+    if (url.startsWith(template.http_1_host) || url.startsWith("/")) {
+      return true;
+    }
+    return false;
+  }
+
+  http(1);
+
+  if(template.links) {
+    var path_checked = [];
+    var paths = [];
+    
+    for(i=0; i<template.links.length; i++) {
+      if (target_is_in_scope(template.links[i])) {
+        
+        var path = template.links[i].replace(template.http_1_host, "");
+        var path_split = path.split("/");
+        var path_to_check = "";
+        
+        for(p in path_split) {
+          if (path_split[p] != "") {
+            path_to_check += "/"+path_split[p];
+
+            if (!path_checked.includes(path_to_check)) {
+              path_checked.push(path_to_check);
+
+              set("path_to_check", path_to_check);
+              http(2);
+            }
+          }
+        }
+
+      }
+    }
+  }
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    matchers:
+      - type: status
+        internal: true
+        status:
+          - 200
+      - type: word
+        words:
+          - "text/html"
+        part: header
+    extractors:
+      - type: xpath
+        name: links
+        part: body
+        internal: true
+        xpath:
+          - "//*/@href|//*/@src"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}{{path_to_check}}"
+    redirects: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        internal: true
+        status:
+          - 200
+      - type: word
+        words:
+          - "text/html"
+        part: header
+      - type: word
+        words:
+          - "<title>Index of"
+        part: body

--- a/http/miscellaneous/directory-listing.yaml
+++ b/http/miscellaneous/directory-listing.yaml
@@ -23,14 +23,14 @@ flow: |
   if(template.links) {
     var path_checked = [];
     var paths = [];
-    
+
     for(i=0; i<template.links.length; i++) {
       if (target_is_in_scope(template.links[i])) {
-        
+
         var path = template.links[i].replace(template.http_1_host, "");
         var path_split = path.split("/");
         var path_to_check = "";
-        
+
         for(p in path_split) {
           if (path_split[p] != "") {
             path_to_check += "/"+path_split[p];

--- a/http/miscellaneous/directory-listing.yaml
+++ b/http/miscellaneous/directory-listing.yaml
@@ -88,6 +88,7 @@ http:
         part: body
         words:
           - "<title>Index of"
+        case-insensitive: true
 
       - type: word
         part: header

--- a/http/miscellaneous/directory-listing.yaml
+++ b/http/miscellaneous/directory-listing.yaml
@@ -5,10 +5,14 @@ info:
   author: theMiddle
   severity: low
   description: Directory Indexing is a web server feature that allows the contents of a directory to be displayed when no index file is present. This can be a security risk as it can expose sensitive files, old backup or unreferenced files.
+  impact: |
+    Sensitive files and directories may be exposed to unauthorized users.
+  remediation: |
+    Disable directory listing in the web server configuration.
   reference:
     - https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
     - https://portswigger.net/kb/issues/00600100_directory-listing
-  tags: miscellaneous,misc,generic,misconfguration,web
+  tags: misc,generic,misconfig,fuzz
 
 flow: |
   function target_is_in_scope(url) {
@@ -52,16 +56,17 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
-    redirects: true
+
+    host-redirects: true
+    max-redirects: 2
     matchers:
-      - type: status
+      - type: dsl
         internal: true
-        status:
-          - 200
-      - type: word
-        words:
-          - "text/html"
-        part: header
+        dsl:
+          - contains(header, "text/html")
+          - status_code_1 == 200
+        condition: and
+
     extractors:
       - type: xpath
         name: links
@@ -73,18 +78,22 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}{{path_to_check}}"
-    redirects: true
+
+    host-redirects: true
+    max-redirects: 2
+
     matchers-condition: and
     matchers:
-      - type: status
-        internal: true
-        status:
-          - 200
       - type: word
-        words:
-          - "text/html"
-        part: header
-      - type: word
+        part: body
         words:
           - "<title>Index of"
-        part: body
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

This PR adds a new template that checks if "directory listing" is enabled on one of the links collected by visiting the BaseURL. The template runs two different HTTP requests: the first one collects links from `src` and `href` attributes on the BaseURL, and the second request checks if a directory listing is present on all path levels in collected links.

#### For example:
If something like `<a href="/wp-content/plugins/foo/css/bar.css">` is found in response, this template checks the following URLs:
```
https://<target>/wp-content/plugins/foo/css/
https://<target>/wp-content/plugins/foo/
https://<target>/wp-content/plugins/
https://<target>/wp-content/
```

#### Why add this template, since already there's the `dir-listing` template?
This template differs from dir-listing since it first collects all possible links in the target response body, and tries to follow them dynamically (and not just statically hard-coded in the template).

#### References:
- https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Review_Old_Backup_and_Unreferenced_Files_for_Sensitive_Information
- https://portswigger.net/kb/issues/00600100_directory-listing

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Google Query: `intitle:index.of`

Matched response data snippet:
```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<html>
 <head>
  <title>Index of /foo</title>
 </head>
 <body>
<h1>Index of /foo</h1>
```

#### Thanks ❤️ 
This PR has been done during a Twitch Live on Rev3rse Security Channel, special thanks to @sparrrgh 

