### PR TITLE
Add detection of CrafterCMS login panel instances.

### DIFF
--- a/http/exposed-panels/craftercms-panel.yaml
+++ b/http/exposed-panels/craftercms-panel.yaml
@@ -1,0 +1,34 @@
+id: craftercms-panel
+
+info:
+  name: CrafterCMS Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    CrafterCMS login panel was detected.
+  reference:
+    - https://craftercms.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"craftercms"
+  tags: panel,craftercms,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/studio/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "craftercms", "crafter software corporation")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Copyright\s+\(C\)\s+([0-9-]+)\s+Crafter'

--- a/http/exposed-panels/craftercms-panel.yaml
+++ b/http/exposed-panels/craftercms-panel.yaml
@@ -23,7 +23,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "craftercms", "crafter software corporation")'
+          - 'contains_any(to_lower(body), "craftercmsnext", "login - craftercms", "crafter software corporation")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **CrafterCMS** software.

References:

- https://craftercms.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/84181c92-0d27-4625-9199-1fd5e33904f5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://52.203.109.180:8080
https://204.236.230.132
https://18.166.37.193
http://154.12.240.240:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://beta.shodan.io/search?query=http.title%3A%22craftercms%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1c4fa87e-311a-4886-b5e8-09d70525d49e)

### Additional References

None