### PR TITLE
Tune "Oracle PeopleSoft Login Panel" template.

### DIFF
--- a/http/exposed-panels/oracle-people-sign-in.yaml
+++ b/http/exposed-panels/oracle-people-sign-in.yaml
@@ -5,6 +5,8 @@ info:
   author: idealphase,righettod
   severity: info
   description: Oracle PeopleSoft login panel was detected.
+  reference:
+    - https://www.oracle.com/applications/peoplesoft/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200

--- a/http/exposed-panels/oracle-people-sign-in.yaml
+++ b/http/exposed-panels/oracle-people-sign-in.yaml
@@ -2,7 +2,7 @@ id: oracle-people-sign-in
 
 info:
   name: Oracle PeopleSoft Login Panel - Detect
-  author: idealphase
+  author: idealphase,righettod
   severity: info
   description: Oracle PeopleSoft login panel was detected.
   classification:
@@ -11,26 +11,32 @@ info:
   metadata:
     max-request: 1
     shodan-query: http.title:"Oracle PeopleSoft Sign-in"
-  tags: oracle,panel
+  tags: oracle,panel,login,detect
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}'
+      - '{{BaseURL}}/psp/csprd/?cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}/psp/retess/?cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}/psp/fscmprod/?cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}/psp/CT920/?cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}/psp/esshrprd/?cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}/psp/ps/?&cmd=login&languageCd=ENG&'
 
-    host-redirects: true
+    stop-at-first-match: true
+    redirects: true
     max-redirects: 2
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '<title>Oracle PeopleSoft Sign-in</title>'
-          - 'alt="Oracle PeopleSoft Sign-in" title="Oracle PeopleSoft Sign-in"'
-        condition: or
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>oracle peoplesoft sign-in</title>", "alt=\"oracle peoplesoft sign-in\" title=\"oracle peoplesoft sign-in\"")'
+        condition: and
 
-      - type: status
-        status:
-          - 200
-# digest: 4a0a004730450220534a813cfd286f86aac6bf1ce17b27b6c7b7de5f18eb4b195db1d5ec6a96288f022100b08a023d57ce6c6abb820161ff4ef992d4cd670007e92cdb2d4dc018d01ef3a9:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)\*\s+Copyright\s+\(c\)\s+([0-9,\s]+)\s+Oracle\s+and\/or\s+its\s+affiliates.'

--- a/http/exposed-panels/oracle-peoplesoft-panel.yaml
+++ b/http/exposed-panels/oracle-peoplesoft-panel.yaml
@@ -1,4 +1,4 @@
-id: oracle-people-sign-in
+id: oracle-peoplesoft-panel
 
 info:
   name: Oracle PeopleSoft Login Panel - Detect
@@ -11,19 +11,26 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-    max-request: 1
+    verified: true
+    max-request: 7
     shodan-query: http.title:"Oracle PeopleSoft Sign-in"
-  tags: oracle,panel,login,detect
+    fofa-query: title="Oracle PeopleSoft Sign-in"
+  tags: oracle,peoplesoft,panel,login,detect
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/psp/csprd/?cmd=login&languageCd=ENG&'
-      - '{{BaseURL}}/psp/retess/?cmd=login&languageCd=ENG&'
-      - '{{BaseURL}}/psp/fscmprod/?cmd=login&languageCd=ENG&'
-      - '{{BaseURL}}/psp/CT920/?cmd=login&languageCd=ENG&'
-      - '{{BaseURL}}/psp/esshrprd/?cmd=login&languageCd=ENG&'
-      - '{{BaseURL}}/psp/ps/?&cmd=login&languageCd=ENG&'
+      - '{{BaseURL}}'
+      - '{{BaseURL}}/{{path}}'
+
+    payloads:
+      path:
+        - psp/csprd/?cmd=login&languageCd=ENG&
+        - psp/retess/?cmd=login&languageCd=ENG&
+        - psp/fscmprod/?cmd=login&languageCd=ENG&
+        - psp/CT920/?cmd=login&languageCd=ENG&
+        - psp/esshrprd/?cmd=login&languageCd=ENG&
+        - psp/ps/?&cmd=login&languageCd=ENG&
 
     stop-at-first-match: true
     redirects: true
@@ -33,7 +40,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>oracle peoplesoft sign-in</title>", "alt=\"oracle peoplesoft sign-in\" title=\"oracle peoplesoft sign-in\"")'
+          - 'contains_any(to_lower(body), "<title>oracle peoplesoft sign-in</title>", "alt=\"oracle peoplesoft sign-in", "title=\"oracle peoplesoft sign-in")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR try to tune/enhance the existing template for **Oracle PeopleSoft** login panel detection. I also added an extractor to get the copyright date to see if the version is an old or recent one. Support for redirection is still required due to the way the soft handle the URL parameters.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Hosts used for the test found via Shodan :

```text
https://campus.hmhn.org
https://maint.ambs.manchester.ac.uk
https://157.188.14.202
https://fscm.afeg.us
https://selfservesa.ouhsc.edu
https://ess-epeople.albertahealthservices.ca
https://hrprd.butler.edu
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/d80e7c21-d7c1-446e-b1d9-e30757265087)

### Additional Details (leave it blank if not applicable)

I used the shodan query present into the template to find test hosts:

https://www.shodan.io/search?query=http.title%3A%22Oracle+PeopleSoft+Sign-in%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/33cda666-4a7d-40cd-a69c-676cb0308f57)

### Additional References:

None