### PR TITLE
Add detection of JFrog Artifactory login panel instances.

### DIFF
--- a/http/exposed-panels/artifactory-panel.yaml
+++ b/http/exposed-panels/artifactory-panel.yaml
@@ -1,0 +1,27 @@
+id: artifactory-panel
+
+info:
+  name: JFrog Artifactory Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    JFrog Artifactory login panel was detected.
+  reference:
+    - https://jfrog.com/artifactory/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"JFrog"
+  tags: panel,jfrog,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui/login/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>jfrog</title>", "jfrog-ui-essentials", "jfrog webapp")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **JFrog Artifactory** software.

References:

- https://jfrog.com/artifactory/

I did not found existing one so I proposed one:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1277c3fd-f675-4a73-a3ef-283074c75e59)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/c76a8a9b-0e71-428b-b003-fd30ffc10ddc)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://139.59.133.106
https://artifact.soprasteria.com
https://159.8.157.137
http://34.71.9.241
http://18.190.88.1
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22JFrog%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/3418c411-9e73-49b5-804f-e3099f5da1de)

### Additional References

None