### PR TITLE
Adding service detection to pg templates

### DIFF
--- a/javascript/enumeration/pgsql/pgsql-default-db.yaml
+++ b/javascript/enumeration/pgsql/pgsql-default-db.yaml
@@ -14,7 +14,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,authenticated,enum
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected = client.ConnectWithDB(Host, Port, User, Pass, Db);

--- a/javascript/enumeration/pgsql/pgsql-file-read.yaml
+++ b/javascript/enumeration/pgsql/pgsql-file-read.yaml
@@ -14,7 +14,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,authenticated,enum
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected =  client.ExecuteQuery(Host, Port, User, Pass, Db, "select pg_ls_dir('./');");

--- a/javascript/enumeration/pgsql/pgsql-list-database.yaml
+++ b/javascript/enumeration/pgsql/pgsql-list-database.yaml
@@ -15,7 +15,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,authenticated,enum
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected =  client.ExecuteQuery(Host, Port, User, Pass, Db, "SELECT datname FROM pg_database");

--- a/javascript/enumeration/pgsql/pgsql-list-password-hashes.yaml
+++ b/javascript/enumeration/pgsql/pgsql-list-password-hashes.yaml
@@ -16,7 +16,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,authenticated,enum
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected =  client.ExecuteQuery(Host, Port, User, Pass, Db, "SELECT usename, passwd FROM pg_shadow");

--- a/javascript/enumeration/pgsql/pgsql-list-users.yaml
+++ b/javascript/enumeration/pgsql/pgsql-list-users.yaml
@@ -14,7 +14,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,enum,authenticated
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected =  client.ExecuteQuery(Host, Port, User, Pass, Db, "SELECT usename FROM pg_user");

--- a/javascript/enumeration/pgsql/pgsql-version-detect.yaml
+++ b/javascript/enumeration/pgsql/pgsql-version-detect.yaml
@@ -14,7 +14,11 @@ info:
     shodan-query: "product:\"PostgreSQL\""
   tags: js,network,postgresql,enum,authenticated
 javascript:
-  - code: |
+  - pre-condition: |
+      var m = require("nuclei/postgres");
+      var c = m.PGClient();
+      c.IsPostgres(Host, Port);
+    code: |
       const postgres = require('nuclei/postgres');
       const client = new postgres.PGClient;
       connected =  client.ExecuteQuery(Host, Port, User, Pass, Db, "select version();");


### PR DESCRIPTION
### Template / PR Information
This will be done automatically in https://github.com/projectdiscovery/nuclei/pull/5291 (postgres + mysql) but for retro-compatibility all templates interacting with postgres (or other services) should first ensure that they are targeting a postgres service. Potentially mysql templates needs to be reviewed as well.

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)