### PR TITLE
Add detection of Micro Focus Application Lifecycle Management login panel instances.

### DIFF
--- a/http/exposed-panels/microfocus-application-lifecycle-management-panel.yaml
+++ b/http/exposed-panels/microfocus-application-lifecycle-management-panel.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Micro Focus Application Lifecycle Management login panel was detected.
   reference:
-    - https://www.microfocus.com/
+    - https://www.opentext.com/products/alm-quality-center
   metadata:
     max-request: 1
     verified: true

--- a/http/exposed-panels/microfocus-application-lifecycle-management-panel.yaml
+++ b/http/exposed-panels/microfocus-application-lifecycle-management-panel.yaml
@@ -1,0 +1,37 @@
+id: microfocus-application-lifecycle-management-panel
+
+info:
+  name: Micro Focus Application Lifecycle Management Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Micro Focus Application Lifecycle Management login panel was detected.
+  reference:
+    - https://www.microfocus.com/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"Micro Focus Application Lifecycle Management"
+  tags: panel,microfocus,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/qcbin/"
+
+    redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "micro focus application lifecycle management", "<div class=\"alm_name\">application lifecycle", "<p class=\"alm_header\">application lifecycle")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Micro\s+Focus\s+Application\s+Lifecycle\s+Management\s+([0-9.]+)'

--- a/http/exposed-panels/microfocus-lifecycle-panel.yaml
+++ b/http/exposed-panels/microfocus-lifecycle-panel.yaml
@@ -1,7 +1,7 @@
-id: microfocus-application-lifecycle-management-panel
+id: microfocus-lifecycle-panel
 
 info:
-  name: Micro Focus Application Lifecycle Management Panel - Detect
+  name: Micro Focus Application Lifecycle Management - Panel
   author: righettod
   severity: info
   description: |


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Micro Focus Application Lifecycle Management** software.

References:

- https://www.opentext.com/products/alm-quality-center

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/5c558c77-5977-458a-8f91-9767b3ca3fca)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://testing.cgi.com
https://alm-stg.vodafone.com
https://alm-prod.vodafone.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Micro%C2%A0Focus%C2%A0Application%C2%A0Lifecycle%C2%A0Management%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/24e5f752-eec0-41a8-bde7-be379221745c)

### Additional References

None