### PR TITLE
fix: split template for HttpOnly and Secure attributes

### DIFF
--- a/http/misconfiguration/cookies-without-httponly.yaml
+++ b/http/misconfiguration/cookies-without-httponly.yaml
@@ -1,7 +1,7 @@
-id: cookies-without-httponly-secure
+id: cookies-without-httponly
 
 info:
-  name: Cookies without HttpOnly or Secure attribute - Detect
+  name: Cookies without HttpOnly attribute - Detect
   author: princechaddha,Mr.Bobo HP
   severity: info
   description: |
@@ -38,6 +38,4 @@ http:
         part: header
         words:
           - "HttpOnly"
-          - "Secure"
         negative: true
-# digest: 4a0a004730450220123181274d69492219d698d89cf1fd5d0b71c908b139b6a52e15df69c7b8c6aa022100da21796dba95fc800f492b76bed8877b493b296856dc7f71fe89da22aff0fe3f:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/cookies-without-secure.yaml
+++ b/http/misconfiguration/cookies-without-secure.yaml
@@ -1,0 +1,41 @@
+id: cookies-without-secure
+
+info:
+  name: Cookies without Secure attribute - Detect
+  author: vthiery
+  severity: info
+  description: |
+    Checks whether cookies in the HTTP response contain the Secure attribute. If the Secure flag is set, it means that the cookie can only be transmitted over HTTPS
+  impact: |
+    Lack of Secure flag on cookies allows the cookie to be sent over unsecure HTTP, making it vulnerable to man-in-the-middle (MITM) attacks.
+  remediation: |
+    Ensure that all cookies are set with the Secure attribute to prevent MITM attacks.
+  reference:
+    - https://owasp.org/www-community/controls/SecureCookieAttribute
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0
+  metadata:
+    verified: true
+    max-request: 1
+  tags: misconfig,http,cookie,generic
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - 'Set-Cookie'
+
+      - type: word
+        part: header
+        words:
+          - "Secure"
+        negative: true


### PR DESCRIPTION
### Template / PR Information

Splitting the template `cookies-without-httponly-secure` into `cookies-without-httponly` and `cookies-without-secure` to allow catching cases where one is set but not the other.