### PR TITLE
Create sparklighter-detect.yaml

### DIFF
--- a/http/technologies/sparklighter-detect.yaml
+++ b/http/technologies/sparklighter-detect.yaml
@@ -1,0 +1,27 @@
+id: sparklighter-detect
+
+info:
+  name: Spark Lighter Detection
+  author: icarot
+  severity: info
+  description: This nuclei template detects a Spark Lighter server, a REST API for Apache Spark on K8S or YARN.
+  classification:
+    cpe: cpe:2.3:a:apache:spark:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 5
+    vendor: lighter
+    product: spark_lighter_server
+    category: productivity
+  tags: tech,lighter,spark,detect
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/lighter/api"
+      - "{{BaseURL}}/lighter/batches"
+      - "{{BaseURL}}/lighter/sessions"
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/http/technologies/sparklighter-detect.yaml
+++ b/http/technologies/sparklighter-detect.yaml
@@ -4,24 +4,32 @@ info:
   name: Spark Lighter Detection
   author: icarot
   severity: info
-  description: This nuclei template detects a Spark Lighter server, a REST API for Apache Spark on K8S or YARN.
+  description: |
+    Detects a Spark Lighter server, a REST API for Apache Spark on K8S or YARN.
   classification:
     cpe: cpe:2.3:a:apache:spark:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 5
-    vendor: lighter
-    product: spark_lighter_server
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: spark
     category: productivity
   tags: tech,lighter,spark,detect
 
-requests:
+http:
   - method: GET
     path:
       - "{{BaseURL}}/lighter/api"
-      - "{{BaseURL}}/lighter/batches"
-      - "{{BaseURL}}/lighter/sessions"
 
+    matchers-condition: and
     matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>Lighter</title>'
+          - '/lighter/favicon.svg'
+        condition: and
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
This nuclei template detects a Spark Lighter server, a REST API for Apache Spark on K8S or YARN.

- References:

https://github.com/exacaster/lighter

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Local machine:**
`$ docker run --name lighterserver -it --rm lighter:latest -p 8080:8080 -p 25333:25333 -e LIGHTER_KUBERNETES_ENABLED=false`

**Docker Kali container:**
`# ~/go/bin/nuclei -t sparklighter-detect.yaml -u "http://172.17.0.3:8080" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/336f5211-91f1-4498-951d-4a4e6992460e)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/3ae68064-1598-4e54-9c9d-1d8c3f18cd0c)