### PR TITLE
adds template to detect bitvise service

### DIFF
--- a/network/detection/bitvise-detect.yaml
+++ b/network/detection/bitvise-detect.yaml
@@ -1,0 +1,35 @@
+id: bitvise-detect
+
+info:
+  name: Bitvise Service - Detect
+  author: abdullahisik
+  severity: info
+  description: |
+    Bitvise service was detected.
+  reference:
+    - https://www.bitvise.com/
+    - https://vulners.com/openvas/OPENVAS:1361412562310813387
+ 
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:/a:bitvise:winsshd
+  metadata:
+    shodan-query: product:"bitvise"
+    max-request: 1
+  tags: seclists,network,ssh,bitvise,detect
+
+tcp:
+  - host:
+      - "{{Hostname}}"
+    port: 22
+
+    matchers:
+      - type: regex
+        regex:
+          - '(?i)Bitvise'
+
+    extractors:
+      - type: regex
+        regex:
+          - "SSH-([0-9.]+)-([0-9.]+) .*"

--- a/network/detection/bitvise-ssh-detect.yaml
+++ b/network/detection/bitvise-ssh-detect.yaml
@@ -1,15 +1,14 @@
 id: bitvise-detect
 
 info:
-  name: Bitvise Service - Detect
+  name: SSH Bitvise Service - Detect
   author: abdullahisik
   severity: info
   description: |
-    Bitvise service was detected.
+    Bitvise SSH service was detected.
   reference:
     - https://www.bitvise.com/
     - https://vulners.com/openvas/OPENVAS:1361412562310813387
- 
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -17,7 +16,7 @@ info:
   metadata:
     shodan-query: product:"bitvise"
     max-request: 1
-  tags: seclists,network,ssh,bitvise,detect
+  tags: network,ssh,bitvise,detect
 
 tcp:
   - host:
@@ -32,4 +31,4 @@ tcp:
     extractors:
       - type: regex
         regex:
-          - "SSH-([0-9.]+)-([0-9.]+) .*"
+          - "SSH([-0-9.]+) FlowSsh: Bitvise ([A-Z a-z()]+) ([0-9.]+)"


### PR DESCRIPTION
### Template / PR Information

This  template detects Bitvise Services 

- References: 
    - https://www.bitvise.com/
    - https://vulners.com/openvas/OPENVAS:1361412562310813387


### Template Validation

I've validated this template locally?
- [👍 ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
[DBG] [bitvise-detect] Dumped Network response for 123.[redacted]:9999

00000000  53 53 48 2d 32 2e 30 2d  38 2e 34 33 20 46 6c 6f  |SSH-2.0-8.43 Flo|
00000010  77 53 73 68 3a 20 42 69  74 76 69 73 65 20 53 53  |wSsh: Bitvise SS|
00000020  48 20 53 65 72 76 65 72  20 28 57 69 6e 53 53 48  |H Server (WinSSH|
00000030  44 29 20 38 2e 34 33 3a  20 66 72 65 65 20 6f 6e  |D) 8.43: free on|
00000040  6c 79 20 66 6f 72 20 70  65 72 73 6f 6e 61 6c 20  |ly for personal |
00000050  6e 6f 6e 2d 63 6f 6d 6d  65 72 63 69 61 6c 20 75  |non-commercial u|
00000060  73 65 0d 0a                                       |se..|

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)