### PR TITLE
Add more matchers to the "IBM Security Access Manager" login panel detection template.

### DIFF
--- a/http/exposed-panels/ibm/ibm-security-access-manager.yaml
+++ b/http/exposed-panels/ibm/ibm-security-access-manager.yaml
@@ -2,7 +2,7 @@ id: ibm-security-access-manager
 
 info:
   name: IBM Security Access Manager Login Panel - Detect
-  author: geeknik
+  author: geeknik,righettod
   severity: info
   description: IBM Security Access Manager login panel was detected.
   reference:
@@ -14,8 +14,9 @@ info:
   metadata:
     max-request: 1
     vendor: ibm
+    shodan-query: http.title:"IBM Security Access Manager"
     product: security_access_manager
-  tags: panel,ibm
+  tags: panel,ibm,login,detect
 
 http:
   - method: GET
@@ -27,7 +28,9 @@ http:
       - type: word
         words:
           - "<title>IBM Security Access Manager</title>"
+          - "IBM Security <em>Access Manager</em>"
         part: body
+        condition: or
 
       - type: word
         words:
@@ -40,4 +43,3 @@ http:
           - "/mga/sps/authsvc/policy/forgot_password"
         part: body
         condition: and
-# digest: 4a0a00473045022100b3c31b972a1af3fbf321e8d2fad135f3c60e69ab84023684e3bdc1903e0a3f75022016212bd0980f645527268ebe265aed9838f5fe47d1fd9a37ffbac227e5765894:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more matchers to the existing template.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the host https://124.109.28.93 found on shodan:

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/ca711af5-d23b-415a-ba95-1985074cb9f7)

### Additional Details (leave it blank if not applicable)

Shodan query used and added to the template: https://www.shodan.io/search?query=http.title%3A%22IBM+Security+Access+Manager%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/2f3a4e89-8e71-4675-88dc-19478d1f28db)

### Additional References:

None