### PR TITLE
Add matchers for IBM WebSphere Application Server (WAS) to tech-detect template.

### DIFF
--- a/http/technologies/tech-detect.yaml
+++ b/http/technologies/tech-detect.yaml
@@ -2,7 +2,7 @@ id: tech-detect
 
 info:
   name: Wappalyzer Technology Detection
-  author: hakluke
+  author: hakluke,righettod
   severity: info
   metadata:
     max-request: 1
@@ -2234,6 +2234,14 @@ http:
           - href="(?:\/|[^>]+)webapp\/wcs\/
         condition: or
         part: body
+        
+      - type: word
+        name: ibm-websphere-application-server
+        words:
+          - 'SRVE0255E:'
+          - 'A WebGroup/Virtual Host to handle'
+        condition: or
+        part: body
 
       - type: regex
         name: bootstrap
@@ -3718,4 +3726,3 @@ http:
         part: server
         words:
           - "istio-envoy"
-# digest: 4a0a00473045022100dda47d007d349ebedb421dbacca584c8a22ec4f7eef5c4500bb051ec65bc11fc02206c9f127f5f0ba79e1ad88514f2e37693741a04f6b9b492a58a6143d05d83c780:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/tech-detect.yaml
+++ b/http/technologies/tech-detect.yaml
@@ -2234,7 +2234,7 @@ http:
           - href="(?:\/|[^>]+)webapp\/wcs\/
         condition: or
         part: body
-        
+
       - type: word
         name: ibm-websphere-application-server
         words:


### PR DESCRIPTION
## Template / PR Information

This PR add matchers to detect **IBM WAS** to the template.

Reference: https://www.ibm.com/support/pages/apar/PM69554

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found on Shodan:

```text
https://113.146.134.148
https://199.255.160.52
https://194.150.56.151:9443
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/001857a8-cf1e-4137-a988-b60141a86386)


### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22SRVE0255E%3A%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/aeb83478-20a0-4642-9f99-2449836dde2d)


### Additional References:

None