### PR TITLE
Remove Dell matcher from sonicwall WAF detect (False Positives)

### DIFF
--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -157,14 +157,6 @@ http:
         part: response
 
       - type: regex
-        name: ats
-        regex:
-          - '(?i)(\()?apachetrafficserver((\/)?\d+(.\d+(.\d+)?)?)'
-          - '(?i)ats((\/)?(\d+(.\d+(.\d+)?)?))?'
-        condition: or
-        part: response
-
-      - type: regex
         name: malcare
         regex:
           - '(?i)malcare'

--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -74,9 +74,9 @@ http:
       - type: regex
         name: teros
         regex:
-          - '(?i)st8(id|.wa|.wf)?.?(\d+|\w+)?'
+          - '(?i)st8(id|.wa|.wf)?.?(\d+|\w+)?='
         condition: or
-        part: response
+        part: header
 
       - type: regex
         name: stricthttp

--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -580,7 +580,6 @@ http:
         regex:
           - '(?i)This.request.is.blocked.by.the.SonicWALL'
           - '(?i)Dell.SonicWALL'
-          - '(?i)\bDell\b'
           - '(?i)Web.Site.Blocked.+\bnsa.banner'
           - '(?i)SonicWALL'
           - '(?i).>policy.this.site.is.blocked<.'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed false positives generated by the Dell matcher

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Matching the word `dell` is very prone to false positives.

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)