### PR TITLE
Fix false positive in Missing SRI template

### DIFF
--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -27,7 +27,7 @@ http:
       - type: xpath
         part: body
         xpath:
-          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-','abcdefghijklmnopqrstuvwxyz+/-'), '^sha(256|384|512)-'))]"
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
 
       - type: word
         words:
@@ -38,6 +38,6 @@ http:
       - type: xpath
         attribute: src
         xpath:
-          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-','abcdefghijklmnopqrstuvwxyz+/-'), '^sha(256|384|512)-'))]"
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
 
 # digest: 4a0a0047304502200e29fdf3695b4eadfb362a6ec5332dff4696a4564e73a096a609363b81776126022100a0e6443350ecc806ce4da1a80d628339d3515f387129fc50651ee687b8265bb8:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -2,12 +2,13 @@ id: missing-sri
 
 info:
   name: Missing Subresource Integrity
-  author: lucky0x0d,PulseSecurity.co.nz
+  author: lucky0x0d,PulseSecurity.co.nz,sullo
   severity: info
   description: |
-    Checks if script tags within the HTML response have Subresource Integrity implemented via the integrity attribute
+    Checks if script tags within the HTML response have Subresource Integrity implemented via the integrity attribute.
   reference:
     - https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html#subresource-integrity
+    - https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
   metadata:
     max-request: 1
   tags: compliance,js,sri,misconfig
@@ -26,7 +27,7 @@ http:
       - type: xpath
         part: body
         xpath:
-          - "//script[contains(@src,'//') and not(contains(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'^sha'))]"
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-','abcdefghijklmnopqrstuvwxyz+/-'), '^sha(256|384|512)-'))]"
 
       - type: word
         words:
@@ -37,6 +38,6 @@ http:
       - type: xpath
         attribute: src
         xpath:
-          - "//script[contains(@src,'//') and not(contains(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'^sha'))]"
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-','abcdefghijklmnopqrstuvwxyz+/-'), '^sha(256|384|512)-'))]"
 
 # digest: 4a0a0047304502200e29fdf3695b4eadfb362a6ec5332dff4696a4564e73a096a609363b81776126022100a0e6443350ecc806ce4da1a80d628339d3515f387129fc50651ee687b8265bb8:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Add reference

### Template / PR Information

- Adjusted character class/regex and match syntax
- Added reference

Source that gave false positive:
```
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"
    integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous">
```

- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity