### PR TITLE
Law Enforcement Site Seized Detection

### DIFF
--- a/http/exposed-panels/seized-site.yaml
+++ b/http/exposed-panels/seized-site.yaml
@@ -1,0 +1,27 @@
+id: seized-site
+
+info:
+  name: Seized Site
+  author: rxerium
+  severity: info
+  description: This website has been seized by law enforcement
+  metadata:
+    shodan-query:
+      - title:"THIS WEBSITE HAS BEEN SEIZED"
+  tags: exposure,seized
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "THIS WEBSITE HAS BEEN SEIZED"
+
+      - type: status
+        status:
+          - 200

--- a/http/miscellaneous/seized-site.yaml
+++ b/http/miscellaneous/seized-site.yaml
@@ -6,9 +6,10 @@ info:
   severity: info
   description: This website has been seized by law enforcement
   metadata:
-    shodan-query:
-      - title:"THIS WEBSITE HAS BEEN SEIZED"
-  tags: exposure,seized
+    max-request: 1
+    verified: true
+    shodan-query: title:"THIS WEBSITE HAS BEEN SEIZED"
+  tags: seized,miscellaneous
 
 http:
   - method: GET
@@ -21,6 +22,7 @@ http:
         part: body
         words:
           - "THIS WEBSITE HAS BEEN SEIZED"
+        case-insensitive: true
 
       - type: status
         status:


### PR DESCRIPTION
This template detects sites that have been seized by law enforcement. Example:

https://46.226.163.240/

![image](https://github.com/user-attachments/assets/03dcb1a6-916a-4c3a-9e61-214c7302b410)


I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)