### PR TITLE
Solve #10119

### DIFF
--- a/http/cves/2020/CVE-2020-27838.yaml
+++ b/http/cves/2020/CVE-2020-27838.yaml
@@ -46,10 +46,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"clientId":"security-admin-console"'
+      - type: regex
+        regex:
+          - '"clientId":\s*"security-admin-console"'
           - '"secret":'
         condition: and
 


### PR DESCRIPTION
### Template / PR Information
False Negatives because of unhandled spaces.
The template now uses a regex expr instead

- Fixed CVE-2020-27838
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO