### PR TITLE
Add detection template for CVE-2024-34351.

### DIFF
--- a/http/cves/2024/CVE-2024-34351.yaml
+++ b/http/cves/2024/CVE-2024-34351.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://www.assetnote.io/resources/research/digging-for-ssrf-in-nextjs-apps
     - https://nvd.nist.gov/vuln/detail/CVE-2024-34351
-    - https://github.com/vercel/next.js/security/advisories/GHSA-fr5h-rqp8-mj6g    
+    - https://github.com/vercel/next.js/security/advisories/GHSA-fr5h-rqp8-mj6g
   metadata:
     max-request: 2
   tags: cve,cve2024,vercel,nextjs,ssrf

--- a/http/cves/2024/CVE-2024-34351.yaml
+++ b/http/cves/2024/CVE-2024-34351.yaml
@@ -22,7 +22,7 @@ http:
       - '{{BaseURL}}/_next/image?w=16&q=10&url=https://{{interactsh-url}}'
 
     matchers:
-        - type: word
-          part: interactsh_protocol
-          words:
-            - 'http'
+      - type: word
+        part: interactsh_protocol
+        words:
+          - 'http'

--- a/http/cves/2024/CVE-2024-34351.yaml
+++ b/http/cves/2024/CVE-2024-34351.yaml
@@ -1,18 +1,32 @@
 id: CVE-2024-34351
 
 info:
-  name: Next.js - SSRF
+  name: Next.js - Server Side Request Forgery (SSRF)
   author: righettod
   severity: high
-  remediation: Upgrade to Next.js version 14.1.1 or higher.
   description: |
     Next.Js, inferior to version 14.1.1, have its image optimization built-in component prone to SSRF.
+  remediation: Upgrade to Next.js version 14.1.1 or higher.
   reference:
     - https://www.assetnote.io/resources/research/digging-for-ssrf-in-nextjs-apps
     - https://nvd.nist.gov/vuln/detail/CVE-2024-34351
     - https://github.com/vercel/next.js/security/advisories/GHSA-fr5h-rqp8-mj6g
+    - https://github.com/vercel/next.js/commit/8f7a6ca7d21a97bc9f7a1bbe10427b5ad74b9085
+    - https://github.com/vercel/next.js/pull/62561
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2024-34351
+    cwe-id: CWE-918
+    epss-score: 0.00062
+    epss-percentile: 0.26843
   metadata:
     max-request: 2
+    product: next.js
+    shodan-query:
+      - http.html:"/_next/static"
+      - cpe:"cpe:2.3:a:zeit:next.js"
+    fofa-query: body="/_next/static"
   tags: cve,cve2024,vercel,nextjs,ssrf
 
 http:
@@ -21,8 +35,15 @@ http:
       - '{{BaseURL}}/_next/image?w=16&q=10&url=http://{{interactsh-url}}'
       - '{{BaseURL}}/_next/image?w=16&q=10&url=https://{{interactsh-url}}'
 
+    stop-at-first-match: true
+    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol
         words:
           - 'http'
+
+      - type: word
+        part: body
+        words:
+          - "The requested resource isn't a valid image"

--- a/http/cves/2024/CVE-2024-34351.yaml
+++ b/http/cves/2024/CVE-2024-34351.yaml
@@ -1,0 +1,28 @@
+id: CVE-2024-34351
+
+info:
+  name: Next.js - SSRF
+  author: righettod
+  severity: high
+  remediation: Upgrade to Next.js version 14.1.1 or higher.
+  description: |
+    Next.Js, inferior to version 14.1.1, have its image optimization built-in component prone to SSRF.
+  reference:
+    - https://www.assetnote.io/resources/research/digging-for-ssrf-in-nextjs-apps
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-34351
+    - https://github.com/vercel/next.js/security/advisories/GHSA-fr5h-rqp8-mj6g    
+  metadata:
+    max-request: 2
+  tags: cve,cve2024,vercel,nextjs,ssrf
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/_next/image?w=16&q=10&url=http://{{interactsh-url}}'
+      - '{{BaseURL}}/_next/image?w=16&q=10&url=https://{{interactsh-url}}'
+
+    matchers:
+        - type: word
+          part: interactsh_protocol
+          words:
+            - 'http'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect exposure to CVE-2024-34351

References:
* https://www.assetnote.io/resources/research/digging-for-ssrf-in-nextjs-apps
* https://nvd.nist.gov/vuln/detail/CVE-2024-34351
* https://github.com/vercel/next.js/security/advisories/GHSA-fr5h-rqp8-mj6g

The only reference to this CVE I found was the PR #9788 that was closed.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Via a local POC against **Next.js** version **[14.1.0](https://github.com/vercel/next.js/tree/v14.1.0)** (`righettod.local` is an hosts file entry pointing to `127.0.0.1`):

![image](https://github.com/user-attachments/assets/97849208-0cbd-4a9b-afd0-4663595eb5d4)

### Additional Details (leave it blank if not applicable)

App used for the POC: [demo.zip](https://github.com/user-attachments/files/16232212/demo.zip)

![image](https://github.com/user-attachments/assets/153e8dc1-0857-40d3-9678-87cd65b31a68)


### Additional References:

None