### PR TITLE
DS_Store template had FPs on UTF-16 encoded HTML files

### DIFF
--- a/http/exposures/files/ds-store-file.yaml
+++ b/http/exposures/files/ds-store-file.yaml
@@ -25,6 +25,12 @@ http:
         condition: or
 
       - type: dsl
+        negative: true
+        dsl:
+          - "contains(to_lower(body), '\0<\0h\0t\0m\0l')"
+          - "contains(to_lower(body), '\0<\0b\0o\0d\0y')"
+
+      - type: dsl
         dsl:
           - 'status_code == 200'
 
@@ -33,4 +39,3 @@ http:
           - 'contains(to_lower(header), "accept-ranges: bytes")'
           - 'contains(to_lower(header), "octet-stream")'
         condition: or
-# digest: 4b0a00483046022100e615e464074ec8d07c0be8de940efbc09b919955cfae6ace638e5954e87044d1022100daaaef38756c1b860b23164372ab226483f028f9403b0ea61a6a29d53d0035cb:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

As in the title: during our scans at CERT PL we detected that the DS_Store template had FPs on UTF-16 encoded HTML files.


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

