### PR TITLE
Create CVE-2024-33610.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-33610.yaml
+++ b/http/cves/2024/CVE-2024-33610.yaml
@@ -1,0 +1,53 @@
+id: CVE-2024-33610
+
+info:
+  name: Sharp Multifunction Printers - Cookie Exposure
+  author: gy741
+  severity: medium
+  description: It was observed that Sharp printers are vulnerable to a listing of session cookies without authentication. Any attacker can list valid cookies by visiting a backdoor webpage and use them to authenticate to the printers.
+  impact: |
+    The exposure of cookies can lead to session hijacking, unauthorized access, and potential data breaches.
+  remediation: |
+    Apply all relevant security patches and product upgrades.
+  reference:
+    - https://pierrekim.github.io/blog/2024-06-27-sharp-mfp-17-vulnerabilities.html#pre-auth-cookies
+    - https://jvn.jp/en/vu/JVNVU93051062/index.html
+    - https://global.sharp/products/copier/info/info_security_2024-05.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2024-33610
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: "Set-Cookie: MFPSESSIONID="
+  tags: cve,cve2024,sharp,printer,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sessionlist.html"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'No.'
+          - 'User'
+          - 'From'
+          - 'Last login'
+          - 'Last access'
+          - 'Language ID'
+          - 'Cookie'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "Set-Cookie: MFPSESSIONID="
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2024-33610

```
It was observed that Sharp printers are vulnerable to a listing of session cookies without authentication. Any attacker can list valid cookies by visiting a backdoor webpage and use them to authenticate to the printers.
```

- References: https://pierrekim.github.io/blog/2024-06-27-sharp-mfp-17-vulnerabilities.html#pre-auth-cookies

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO