### PR TITLE
Adding additional check to /code/privesc/linux/binary

### DIFF
--- a/code/privilege-escalation/linux/binary/privesc-agetty.yaml
+++ b/code/privilege-escalation/linux/binary/privesc-agetty.yaml
@@ -1,0 +1,41 @@
+id: privesc-agetty
+
+info:
+  name: agetty - Privilege Escalation
+  author: bobakabill
+  severity: high
+  description: |
+    The agetty command in Linux is used to invoke the /bin/login command for a given user. If the SUID bit is set, it can be used to gain a high-privilege s>
+  reference:
+    - https://gtfobins.github.io/gtfobins/agetty/
+  metadata:
+    verified: true
+    max-request: 3
+  tags: code,linux,find,privesc,local
+
+self-contained: true
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+     find /usr/sbin/agetty -perm /4000
+
+  - engine:
+      - sh
+      - bash
+    source: |
+      find /usr/sbin/agetty -perm /6000
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "/usr/sbin/agetty"
+
+      - type: word
+        part: code_2_response
+        words:
+          - "/usr/sbin/agetty"
+# digest: 4a0a00473045022100a538ae5a5fe0337a1441bce017745d6bd64eec5fcc941fde9708a999469ad9ce0220556e7c14a79a88d1e5e37309085d79af25d63bfd83ccb0b80d5f4857b21b

--- a/code/privilege-escalation/linux/binary/privesc-agetty.yaml
+++ b/code/privilege-escalation/linux/binary/privesc-agetty.yaml
@@ -10,7 +10,7 @@ info:
     - https://gtfobins.github.io/gtfobins/agetty/
   metadata:
     verified: true
-    max-request: 3
+    max-request: 2
   tags: code,linux,find,privesc,local
 
 self-contained: true
@@ -19,23 +19,10 @@ code:
       - sh
       - bash
     source: |
-     find /usr/sbin/agetty -perm /4000
+     find /bin /sbin /usr/bin /usr/sbin /usr/local/sbin -type f -name agetty 2>/dev/null -perm /4000
+     find /bin /sbin /usr/bin /usr/sbin /usr/local/sbin -type f -name agetty 2>/dev/null -perm /6000
 
-  - engine:
-      - sh
-      - bash
-    source: |
-      find /usr/sbin/agetty -perm /6000
-
-    matchers-condition: or
     matchers:
       - type: word
-        part: code_1_response
         words:
-          - "/usr/sbin/agetty"
-
-      - type: word
-        part: code_2_response
-        words:
-          - "/usr/sbin/agetty"
-# digest: 4a0a00473045022100a538ae5a5fe0337a1441bce017745d6bd64eec5fcc941fde9708a999469ad9ce0220556e7c14a79a88d1e5e37309085d79af25d63bfd83ccb0b80d5f4857b21b
+          - "agetty"


### PR DESCRIPTION
### Template / PR Information
Added template to detect potential privesc with agetty binary by checking for SUID bit. Would have used similar method to other privesc checks, but due to agetty opening a shell I believe that nuclei passing code commands through stdin makes the shell unavailable (would appreciate correction on that, that way feels "more right.")

- Added agetty privilege escalation check
- References: https://gtfobins.github.io/gtfobins/agetty/

### Template Validation

I've validated this template locally?
- [x ] YES
- [ ] NO



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)