### PR TITLE
fix: false positive erlang-daemon.yaml

### DIFF
--- a/network/misconfig/erlang-daemon.yaml
+++ b/network/misconfig/erlang-daemon.yaml
@@ -2,7 +2,7 @@ id: erlang-daemon
 
 info:
   name: Erlang Port Mapper Daemon
-  author: pussycat0x
+  author: pussycat0x,daffainfo
   severity: low
   description: |
     The erlang port mapper daemon is used to coordinate distributed erlang instances. His job is to keep track of which node name listens on which address. Hence, epmd map symbolic node names to machine addresses.
@@ -23,15 +23,21 @@ tcp:
       - "{{Hostname}}"
     port: 4369
 
+    matchers-condition: and
     matchers:
       - type: word
         words:
           - "HTTP/1.1"
         negative: true
 
+      - type: word
+        words:
+          - "name"
+          - "at port"
+        condition: and
+
     extractors:
-      - type: dsl
-        name: default-instances
-        dsl:
-          - trim(raw, '[ ]')
+      - type: regex
+        regex:
+          - 'name (.*?) at port ([0-9]+)'
 # digest: 4a0a00473045022100cd83b7db7a738badc1ee1068f3a27f5e39a1eafbc3fd6c11c58bc700109e3f2a022071036860511978e2b00c92aa9a2b0194d89a829466b94273f7824ddf95aca5af:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The template only detects if the response doesnt have `HTTP/1.1` string or not, that can lead a lot of false positive. For example I scanned ssh server and the template was triggered
```
nuclei -u 150.230.131.118:22 -t network/misconfig/erlang-daemon.yaml --debug
```