### PR TITLE
Add detection of  Falcosidekick UI login panel instances.

### DIFF
--- a/http/exposed-panels/falcosidekick-panel.yaml
+++ b/http/exposed-panels/falcosidekick-panel.yaml
@@ -1,0 +1,26 @@
+id: falcosidekick-panel
+
+info:
+  name: Falcosidekick UI Login Panel - Detect
+  author: righettod
+  severity: info
+  description: Falcosidekick UI login panel was detected.
+  reference:
+    - https://github.com/falcosecurity/falcosidekick-ui
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Falcosidekick"
+  tags: panel,falco,detect,login
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/login/'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "falcosidekick ui", "falcosidekick-ui")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Falcosidekick UI** software.

References:

- https://github.com/falcosecurity/falcosidekick-ui

I did not found any existing template:

![image](https://github.com/user-attachments/assets/34b20b93-9460-4468-84e3-fdcdaddbaf27)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://35.241.39.11
```

![image](https://github.com/user-attachments/assets/ae3deed0-1e22-4404-8e7f-a84cd97a9753)

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Falcosidekick%22

![image](https://github.com/user-attachments/assets/26c4b029-0114-4685-abee-2716a112a7d7)

### Additional References

None