### PR TITLE
Added CVE-2024-5421 Template

### DIFF
--- a/http/cves/2024/CVE-2024-5421.yaml
+++ b/http/cves/2024/CVE-2024-5421.yaml
@@ -25,7 +25,7 @@ info:
 
 http:
   - method: GET
-    path: 
+    path:
       - "{{BaseURL}}/info/dir?/"
 
     matchers-condition: and

--- a/http/cves/2024/CVE-2024-5421.yaml
+++ b/http/cves/2024/CVE-2024-5421.yaml
@@ -1,0 +1,43 @@
+id: CVE-2024-5421
+
+info:
+  name: SEH utnserver Pro/ProMAX / INU-100 20.1.22 - Authenticated File Disclosure  
+  author: bl4ckp4r4d1s3
+  severity: high
+  description: |
+    A vulnerability was identified in utnserver Pro, utnserver ProMAX, and INU-100 version 20.1.22 and earlier, impacting the file handling functions. This flaw results in authenticated file disclosure, granting unauthorized access to sensitive files and directories. Although authentication is required, the vulnerability poses a significant risk of data exposure. This vulnerability is publicly disclosed and identified as CVE-2024-5421.
+  reference:
+    - https://cyberdanube.com/en/en-multiple-vulnerabilities-in-seh-untserver-pro/index.html
+    - https://seclists.org/fulldisclosure/2024/Jun/4
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:L
+    cvss-score: 8.7
+    cve-id: CVE-2024-5421
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: SEH HTTP Server
+    vendor: SEH Computertechnik
+    product: utnserver Pro/ProMAX / INU-100
+    version: 0 - 20.1.22
+  tags: cve,cve2024,utnserver,os command
+
+http:
+  - method: GET
+    path: 
+      - "{{BaseURL}}/info/dir?/"
+
+    matchers:
+      - type: word
+        name: Authenticated File Disclosure
+        words:
+          - "application"
+          - "dev"
+          - "etc"
+        part: body
+
+      - type: status
+        status:
+          - 200
+

--- a/http/cves/2024/CVE-2024-5421.yaml
+++ b/http/cves/2024/CVE-2024-5421.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-5421
 
 info:
-  name: SEH utnserver Pro/ProMAX / INU-100 20.1.22 - File Exposure
+  name: SEH utnserver Pro/ProMAX/INU-100 20.1.22 - File Exposure
   author: bl4ckp4r4d1s3
   severity: high
   description: |
@@ -18,9 +18,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-    shodan-query: SEH HTTP Server
-    vendor: SEH Computertechnik
-    product: utnserver Pro/ProMAX / INU-100
+    shodan-query: "SEH HTTP Server"
   tags: cve,cve2024,utnserver,seh,exposure
 
 http:

--- a/http/cves/2024/CVE-2024-5421.yaml
+++ b/http/cves/2024/CVE-2024-5421.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-5421
 
 info:
-  name: SEH utnserver Pro/ProMAX / INU-100 20.1.22 - Authenticated File Disclosure  
+  name: SEH utnserver Pro/ProMAX / INU-100 20.1.22 - File Exposure
   author: bl4ckp4r4d1s3
   severity: high
   description: |
@@ -9,6 +9,7 @@ info:
   reference:
     - https://cyberdanube.com/en/en-multiple-vulnerabilities-in-seh-untserver-pro/index.html
     - https://seclists.org/fulldisclosure/2024/Jun/4
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-5421
   classification:
     cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:L
     cvss-score: 8.7
@@ -20,24 +21,23 @@ info:
     shodan-query: SEH HTTP Server
     vendor: SEH Computertechnik
     product: utnserver Pro/ProMAX / INU-100
-    version: 0 - 20.1.22
-  tags: cve,cve2024,utnserver,os command
+  tags: cve,cve2024,utnserver,seh,exposure
 
 http:
   - method: GET
     path: 
       - "{{BaseURL}}/info/dir?/"
 
+    matchers-condition: and
     matchers:
       - type: word
-        name: Authenticated File Disclosure
-        words:
-          - "application"
-          - "dev"
-          - "etc"
         part: body
+        words:
+          - "/var/tmp</td>"
+          - "File System Info"
+          - 'face="courier'
+        condition: and
 
       - type: status
         status:
           - 200
-


### PR DESCRIPTION
### Template / PR Information
This template detects the CVE-2024-5421 vulnerability, which involves authenticated file disclosure in SEH UTN Server Pro/ProMAX/INU-100 devices, affecting versions 20.1.22 and below.

- Added CVE-2024-5421
- References:
https://cyberdanube.com/en/en-multiple-vulnerabilities-in-seh-untserver-pro/index.html
https://seclists.org/fulldisclosure/2024/Jun/4
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)