### PR TITLE
Add detection of KIALI login panel instances.

### DIFF
--- a/http/exposed-panels/kiali-panel.yaml
+++ b/http/exposed-panels/kiali-panel.yaml
@@ -4,12 +4,14 @@ info:
   name: Kiali - Detect
   author: righettod
   severity: info
-  description: kiali panel was detected.
+  description: |
+    kiali panel was detected.
   reference:
     - https://kiali.io/
   metadata:
     verified: true
-    shodan-query: http.title:"Kiali"
+    max-request: 2
+    shodan-query: title:"Kiali"
   tags: panel,kiali,detect,login
 
 http:
@@ -18,12 +20,14 @@ http:
       - "{{BaseURL}}/kiali/api/status"
       - "{{BaseURL}}/kiali/"
 
+    host-redirects: true
+    max-redirects: 2
     stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "kiali-ui", "<title>kiali</title>", "kiali version")'
+          - 'contains_any(to_lower(body), "kiali-ui", "<title>kiali", "kiali version")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/kiali-panel.yaml
+++ b/http/exposed-panels/kiali-panel.yaml
@@ -1,0 +1,34 @@
+id: kiali-panel
+
+info:
+  name: Kiali - Detect
+  author: righettod
+  severity: info
+  description: kiali panel was detected.
+  reference:
+    - https://kiali.io/
+  metadata:
+    verified: true
+    shodan-query: http.title:"Kiali"
+  tags: panel,kiali,detect,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/kiali/api/status"
+      - "{{BaseURL}}/kiali/"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "kiali-ui", "<title>kiali</title>", "kiali version")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"Kiali version":\s*"([a-z0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **KIALI** software.

I did not found any existing one so I proposed this PR:

![image](https://github.com/user-attachments/assets/f56a4b03-02fa-410c-92b8-ebc9e1a563b0)

References:

- https://kiali.io/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/583876d2-fb63-4e4a-9baa-454e7ff22c02)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://3.248.53.102
http://172.171.156.120:8080
http://35.236.229.58
http://34.128.119.224
https://52.192.171.106
http://52.192.77.254
https://175.41.217.119
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Kiali%22

![image](https://github.com/user-attachments/assets/77e4a166-bf20-4501-8868-3b485871233e)

### Additional References

None