### PR TITLE
Add detection of HashiCorp Vault login panel instances.

### DIFF
--- a/http/exposed-panels/hashicorp-vault-panel.yaml
+++ b/http/exposed-panels/hashicorp-vault-panel.yaml
@@ -1,0 +1,34 @@
+id: hashicorp-vault-panel
+
+info:
+  name: HashiCorp Vault - Detect
+  author: righettod
+  severity: info
+  description: HashiCorp Vault panel was detected.
+  reference:
+    - https://developer.hashicorp.com/vault
+  metadata:
+    verified: true
+    shodan-query: http.html:"vault/config/environment"
+  tags: panel,hashicorp,detect,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/v1/sys/health"
+      - "{{BaseURL}}/ui/vault/auth"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 429'
+          - 'contains_any(to_lower(body), "vault-cluster", "vault/config/environment")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"version":\s*"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **HashiCorp Vault** software.

References:

- https://developer.hashicorp.com/vault

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/7cbee23c-a255-4f62-b8d4-17a71c7d4034)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://5.187.2.124
https://35.242.145.145
https://52.209.184.65
https://217.21.35.219
https://3.125.204.179:8443
https://172.125.129.35
https://157.230.81.232
https://91.215.136.106
http://13.232.149.132
https://44.239.63.28
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22vault%2Fconfig%2Fenvironment%22

![image](https://github.com/user-attachments/assets/a2e06fd6-3573-48b9-8f3f-0cc8ed6e543c)

### Additional References

None