### PR TITLE
New template for detecting Fortinet CVE-2023-27997

### DIFF
--- a/http/cves/2023/CVE-2023-27997.yaml
+++ b/http/cves/2023/CVE-2023-27997.yaml
@@ -1,0 +1,76 @@
+id: CVE-2023-27997
+
+info:
+  name: Pre-authentication Remote Code Execution on Fortigate VPN
+  author: Autobahn Security
+  severity: high
+  description: |
+    A heap-based buffer overflow vulnerability [CWE-122] in FortiOS version 7.2.4 and below, version 7.0.11 and below, version 6.4.12 and below, version 6.0.16 and below and FortiProxy version 7.2.3 and below, version 7.0.9 and below, version 2.0.12 and below, version 1.2 all versions, version 1.1 all versions SSL-VPN may allow a remote attacker to execute arbitrary code or commands via specifically crafted requests.
+  reference:
+    - https://blog.lexfo.fr/xortigate-cve-2023-27997.html
+    - https://github.com/advisories/GHSA-2hj2-fcr9-9p35
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-27997
+  metadata:
+    verified: true
+  tags: cve,cve2023,fortinet,fortios,fortigate
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    host-redirects: true
+    max-redirects: 1
+
+    extractors:
+      - type: regex
+        part: header
+        internal: true
+        name: last_modified_year
+        group: 1
+        regex:
+          - "Last-Modified: [\\w]+, [0-9]+ [\\w]+ ([0-9]+)"
+
+      - type: regex
+        part: header
+        internal: true
+        name: last_modified_month
+        group: 1
+        regex:
+          - "Last-Modified: [\\w]+, [0-9]+ ([\\w]+) [0-9]+"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "Server: xxxxxxxx-xxxxx"
+
+      - type: dsl
+        dsl:
+          - "to_number(last_modified_year) < 2023"
+
+      - type: word
+        part: last_modified_month
+        words:
+          - Jan
+          - Feb
+          - Mar
+          - Apr
+          - May
+          - Jun
+          - Jul
+          - Aug
+          - Sep
+          - Oct
+          - Nov
+          - Dec
+
+      - type: word
+        part: body
+        words:
+          - "top.location=\"/remote/login\";"


### PR DESCRIPTION
### Template / PR Information

During our sister company's Red Team exercise on their client's systems, the team found that we could determine the patch level from the Last-Modified header in the response with medium confidence. We also compare it with the result from other tools [1] to scan multiple targets and most of the result turns out the same

- References:
[1] [BishopFox/CVE-2023-27997-check](https://github.com/BishopFox/CVE-2023-27997-check)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)