### PR TITLE
Add more matchers to the Oracle Commerce Business Control Center login panel detection template.

### DIFF
--- a/http/exposed-panels/oracle-business-control.yaml
+++ b/http/exposed-panels/oracle-business-control.yaml
@@ -2,9 +2,11 @@ id: oracle-business-control
 
 info:
   name: Oracle Commerce Business Control Center Login Panel - Detect
-  author: dhiyaneshDk
+  author: dhiyaneshDk,righettod
   severity: info
   description: Oracle Commerce Business Control Center login panel was detected.
+  reference:
+    - https://docs.oracle.com/cd/E23095_01/Platform.93/ATGBCCAdminGuide/html/s0101introductiontotheatgbusinesscont01.html
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -20,14 +22,19 @@ http:
   - method: GET
     path:
       - '{{BaseURL}}/atg/bcc'
+      - '{{BaseURL}}/atg/user/html/login.jsp'
+    
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
       - type: word
         words:
           - '<title>Oracle Commerce Business Control Center</title>'
+          - '/atg/userprofiling/InternalProfileFormHandler.loginSuccessURL'
+          - '/atg/userprofiling/InternalProfileFormHandler.loginErrorURL'
+        condition: or
 
       - type: status
         status:
           - 200
-# digest: 490a00463044022053e01b77ea1a1e685d1db0bf5c04bdd1ec7c937037c1f0a468192cfe1a0ce40e022027ac62488ae6b091b8ec611d2ea461fed923362a0d494718b77a4c1e75656ab7:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more matchers, as well as a reference entry, to the existing template.

Reference: https://docs.oracle.com/cd/E23095_01/Platform.93/ATGBCCAdminGuide/html/s0101introductiontotheatgbusinesscont01.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the host http://bcc.woolworths.co.za/ found on Google:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/1eb61520-a4aa-46d0-bc3a-a7d9925a57f9)


#### Additional Details (leave it blank if not applicable)

I did not achieved to find a valid Shodan query and it seems that the one from the template do not hosts anymore:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/5c846261-4748-44f3-800f-3748c73568a8)

### Additional References:

None