### PR TITLE
Add more matchers to the "IBM Maximo" login panel detection template.

### DIFF
--- a/http/exposed-panels/ibm/ibm-maximo-login.yaml
+++ b/http/exposed-panels/ibm/ibm-maximo-login.yaml
@@ -36,7 +36,6 @@ http:
         words:
           - "maximo-icon.png"
           - "IBM"
-          - "Maximo"
         condition: and
 
       - type: status

--- a/http/exposed-panels/ibm/ibm-maximo-login.yaml
+++ b/http/exposed-panels/ibm/ibm-maximo-login.yaml
@@ -2,11 +2,12 @@ id: ibm-maximo-login
 
 info:
   name: IBM Maximo Login Panel - Detect
-  author: ritikchaddha
+  author: ritikchaddha,righettod
   severity: info
   description: IBM Maximo login panel was detected.
   reference:
     - https://www.ibm.com/support/pages/what-default-username-and-password-websphere-application-server-community-edition-and-how-add-users-admin-group
+    - https://www.ibm.com/products/maximo
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -18,12 +19,12 @@ info:
     product: maximo_asset_management
     shodan-query: http.favicon.hash:-399298961
     fofa-query: icon_hash=-399298961
-  tags: maximo,panel,ibm
+  tags: maximo,panel,ibm,login,detect
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/maximo/webclient/login/login.jsp"
+      - "{{BaseURL}}/maximo/webclient/login/login.jsp?appservauth=true"
 
     host-redirects: true
     max-redirects: 2
@@ -35,9 +36,16 @@ http:
         words:
           - "maximo-icon.png"
           - "IBM"
+          - "Maximo"
         condition: and
 
       - type: status
         status:
           - 200
-# digest: 4a0a004730450220108beea62e9138f7191cbc0b7b73120efe1cea19d5045abe5b9c370a44c9404e022100e266d1db3b98b7964ba3fa722ffe802d59d55f359ccf759470f532fa45c333ad:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Copyright\s+IBM\s+Corp\.\s+([0-9-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more matchers to the existing template as well as an extractor to have a look on old the instance is.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found on shodan using the query from the initial template:

```text
https://89.221.187.235
https://159.8.215.60
https://159.8.189.44
https://169.61.75.128
https://169.54.91.109
https://169.47.184.4
https://169.47.47.201
https://169.47.184.18
https://169.55.75.233
https://169.55.176.29
https://169.55.176.20
https://169.55.93.124
https://169.47.47.198
https://169.47.47.197
https://177.128.173.21
https://169.55.109.155
https://169.44.156.236
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/f145a455-e53f-4c1e-b251-1a04f4489384)


### Additional Details (leave it blank if not applicable)

None

### Additional References:

None