### PR TITLE
Create apache-ozone-detect.yaml and apache-ozone-conf.yaml

### DIFF
--- a/http/exposures/configs/apache-ozone-conf.yaml
+++ b/http/exposures/configs/apache-ozone-conf.yaml
@@ -1,0 +1,32 @@
+id: apache-ozone-conf
+
+info:
+  name: Apache Ozone - Exposure
+  author: icarot
+  severity: info
+  description: |
+    Detects if path /conf of Apache Ozone web application is exposed.
+  classification:
+    cpe: cpe:2.3:a:apache:ozone:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: ozone
+    shodan-query: title:"Apache Ozone"
+  tags: tech,ozone,apache,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/conf"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<source>ozone-default.xml</source>'
+          - 'ozone'
+
+      - type: status
+        status:
+          - 200

--- a/http/exposures/configs/apache-ozone-conf.yaml
+++ b/http/exposures/configs/apache-ozone-conf.yaml
@@ -23,9 +23,16 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - '<source>ozone-default.xml</source>'
           - 'ozone'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'text/xml'
 
       - type: status
         status:

--- a/http/technologies/apache/apache-ozone-detect.yaml
+++ b/http/technologies/apache/apache-ozone-detect.yaml
@@ -10,7 +10,6 @@ info:
     cpe: cpe:2.3:a:apache:ozone:-:*:*:*:*:*:*:*
   metadata:
     max-request: 1
-    verified: true
     vendor: apache
     product: ozone
     shodan-query: title:"Apache Ozone"

--- a/http/technologies/apache/apache-ozone-detect.yaml
+++ b/http/technologies/apache/apache-ozone-detect.yaml
@@ -1,0 +1,32 @@
+id: apache-ozone-detect
+
+info:
+  name: Apache Ozone - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Ozone web application, a scalable, redundant, and distributed object store for Hadoop and Cloud-native environments. 
+  classification:
+    cpe: cpe:2.3:a:apache:ozone:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    verified: true
+    vendor: apache
+    product: ozone
+    shodan-query: title:"Apache Ozone"
+  tags: tech,ozone,apache,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/static/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Apache Ozone</title>'
+
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-ozone-detect.yaml
+++ b/http/technologies/apache/apache-ozone-detect.yaml
@@ -5,7 +5,7 @@ info:
   author: icarot
   severity: info
   description: |
-    Detects a Apache Ozone web application, a scalable, redundant, and distributed object store for Hadoop and Cloud-native environments. 
+    Detects a Apache Ozone web application, a scalable, redundant, and distributed object store for Hadoop and Cloud-native environments.
   classification:
     cpe: cpe:2.3:a:apache:ozone:-:*:*:*:*:*:*:*
   metadata:


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache Ozone web application, a scalable, redundant, and distributed object store for Hadoop and Cloud-native environments.
* Detects if path /conf of Apache Ozone web application is exposed.

- References:

https://github.com/apache/ozone

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Ozone Docker:**

1. Running container:

`$ docker run --rm --name ozone_container -p 9878:9878 apache/ozone`

2. Acessing the Apache Allura service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ozone_container`

And the access URL will be http://<obteined_inspect_IP_Address>:9878/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-ozone-detect.yaml -t apache-ozone-conf.yaml -u "http://<obteined_inspect_IP_Address>:9878" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/2e775b9b-2491-406b-ab62-4cd59ce5546f)

![image](https://github.com/user-attachments/assets/6b085c4b-7296-46a6-8437-51e40e40d91c)

![image](https://github.com/user-attachments/assets/078ae701-c679-4187-a702-8d0d397940f4)
