### PR TITLE
Add more matchers/extractors to the "Gradle Enterprise Build Cache Node" login panel detection template. 

### DIFF
--- a/http/exposed-panels/gradle/gradle-cache-node-detect.yaml
+++ b/http/exposed-panels/gradle/gradle-cache-node-detect.yaml
@@ -2,32 +2,36 @@ id: gradle-cache-node-detect
 
 info:
   name: Gradle Enterprise Build Cache Node Login Panel - Detect
-  author: Adam Crosser
+  author: Adam Crosser,righettod
   severity: info
   description: Gradle Enterprise Build Cache Node login panel was detected.
   reference:
-    - https://gradle.com
+    - https://gradle.com/gradle-enterprise-solutions/build-cache/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
     max-request: 1
-  tags: panel,gradle,cache
+    verified: true
+    shodan-query: http.html:"Gradle Enterprise Build Cache Node"
+  tags: panel,gradle,detect
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}'
+      - "{{BaseURL}}"
 
     matchers:
-      - type: regex
-        regex:
-          - "<span>Gradle Enterprise Build Cache Node (.*)</span>"
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 401'
+          - 'contains_any(to_lower(body), "gradle enterprise build cache node", "com.gradle.error.fallback")'
+        condition: and
 
     extractors:
       - type: regex
         part: body
         group: 1
         regex:
-          - "<span>Gradle Enterprise Build Cache Node (.*)</span>"
-# digest: 4b0a004830460221008dbdc2d78f296e38531085c0f85a1047485cad55a664d50c4c809349f0932728022100be5036f154a06dc26a667d3600144487619fd4d8c4df4f4936e1dd768710f0e7:922c64590222798bb761d5b6d8e72950
+          - '(?i)"applicationVersion":"([0-9.]+)"'
+          - '(?i)Gradle\s+Enterprise\s+Build\s+Cache\s+Node\s+([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR add more matchers to the existing template as well as an extractor to extract the version.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found on **shodan**:

```text
https://34.160.122.48
http://3.120.29.251
https://3.77.66.216
https://18.197.251.252
http://65.21.131.185
http://35.172.100.215
https://34.122.133.60
http://54.71.157.77
https://44.238.237.13
https://3.37.142.127
```

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/4c107ae7-e480-4008-bec0-80a3bc7e3806)

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Gradle+Enterprise+Build+Cache+Node%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/0df3e786-4faf-4b6b-80cf-d88f99af4e4a)

### Additional References:

None