### PR TITLE
Update severity of polyfill-backdoor to high

### DIFF
--- a/http/vulnerabilities/backdoor/polyfill-backdoor.yaml
+++ b/http/vulnerabilities/backdoor/polyfill-backdoor.yaml
@@ -3,7 +3,7 @@ id: polyfill-backdoor
 info:
   name: Polyfill.io - Detection
   author: kazet
-  severity: low
+  severity: high
   description: |
     The polyfill.io CDN was suspected to serve malware.
   reference:

--- a/http/vulnerabilities/backdoor/polyfill-backdoor.yaml
+++ b/http/vulnerabilities/backdoor/polyfill-backdoor.yaml
@@ -1,7 +1,7 @@
 id: polyfill-backdoor
 
 info:
-  name: Polyfill.io - Detection
+  name: Polyfill.io - Backdoor
   author: kazet
   severity: high
   description: |


### PR DESCRIPTION
### Template / PR Information

According to CVE-2024-38526, the severity of the polyfill check should be "high".

- References:
    - https://github.com/projectdiscovery/nuclei-templates/pull/10153/files
    - https://nvd.nist.gov/vuln/detail/CVE-2024-38526

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
