### PR TITLE
cisco-firepower-management-login

### DIFF
--- a/http/exposed-panels/cisco-firepower-panel.yaml
+++ b/http/exposed-panels/cisco-firepower-panel.yaml
@@ -38,4 +38,4 @@ http:
         part: body
         group: 1
         regex:
-         - "'version':\\s*'(\\d+\\.\\d+\\.\\d+)'"
+          - "'version':\\s*'(\\d+\\.\\d+\\.\\d+)'"

--- a/http/exposed-panels/cisco-firepower-panel.yaml
+++ b/http/exposed-panels/cisco-firepower-panel.yaml
@@ -1,30 +1,34 @@
-id: cisco-firepower-management-login
+id: cisco-firepower-panel
 
 info:
   name: Cisco Firepower Management Center login - Detect
   author: Charles D
   severity: info
-  description: Cisco Firepower Management Centerlogin panel was detected
+  description: |
+    Cisco Firepower Management Centerlogin panel was detected
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
     max-request: 1
     shodan-query: html:"cisco firepower management"
-  tags: console,login,cisco
+    verified: true
+  tags: login,cisco,panel,console
 
 http:
   - method: GET
     path:
       - '{{BaseURL}}/ui/login'
-    
+
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "Cisco Firepower Management Center"
-        part: body
-    
+          - "Login"
+        condition: and
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
Adding a Cisco firepower management login panel, did not see any in for nuclei.  For shodan query that is the only one that seems to show the result