### PR TITLE
add cve-2023-6505

### DIFF
--- a/http/cves/2023/CVE-2023-6505.yaml
+++ b/http/cves/2023/CVE-2023-6505.yaml
@@ -1,17 +1,18 @@
 id: CVE-2023-6505
 
 info:
-  name: Prime Mover < 1.9.3 - Directory Listing to Sensitive Data Exposure
+  name: Prime Mover < 1.9.3 - Sensitive Data Exposure
   author: securityforeveryone.com
   severity: high
   description: |
     Prime Mover plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 1.9.2 via directory listing in the 'prime-mover-export-files/1/' folder. This makes it possible for unauthenticated attackers to extract sensitive data including site and configuration information, directories, files, and password hashes.
-  remediation: Fixed in 1.9.3
+  remediation: |
+    Fixed in 1.9.3
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-6505
     - https://wpscan.com/vulnerability/eca6f099-6af0-4f42-aade-ab61dd792629
     - https://research.cleantalk.org/cve-2023-6505-prime-mover-poc-exploit/
     - https://github.com/fkie-cad/nvd-json-data-feeds
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6505
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -20,10 +21,12 @@ info:
     epss-percentile: 0.36916
     cpe: cpe:2.3:a:codexonics:prime_mover:*:*:*:*:*:wordpress:*:*
   metadata:
+    max-request: 1
     vendor: codexonics
     product: prime_mover
     framework: wordpress
-  tags: wpscan,wordpress,exposure,cve,cve2023
+    fofa-query: body="/wp-content/plugins/prime-mover"
+  tags: cve,cve2023,wp,wp-plugin,wordpress,exposure,prime-mover,listing
 
 http:
   - method: GET
@@ -33,11 +36,11 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - 'Index of /wp-content/uploads/prime-mover-export-files/1'
           - '.wprime'
         condition: or
-        part: body
 
       - type: status
         status:

--- a/http/cves/2023/CVE-2023-6505.yaml
+++ b/http/cves/2023/CVE-2023-6505.yaml
@@ -1,0 +1,44 @@
+id: CVE-2023-6505
+
+info:
+  name: Prime Mover < 1.9.3 - Directory Listing to Sensitive Data Exposure
+  author: securityforeveryone.com
+  severity: high
+  description: |
+    Prime Mover plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 1.9.2 via directory listing in the 'prime-mover-export-files/1/' folder. This makes it possible for unauthenticated attackers to extract sensitive data including site and configuration information, directories, files, and password hashes.
+  remediation: Fixed in 1.9.3
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6505
+    - https://wpscan.com/vulnerability/eca6f099-6af0-4f42-aade-ab61dd792629
+    - https://research.cleantalk.org/cve-2023-6505-prime-mover-poc-exploit/
+    - https://github.com/fkie-cad/nvd-json-data-feeds
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-6505
+    epss-score: 0.00087
+    epss-percentile: 0.36916
+    cpe: cpe:2.3:a:codexonics:prime_mover:*:*:*:*:*:wordpress:*:*
+  metadata:
+    vendor: codexonics
+    product: prime_mover
+    framework: wordpress
+  tags: wpscan,wordpress,exposure,cve,cve2023
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/uploads/prime-mover-export-files/1/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Index of /wp-content/uploads/prime-mover-export-files/1'
+          - '.wprime'
+        condition: or
+        part: body
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2023/CVE-2023-6505.yaml
+++ b/http/cves/2023/CVE-2023-6505.yaml
@@ -2,7 +2,7 @@ id: CVE-2023-6505
 
 info:
   name: Prime Mover < 1.9.3 - Sensitive Data Exposure
-  author: securityforeveryone.com
+  author: securityforeveryone
   severity: high
   description: |
     Prime Mover plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 1.9.2 via directory listing in the 'prime-mover-export-files/1/' folder. This makes it possible for unauthenticated attackers to extract sensitive data including site and configuration information, directories, files, and password hashes.
@@ -11,7 +11,6 @@ info:
   reference:
     - https://wpscan.com/vulnerability/eca6f099-6af0-4f42-aade-ab61dd792629
     - https://research.cleantalk.org/cve-2023-6505-prime-mover-poc-exploit/
-    - https://github.com/fkie-cad/nvd-json-data-feeds
     - https://nvd.nist.gov/vuln/detail/CVE-2023-6505
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N


### PR DESCRIPTION
CVE-2023-6505

Apache normally creates the .htaccess file and the vulnerability does not arise. The Nginx server must manually add this protection to the configuration files. When it is not added, we can see very critical files in the directory. I used OR in the template because if it has never taken a backup, we will not encounter that file type, we will only see the directory.

poc: https://wpscan.com/vulnerability/eca6f099-6af0-4f42-aade-ab61dd792629/?ref=securitricks.com

https://plugins.trac.wordpress.org/browser/prime-mover/trunk/changelog.txt


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)