### PR TITLE
Lorex Panel

### DIFF
--- a/http/exposed-panels/lorex-panel.yaml
+++ b/http/exposed-panels/lorex-panel.yaml
@@ -1,29 +1,35 @@
-id: lorex-panel-detect
+id: lorex-panel
 
 info:
-  name: lorex Panel
+  name: Lorex Panel - Detect
   author: rxerium
   severity: info
-  description: A lorex panel was detected.
+  description: |
+    A lorex panel was detected.
   reference:
     - https://www.lorex.com/
   classification:
     cwe-id: CWE-200
   metadata:
+    verified: true
     max-request: 1
-  tags: panel
+    shodan-query: html:"<title>WEB SERVICE</title>"
+  tags: panel,login,detect
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
 
+    host-redirects: true
+    max-redirects: 2
+
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - '<title>WEB SERVICE</title>'
-        part: body
 
       - type: status
         status:

--- a/http/exposed-panels/lorex-panel.yaml
+++ b/http/exposed-panels/lorex-panel.yaml
@@ -13,8 +13,8 @@ info:
   metadata:
     verified: true
     max-request: 1
-    shodan-query: html:"<title>WEB SERVICE</title>"
-  tags: panel,login,detect
+    shodan-query: "Lorex"
+  tags: panel,login,detect,lorex
 
 http:
   - method: GET
@@ -26,11 +26,8 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '<title>WEB SERVICE</title>'
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains_all(tolower(body), "<title>web service</title>", "lorex")'
+          - 'contains_any(body, "/LOREX_webplugin", "lorex_msg")'
+        condition: or

--- a/http/exposed-panels/lorex-panel.yaml
+++ b/http/exposed-panels/lorex-panel.yaml
@@ -1,0 +1,30 @@
+id: lorex-panel-detect
+
+info:
+  name: lorex Panel
+  author: rxerium
+  severity: info
+  description: A lorex panel was detected.
+  reference:
+    - https://www.lorex.com/
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+  tags: panel
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>WEB SERVICE</title>'
+        part: body
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hey team, here is a panel detection template for Lorex. Do you reckon we could strenghten the matchers and match on anything else?

Here is an example host running Lorex:
http://173.30.57.30

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)