### PR TITLE
Update springboot-configprops.yaml

### DIFF
--- a/http/misconfiguration/springboot/springboot-configprops.yaml
+++ b/http/misconfiguration/springboot/springboot-configprops.yaml
@@ -24,7 +24,7 @@ http:
         words:
           - "org.springframework.boot.actuate"
           - "beans"
-          - "contexts"
+          - "context"
         condition: and
 
       - type: status


### PR DESCRIPTION
### Template / PR Information

I have seen a few endpoints where `/configprops` path is present with disclosing the sensitive information but the template didn't detect it. So, I tried debugging the issue and found out that the keyword `contexts` was not there at all but instead I could find the word `context` in the response. So this PR is just to replace `contexts` to `context`.

- Fixed http/misconfiguration/springboot/springboot-configprops.yaml
- References:

### Template Validation

I've validated this template locally?
- [ ] YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)