### PR TITLE
Use `cname` dsl instead of resolve helper

### DIFF
--- a/http/takeovers/aftership-takeover.yaml
+++ b/http/takeovers/aftership-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502203bd36036183a037bd252566dbbb5e7f0816219e8cea973674b3f087995c41183022100b4efe16a28cab2e2e12dfe9019bbf1fe083d72eb5c660a2ab0bdbd5dce65d877:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/agilecrm-takeover.yaml
+++ b/http/takeovers/agilecrm-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502203e5437cdfd4734103ae21b5624d49a86012197e68f1ef22d4c61fd6506d2fd6b02210087c84457ec74570230a4ef789f50de0e6ad5bb3bdc311ddf92f804922863588c:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/aha-takeover.yaml
+++ b/http/takeovers/aha-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502210081e62f08cee1995440a0f533dac16d17a3d3e09858d21de29e4eb7768384812702204e28ac0c2110a91fb6eb08414f3cec591f0efff3b7e935cd6b23a82346138dda:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/airee-takeover.yaml
+++ b/http/takeovers/airee-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100cb3b0d821630b1eb25fed8fae0a01c86dfdd0a5c047890f73228940bacad89b9022100b885654efd91153696697c0aa418b20838ae50cf6fe9fc2afd7a119b36f9c69e:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/anima-takeover.yaml
+++ b/http/takeovers/anima-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022052bc2aa8ee8306b3823bcb5602709089422854a4efc741cbe5fc42a38518a7270221009f05c449b7fddb5dadc6579dd533cf5c57db6b43308cedff609e52d8b97f112a:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/announcekit-takeover.yaml
+++ b/http/takeovers/announcekit-takeover.yaml
@@ -34,5 +34,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100abf4b3ac11f8489ae50ed7777d1f7d75274fa69a6f4a9fdb621096c7276890d9022100ddc4b39e3a090dfd6f23f0454b07cd6fc159fc4b9671168dbd4d3f85b626dbed:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/bigcartel-takeover.yaml
+++ b/http/takeovers/bigcartel-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022028493e5884364496cbe6db730031be69815e0db1681e8f82ceacc7cd72e7d35a022064ac6129e32c1bb9c265656259d8121e230e5339bced107b32285d2564920464:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/bitbucket-takeover.yaml
+++ b/http/takeovers/bitbucket-takeover.yaml
@@ -35,5 +35,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100800b04f4ce1fd3e4172c69ae962d1f36497dae9f92fb9adfa008f59e03b34c57022100eaf82edf3723c0158c2bd6f95e845b39cec747746577fb827de72bf03a2bbbfc:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/campaignmonitor-takeover.yaml
+++ b/http/takeovers/campaignmonitor-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100b819e2a332f9b5b7e20bb3d40809c79a572af68df43acc74cceec70c6ca2b263022100daabd6735cb9915204d98a7d66a3cf771c8485f50f54fa2d401f9726aaaf38ff:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/canny-takeover.yaml
+++ b/http/takeovers/canny-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100fdcb56474033a16495df92a420a76351d7817ea33497bf19673e71d271289ce2022100cfffee90b4b903e5be13da672bf2509c548c7b082d89337f5ad245230409697e:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/cargo-takeover.yaml
+++ b/http/takeovers/cargo-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022039c5b3256b28da9c9e9221e0023c40b4bf59550b34299d1025a9e3752546cdc20220697f0d05275826042cd6694b7964d3f91b47cacc86e1a7f346d33f2b67793608:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/cargocollective-takeover.yaml
+++ b/http/takeovers/cargocollective-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502207891f1026ddf30a2dcef1e667b9e29c941a2b79f0392a0d0ef4cd6d5a7cdc974022100fd75665d6b068730f9b891b0535047a188904f9babb359f3e93a1490025d71f9:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/clever-takeover.yaml
+++ b/http/takeovers/clever-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100997963360f12bfd0cfd2950139969b09b58f492fe8bb7d3e87105c8f39be376002203355a8edcf3dd6dd71a699ca4a01ad3499f7001b39e48c7cae5265064ab55a3f:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/flexbe-takeover.yaml
+++ b/http/takeovers/flexbe-takeover.yaml
@@ -36,5 +36,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022058ef15819ab6fb25b5f79436a3f8d581e504c0f6f92f9dc3c18fa2478bf3c3f80221009fa3274b5d611c04ce851a3c53d8af98e913475ec2a8c006bf80591531f6954a:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/frontify-takeover.yaml
+++ b/http/takeovers/frontify-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a004830460221009c8f88d2710cb52115876d7245b631b675280b8c02b46e23284711ac5377fbac022100f9412dfc45bba2e7b8f47426ee6405789a9eaa8e4270d9a430c52efcba1a9ceb:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/gemfury-takeover.yaml
+++ b/http/takeovers/gemfury-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100a4a5a5c7f4cbdea4dfe6ba54f24e8d115c4b4ed97463e0b6f2f59089005693d402201739eab6a73212a6753bfc7014fef9f080667f4ecf1562df1d3ebdfe569a65b5:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/getresponse-takeover.yaml
+++ b/http/takeovers/getresponse-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100c9544f43f7e76dae73b99c44544483505e22d05b811b3d3014ea7478651a13b50220183d82c1d47b04cd7433045c3b661617768399b5fde5465ae365d81b9ba8c1a7:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/ghost-takeover.yaml
+++ b/http/takeovers/ghost-takeover.yaml
@@ -34,5 +34,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100ef6e9387b76c6b0d10b0bb7578cabcb6318183cb7aa0a96921c7cccb3d23f19f02205779e8fdd4e525c1f6fdb6d24bdf06d512233517910e22958b12fa01ba90f2c5:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/gitbook-takeover.yaml
+++ b/http/takeovers/gitbook-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022007ba7ff01d235a698a165e83cd1ec53b8f0f2c1c9df81dc1d1c1c7263ab997ae02202a1d4d50779a1120aa7674e464dcf262df262770bd0b4f34c2508b625dc1b0ff:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/github-takeover.yaml
+++ b/http/takeovers/github-takeover.yaml
@@ -38,5 +38,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100da69c3934ab685046db34fd5b530f9a94a05843b80c64b9bd0c124de5f99b3bc022100baeb8a7a60d2cc78907aa619a65bba8bfaff269182513a5260167813f14407bf:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/gohire-takeover.yaml
+++ b/http/takeovers/gohire-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022037b397c0657ab6c3ea60424bfe1551b5d4674a30c654fd687baee22a578595b2022051cd6752d29108a910e38993aea9fcb8b51bb6596d82f4f485cc8c21a81e939d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/hatenablog-takeover.yaml
+++ b/http/takeovers/hatenablog-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a004830460221008f1bd167e0d54c56419cfacf1f579b4a94ec793afcd2d71e41178d2c9911970f022100ea66618ec13a8f8f92c100bf9172d271c29ac6c890aebdec3a5745077d0549ef:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helpdocs-takeover.yaml
+++ b/http/takeovers/helpdocs-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a004630440220482c6b083ccbabb1e2158009605bfe5dcbccf91764b760ebdaf751144015b6db022038fc8950954039feeb1f93f637a0bc96e0e5c1f248fdfc15d231bd01ec86e675:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helpjuice-takeover.yaml
+++ b/http/takeovers/helpjuice-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100a35d9fdeea4128eb38c04dea1b5d3693810c966a13e599dcc2be949fe36554820221009a7e1fa76dcfb51b1c2fe04202c129cf7b893465f48049feccaeb79258a0a366:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helprace-takeover.yaml
+++ b/http/takeovers/helprace-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022027d08153b33fe40911fd49617721948492c62cc3d3d544c406599e8961424af5022100943309fe155a4cf41828089ec841eaeadb44e39a7e7c66113725e3eb40bf14e4:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/helpscout-takeover.yaml
+++ b/http/takeovers/helpscout-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100a14491277e022059a4d27c53642a673066e07741fc8df713ef9fca58978f2036022100a50455f2613321de05c5f0d730176a9d9edaef962b414b6dd344438c18b8c47d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/hubspot-takeover.yaml
+++ b/http/takeovers/hubspot-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402206ce71ca779690190161ec883a0f6a10d9d38905219eba277ea6dfb04d7466cd4022027eb6f3bd3010a4a5d68befc5b652eac733f20cefb5f1f9019d1f5020f40e148:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/intercom-takeover.yaml
+++ b/http/takeovers/intercom-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a004830460221009aef81a7fc6a59a2ba6de62e3772517f8c0dd2b1fb2c9c7cd325f9a7bea24645022100c585d84759bd8e0084076b7b4f684e29e878e894f643e4a16f0ec7c17ddf2b6d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/jazzhr-takeover.yaml
+++ b/http/takeovers/jazzhr-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022029f3b863ed50f24393d86e83c928ff07f9eb39bdeefdcd9093120debbfcdf049022100a00a29f9bd49422c3ee702f888dedd6d166e73eee1b56732cff1e8939c938b60:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/jetbrains-takeover.yaml
+++ b/http/takeovers/jetbrains-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402205e36ff70f8a0907caca607574e3bba5cdf53e03b530dfc7418b8dd26746b6b3c02203a03022c7dd004ea62891eeda1133a8bbb4cf7596d269f047d4f2b5abe6d921f:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/kinsta-takeover.yaml
+++ b/http/takeovers/kinsta-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100c1180edbebb878f2804b827537d695ea36e9d3cab087819d029d1e89230fae4302203cd91b5cdc16051046d223660b4487a540a298336b4347f0e7c03f56cef75d73:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/launchrock-takeover.yaml
+++ b/http/takeovers/launchrock-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022024aad780c453db09ec0aa72dc5d26dd07ea0307eefb7cbd8ad014380bfeca9d7022100ede17fb171220b83769a563fa26398d7be46bd50363522e38f008bb2b15c8cc4:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/leadpages-takeover.yaml
+++ b/http/takeovers/leadpages-takeover.yaml
@@ -34,5 +34,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100a7abea52b53bc6e3b854fe480b6ceddf1d28a773c7cb45b063cb84894dce86df0220023489a7dfa027e01a533d41eb0242aa9c7693238d060be9e9546e468c6b7c93:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/lemlist-takeover.yaml
+++ b/http/takeovers/lemlist-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100b12fa0b4978f85ed3cbe41639ef1128582cc49f9cbdf4a80f3a5bdb0be0bee31022045c0a3b23c1b9d3d1ef6be6d6259807aecab1191bf352df7c7f035044e3c5497:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/mashery-takeover.yaml
+++ b/http/takeovers/mashery-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502201149e8f9fc9b0d0351c9ad314e60423a0868e8fae542b3a1ac7993dba931ef1d0221008049d9334895aef36c83670111facb54c8a21f0d0c0fda7ac1fab4f2a5238075:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/meteor-takeover.yaml
+++ b/http/takeovers/meteor-takeover.yaml
@@ -25,5 +25,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100dd786b650d96f7b610f6fabb775fb0a1bdbdc399098915fed785dc96c4096290022100efa3ad374411b3b54f0901c2147f72f158c6e217fcf25d1ecc77b2ad9a38a28f:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/netlify-takeover.yaml
+++ b/http/takeovers/netlify-takeover.yaml
@@ -38,5 +38,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502204764f51efe7fea4b2004ff43b29b32c53238303e8951f73f30fbf6bd76e1e7b8022100cb22252706a3c243c470c662f9f71fa85726f93f718d7fe53b3e5147a828750b:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/ngrok-takeover.yaml
+++ b/http/takeovers/ngrok-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100be3ad2b3fe9c69371245fb062c73d6fef40199eed88340cee28ff023664fa76202203c6a116f08d99806c26409d9284df5ac6c93e5c5886bb79b8824e8e641c55d70:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pagewiz-takeover.yaml
+++ b/http/takeovers/pagewiz-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100934d069e3bf75bd8206fbf531673a2d73e303c35f6a572ba6086c22a1f7b1ab402204e9b7508bb47942f8d3575b0284ca41734db910ce460d81cb9a1604d6c9a00db:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pantheon-takeover.yaml
+++ b/http/takeovers/pantheon-takeover.yaml
@@ -34,5 +34,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a004730450221008c7dd4e22a1d4fde29ea63656635b7adbc8f5abf044130945e4a69df607215c00220629314f1d78cd8df1bde642f05b1febd922fd801bfbf4e5980a29defe2a57e69:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/pingdom-takeover.yaml
+++ b/http/takeovers/pingdom-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100b2bc3e8ad65a671ca4425f64dd44280a4809d55718706a6f6f005a5ee28d7420022100a00a7a1e403a95d522aa6fbe0fc30e92505eac559c53a8503cbb574c6b5e32af:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/proposify-takeover.yaml
+++ b/http/takeovers/proposify-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022034258f2fca01e39007e9d33458f41536b1903c50ed5ddacba8805bfded9c10b80220441b9f318c24301fdeaf66b9e1fe593a01aa1988cbb0b3fed8fd2c456336a667:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/readme-takeover.yaml
+++ b/http/takeovers/readme-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100ce949e30e457000311f37d3f507775ffb4ad50c2b614cf12956ce4e7805bf313022100a1f155c7443b863e38dbe30ba9b02e94aa7504be85e029d837887d7c25d2a045:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/readthedocs-takeover.yaml
+++ b/http/takeovers/readthedocs-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402205b73bb8a1171ae52b384c6eb817ed2be50e3e243f754c2f19806a5d4ae45a35f02205fd4870a807fb475b6e1322e6135385950d8b1ecca8e5fbfcea83c1b364362a5:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/shopify-takeover.yaml
+++ b/http/takeovers/shopify-takeover.yaml
@@ -45,5 +45,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a004730450220204856f7e988020fdcb4ae366636d5955319303a33a7b6e83099bef036aa4c72022100b0d493e583dcb4b1d9db9197368a4405bef1b303b74fcc3abe8b99fe13ff46e7:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/short-io.yaml
+++ b/http/takeovers/short-io.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402200547045a93bd650f749334f481c7e85b6b70c5bda668debc7edc236f405f2170022022336404658166b4297713e33a77f79de3c3cca8f25630301b2e4c90b2778c7b:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/simplebooklet-takeover.yaml
+++ b/http/takeovers/simplebooklet-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100ec8a2d5fa51dea56e883426cf67a8d347db6169360c9336c06f36bf5f09efede022100f5157c422980294a6369eaf2c985ae49681e7a1438c5ee44e4b42497bed2b161:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/smartjob-takeover.yaml
+++ b/http/takeovers/smartjob-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502206d2af6a49847e8d78c4804f876d0ccda8d71bdbe74d91a0a9d3e9c074428b07c022100e95814e3f5de541f6c2a0da04d93f11fb16fcd17a1db33c638d383e6ff9d9e99:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/smugmug-takeover.yaml
+++ b/http/takeovers/smugmug-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100b1226725e7147551cc8b60993b4c27b9404d7c216e70d947284e74f11f59f0b402200d4046e85887737a8f83988735889b386beaed3dc3011dd2832b5a038810ee4b:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/softr-takeover.yaml
+++ b/http/takeovers/softr-takeover.yaml
@@ -35,5 +35,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100f773bd5a97c78de8be263cdf809ec456f7c2eb6b32f2486fb1e61a99d2cd51fb02201bfdd4f5a49437f0edcee10f3c62c501e26f12289b66e2ceb03200b2c14511c5:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/sprintful-takeover.yaml
+++ b/http/takeovers/sprintful-takeover.yaml
@@ -38,5 +38,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402202faae6dd1e1075349daf0b9382c13500e2c12d16a131791a95c98e025a80543202200a4d444f499455ad564b5cf9be22d31ce9e001595e92ab77b2b91e4160940d36:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/squadcast-takeover.yaml
+++ b/http/takeovers/squadcast-takeover.yaml
@@ -37,5 +37,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a004830460221009bd4e2c96f378728a169b30d9f8dbb6709bb0b212fd48297c86d27d05bf8e6e0022100b8618a8aa2e41507730211937599b02a39cce1b8662ae0da5f0ea632ee222517:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/strikingly-takeover.yaml
+++ b/http/takeovers/strikingly-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a004830460221009e5d298567c427fc0d1a199cbb2634c5fdc7f11b95dad2657d2314b3675056e5022100d08db1a81efc9de0013e99f5968cb948ee6cca04c57c331bd6aa6d23d194a859:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surge-takeover.yaml
+++ b/http/takeovers/surge-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100c5e76f50cc351a887ab8bbbc9256b132fc7fd3ce128f1107cfa8a3566a8ade57022100bc48b903cb92bea6c0303e77b1d142eacd8dcd1edb4466bc76781f82e171a7a9:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surveygizmo-takeover.yaml
+++ b/http/takeovers/surveygizmo-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502204ac3696d5bb6b669b0d7fd8ac6603a2cc19d89b9f5cf468b9c212938ea1886dc022100c8c75e133f38a8a81eef8cea037b689be65102e87094287ac76f6db0aff68f22:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/surveysparrow-takeover.yaml
+++ b/http/takeovers/surveysparrow-takeover.yaml
@@ -32,5 +32,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100a5d612e8edd2e7e0be76838eafb7fc5255b09b098f6a5984d80674fae34dbec702202ded396f540ff22e864c5c7584feea766ed7c012d225ff0b6854e487d4368e6d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tave-takeover.yaml
+++ b/http/takeovers/tave-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100f567fa227ec1c59ea5e3cd810ff5fa7165cb404dd5c23c4889fd57a9e8d600320220561e1f08ae5f4a8f8ccb587892a42ae224f67044eac30646fb8e25ce86e56cf8:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/teamwork-takeover.yaml
+++ b/http/takeovers/teamwork-takeover.yaml
@@ -27,5 +27,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402200c14959578832299911cfd57d60b8d2742088dcd2a6859ee930dca59c18d3d8102201c8783b996d7e0adbe4fb289016896ba02fc9a8b12f0fab47abb54d96a262fb7:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tilda-takeover.yaml
+++ b/http/takeovers/tilda-takeover.yaml
@@ -34,5 +34,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502202336fcd9a9f8d6c225058e80a03e5698c9aaff69b30cb55f7db16756da443f59022100a1411c4e1c57bd88cb6850e53bb523bf8c33c19d101c2764b7b2e7572a9548bf:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/tumblr-takeover.yaml
+++ b/http/takeovers/tumblr-takeover.yaml
@@ -38,5 +38,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402206bf1167a9114d4022f618a63a9308698d869c9fa8e51cbf1214b692f4dcd12a4022073558f02e64b15ed6512e98855a6f1d26b9db6d51091ffe75ae2b39fea7cdc3b:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uberflip-takeover.yaml
+++ b/http/takeovers/uberflip-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022100daf9a1e1c0d06425b0dc3694ebf3bc3765d763ec74894d6108a340b90d9d47360220313466225809ee86d23bde59df5029bdce7aca0d01c64439a428875bd494972a:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uptime-takeover.yaml
+++ b/http/takeovers/uptime-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402206ae2e4db61257dc700fe2d71b47dfbe0f242e7a9531703ebe3faad83112f25fa02204de1723eed20893ec58a00cb7f0cd7caa2ba0c32cb0fdd897f98626fd8a39677:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uptimerobot-takeover.yaml
+++ b/http/takeovers/uptimerobot-takeover.yaml
@@ -40,5 +40,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a004630440220107442093374d13645d0fc634dbd22e0f935034d353c5e008af1f425915be41e0220425e7e0dc419aa3b41478ad23144a355d6a91a2b2e2b57ff14075160cef6f917:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/uservoice-takeover.yaml
+++ b/http/takeovers/uservoice-takeover.yaml
@@ -30,5 +30,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022078cb1c9e43356b1552b148b33bf5f893b30896bd5abe83163c7309be3645b321022100ab778902fad53051087acce72732788a6769482f444d888820afd1b18fc1d4d2:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/vend-takeover.yaml
+++ b/http/takeovers/vend-takeover.yaml
@@ -29,5 +29,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a00463044022022b0dbe1f5b60787a47074d6cae789b61b13c818f2ca63ce171a19619234fad902205964e2fbce1403f6666f39493673d3a872b6ba0b754e33dde78521d860fbd95d:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wishpond-takeover.yaml
+++ b/http/takeovers/wishpond-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a0048304602210083675b02f7c8e221e2d34f7d84d811f5e4fc33bd8efd54d643bf93e50eab8c8e022100814989f73d6a81f313d461120e8267717dea9e516ee28e9489f067bb462d7f95:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wix-takeover.yaml
+++ b/http/takeovers/wix-takeover.yaml
@@ -35,5 +35,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100a0cd6884c061b436ce7561a8d58fd8854b9c2c170c58015efba8998235279be902210095a56be16d9ddb30e7ff4524c444d5337b8952e5dc963380d83bb061d9091a7c:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wordpress-takeover.yaml
+++ b/http/takeovers/wordpress-takeover.yaml
@@ -37,5 +37,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 490a0046304402200e210350415af8d696a974aad4b7afad97e09eb49b626d286ba49bfc002c57d102202c34a0126212979cb71c47da6b0a283c71c61f4aba18f41b8bdbec5b70c10328:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/worksites-takeover.yaml
+++ b/http/takeovers/worksites-takeover.yaml
@@ -47,5 +47,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a00473045022015e2656c9f329d20fd4891ffcb9834632dac58c492aa84ac9c1666ee62136621022100a36e344c48be6ee62f9f857801310f73f405cd9b5df22503a00171ea141b17c1:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/wufoo-takeover.yaml
+++ b/http/takeovers/wufoo-takeover.yaml
@@ -31,5 +31,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4a0a0047304502201d2109545256fa0c6655011f8c2109fa145b39721cb7fd66b54240071e31dbed022100fb299c8eeb837c84fbb26d69c8c805d8add5b67d09e6a7b8a9ca73dd7cd77233:922c64590222798bb761d5b6d8e72950

--- a/http/takeovers/zendesk-takeover.yaml
+++ b/http/takeovers/zendesk-takeover.yaml
@@ -33,5 +33,5 @@ http:
     extractors:
       - type: dsl
         dsl:
-          - "resolve(Host, 'cname')"
+          - cname
 # digest: 4b0a00483046022100a3eb6a6435a19adedbce449af23b505508d27a492504f2b6de496d0ea53d2dec022100ea6e2f16a078c3406b623e4c67bd1ee41c4273bef10fe48f8fee50f5cc35822a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
With upcoming release of nuclei, `cname` information will be available as part of existing HTTP request via `cname` that can be directly accessed in dsl, so we don't have to resolve it separately.

Follow up updates for https://github.com/projectdiscovery/nuclei-templates/pull/10224 with latest support in nuclei https://github.com/projectdiscovery/nuclei/pull/5389