### PR TITLE
Create softether-vpn-default-login.yaml

### DIFF
--- a/http/default-logins/softether-vpn-default-login.yaml
+++ b/http/default-logins/softether-vpn-default-login.yaml
@@ -1,0 +1,39 @@
+id: softether-vpn-default-login
+
+info:
+  name: SoftEther VPN Admin Console - Default Login
+  author: bhutch
+  severity: high
+  description: |
+    The administrative password for the SoftEther VPN Server is blank.
+  reference:
+    - https://www.softether.org/4-docs/1-manual/3._SoftEther_VPN_Server_Manual/3.3_VPN_Server_Administration#Administration_Authority_for_the_Entire_SoftEther_VPN_Server
+  metadata:
+    shodan-query: title:"SoftEther VPN Server"
+    verified: true
+  tags: panel,vpn,softether,default-login
+
+http:
+  - raw:
+      - |
+        GET /admin/default/ HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ':' + password)}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - administrator
+      password:
+        -
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>SoftEther VPN Server HTML5 Web Administration Console (Under construction!)</title>'
+
+      - type: status
+        status:
+          - 200

--- a/http/default-logins/softether/softether-vpn-default-login.yaml
+++ b/http/default-logins/softether/softether-vpn-default-login.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     shodan-query: title:"SoftEther VPN Server"
     verified: true
+    max-request: 1
   tags: panel,vpn,softether,default-login
 
 http:
@@ -32,7 +33,9 @@ http:
       - type: word
         part: body
         words:
-          - '<title>SoftEther VPN Server HTML5 Web Administration Console (Under construction!)</title>'
+          - 'Create new Virtual Hub'
+          - 'Toggle navigation'
+        condition: and
 
       - type: status
         status:

--- a/http/default-logins/softether/softether-vpn-default-login.yaml
+++ b/http/default-logins/softether/softether-vpn-default-login.yaml
@@ -9,10 +9,10 @@ info:
   reference:
     - https://www.softether.org/4-docs/1-manual/3._SoftEther_VPN_Server_Manual/3.3_VPN_Server_Administration#Administration_Authority_for_the_Entire_SoftEther_VPN_Server
   metadata:
-    shodan-query: title:"SoftEther VPN Server"
     verified: true
     max-request: 1
-  tags: panel,vpn,softether,default-login
+    shodan-query: title:"SoftEther VPN Server"
+  tags: misconfig,vpn,softether,default-login
 
 http:
   - raw:


### PR DESCRIPTION
### Template / PR Information

SoftEther VPN is F/OSS multi-protocol VPN software.

When deployed, the administrator password is blank. Administrators are expected to immediately change it using the VPN Server Manager.

This template identifies SoftEther VPN targets that have a blank administrator password.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO