### PR TITLE
Add detection of CrafterCMS instances.

### DIFF
--- a/http/technologies/craftercms-detect.yaml
+++ b/http/technologies/craftercms-detect.yaml
@@ -1,0 +1,34 @@
+id: craftercms-detect
+
+info:
+  name: CrafterCMS - Detect
+  author: righettod
+  severity: info
+  description: |
+    CrafterCMS was detected.
+  reference:
+    - https://craftercms.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"craftercms"
+  tags: tech,craftercms,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/studio"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 404'
+          - 'contains_any(to_lower(body), "craftercms", "crafter software corporation")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Copyright\s+\(C\)\s+([0-9-]+)\s+Crafter'

--- a/http/technologies/craftercms-detect.yaml
+++ b/http/technologies/craftercms-detect.yaml
@@ -17,14 +17,15 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/studio"
+      - "{{BaseURL}}"
 
+    host-redirects: true
+    max-redirects: 2
     matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 404'
-          - 'contains_any(to_lower(body), "craftercms", "crafter software corporation")'
-        condition: and
+      - type: word
+        part: header
+        words:
+          - 'CrafterCMS'
 
     extractors:
       - type: regex


### PR DESCRIPTION
> [!IMPORTANT]
> 💡It was adapted to prevent collisions with the  #9759 proposed template.

Hi,

This PR propose a template to detect instance of the **CrafterCMS** software.

References:

- https://craftercms.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/84674afe-75cf-4aaf-bd3c-3def99c2cd38)

👀Ones in the yellow square have their login panel exposed too. So, to prevent duplicate with #9759 , I defined the condition to not detect them in this template.

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://52.203.109.180:8080
http://16.162.16.177
https://204.236.230.132
https://18.166.37.193
http://208.83.64.155:9080
http://43.198.141.173
http://154.12.240.240:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://beta.shodan.io/search?query=http.title%3A%22craftercms%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/75ef2ec8-ba2d-4fc4-93eb-369130a5728b)

### Additional References

None