### PR TITLE
Add detection of QlikView AccessPoint login panel instances.

### DIFF
--- a/http/exposed-panels/qlikview-accesspoint-panel.yaml
+++ b/http/exposed-panels/qlikview-accesspoint-panel.yaml
@@ -7,25 +7,24 @@ info:
   description: |
     QlikView AccessPoint login panel was detected.
   reference:
-    - https://www.qlik.com/
     - https://help.qlik.com/en-US/qlikview/May2023/Subsystems/QMC/Content/QV_QMC/QMC_System_Setup_QlikViewWebServers_AccessPoint.htm
   metadata:
-    max-request: 1
     verified: true
-    shodan-query: http.title:"QlikView - AccessPoint"
+    max-request: 1
+    shodan-query: title:"QlikView - AccessPoint"
   tags: panel,qlikview,login,detect
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}"
+      - "{{BaseURL}}/qlikview/FormLogin.htm"
 
-    redirects: true
-    max-redirects: 3
+    host-redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>qlikview - accesspoint</title>", "alt=\"qlikview")'
+          - 'contains_any(to_lower(body), "<title>qlikview - accesspoint", "alt=\"qlikview")'
         condition: and

--- a/http/exposed-panels/qlikview-accesspoint-panel.yaml
+++ b/http/exposed-panels/qlikview-accesspoint-panel.yaml
@@ -19,7 +19,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
-      
+
     redirects: true
     max-redirects: 3
 

--- a/http/exposed-panels/qlikview-accesspoint-panel.yaml
+++ b/http/exposed-panels/qlikview-accesspoint-panel.yaml
@@ -1,0 +1,31 @@
+id: qlikview-accesspoint-panel
+
+info:
+  name: QlikView AccessPoint Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    QlikView AccessPoint login panel was detected.
+  reference:
+    - https://www.qlik.com/
+    - https://help.qlik.com/en-US/qlikview/May2023/Subsystems/QMC/Content/QV_QMC/QMC_System_Setup_QlikViewWebServers_AccessPoint.htm
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"QlikView - AccessPoint"
+  tags: panel,qlikview,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      
+    redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>qlikview - accesspoint</title>", "alt=\"qlikview")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **QlikView AccessPoint** software.

References:

- https://www.qlik.com/
- https://help.qlik.com/en-US/qlikview/May2023/Subsystems/QMC/Content/QV_QMC/QMC_System_Setup_QlikViewWebServers_AccessPoint.htm

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/31a79a79-2b74-4e53-8a57-53ca49ec2084)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://qlikview.soprasteria.com
https://141.138.64.86
https://210.87.7.253
https://qlikview-emea.abbott.com
https://208.88.165.181
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22QlikView+-+AccessPoint%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/46a157ab-2ac9-4636-b92e-29472f1d4be7)

### Additional References

None