### PR TITLE
Add 'error.ghost.org' to ghost.io takeover

### DIFF
--- a/http/takeovers/ghost-takeover.yaml
+++ b/http/takeovers/ghost-takeover.yaml
@@ -25,6 +25,7 @@ http:
       - type: word
         part: header
         words:
+          - 'error.ghost.org'
           - 'offline.ghost.org'
 
       - type: status

--- a/http/takeovers/ghost-takeover.yaml
+++ b/http/takeovers/ghost-takeover.yaml
@@ -27,6 +27,7 @@ http:
         words:
           - 'error.ghost.org'
           - 'offline.ghost.org'
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated Ghost takeover detection template to include 'error.ghost.org' in header matchers for improved accuracy.
- References: N/A

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
