### PR TITLE
Add extractors to the "IBM Service Assistant" login panel detection template.

### DIFF
--- a/http/exposed-panels/ibm/ibm-service-assistant.yaml
+++ b/http/exposed-panels/ibm/ibm-service-assistant.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   description: IBM Service Assistant login panel was detected.
   reference:
-    - https://mediacenter.ibm.com/media/Using+the+IBM+Support+Assistant/0_ffe9o5w1 
+    - https://mediacenter.ibm.com/media/Using+the+IBM+Support+Assistant/0_ffe9o5w1
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -34,6 +34,6 @@ http:
       - type: regex
         part: body
         group: 1
-        regex:          
+        regex:
           - '(?i)([a-z0-9\s]+)\s+Service\s+Assistant\s+Tool'
           - '(?i)svcProductMtm\s+=\s+.?([0-9a-z\-]+).?'

--- a/http/exposed-panels/ibm/ibm-service-assistant.yaml
+++ b/http/exposed-panels/ibm/ibm-service-assistant.yaml
@@ -2,16 +2,18 @@ id: ibm-service-assistant
 
 info:
   name: IBM Service Assistant Login Panel - Detect
-  author: dhiyaneshDK
+  author: dhiyaneshDK,righettod
   severity: info
   description: IBM Service Assistant login panel was detected.
+  reference:
+    - https://mediacenter.ibm.com/media/Using+the+IBM+Support+Assistant/0_ffe9o5w1 
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
     max-request: 1
     shodan-query: http.title:"Welcome to Service Assistant"
-  tags: panel,ibm,service
+  tags: panel,ibm,service,login,detect
 
 http:
   - method: GET
@@ -27,4 +29,11 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a004730450221009dfb2b04022e1d677249671c42cfa583257d74854eb9e09d614c77a50e443e9e02201795f12826ce8883a64aa98673a48224e65016d081a8c7b415709f8469ad17d2:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:          
+          - '(?i)([a-z0-9\s]+)\s+Service\s+Assistant\s+Tool'
+          - '(?i)svcProductMtm\s+=\s+.?([0-9a-z\-]+).?'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add extractors to extract the type of the system as well as the assistant product version.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found on **shodan** using the query from the original template:

```text
https://160.99.1.84
https://160.217.208.150:8443
https://164.8.71.148:7443
https://164.8.71.148:8443
https://12.206.226.5
https://196.35.255.131
https://177.152.129.7
https://203.251.44.85:7443
https://140.113.107.23
https://223.86.220.145
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/146513bd-c488-4b6c-9365-48aedac42b76)


### Additional Details (leave it blank if not applicable)

None

### Additional References:

None