### PR TITLE
Refactor the "Jaeger UI" template.

### DIFF
--- a/http/misconfiguration/jaeger-ui-dashboard.yaml
+++ b/http/misconfiguration/jaeger-ui-dashboard.yaml
@@ -2,26 +2,34 @@ id: jaeger-ui-dashboard
 
 info:
   name: Jaeger UI
-  author: dhiyaneshDK
+  author: dhiyaneshDK,righettod
   severity: low
   description: Jaeger UI dashboard is exposed.
+  reference:
+    - https://www.jaegertracing.io/
   metadata:
     max-request: 1
+    verified: true
     shodan-query: http.title:"Jaeger UI"
   tags: misconfig
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/search"
+      - '{{BaseURL}}/search'
+      - '{{BaseURL}}/api/services'
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        words:
-          - '<title>Jaeger UI</title>'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>jaeger ui", "jaeger_version", "jaeger_config_js", "jaeger-ui-root", "jaeger-query")'
+        condition: and
 
-      - type: status
-        status:
-          - 200
-# digest: 4a0a004730450220554f31341b2922ec383783e139d8de594ce47934ea00158c9d10f77b5261656b0221008ab7acf0248d074fe87f91d75d8731ad61a2f9b7a466ba4b265670f397ed168f:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"gitVersion":\s*"([a-z0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Jaeger** software as well as its version.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
http://3.121.62.79
https://173.212.233.70
http://34.36.186.0
http://34.107.195.208
http://34.149.89.101
http://34.111.49.88
https://62.209.153.125
http://34.149.251.26
http://34.149.13.104
http://120.77.181.193
```

![image](https://github.com/user-attachments/assets/38e2d97c-0805-457e-af8d-8d836a412ae1)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Jaeger+UI%22

![image](https://github.com/user-attachments/assets/5e0459fa-49d9-4323-9c40-2d7e3d0ed4cd)

### Additional References:

None