### PR TITLE
Refactor the "Axway API Manager" template. 

### DIFF
--- a/http/exposed-panels/axway-api-manager-panel.yaml
+++ b/http/exposed-panels/axway-api-manager-panel.yaml
@@ -2,27 +2,36 @@ id: axway-api-manager-panel
 
 info:
   name: Axway API Manager Panel - Detect
-  author: johnk3r
+  author: johnk3r,righettod
   severity: info
+  description: Axway API Manager panel was detected.
+  reference:
+    - https://docs.axway.com/bundle/axway-open-docs/page/docs/index.html
+    - https://www.postman.com/api-evangelist/axway/api/06c40de2-3954-4c68-ae10-a7eded330b05
+    - https://www.postman.com/api-evangelist/axway/api/ce2ac156-4353-46b9-b148-944ab7721ed6
   metadata:
     verified: true
     max-request: 1
     shodan-query: http.title:"Axway API Manager Login"
-  tags: panel,axway,detect
+  tags: panel,axway,detect,login
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/api/portal/v1.4/appinfo"
       - "{{BaseURL}}"
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Axway API Manager Login</title>"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "axway api manager login", "vordel/apiportal/app-login", "api manager", "api portal")'
+        condition: and
 
-      - type: status
-        status:
-          - 200
-# digest: 4b0a004830460221009806e6b46f0d419351aea507da113cdc16e7d0bb46d91d3356f8404c5aacd303022100d97a07a55afba6cc59ae9c4884f13cdff91afe76fb8f880dfe067c7e963d6920:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"productVersion":\s*"([0-9.]+)"'

--- a/http/exposed-panels/axway-api-manager-panel.yaml
+++ b/http/exposed-panels/axway-api-manager-panel.yaml
@@ -26,7 +26,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "axway api manager login", "vordel/apiportal/app-login", "api manager", "api portal")'
+          - 'contains_any(to_lower(body), "axway api manager login", "vordel/apiportal/app-login")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Axway API Manager** software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
https://apim.digital.equans.com
https://34.240.62.130:8083
https://13.51.105.227
https://195.53.177.110
https://103.52.46.147
https://129.148.22.122
https://172.65.245.58:8089
https://54.206.109.157:8089
https://54.79.130.25:8089
```

![image](https://github.com/user-attachments/assets/78fb846a-cc1c-40c5-8f4a-180718470b50)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Axway+API+Manager+Login%22

![image](https://github.com/user-attachments/assets/3a43de40-4051-4a77-b602-25b3355b7ebf)

### Additional References:

None