### PR TITLE
Update http takeover templates to show misconfigured cname

### DIFF
--- a/http/takeovers/aftership-takeover.yaml
+++ b/http/takeovers/aftership-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - Oops.</h2><p class="text-muted text-tight">The page you're looking for doesn't exist.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/aftership-takeover.yaml
+++ b/http/takeovers/aftership-takeover.yaml
@@ -25,5 +25,9 @@ http:
       - type: word
         words:
           - Oops.</h2><p class="text-muted text-tight">The page you're looking for doesn't exist.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
 
 # digest: 490a004630440220222d1eb4e6f6121f15f5bc09566c05a04be84da680f71151b9a0217d13854d4b022066636a5d0f9d9541086bec1f1a65690fb36c5586c1735868842af4a0c58eaee5:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/agilecrm-takeover.yaml
+++ b/http/takeovers/agilecrm-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - Sorry, this page is no longer available.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/agilecrm-takeover.yaml
+++ b/http/takeovers/agilecrm-takeover.yaml
@@ -25,5 +25,9 @@ http:
       - type: word
         words:
           - Sorry, this page is no longer available.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
 
 # digest: 4a0a00473045022100df8d7f10e37c0ea9ad8a43cad43285d174c0a517c03a1edd9acadc1c33996b3e022020a8458c4c9b14fcb69b1b580d4cd1df4b3978b8b02092699f8cced34099e500:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/aha-takeover.yaml
+++ b/http/takeovers/aha-takeover.yaml
@@ -25,5 +25,9 @@ http:
       - type: word
         words:
           - There is no portal here ... sending you back to Aha!
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
 
 # digest: 4a0a0047304502202da63a10b501a98c072a6776384f2bb642c837e7641d4dd212870daca7f3d9c4022100cc8c4ca48ad64c1bf9fc3388866897a00f598074de0029df772a908fd56e7afa:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/aha-takeover.yaml
+++ b/http/takeovers/aha-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - There is no portal here ... sending you back to Aha!
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/airee-takeover.yaml
+++ b/http/takeovers/airee-takeover.yaml
@@ -26,4 +26,9 @@ http:
         name: airee
         words:
           - 'Ошибка 402. Сервис Айри.рф не оплачен'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 480a0045304302201fceaf9dc7e08c32388d3b25f15a78412295bf2d92087a506409f47b869448bd021f0b2d66db8da614dd8fafccc4e5bf7d5b7913386a434495fb55e2d1c0662a32:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/airee-takeover.yaml
+++ b/http/takeovers/airee-takeover.yaml
@@ -26,6 +26,7 @@ http:
         name: airee
         words:
           - 'Ошибка 402. Сервис Айри.рф не оплачен'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/anima-takeover.yaml
+++ b/http/takeovers/anima-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - "If this is your website and you've just created it, try refreshing in a minute"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/anima-takeover.yaml
+++ b/http/takeovers/anima-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - "If this is your website and you've just created it, try refreshing in a minute"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100dc61f6f23fb5b89280618c559a5a94234bd675ee6529ce314614fdaef00723c202205ca59abbb43ac8b43633f12437e8e3871234c8df3a8be291a2890e95ada73b68:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/announcekit-takeover.yaml
+++ b/http/takeovers/announcekit-takeover.yaml
@@ -30,6 +30,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/announcekit-takeover.yaml
+++ b/http/takeovers/announcekit-takeover.yaml
@@ -30,4 +30,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450220411ce0a310d41e6a13fec4c4e48258ef47b6f97caa6f60fe2dbedf33aac7b52b022100db40ab50a70f049a2baf180b003297fbe4e98aef554cd1c625616f1a7ae9a82d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/aws-bucket-takeover.yaml
+++ b/http/takeovers/aws-bucket-takeover.yaml
@@ -71,6 +71,7 @@ http:
           - "oss-me-east-1.aliyuncs.com"
         negative: true
 
+
     extractors:
       - type: regex
         part: body

--- a/http/takeovers/bigcartel-takeover.yaml
+++ b/http/takeovers/bigcartel-takeover.yaml
@@ -29,6 +29,7 @@ http:
       - type: dsl
         dsl:
           - '!contains(host,"bigcartel.com")'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/bigcartel-takeover.yaml
+++ b/http/takeovers/bigcartel-takeover.yaml
@@ -29,4 +29,9 @@ http:
       - type: dsl
         dsl:
           - '!contains(host,"bigcartel.com")'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100925b0be6cfcab185f932f0f073603f7240331485b0bc86ef326a6200d00be8f6022100fb1f27f39b22bb7b171bed7a45741877556f338a31086be1ad116d66d62f4670:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/bitbucket-takeover.yaml
+++ b/http/takeovers/bitbucket-takeover.yaml
@@ -31,4 +31,9 @@ http:
         words:
           - "text/plain"
         part: header
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100c094e34cf6d07e1c771f27f42193b0798c3a060af2d82d2d9bdd68976a43314c0221008e9f7aa2de005c4d1aaa61c13c0f932d5fad0e3293793f601cfed2bb8b49dba6:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/bitbucket-takeover.yaml
+++ b/http/takeovers/bitbucket-takeover.yaml
@@ -31,6 +31,7 @@ http:
         words:
           - "text/plain"
         part: header
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/campaignmonitor-takeover.yaml
+++ b/http/takeovers/campaignmonitor-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - '<strong>Trying to access your account?</strong>'
           - 'or <a href="mailto:help@createsend.com'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100819a18f9b86c9ddae6d1d8e7d0d7088f961b901bbf64ed52caa6d0d7d0700157022100d61fd5a1bc6a2d4b6df76ffeab57fb65851dd176ebd9eb7ec62559c646d99a98:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/campaignmonitor-takeover.yaml
+++ b/http/takeovers/campaignmonitor-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - '<strong>Trying to access your account?</strong>'
           - 'or <a href="mailto:help@createsend.com'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/canny-takeover.yaml
+++ b/http/takeovers/canny-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - 'Company Not Found'
           - 'There is no such company. Did you enter the right URL?'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/canny-takeover.yaml
+++ b/http/takeovers/canny-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - 'Company Not Found'
           - 'There is no such company. Did you enter the right URL?'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100e95e874db3fb64d398f7de9bf94384f2c59ae0fe2fb2d336f6f1e9ceb1b5198702204ffcbe8c8a191927de05681b857f561e8a2d5c662d505c009fc0e26db4bb65b0:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/cargo-takeover.yaml
+++ b/http/takeovers/cargo-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - "If you're moving your domain away from Cargo you must make this configuration through your registrar's DNS control panel."
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/cargo-takeover.yaml
+++ b/http/takeovers/cargo-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - "If you're moving your domain away from Cargo you must make this configuration through your registrar's DNS control panel."
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100c56264fb56e062874dcaa3d5bf5d6d893f542f6cb6a0dc08812796bc8364ef7f022100fc1b0425d42fabb17822a50bf092be6557a2205913a9b38e9fd7b549cb4eee7d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/cargocollective-takeover.yaml
+++ b/http/takeovers/cargocollective-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - '<div class="notfound">'
           - '404 Not Found<br>'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502206e3e3a36081a8592520a2de1a112710b7bc015cccef9821507fc0064e33d7b780221008d1ad7b1bbc8e7687d2c8efe1be0fb64bf95a3402f36ba08bb4a2576ab6d7fff:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/cargocollective-takeover.yaml
+++ b/http/takeovers/cargocollective-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - '<div class="notfound">'
           - '404 Not Found<br>'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/clever-takeover.yaml
+++ b/http/takeovers/clever-takeover.yaml
@@ -28,5 +28,9 @@ http:
           - "The application you're trying to access doesn't seem to exist"
           - "support@clever-cloud.com"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
 
 # digest: 4a0a0047304502200a5e85c22f866e219ce404626a6c67addb67e89b5b92e10d9fd83b434e7336c3022100f862c3ca1bb2fb5467e28896d545cd1d2d17ef6fe6d9027fc95226caba6b5ca4:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/clever-takeover.yaml
+++ b/http/takeovers/clever-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - "The application you're trying to access doesn't seem to exist"
           - "support@clever-cloud.com"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/flexbe-takeover.yaml
+++ b/http/takeovers/flexbe-takeover.yaml
@@ -32,4 +32,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100f23c68360f3c8ffde41189aeb0c5571b3c4ad3e7c2e9b9c0afce192211737d2b022024647b913ab69f9aad45be5b47bc86466c29cce9c87a3f3d5315394e320d4d6f:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/flexbe-takeover.yaml
+++ b/http/takeovers/flexbe-takeover.yaml
@@ -32,6 +32,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/frontify-takeover.yaml
+++ b/http/takeovers/frontify-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - 404 - Page Not Found
           - Oops… looks like you got lost
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/frontify-takeover.yaml
+++ b/http/takeovers/frontify-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - 404 - Page Not Found
           - Oops… looks like you got lost
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a00463044022021b423105a656ced8ce8e422c0bddf2ed4b3f550ca7d7c9ac82743af2195e3f3022034a251441fb9da75665b9a0dce13a77c96aa2459116904b043670e79022a7ebd:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/gemfury-takeover.yaml
+++ b/http/takeovers/gemfury-takeover.yaml
@@ -29,6 +29,7 @@ http:
         part: header
         words:
           - "Location: https://gemfury.com/404"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/gemfury-takeover.yaml
+++ b/http/takeovers/gemfury-takeover.yaml
@@ -29,4 +29,9 @@ http:
         part: header
         words:
           - "Location: https://gemfury.com/404"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100e7d6dba0eda3d3930f3dca078b7ad077afffc4dd087816a8d927f4c53d8c7687022100d893083aed1f67decbf6e1e59e4e1244fccc936e2f881303f15d0f4fdef4f437:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/getresponse-takeover.yaml
+++ b/http/takeovers/getresponse-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - 'With GetResponse Landing Pages, lead generation has never been easier'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a004630440220050020aa27e758170d84b6e73692424006b84848ca5faae8e6bffadccc5c2000022016771fdf888e33a79802255d3530b581f338b6933415a56c05a3feb2a3ee777c:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/getresponse-takeover.yaml
+++ b/http/takeovers/getresponse-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - 'With GetResponse Landing Pages, lead generation has never been easier'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/ghost-takeover.yaml
+++ b/http/takeovers/ghost-takeover.yaml
@@ -30,4 +30,9 @@ http:
       - type: status
         status:
           - 302
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100a5aa3c5ce4a8bc142b327031cd1fb21f5732356c4fb0ea207c8f9752f67f4c35022001ad7f03961d10bd1810747fc83882f4f22b7c6a6b080da3ecf474d6d9ceba2e:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/ghost-takeover.yaml
+++ b/http/takeovers/ghost-takeover.yaml
@@ -30,6 +30,7 @@ http:
       - type: status
         status:
           - 302
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/gitbook-takeover.yaml
+++ b/http/takeovers/gitbook-takeover.yaml
@@ -28,4 +28,9 @@ http:
           - "If you need specifics, here's the error"
           - "Domain not found"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a00463044022052ee60fe1e2ef8770b8e8cbce78d52f642c4db18a81c84a23cf711895b5893fa02204de56d859be0fc6514cfcf19609067c70683e9938c8b9c3b56a034d2d1a3d609:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/gitbook-takeover.yaml
+++ b/http/takeovers/gitbook-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - "If you need specifics, here's the error"
           - "Domain not found"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/github-takeover.yaml
+++ b/http/takeovers/github-takeover.yaml
@@ -34,4 +34,9 @@ http:
           - '!contains(host,"github.com")'
           - '!contains(host,"github.io")'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100bb060bc8d7e38ff45b518bb436e03abc7179df307c79f75d9adbac9db571fc280220235be437c7bb36a211f7394383c66307e07cb0360b717690d37dab1b2e547e74:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/github-takeover.yaml
+++ b/http/takeovers/github-takeover.yaml
@@ -34,6 +34,7 @@ http:
           - '!contains(host,"github.com")'
           - '!contains(host,"github.io")'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/gohire-takeover.yaml
+++ b/http/takeovers/gohire-takeover.yaml
@@ -29,6 +29,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/gohire-takeover.yaml
+++ b/http/takeovers/gohire-takeover.yaml
@@ -29,4 +29,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a0046304402204f44da86889c616cf2b3196d930ed7be82e7776bf8c94b5c026d538b2ac1632a0220492bbc32c0310565248ae8cb06b828c52710ef50977055553862690c15381f93:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/hatenablog-takeover.yaml
+++ b/http/takeovers/hatenablog-takeover.yaml
@@ -26,4 +26,9 @@ http:
       - type: word
         words:
           - "404 Blog is not found"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100cccbda6f194b9c13e8d429fd19d5d99b9268c9ed3ac3886b5ca81a70bae502e5022100c63cbb05f231049af04acf8cdc226426618570036ed0b0b17b1ce7e576ab5acd:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/hatenablog-takeover.yaml
+++ b/http/takeovers/hatenablog-takeover.yaml
@@ -26,6 +26,7 @@ http:
       - type: word
         words:
           - "404 Blog is not found"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/helpdocs-takeover.yaml
+++ b/http/takeovers/helpdocs-takeover.yaml
@@ -28,4 +28,9 @@ http:
         part: body
         words:
           - "You've tried to access an account/page that does not exist"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100d14a2588e716661e039af2e59ffb3bbea00f668324088aee429b9de8b8f1811802202d413b89505505d9e46a2f08ee2ee2896d802b983c85a4fa66c8ce1851b77040:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helpdocs-takeover.yaml
+++ b/http/takeovers/helpdocs-takeover.yaml
@@ -28,6 +28,7 @@ http:
         part: body
         words:
           - "You've tried to access an account/page that does not exist"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/helpjuice-takeover.yaml
+++ b/http/takeovers/helpjuice-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - We could not find what you're looking for.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/helpjuice-takeover.yaml
+++ b/http/takeovers/helpjuice-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - We could not find what you're looking for.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100f6cc8d12b3d37ce071d0f0991b48a2cde1418c6306fdaff878e637d95da5c809022100ea84154d67d1ef86b4ba76171d91b9f7869dc5d291e7aa44cb168dcb38fc0178:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helprace-takeover.yaml
+++ b/http/takeovers/helprace-takeover.yaml
@@ -26,4 +26,9 @@ http:
         words:
           - "Alias not configured!"
           - "Admin of this Helprace account needs to set up domain alias"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502210087860d3c24c0e128ed5238827375c4ab06496c1780dee8ce4dd39a7906ca0ae00220710d80043d511d5517f1bc91d5d85a543306e03b08dcfc32c1fa85dd555fdf9b:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helprace-takeover.yaml
+++ b/http/takeovers/helprace-takeover.yaml
@@ -26,6 +26,7 @@ http:
         words:
           - "Alias not configured!"
           - "Admin of this Helprace account needs to set up domain alias"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/helpscout-takeover.yaml
+++ b/http/takeovers/helpscout-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - "No settings were found for this company:"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100f82db3b5d07dfbfb6f11abb9f0abc7a1991698b51abcdbe03bc6b13f41d7710b022017ff27474089ced18f311f6798e2ed903d149f3da6ccd0efd91bab91c6c4d21f:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helpscout-takeover.yaml
+++ b/http/takeovers/helpscout-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - "No settings were found for this company:"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/hubspot-takeover.yaml
+++ b/http/takeovers/hubspot-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - "Domain not found"
           - "does not exist in our system"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/hubspot-takeover.yaml
+++ b/http/takeovers/hubspot-takeover.yaml
@@ -28,4 +28,9 @@ http:
           - "Domain not found"
           - "does not exist in our system"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100a15863236633756d1edb190b798d1e8a6f4d6f5babf13f4f5556048598473beb02201f67a22838abed7e84f98d3f1ea74c297833e39784aac4808c60baa6d7957b0d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/intercom-takeover.yaml
+++ b/http/takeovers/intercom-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - '<h1 class="headline">Uh oh. That page doesn\’t exist.</h1>'
           - 'This page is reserved for artistic dogs.'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450221009d1ef63eb341e158cc4d429a755e07147b7a1df890918864db4d508b28d5647d02202f93b47c9dfc0376a95d3eaf020e73ebfed0a3ca5dcaccc0012fe4e1265b5d14:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/intercom-takeover.yaml
+++ b/http/takeovers/intercom-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - '<h1 class="headline">Uh oh. That page doesn\’t exist.</h1>'
           - 'This page is reserved for artistic dogs.'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/jazzhr-takeover.yaml
+++ b/http/takeovers/jazzhr-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - This account no longer active
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/jazzhr-takeover.yaml
+++ b/http/takeovers/jazzhr-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - This account no longer active
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450221008f8a526afe19043f972676b23a0ad16e3eb20d1fd15d567f85aa4c69af7490a40220174307601261325b2c937087854fdcaaf5e8f5ece73f6b1295e4e1cc83ae6777:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/jetbrains-takeover.yaml
+++ b/http/takeovers/jetbrains-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - is not a registered InCloud YouTrack.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a0048304602210081c1d412bdc5f9e45cd525b55171816a1ebd0e7c9d36e938bb57b441fe76edde0221009edfcf6086e6d9917073aa89ae5973b6b44be71db9e20919edb8a67f8f135a54:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/jetbrains-takeover.yaml
+++ b/http/takeovers/jetbrains-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - is not a registered InCloud YouTrack.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/kinsta-takeover.yaml
+++ b/http/takeovers/kinsta-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - No Site For Domain
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/kinsta-takeover.yaml
+++ b/http/takeovers/kinsta-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - No Site For Domain
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502206044400efee80464021a449f3f2b0c26398e6453922d5d91170853fe77e53392022100b72b2fe2baa52138448d8b0be94b1ee244c1d373065cad601ef8d2566b5f1de4:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/launchrock-takeover.yaml
+++ b/http/takeovers/launchrock-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - It looks like you may have taken a wrong turn somewhere. Don't worry...it happens to all of us.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a0048304602210090dbe87f01c8309c771d28afa1d230137e25756c084b12ab3c7122b2a7630261022100a85fe10454d6207a146bd59f225234643f5da44be48fd4495dca47a8646d9fc3:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/launchrock-takeover.yaml
+++ b/http/takeovers/launchrock-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - It looks like you may have taken a wrong turn somewhere. Don't worry...it happens to all of us.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/leadpages-takeover.yaml
+++ b/http/takeovers/leadpages-takeover.yaml
@@ -30,4 +30,9 @@ http:
           - "The page you’re looking for may have been moved"
           - "Double-check that you have the right web address and give it another go!"
         condition: or
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502200dd0c65ea9c1bde329bbbbc48da6968bd7a8764db818f4b0b2662aa5f90cbcad0221009333f1d86ecbe74e5a099b1f2851f72ce7a74d2733da0c9813bd1c2e502707a8:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/leadpages-takeover.yaml
+++ b/http/takeovers/leadpages-takeover.yaml
@@ -30,6 +30,7 @@ http:
           - "The page you’re looking for may have been moved"
           - "Double-check that you have the right web address and give it another go!"
         condition: or
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/lemlist-takeover.yaml
+++ b/http/takeovers/lemlist-takeover.yaml
@@ -29,6 +29,7 @@ http:
           - "Custom domain check"
           - "app.lemlist.com"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/lemlist-takeover.yaml
+++ b/http/takeovers/lemlist-takeover.yaml
@@ -29,5 +29,10 @@ http:
           - "Custom domain check"
           - "app.lemlist.com"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 
 # digest: 4b0a0048304602210099908eacc7046289b5a30398972ec745cf09ab068ece8b8538ba44ddb5dd35a7022100d072f3859b82c4cda35df540e8a0fa3f30480d8d0a26634ee55eb5fb2c9d71fe:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/mashery-takeover.yaml
+++ b/http/takeovers/mashery-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - Unrecognized domain <strong>
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/mashery-takeover.yaml
+++ b/http/takeovers/mashery-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - Unrecognized domain <strong>
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a004630440220750d4b0e60b943b940f6294035333c6aab7d5991a49b76cd9781c5143141aa7a0220064abdac1cfa23c8e64075bb9c8eb3660c2ee351f051877cfdd4bd704c0c4d0d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/meteor-takeover.yaml
+++ b/http/takeovers/meteor-takeover.yaml
@@ -21,4 +21,9 @@ http:
       - type: word
         words:
           - "404 Not Found: No applications registered for host '"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a004630440220106fbac97760646029437a8745d2c52c78542cf9bfe774465264cbd0c3bd272b02200d06849853bdb1d987dae68ca4f28585ee62c27c4e3edbd6d2639ef754f75af0:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/meteor-takeover.yaml
+++ b/http/takeovers/meteor-takeover.yaml
@@ -21,6 +21,7 @@ http:
       - type: word
         words:
           - "404 Not Found: No applications registered for host '"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/netlify-takeover.yaml
+++ b/http/takeovers/netlify-takeover.yaml
@@ -34,6 +34,7 @@ http:
         part: header
         words:
           - "Netlify"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/netlify-takeover.yaml
+++ b/http/takeovers/netlify-takeover.yaml
@@ -34,4 +34,9 @@ http:
         part: header
         words:
           - "Netlify"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450221009a5a121d786fe47e6abfdf7b52f451237d696d19fa9df212b83dab270e03509b0220481f0dfdf70ae43cf23a05b969ad56aedcbb2f3f202d208b5b911e54342eb00c:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/ngrok-takeover.yaml
+++ b/http/takeovers/ngrok-takeover.yaml
@@ -26,6 +26,7 @@ http:
         words:
           - ngrok.io not found
           - Tunnel *.ngrok.io not found
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/ngrok-takeover.yaml
+++ b/http/takeovers/ngrok-takeover.yaml
@@ -26,4 +26,9 @@ http:
         words:
           - ngrok.io not found
           - Tunnel *.ngrok.io not found
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a004830460221008cf6a9807fc46be1355a7147dccd0eb9da046a96308c2f7ec21d020634e17c7002210084a3569ad587a666c3f615fc707f8efaaec9c5ce7ad73bd0720b3da2b25e65ec:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pagewiz-takeover.yaml
+++ b/http/takeovers/pagewiz-takeover.yaml
@@ -28,4 +28,9 @@ http:
           - 'Start Your New Landing Page Now!'
           - 'pagewiz'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450220438d742994d111e4fa56adb384f11133af7019c3faf6ca8c6d8a634a3e591260022100d7bf8ba3814fab3b200485663be1161f0d6a8ad33224bd486730ec0f7bfed45e:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pagewiz-takeover.yaml
+++ b/http/takeovers/pagewiz-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - 'Start Your New Landing Page Now!'
           - 'pagewiz'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/pantheon-takeover.yaml
+++ b/http/takeovers/pantheon-takeover.yaml
@@ -30,6 +30,7 @@ http:
       - type: dsl
         dsl:
           - '!contains(host,"apigee.io")'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/pantheon-takeover.yaml
+++ b/http/takeovers/pantheon-takeover.yaml
@@ -30,4 +30,9 @@ http:
       - type: dsl
         dsl:
           - '!contains(host,"apigee.io")'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100eb34ca91df59d23692e3ef0fa3a62e217b7320372b4e58dc7e1877ac65dae3b50220168496114bc754b3dfd3a66b6d92331f74517a0266fd3cf7853523445a18136e:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pingdom-takeover.yaml
+++ b/http/takeovers/pingdom-takeover.yaml
@@ -26,6 +26,7 @@ http:
         words:
           - Public Report Not Activated
           - This public report page has not been activated by the user
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/pingdom-takeover.yaml
+++ b/http/takeovers/pingdom-takeover.yaml
@@ -26,4 +26,9 @@ http:
         words:
           - Public Report Not Activated
           - This public report page has not been activated by the user
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100afda4c99e426c70cabf279d2bd2ba47c066c1865232547806d4e7cc14228c927022100a8a67314e0aa40fd5666e734ef69b3fbd1288225afa7ed3911add364adc54600:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/proposify-takeover.yaml
+++ b/http/takeovers/proposify-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - If you need immediate assistance, please contact <a href="mailto:support@proposify.biz
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100dcd0362df06ad3d224b52f3905afa42f8d0fd9325b3815b7068d7345f25c37ba022100e0cc8b3fc0073e42516de82fd4eb79b4735ef72a3c9635843cd7e983c559b0ff:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/proposify-takeover.yaml
+++ b/http/takeovers/proposify-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - If you need immediate assistance, please contact <a href="mailto:support@proposify.biz
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/readme-takeover.yaml
+++ b/http/takeovers/readme-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - 'Project doesnt exist... yet!'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100934f29d16e67282ea4584c2cdb6aa86cef2e6acfcf2b7360c7c95a56af079755022020197632f0b09941f102ff281691c6badfdfe1bd218fd9f11a1378fb0948ed36:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/readme-takeover.yaml
+++ b/http/takeovers/readme-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - 'Project doesnt exist... yet!'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/readthedocs-takeover.yaml
+++ b/http/takeovers/readthedocs-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - unknown to Read the Docs
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/readthedocs-takeover.yaml
+++ b/http/takeovers/readthedocs-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - unknown to Read the Docs
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100b33497bd5d29e727bd5b2dee2741f81c3cd678f67ce496862009f03491c74a1402200c0a2e755d30c7ae368ba919cec855cd8776da7edb32b2f23b09f8e76d44ea03:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/shopify-takeover.yaml
+++ b/http/takeovers/shopify-takeover.yaml
@@ -41,6 +41,7 @@ http:
           - '!contains(host,"myshopify.com")'
           - '!contains(host,"shopify.com")'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/shopify-takeover.yaml
+++ b/http/takeovers/shopify-takeover.yaml
@@ -41,4 +41,9 @@ http:
           - '!contains(host,"myshopify.com")'
           - '!contains(host,"shopify.com")'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450221008da05517cfb242d1242e3366300e8d39df5723c33041620c06f99af3347c58d002206e4e69f6968bf7fe0137d469ec299a7bf03bf2b5f58f7a3760e21bff906223a1:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/short-io.yaml
+++ b/http/takeovers/short-io.yaml
@@ -27,6 +27,7 @@ http:
           - "Link does not exist"
           - "This domain is not configured on Short.io"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/short-io.yaml
+++ b/http/takeovers/short-io.yaml
@@ -27,4 +27,9 @@ http:
           - "Link does not exist"
           - "This domain is not configured on Short.io"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100d0e5e5b71767ee8aaaa8d8ef6477dab2f50fed729807e4c14167889f652518e102210083d46341f8300d1bb8c48391d24b12950470f7cdc12d6a403bda413362432256:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/simplebooklet-takeover.yaml
+++ b/http/takeovers/simplebooklet-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - We can't find this <a href="https://simplebooklet.com
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/simplebooklet-takeover.yaml
+++ b/http/takeovers/simplebooklet-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - We can't find this <a href="https://simplebooklet.com
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100d379bb62e1918dbe1c7da51210a9fc78c13eece51503c29cb71860a01eb735b602206884dd42bc3f71c2f6d4043439024fca4d476b9c34458d1e0ad192e9e7b54f61:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/smartjob-takeover.yaml
+++ b/http/takeovers/smartjob-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - Job Board Is Unavailable
           - This job board website is either expired
           - This job board website is either expired or its domain name is invalid.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a00463044022049c3138d38ce6c96f3636124f2b2a35ecab7822c53ff156452157313d00b716a022009ed4801471c1fc944d902ea91541670c2bca9470c2fb81e149dff87a5b02b96:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/smartjob-takeover.yaml
+++ b/http/takeovers/smartjob-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - Job Board Is Unavailable
           - This job board website is either expired
           - This job board website is either expired or its domain name is invalid.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/smugmug-takeover.yaml
+++ b/http/takeovers/smugmug-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - '{"text":"Page Not Found"'
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/smugmug-takeover.yaml
+++ b/http/takeovers/smugmug-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - '{"text":"Page Not Found"'
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a0046304402203f4770f8a1f7362fdd2191c47eebe79f4ee07650c68bef4124ea2a79b8e9e47402200bb66b165626620135c8a0de6d3bc0606a67e47abbc01b42898333d03ae0cf1d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/softr-takeover.yaml
+++ b/http/takeovers/softr-takeover.yaml
@@ -31,4 +31,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502201d900ebfa70bd8f26a199b76f610632623ce88a5846803b3f3bd77a422484117022100f9a6b0cffd9921d7216622ab4d51e348889b1a79a9cc10f9cd8111afa77bbf41:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/softr-takeover.yaml
+++ b/http/takeovers/softr-takeover.yaml
@@ -31,6 +31,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/sprintful-takeover.yaml
+++ b/http/takeovers/sprintful-takeover.yaml
@@ -34,6 +34,7 @@ http:
       - type: status
         status:
           - 200
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/sprintful-takeover.yaml
+++ b/http/takeovers/sprintful-takeover.yaml
@@ -34,4 +34,9 @@ http:
       - type: status
         status:
           - 200
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a00463044022052c4d55ecb28b529b3d7c47a42a7bc5144d2e96c184ed2f0a931178a2e7244f602206c0d64bddfb174e41ab4935bfa3f3136efb8d37d33d66d3183dd46eaf849c513:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/squadcast-takeover.yaml
+++ b/http/takeovers/squadcast-takeover.yaml
@@ -33,6 +33,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/squadcast-takeover.yaml
+++ b/http/takeovers/squadcast-takeover.yaml
@@ -33,4 +33,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022073e3651947c403258a6376ad586534893f46abfcd2d9728c1d0edbeab2ff2be4022100f20a52cd2ab0ea4a4ebeabc28511e0ccb3aaaebffaac719e499d3662b7a127e7:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/strikingly-takeover.yaml
+++ b/http/takeovers/strikingly-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - "But if you're looking to build your own website"
           - "you've come to the right place."
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/strikingly-takeover.yaml
+++ b/http/takeovers/strikingly-takeover.yaml
@@ -28,4 +28,9 @@ http:
           - "But if you're looking to build your own website"
           - "you've come to the right place."
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100fd7a1661a98893ad578e0b9827ec85416a438c34c8af9f9eca4811cbc742efc3022100e4d9c870f2d602476dcabc0e533cd958e0c2fb5483e81beba34316d149563602:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surge-takeover.yaml
+++ b/http/takeovers/surge-takeover.yaml
@@ -29,4 +29,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450221008687ea9c91087816fda6cde6f2654de22d64f00f4452d3c150919a3d02c09d80022010aceb815c267cd65a6a2d4a9e2632b00ab2724596e2edaa4f816b872406f809:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surge-takeover.yaml
+++ b/http/takeovers/surge-takeover.yaml
@@ -29,6 +29,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/surveygizmo-takeover.yaml
+++ b/http/takeovers/surveygizmo-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - data-html-name
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100d848c1222e65f12a28e0e34840a126a71a103b5f06eaa2d6b9b2bfcc0bca00c0022074e9a9958b785a215ddea9755598098e3e1457277ddd97db0ff9b6f92cea1ce8:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surveygizmo-takeover.yaml
+++ b/http/takeovers/surveygizmo-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - data-html-name
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/surveysparrow-takeover.yaml
+++ b/http/takeovers/surveysparrow-takeover.yaml
@@ -28,6 +28,7 @@ http:
           - "ouch!"
           - "SurveySparrow"
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/surveysparrow-takeover.yaml
+++ b/http/takeovers/surveysparrow-takeover.yaml
@@ -28,4 +28,9 @@ http:
           - "ouch!"
           - "SurveySparrow"
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100ff4d63e33b67fb2ff21325b11008922a19e3bad15fead71e40a2168fef4b34e3022100bb737388806f6773e498a74f759fe708048d904fe6600f668ba726af4f883332:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tave-takeover.yaml
+++ b/http/takeovers/tave-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - "<h1>Error 404: Page Not Found</h1>"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/tave-takeover.yaml
+++ b/http/takeovers/tave-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - "<h1>Error 404: Page Not Found</h1>"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100fbf23b46ef8a4aa8d273f247e72f3259c4c32b43ec758e4e3877e7b33ddfc5cd022100cfd9f6c876dc572379c1829ad85feb73bb1e8168b78db98e9d592c5eeb400551:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/teamwork-takeover.yaml
+++ b/http/takeovers/teamwork-takeover.yaml
@@ -23,6 +23,7 @@ http:
       - type: word
         words:
           - "Oops - We didn't find your site."
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/teamwork-takeover.yaml
+++ b/http/takeovers/teamwork-takeover.yaml
@@ -23,4 +23,9 @@ http:
       - type: word
         words:
           - "Oops - We didn't find your site."
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100d2e1923e8aea236705b052924c0ad3bd51139d068896daf041838ea275eb5f5402206f2a3fda681ca3fb7207264838b9834596500b0db1355c6f410e818fe18d0a98:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tilda-takeover.yaml
+++ b/http/takeovers/tilda-takeover.yaml
@@ -30,4 +30,9 @@ http:
         words:
           - "<title>Please renew your subscription</title>"
         negative: true
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4b0a00483046022100cf20f7eef7723e0643d0412903381668918ed4e468e71f0715c9bdec5a7688a2022100c7eca7751306592f4fc039c2da9e2ecc1b38f7099420e7ac2bac389bf5845811:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tilda-takeover.yaml
+++ b/http/takeovers/tilda-takeover.yaml
@@ -30,6 +30,7 @@ http:
         words:
           - "<title>Please renew your subscription</title>"
         negative: true
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/tumblr-takeover.yaml
+++ b/http/takeovers/tumblr-takeover.yaml
@@ -34,4 +34,9 @@ http:
           - '!contains(host,"txmblr.com")'
           - '!contains(host,"umblr.com")'
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a0046304402201598cd0a842a4fd108c938690442844d43bf8ee7e343be7192e5bdc8f33f756602207f36b901ac8eb26b5704bb2e5db2669ffefac79385e38b3b838cc2d2eef9ce06:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tumblr-takeover.yaml
+++ b/http/takeovers/tumblr-takeover.yaml
@@ -34,6 +34,7 @@ http:
           - '!contains(host,"txmblr.com")'
           - '!contains(host,"umblr.com")'
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/uberflip-takeover.yaml
+++ b/http/takeovers/uberflip-takeover.yaml
@@ -26,6 +26,7 @@ http:
       - type: word
         words:
           - "Non-hub domain, The URL you've accessed does not provide a hub."
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/uberflip-takeover.yaml
+++ b/http/takeovers/uberflip-takeover.yaml
@@ -26,4 +26,9 @@ http:
       - type: word
         words:
           - "Non-hub domain, The URL you've accessed does not provide a hub."
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a0046304402205cf61bf00b014ac3c3255c63485f0ea5b59b91fd641a81ffc936a90eb42ad2b802205ba4878ce63ae460a30160dca5a73e94cabe8703642765631a1f324e88cda068:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uptime-takeover.yaml
+++ b/http/takeovers/uptime-takeover.yaml
@@ -29,4 +29,9 @@ http:
       - type: status
         status:
           - 302
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502210085a0ff88eac411c553fefc9111615b5fce5421ae019fb6dfb33e3bbf3bbdb1900220273c69814eb607b21b37aafc4a857b565437c0e3941118da9b80a636280a56a6:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uptime-takeover.yaml
+++ b/http/takeovers/uptime-takeover.yaml
@@ -29,6 +29,7 @@ http:
       - type: status
         status:
           - 302
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/uptimerobot-takeover.yaml
+++ b/http/takeovers/uptimerobot-takeover.yaml
@@ -36,6 +36,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/uptimerobot-takeover.yaml
+++ b/http/takeovers/uptimerobot-takeover.yaml
@@ -36,4 +36,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a004730450220721196f64418a6eb526f619f162fcd1fbab5d2b0fe31bf1384cce7b528c31c88022100dac350b5f6b730091041f3aabe46735bed8e0b78fce6a268e96bc59e1f00a7c0:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uservoice-takeover.yaml
+++ b/http/takeovers/uservoice-takeover.yaml
@@ -26,4 +26,9 @@ http:
       - type: word
         words:
           - "This UserVoice subdomain is currently available!"
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022100aa09c8b6fdbe7b84793de16fcfbc2b1f9b47a5bec7c8562618c6dffe1699ac2f02204354322492f299f876e5674a252217ed8f985d04f027e894e302e548ecbd0522:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uservoice-takeover.yaml
+++ b/http/takeovers/uservoice-takeover.yaml
@@ -26,6 +26,7 @@ http:
       - type: word
         words:
           - "This UserVoice subdomain is currently available!"
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/vend-takeover.yaml
+++ b/http/takeovers/vend-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         words:
           - Looks like you've traveled too far into cyberspace.
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/vend-takeover.yaml
+++ b/http/takeovers/vend-takeover.yaml
@@ -25,4 +25,9 @@ http:
       - type: word
         words:
           - Looks like you've traveled too far into cyberspace.
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a00473045022005cad28da3999701b4d14ebc07e85adaf1faaf878a328e581d9661bffe34864d022100d7baee7ef3c9c736ad4ca5e8946d4861a2df3d9d9e81a2e5f9823acb058564c2:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wishpond-takeover.yaml
+++ b/http/takeovers/wishpond-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - https://www.wishpond.com/404?campaign=true
           - 'Oops! There isn’t a Wishpond Campaign published to this page.'
         condition: or
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/wishpond-takeover.yaml
+++ b/http/takeovers/wishpond-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - https://www.wishpond.com/404?campaign=true
           - 'Oops! There isn’t a Wishpond Campaign published to this page.'
         condition: or
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502207293f11f5db62b0ad65eb3f64c1c7eeef99b286a8f5a309a3ccea7c41d6f2a9c0221009daf8076c7f2cd449d216cd809d1906295d848581b43e5a800374a8c10c98e07:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wix-takeover.yaml
+++ b/http/takeovers/wix-takeover.yaml
@@ -31,5 +31,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
 
 # digest: 4a0a00473045022064e66b00c42664cbb39163c2885d293e24428ccf16cd22c4b474e0ab00dbe36e0221009744fe99f306cb4dd01d034c28b7dbdf162cc8818f3f761d729eef8b13473f36:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wix-takeover.yaml
+++ b/http/takeovers/wix-takeover.yaml
@@ -31,6 +31,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/wordpress-takeover.yaml
+++ b/http/takeovers/wordpress-takeover.yaml
@@ -33,4 +33,9 @@ http:
         words:
           - "cannot be registered"
         negative: true
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a00463044022010ac85e82235d21220b2b93292c2f1b6f510fc2b7d63a0098c379ca79088791e02203e378ce297ff06b4e72664846fbf2b9f7220502a83f76249b0cf4b12e2fda6ca:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wordpress-takeover.yaml
+++ b/http/takeovers/wordpress-takeover.yaml
@@ -33,6 +33,7 @@ http:
         words:
           - "cannot be registered"
         negative: true
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/worksites-takeover.yaml
+++ b/http/takeovers/worksites-takeover.yaml
@@ -43,6 +43,7 @@ http:
       - type: status
         status:
           - 404
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/worksites-takeover.yaml
+++ b/http/takeovers/worksites-takeover.yaml
@@ -43,4 +43,9 @@ http:
       - type: status
         status:
           - 404
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 490a004630440220250de7667d4b6a40352ae56620035450b47c67b9e108538e5fcbe16e24a2aac40220080aae3c7a8d7bf802e14e117926b51d163414b8113ddd517384a44dcd3d1e32:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wufoo-takeover.yaml
+++ b/http/takeovers/wufoo-takeover.yaml
@@ -27,6 +27,7 @@ http:
           - Profile not found
           - Hmmm....something is not right.
         condition: and
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/wufoo-takeover.yaml
+++ b/http/takeovers/wufoo-takeover.yaml
@@ -27,4 +27,9 @@ http:
           - Profile not found
           - Hmmm....something is not right.
         condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502200dff4aa3d7f58de4968936c13afe0b66f0c5b6db0de718289013749c1977474b022100b8dc277a832e656b48899f3e87f28f820b2e151f4a67988392fddaaf286da17c:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/zendesk-takeover.yaml
+++ b/http/takeovers/zendesk-takeover.yaml
@@ -29,4 +29,9 @@ http:
           - "this help center no longer exists"
           - "Help Center Closed"
         condition: or
+    extractors:
+      - type: dsl
+        dsl:
+          - "resolve(Host, 'cname')"
+
 # digest: 4a0a0047304502207f13a85b5f36efa57d0417babbb39d81e6573465eb6125f2ea3f06bdedfd3b7702210082fd4d63db637fc0ce9dd06c534393dfdd113a06b4b1408dcb348d941ead9c2a:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/zendesk-takeover.yaml
+++ b/http/takeovers/zendesk-takeover.yaml
@@ -29,6 +29,7 @@ http:
           - "this help center no longer exists"
           - "Help Center Closed"
         condition: or
+
     extractors:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

I am updating all HTTP based subdomain takeover templates to show cname in extracted-results. It helps in an automation to point out misconfiguration area and run additional flow based on it. Additionally it also helps researcher to have a summarised view of all the detected cname to quickly know if it a known false positive or not.     


### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)
Although i ran all sub takeover templates after modification and didn't received any error, still marking it as not validated becuase i have not ran them on vulnerable targets.


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)