### PR TITLE
Refactor the "ActiveMQ" template.

### DIFF
--- a/http/exposed-panels/activemq-panel.yaml
+++ b/http/exposed-panels/activemq-panel.yaml
@@ -32,7 +32,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 || status_code == 401'
+          - 'status_code == 200'
           - 'contains_any(to_lower(body), "<title>apache activemq</title>", "<h2>welcome to the apache activemq!</h2>", "manage activemq broker", "activemq console")'
         condition: and
 

--- a/http/exposed-panels/activemq-panel.yaml
+++ b/http/exposed-panels/activemq-panel.yaml
@@ -2,11 +2,12 @@ id: activemq-panel
 
 info:
   name: Apache ActiveMQ Exposure
-  author: pdteam
+  author: pdteam,righettod
   severity: info
   description: An Apache ActiveMQ implementation was discovered.
   reference:
     - https://activemq.apache.org/
+    - https://activemq.apache.org/components/classic/documentation/rest
   classification:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*
@@ -17,17 +18,28 @@ info:
     shodan-query:
       - cpe:"cpe:2.3:a:apache:activemq"
       - product:"activemq openwire transport"
-  tags: panel,activemq,apache
+      - http.title:"Apache ActiveMQ"
+  tags: panel,activemq,apache,login
 
 http:
   - method: GET
     path:
-      - '{{BaseURL}}'
+      - "{{BaseURL}}/admin/"
+      - "{{BaseURL}}/demo/"
+      - "{{BaseURL}}"
 
+    stop-at-first-match: true
     matchers:
-      - type: word
-        words:
-          - '<h2>Welcome to the Apache ActiveMQ!</h2>'
-          - '<title>Apache ActiveMQ</title>'
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 401'
+          - 'contains_any(to_lower(body), "apache activemq", "manage activemq broker", "activemq console")'
         condition: and
-# digest: 490a0046304402200680997e4c289c87060383d51f4bb6961f032074940d7a88d3138c2409d5d33d022034ae36716fa244b3aeac8f14f6396f8559ca6197384d895d23af31b722998851:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Copyright\s+([0-9\-]+)'
+          - '(?i)<td>Version<\/td>[\r\n\s]+<td>[\r\n\s]+<b>([0-9.]+)<\/b>'

--- a/http/exposed-panels/activemq-panel.yaml
+++ b/http/exposed-panels/activemq-panel.yaml
@@ -42,4 +42,4 @@ http:
         group: 1
         regex:
           - '(?i)Copyright\s+([0-9\-]+)'
-          - '(?i)<td>Version<\/td>[\r\n\s]+<td>[\r\n\s]+<b>([0-9.]+)<\/b>'
+          - '(?i)<td>Version<\/td>[\r\n\s]*<td>[\r\n\s]*<b>([0-9.]+)<\/b>'

--- a/http/exposed-panels/activemq-panel.yaml
+++ b/http/exposed-panels/activemq-panel.yaml
@@ -33,7 +33,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200 || status_code == 401'
-          - 'contains_any(to_lower(body), "apache activemq", "manage activemq broker", "activemq console")'
+          - 'contains_any(to_lower(body), "<title>apache activemq</title>", "<h2>welcome to the apache activemq!</h2>", "manage activemq broker", "activemq console")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **ActiveMQ** software as well as an open admin panel.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
https://23.88.97.197:8443
https://51.254.71.204
https://34.236.246.138
https://167.206.202.176
https://8.142.6.185:8443
http://139.9.140.255
http://103.37.152.192
http://101.236.9.10:8080
```

![image](https://github.com/user-attachments/assets/be150f87-1671-4850-b3c6-0f9a4b105fb3)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Apache+ActiveMQ%22

![image](https://github.com/user-attachments/assets/e7a3ba3d-4669-47e5-81f0-5abf976cd331)

### Additional References:

None