### PR TITLE
Improved shodan query for CVE-2024-36401.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-36401.yaml
+++ b/http/cves/2024/CVE-2024-36401.yaml
@@ -2,7 +2,9 @@ id: CVE-2024-36401
 
 info:
   name: GeoServer RCE in Evaluating Property Name Expressions
-  author: DhiyaneshDk
+  author: 
+   - DhiyaneshDk
+   - GarysMortalEnemy
   severity: critical
   description: |
     In the GeoServer version prior to 2.25.1, 2.24.3 and 2.23.5 of GeoServer, multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users through specially crafted input against a default GeoServer installation due to unsafely evaluating property names as XPath expressions.
@@ -18,7 +20,7 @@ info:
     max-request: 1
     vendor: osgeo
     product: geoserver
-    shodan-query: http.title:"geoserver"
+    shodan-query: Server: GeoHttpServer
     fofa-query:
       - title="geoserver"
       - app="geoserver"


### PR DESCRIPTION
Returns ~50k accurate results compared to ~900 before. Source: https://www.vicarius.io/vsociety/posts/geoserver-rce-cve-2024-36401

### Template / PR Information

I've updated the shodan query to catch more comprehensively by matching keys in the body without needing to rely on the http title response

- Updated CVE-2024-36401
- References: https://www.vicarius.io/vsociety/posts/geoserver-rce-cve-2024-36401

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
![image](https://github.com/user-attachments/assets/f853696c-475d-45bd-b8c0-d5830456e46f)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)