### PR TITLE
Add detection of Gradle Develocity Build Cache Node login panel instances.

### DIFF
--- a/http/exposed-panels/gradle/gradle-develocity-panel.yaml
+++ b/http/exposed-panels/gradle/gradle-develocity-panel.yaml
@@ -1,0 +1,33 @@
+id: gradle-develocity-panel
+
+info:
+  name: Gradle Develocity Build Cache Node Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Gradle Develocity Build Cache Node login panel was detected.
+  reference:
+    - https://gradle.com/gradle-enterprise-solutions/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"Develocity Build Cache Node"
+  tags: panel,gradle,detect,login
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 401'
+          - 'contains_any(to_lower(body), "develocity build cache node", "develocity", "com.gradle.error.fallback")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"applicationVersion":"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Gradle Develocity Build Cache Node** software.

References:

- https://gradle.com/gradle-enterprise-solutions/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/558fae70-4117-46f2-add1-7179f7d741f5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://3.68.187.226
http://167.235.181.245
https://65.108.92.217
https://65.108.123.49
https://13.49.210.243
http://130.211.73.154
https://35.209.241.50
http://34.215.173.211
https://13.238.113.216
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Develocity+Build+Cache+Node%22

![image](https://github.com/projectdiscovery/nuclei-templates/assets/1573775/b73429c3-6ceb-44cb-a960-a1ac5f32c6d9)

### Additional References

None