### PR TITLE
Add new path for phpmyadmin

### DIFF
--- a/http/exposed-panels/phpmyadmin-panel.yaml
+++ b/http/exposed-panels/phpmyadmin-panel.yaml
@@ -35,6 +35,7 @@ http:
         - "/web/phpmyadmin/"
         - "/xampp/phpmyadmin/"
         - "/phpMyAdmin/"
+        - "/phpma/"
 
     stop-at-first-match: true
     matchers:


### PR DESCRIPTION
I have observed several phpmyadmin instances on /phpma/ which is a common short form of phpmyadmin. Should be useful to add this to the list of possible locations