### PR TITLE
Create apache-pinot-detect.yaml and apache-pinot-config.yaml

### DIFF
--- a/http/exposures/configs/apache-pinot-config.yaml
+++ b/http/exposures/configs/apache-pinot-config.yaml
@@ -1,0 +1,40 @@
+id: apache-pinot-config
+
+info:
+  name: Apache Pinot - Exposure
+  author: icarot
+  severity: medium
+  description: |
+    Detects if path Appconfigs of Apache Pinot web application is exposed, getting internal information about the configuration made.
+  classification:
+    cpe: cpe:2.3:a:apache:pinot:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: pinot
+  tags: config,exposed,pinot,apache
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/appconfigs"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'systemConfig'
+          - 'runtimeConfig'
+          - 'pinotConfig'
+          - 'jvmConfig'
+          - 'systemProperties'
+        condition: and
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: config
+        part: body
+        json:
+          - '.[].systemProperties."basedir",.[].systemProperties."user.home",.[].systemProperties."user.name",.[].systemProperties."user.dir",.[].systemProperties."app.home",.[].systemProperties."java.home",.[].systemProperties."java.runtime.version",.systemConfig.name,.[].systemProperties."os.version"'

--- a/http/exposures/configs/apache-pinot-config.yaml
+++ b/http/exposures/configs/apache-pinot-config.yaml
@@ -10,9 +10,11 @@ info:
     cpe: cpe:2.3:a:apache:pinot:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    verified: true
     vendor: apache
     product: pinot
-  tags: config,exposed,pinot,apache
+    shodan-query: title:"Apache Pinot"
+  tags: config,exposure,pinot,apache
 
 http:
   - method: GET
@@ -22,19 +24,18 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
-          - 'systemConfig'
-          - 'runtimeConfig'
-          - 'pinotConfig'
-          - 'jvmConfig'
-          - 'systemProperties'
+          - '"systemConfig"'
+          - '"pinotConfig"'
+          - '"jvmConfig"'
         condition: and
+
+      - type: word
+        part: header
+        words:
+          - 'application/json'
+
       - type: status
         status:
           - 200
-    extractors:
-      - type: json
-        name: config
-        part: body
-        json:
-          - '.[].systemProperties."basedir",.[].systemProperties."user.home",.[].systemProperties."user.name",.[].systemProperties."user.dir",.[].systemProperties."app.home",.[].systemProperties."java.home",.[].systemProperties."java.runtime.version",.systemConfig.name,.[].systemProperties."os.version"'

--- a/http/technologies/apache/apache-pinot-detect.yaml
+++ b/http/technologies/apache/apache-pinot-detect.yaml
@@ -10,8 +10,10 @@ info:
     cpe: cpe:2.3:a:apache:pinot:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    verified: true
     vendor: apache
     product: pinot
+    shodan-query: title:"Apache Pinot"
   tags: tech,pinot,apache,detect
 
 http:
@@ -24,8 +26,7 @@ http:
       - type: word
         words:
           - '<title>Apache Pinot</title>'
-          - 'Pinot Controller UI'
-        condition: and
+
       - type: status
         status:
           - 200

--- a/http/technologies/apache/apache-pinot-detect.yaml
+++ b/http/technologies/apache/apache-pinot-detect.yaml
@@ -1,0 +1,31 @@
+id: apache-pinot-detect
+
+info:
+  name: Apache Pinot - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Pinot web application, A realtime distributed OLAP datastore.
+  classification:
+    cpe: cpe:2.3:a:apache:pinot:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: pinot
+  tags: tech,pinot,apache,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Apache Pinot</title>'
+          - 'Pinot Controller UI'
+        condition: and
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
This nuclei templates:

* Detects a Apache Pinot web application, A realtime distributed OLAP datastore.
* Detects if path Appconfigs of Apache Pinot web application is exposed, getting internal information about the configuration made.

- References:

https://github.com/apache/pinot

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Execute Docker Container:**

`$ docker run --rm -p 9000:9000 --name pinot_container apachepinot/pinot:latest QuickStart -type batch`
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' pinot_container`

**Docker Kali container:**

`# ~/go/bin/nuclei -t apache-pinot-detect.yaml -t apache-pinot-config.yaml -u "http://<IP_obtained_Docker_Inspect>:9000/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/a859cb0c-58a4-45fe-93e2-00500647cd66)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/b50e51e7-061a-4ad1-9a70-4a9b0287d3ba)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/15ae6c2f-e78a-4c05-ab30-1a9e75b4d671)

![image](https://github.com/projectdiscovery/nuclei-templates/assets/18042205/9cb5e296-636a-43f0-909e-c19423c1a0c6)
