### PR TITLE
Add detection of EasyVista login panel instances.

### DIFF
--- a/http/exposed-panels/easyvista-panel.yaml
+++ b/http/exposed-panels/easyvista-panel.yaml
@@ -1,0 +1,35 @@
+id: easyvista-panel
+
+info:
+  name: EasyVista Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    EasyVista login panel was detected.
+  reference:
+    - https://www.easyvista.com/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Easyvista"
+  tags: panel,easyvista,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>easyvista apps</title>", "easyvista-bundle.min.js", "packages_com_easyvista_core")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)package:\s+"([a-z0-9._-]+)"'
+          - '(?i)version&nbsp;:&nbsp;([a-z0-9._-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **EasyVista** software.

References:

- https://www.easyvista.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/296d4a51-a0d5-4e7e-a5a1-62dca5e368ff)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://85.90.52.39
https://ezvapps.bcn.cat
https://151.22.13.37
https://oxymo.soprasteria.com
https://44.241.62.109
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Easyvista%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/e11a3547-d9d5-4096-abba-43d5de65956b)

### Additional References

None