### PR TITLE
Refactor the Tomcat template

### DIFF
--- a/http/exposed-panels/tomcat/tomcat-exposed.yaml
+++ b/http/exposed-panels/tomcat/tomcat-exposed.yaml
@@ -1,13 +1,15 @@
-id: tomcat-exposed-docs
+id: tomcat-exposed
 
 info:
-  name: Tomcat exposed docs
-  author: Podalirius
+  name: Tomcat exposed - Detect
+  author: Podalirius,righettod
+  description: Tomcat instance was detected.
   severity: info
   classification:
     cpe: cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    verified: true
     vendor: apache
     product: tomcat
     shodan-query:
@@ -24,23 +26,26 @@ info:
 http:
   - method: GET
     path:
+      - '{{BaseURL}}/host-manager/html'
+      - '{{BaseURL}}/manager/status'
+      - '{{BaseURL}}/manager/html'
       - '{{BaseURL}}/docs/'
+      - '{{BaseURL}}/examples/'
 
-    matchers-condition: and
+    stop-at-first-match: true
+
     matchers:
-      - type: word
-        words:
-          - 'Apache Tomcat'
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 401'
+          - 'contains_any(to_lower(body), "apache tomcat", "tomcat-users.xml")'
         condition: and
-
-      - type: status
-        status:
-          - 200
 
     extractors:
       - type: regex
         part: body
         group: 1
         regex:
-          - '<div class="versionInfo">[ \n\t]*(Version[ \n\t]*[^\n\t<]+)[ \n\t]*<time'
-# digest: 4b0a00483046022100e6dc2d9d6fa2e1dea5c5f126e696b23d549ce3c851378fe5c818f46a7856e4120221008dd4bfa8d0eb137626e86bddb522da573c9a58b84a6c7e5530193f79a55627a9:922c64590222798bb761d5b6d8e72950
+          - 'Version\s+([0-9.]+),'
+          - '(?i)/lib/([a-z0-9.]+)/webapps'
+          - '(?i)<h3>Apache\s+Tomcat/([0-9.]+)'

--- a/http/exposed-panels/tomcat/tomcat-exposed.yaml
+++ b/http/exposed-panels/tomcat/tomcat-exposed.yaml
@@ -1,10 +1,10 @@
 id: tomcat-exposed
 
 info:
-  name: Tomcat exposed - Detect
+  name: Tomcat Exposed - Detect
   author: Podalirius,righettod
-  description: Tomcat instance was detected.
   severity: info
+  description: An Apache Tomcat instance was detected.
   classification:
     cpe: cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*
   metadata:
@@ -21,7 +21,7 @@ info:
       - body="apache tomcat"
       - title="apache tomcat"
     google-query: intitle:"apache tomcat"
-  tags: version,tomcat,docs,panel,apache
+  tags: tomcat,panel,apache,detect
 
 http:
   - method: GET
@@ -33,7 +33,6 @@ http:
       - '{{BaseURL}}/examples/'
 
     stop-at-first-match: true
-
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of the instance of an Tomcat.

HTTP 401 was detected, addition to the HTTP 200, to allow a credentials guessing operations against the exposed management interfaces.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
http://18.132.251.155
http://121.89.241.254
http://207.46.233.90:8080
https://157.230.193.155
https://15.73.145.20
http://123.60.53.126:8080
```

![image](https://github.com/user-attachments/assets/878e3b94-c3b5-4f65-8761-deda9210694b)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22apache+tomcat%22

![image](https://github.com/user-attachments/assets/841792e8-7c24-4797-8f5b-2b9f0885fd36)

### Additional References:

None