### PR TITLE
add CVE-2023-4220

### DIFF
--- a/http/cves/2023/CVE-2023-4220.yaml
+++ b/http/cves/2023/CVE-2023-4220.yaml
@@ -21,7 +21,7 @@ info:
     vendor: chamilo
     product: chamilo_lms
     shodan-query: cpe:"cpe:2.3:a:chamilo:chamilo_lms"
-  tags: cve,cve2024,chamilo,lms,rce
+  tags: cve,cve2023,chamilo,lms,rce
 variables:
   filename: "{{rand_base(10)}}"
   num: "{{rand_int(1000, 9999)}}"
@@ -40,7 +40,7 @@ http:
         {{md5(num)}}
 
         --------------------------SwxF5rRaZb4lETWlpulXn3--
- 
+
       - |
         GET /main/inc/lib/javascript/bigupload/files/{{filename}}.txt HTTP/1.1
         Host: {{Hostname}}

--- a/http/cves/2023/CVE-2023-4220.yaml
+++ b/http/cves/2023/CVE-2023-4220.yaml
@@ -8,9 +8,9 @@ info:
     Unrestricted file upload in big file upload functionality in `/main/inc/lib/javascript/bigupload/inc/bigUpload.php` in Chamilo LMS <= v1.11.24 allows unauthenticated attackers to perform stored cross-site scripting attacks and obtain remote code execution via uploading of web shell.
   reference:
     - https://github.com/Ziad-Sakr/Chamilo-LMS-CVE-2023-4220-Exploit
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-4220
     - https://github.com/charlesgargasson/CVE-2023-4220
     - https://starlabs.sg/advisories/23/23-4220/
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-4220
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -20,6 +20,7 @@ info:
     epss-percentile: 0.52876
     cpe: cpe:2.3:a:chamilo:chamilo_lms:*:*:*:*:*:*:*:*
   metadata:
+    max-request: 2
     vendor: chamilo
     product: chamilo_lms
     shodan-query: "X-Powered-By: Chamilo"

--- a/http/cves/2023/CVE-2023-4220.yaml
+++ b/http/cves/2023/CVE-2023-4220.yaml
@@ -1,4 +1,5 @@
 id: CVE-2023-4220
+
 info:
   name: Chamilo LMS <= 1.11.24 - Remote Code Execution
   author: securityforeveryone
@@ -9,6 +10,7 @@ info:
     - https://github.com/Ziad-Sakr/Chamilo-LMS-CVE-2023-4220-Exploit
     - https://nvd.nist.gov/vuln/detail/CVE-2023-4220
     - https://github.com/charlesgargasson/CVE-2023-4220
+    - https://starlabs.sg/advisories/23/23-4220/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -20,8 +22,9 @@ info:
   metadata:
     vendor: chamilo
     product: chamilo_lms
-    shodan-query: cpe:"cpe:2.3:a:chamilo:chamilo_lms"
-  tags: cve,cve2023,chamilo,lms,rce
+    shodan-query: "X-Powered-By: Chamilo"
+  tags: cve,cve2023,chamilo,lms,rce,intrusive,file-upload
+
 variables:
   filename: "{{rand_base(10)}}"
   num: "{{rand_int(1000, 9999)}}"

--- a/http/cves/2023/CVE-2023-4220.yaml
+++ b/http/cves/2023/CVE-2023-4220.yaml
@@ -1,0 +1,53 @@
+id: CVE-2023-4220
+info:
+  name: Chamilo LMS <= 1.11.24 - Remote Code Execution
+  author: securityforeveryone
+  severity: medium
+  description: |
+    Unrestricted file upload in big file upload functionality in `/main/inc/lib/javascript/bigupload/inc/bigUpload.php` in Chamilo LMS <= v1.11.24 allows unauthenticated attackers to perform stored cross-site scripting attacks and obtain remote code execution via uploading of web shell.
+  reference:
+    - https://github.com/Ziad-Sakr/Chamilo-LMS-CVE-2023-4220-Exploit
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-4220
+    - https://github.com/charlesgargasson/CVE-2023-4220
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2023-4220
+    cwe-id: CWE-434
+    epss-score: 0.00163
+    epss-percentile: 0.52876
+    cpe: cpe:2.3:a:chamilo:chamilo_lms:*:*:*:*:*:*:*:*
+  metadata:
+    vendor: chamilo
+    product: chamilo_lms
+    shodan-query: cpe:"cpe:2.3:a:chamilo:chamilo_lms"
+  tags: cve,cve2024,chamilo,lms,rce
+variables:
+  filename: "{{rand_base(10)}}"
+  num: "{{rand_int(1000, 9999)}}"
+
+http:
+  - raw:
+      - |
+        POST /main/inc/lib/javascript/bigupload/inc/bigUpload.php?action=post-unsupported HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=------------------------SwxF5rRaZb4lETWlpulXn3
+
+        --------------------------SwxF5rRaZb4lETWlpulXn3
+        Content-Disposition: form-data; name="bigUploadFile"; filename="{{filename}}.txt"
+        Content-Type: application/octet-stream
+
+        {{md5(num)}}
+
+        --------------------------SwxF5rRaZb4lETWlpulXn3--
+ 
+      - |
+        GET /main/inc/lib/javascript/bigupload/files/{{filename}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body_2,"{{md5(num)}}")'
+          - 'status_code_1 == 200 && status_code_2 == 200'
+        condition: and


### PR DESCRIPTION
CVE-2023-4220
https://github.com/Ziad-Sakr/Chamilo-LMS-CVE-2023-4220-Exploit

a template that loads and tests a text file instead of a malicious shell on the system.


I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)