### PR TITLE
Add detection of IBM WAS via a special headers

### DIFF
--- a/http/technologies/tech-detect.yaml
+++ b/http/technologies/tech-detect.yaml
@@ -2243,6 +2243,14 @@ http:
         condition: or
         part: body
 
+      - type: word
+        name: ibm-websphere-application-server
+        words:
+          - '$wsep:'
+          - '$WSEP:'
+        condition: or
+        part: all_headers
+
       - type: regex
         name: bootstrap
         regex:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add the detection of the IBM WAS via the special header `$WSEP:`

References:
- https://www.ibm.com/docs/en/was/8.5.5?topic=SSEQTP_8.5.5/com.ibm.websphere.nd.multiplatform.doc/ae/rweb_custom_props.htm#com.ibm.ws.webcontainer.suppressErrorPageODRHeader__title__1
- https://stackoverflow.com/questions/44263965/how-to-suppress-wsep-header-in-websphere-liberty-core-17-0-0-1

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via Shodan:

```text
http://218.77.105.11:9080
http://60.174.141.86:9080
http://212.200.132.75:9080
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/dfe1ea57-cdfb-43ab-8cfe-df4aca75cf48)


### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=%24wsep

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/63207cd7-0a36-406c-90bc-c743acc1ec46)


### Additional References:

None