### PR TITLE
Add detection of Oracle Access Management login panel instances.

### DIFF
--- a/http/exposed-panels/oracle-access-management.yaml
+++ b/http/exposed-panels/oracle-access-management.yaml
@@ -1,0 +1,40 @@
+id: oracle-access-management
+
+info:
+  name: Oracle Access Management Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Oracle Access Management login panel was detected.
+  classification:
+    cpe: cpe:2.3:a:oracle:access_manager:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Oracle Access Management"
+    vendor: oracle
+    verified: true
+  tags: panel,oracle,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/oam/pages/login.jsp"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Login - Oracle Access Management"
+          - "/oam/server/auth_cred_submit"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Login\s+-\s+Oracle\s+Access\s+Management\s+([a-z0-9]+)</title>'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Oracle Access Management** software.

References:

- https://www.oracle.com/security/identity-management/access-management/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/399daf5c-5b8e-4b47-9719-b69ef14ab2bd)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://sso.adminsolutionsuat.mercer.com
https://iam.cs-tst.nphies.sa
https://oamfcatest-pub.opc.oracleoutsourcing.com
https://169.155.149.250
https://hrbl-oasafety-idm.oracleindustry.com
https://sisda.sakata.com.br
https://kowa-prod3-oasafety-idm.oracleindustry.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Oracle+Access+Management%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/292eb0d8-51dc-47b5-9313-d21178d672f1)

### Additional References

None