### PR TITLE
Added time-based-sqli to ignore

### DIFF
--- a/.nuclei-ignore
+++ b/.nuclei-ignore
@@ -38,3 +38,4 @@ files:
   - dns/txt-service-detect.yaml
   - javascript/enumeration/pop3/pop3-capabilities-enum.yaml
   - javascript/enumeration/redis/redis-require-auth.yaml
+  - dast/vulnerabilities/sqli/time-based-sqli.yaml


### PR DESCRIPTION
### Template / PR Information

Added `dast/vulnerabilities/sqli/time-based-sqli.yaml` to `.nuclei-ignore` as it was producing false positive results; therefore, it will no longer run in the default dast scan. We will update this once we have SQL injection analyzer support added to Nuclei

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)