### PR TITLE
fix: false positive on pop3-capabilities-enum.yaml

### DIFF
--- a/javascript/enumeration/pop3/pop3-capabilities-enum.yaml
+++ b/javascript/enumeration/pop3/pop3-capabilities-enum.yaml
@@ -2,7 +2,7 @@ id: pop3-capabilities-enum
 
 info:
   name: POP3 Capabilities - Enumeration
-  author: pussycat0x
+  author: pussycat0x,daffainfo
   severity: info
   description: |
     POP3 capabilities are defined in RFC 2449. The CAPA command allows a client to ask a server what commands it supports and possibly any site-specific policy. Besides the list of supported commands, the IMPLEMENTATION string giving the server version may be available.
@@ -23,8 +23,7 @@ javascript:
       let conn = c.Open('tcp', `${Host}:${Port}`);
       conn.Send(data);
       let result = conn.RecvString();
-      let cleanedData = result.replace(/\+OK Dovecot ready\.\r\n\+OK|\r\n|\s/g, " ");
-      console.log(Export(cleanedData))
+      Export(result);
 
     args:
       Host: "{{Host}}"
@@ -36,6 +35,10 @@ javascript:
         dsl:
           - "success == true"
 
+      - type: regex
+        regex:
+          - '\+OK.*'
+
       - type: word
         words:
           - "HTTP/1.1"
@@ -43,7 +46,6 @@ javascript:
 
     extractors:
       - type: dsl
-        name:
         dsl:
-          - response
+          - replace_regex(replace_regex(response, "\\+OK.*\\r\\n\\+OK.*\\r\\n", ""), "\\r\\n", " ")
 # digest: 4a0a0047304502205ee9fb4328d4c7601dcd2216a6d20addbf5330be29a7dacc18ebadd9d98ec60c022100e0bbcf935dd62250ed205d1fdaf7c6ce1bc8188cac860752df55c8b5320b61ff:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The template only detects if the response doesnt have HTTP/1.1 string or not, that can lead a lot of false positive. For example I scanned ssh server and the template was triggered

```
nuclei -u 150.230.131.118:22 -t javascript/enumeration/pop3/pop3-capabilities-enum.yaml --debug
```

And the output will broken if we scan pop3 servers other than dovecot server (e.g: MPOP3D)