### PR TITLE
Refactor the CheckMK template.

### DIFF
--- a/http/exposed-panels/checkmk/checkmk-login.yaml
+++ b/http/exposed-panels/checkmk/checkmk-login.yaml
@@ -2,35 +2,37 @@ id: checkmk-login
 
 info:
   name: Checkmk Login Panel - Detect
-  author: princechaddha
+  author: princechaddha,righettod
   severity: info
   description: Checkmk login panel was detected.
+  reference:
+    - https://checkmk.com/ 
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
-    cpe: cpe:2.3:a:tribe29:checkmk:*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:checkmk:checkmk:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 1
-    vendor: tribe29
+    max-request: 5
+    vendor: checkmk
     product: checkmk
-  tags: login,tech,synology,rackstation,panel,tribe29
+    verified: true
+    shodan-query: http.title:"Check_MK"
+  tags: panel,checkmk,detect,login
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/check_mk/login.py"
+      - "{{BaseURL}}/"
 
-    matchers-condition: or
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
     matchers:
-      - type: word
-        part: body
-        words:
-          - '<title>Check_MK Multisite Login</title>'
-
-      - type: regex
-        part: body
-        regex:
-          - '<title>Checkmk ([A-Za-z_0-9 ]+)<\/title>'
+        - type: dsl
+          dsl:
+            - 'status_code == 200 || status_code == 401'
+            - 'contains_any(to_lower(body), "check_mk multisite login", "checkmk", "check_mk mobile")'
+          condition: and
 
     extractors:
       - type: regex
@@ -39,4 +41,3 @@ http:
         regex:
           - '<div id="version">([0-9.a-z]+)<\/div>'
           - '<div id="foot">Version: ([0-9.a-z]+)'
-# digest: 4b0a00483046022100b310dc2eb2c1633e9d63b74c63df7b1dfee65e41b00f931d7ba59a93b5655910022100dc129226cfb39444cfd03083edd885b212c317aedc94300267e185c5b25d6290:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/checkmk/checkmk-login.yaml
+++ b/http/exposed-panels/checkmk/checkmk-login.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   description: Checkmk login panel was detected.
   reference:
-    - https://checkmk.com/ 
+    - https://checkmk.com/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -28,11 +28,11 @@ http:
     max-redirects: 5
     stop-at-first-match: true
     matchers:
-        - type: dsl
-          dsl:
-            - 'status_code == 200 || status_code == 401'
-            - 'contains_any(to_lower(body), "check_mk multisite login", "checkmk", "check_mk mobile")'
-          condition: and
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 401'
+          - 'contains_any(to_lower(body), "check_mk multisite login", "checkmk", "check_mk mobile")'
+        condition: and
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the CheckMK software, whatever the final path in place.

It is the reason why I added support for up to 5 redirections because, in my test, I seen such case.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
http://37.97.160.213
https://51.15.21.13
http://52.212.130.205
http://192.34.60.9
https://173.249.53.90
http://163.178.105.86
https://35.197.144.191
```

![image](https://github.com/user-attachments/assets/80f359f4-1032-47a6-bc2b-2140e96623d6)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Check_MK%22

![image](https://github.com/user-attachments/assets/87386ed3-c877-425e-85cb-ea3770297bdd)

### Additional References:

None