### PR TITLE
Add detection of Oracle Application Server login panel instances.

### DIFF
--- a/http/exposed-panels/oracle-application-server-panel.yaml
+++ b/http/exposed-panels/oracle-application-server-panel.yaml
@@ -1,7 +1,7 @@
 id: oracle-application-server-panel
 
 info:
-  name: Oracle Application Server Login Panel - Detect
+  name: Oracle Application Server Panel - Detect
   author: righettod
   severity: info
   description: |
@@ -18,6 +18,11 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/em/console/ias/oc4j/home"
+      - "{{BaseURL}}"
+
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl

--- a/http/exposed-panels/oracle-application-server-panel.yaml
+++ b/http/exposed-panels/oracle-application-server-panel.yaml
@@ -5,6 +5,8 @@ info:
   author: righettod
   severity: info
   description: Oracle Application Server login panel was detected.
+  reference:
+    - https://www.oracle.com/middleware/technologies/internet-application-server.html
   metadata:
     shodan-query: http.title:"Oracle Containers for J2EE"
     max-request: 1

--- a/http/exposed-panels/oracle-application-server-panel.yaml
+++ b/http/exposed-panels/oracle-application-server-panel.yaml
@@ -1,0 +1,29 @@
+id: oracle-application-server-panel
+
+info:
+  name: Oracle Application Server Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Oracle Application Server login panel was detected.
+  metadata:
+    shodan-query: http.title:"Oracle Containers for J2EE"
+    max-request: 1
+  tags: panel,oracle,containers,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/em/console/ias/oc4j/home"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "login to oracle application server control", "oracle enterprise manager")'
+        condition: and
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '(?i)Copyright\s+&copy;\s+([0-9,\s]+),\s+Oracle'

--- a/http/exposed-panels/oracle-application-server-panel.yaml
+++ b/http/exposed-panels/oracle-application-server-panel.yaml
@@ -4,12 +4,14 @@ info:
   name: Oracle Application Server Login Panel - Detect
   author: righettod
   severity: info
-  description: Oracle Application Server login panel was detected.
+  description: |
+    Oracle Application Server login panel was detected.
   reference:
     - https://www.oracle.com/middleware/technologies/internet-application-server.html
   metadata:
-    shodan-query: http.title:"Oracle Containers for J2EE"
+    verified: true
     max-request: 1
+    shodan-query: http.title:"Oracle Containers for J2EE"
   tags: panel,oracle,containers,login,detect
 
 http:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Oracle Application Server** (OAS) software.

👀This template seems quite similar to [oracle-containers-panel.yaml](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposed-panels/oracle-containers-panel.yaml) but this proposed template really focus on finding the OAS login panel that is referenced on the **Oracle Containers for J2EE** page:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f5cb0f03-7a22-45f4-a761-97173c601eeb)

Indeed, it is possible that the **Oracle Containers for J2EE** is up without that the login page being reachable. See this example:

https://37.230.240.25:8443/

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/72711881-73e5-4f84-8e35-44302f22386c)

References:

- https://www.oracle.com/middleware/technologies/internet-application-server.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/693ded30-4d49-423d-a80e-c672fc39ca01)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://189.180.189.172
http://63.241.189.45:8080
http://24.152.80.77:8080
http://177.35.125.88:8080
http://200.103.66.82:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Oracle+Containers+for+J2EE%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/397e94c0-dc26-480f-b12b-8ddd4df30126)

### Additional References

None