### PR TITLE
Better filtering of old IE-only http scripts

### DIFF
--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -28,7 +28,7 @@ http:
         part: body
         negative: true
         regex:
-          - "(?mi)<!--\\[if lt IE [0-9]*\\]>\\s*<script src=\"http://"
+          - "(?mi)<!--\\[if (lt|lte) IE [0-9]*\\]>\\s*<script[^>]*\\ssrc=\"http://"
 
       - type: regex
         part: body


### PR DESCRIPTION
### Template / PR Information

Sometimes a script is served using http:// but only for old browsers, e.g. because it's a polyfill and the administrators don't believe the browser to have modern root certificates. This change improves the skipping of such cases.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

