### PR TITLE
Update detection of HashiCorp Vault login panel instances.

### DIFF
--- a/http/exposed-panels/vault-panel.yaml
+++ b/http/exposed-panels/vault-panel.yaml
@@ -2,16 +2,20 @@ id: vault-panel
 
 info:
   name: Vault Login Panel - Detect
-  author: DhiyaneshDK
+  author: DhiyaneshDK,righettod
   severity: info
   description: Vault login panel was detected.
+  reference:
+    - https://developer.hashicorp.com/vault
+    - https://developer.hashicorp.com/vault/api-docs
+    - https://developer.hashicorp.com/vault/api-docs#help
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
     cpe: cpe:2.3:a:hashicorp:vault:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 2
+    max-request: 4
     vendor: hashicorp
     product: vault
     shodan-query: http.favicon.hash:-919788577
@@ -22,19 +26,17 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/v1/sys/health"
-      - "{{BaseURL}}/ui/vault/auth?with=oidc%2F"
+      - "{{BaseURL}}/ui/vault/auth"
+      - "{{BaseURL}}/ui/auth"
+      - "{{BaseURL}}/v1/sys/health?help=1"
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        words:
-          - "<title>Vault</title>"
-          - "vault/"
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 429'
+          - 'contains_any(to_lower(body), "vault-cluster", "vault/config/environment", "<title>vault</title>", "hashicorp vault api")'
         condition: and
-
-      - type: status
-        status:
-          - 200
 
     extractors:
       - type: json
@@ -42,4 +44,3 @@ http:
         name: version
         json:
           - ".version"
-# digest: 4a0a00473045022100e4e1228ec2992872d862ee250f3634139933c4ec3e3e98a79a7280aff67d3d7e022074dcd7b9f098a4070fe881bec25860567a7144687a3cdc170b8b80e64c2840e7:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **HashiCorp Vault** software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Test against the following hosts found via shodan:

```text
https://5.187.2.124
https://35.242.145.145
https://52.209.184.65
https://217.21.35.219
https://3.125.204.179:8443
https://172.125.129.35
https://157.230.81.232
https://91.215.136.106
http://13.232.149.132
https://44.239.63.28
```

![image](https://github.com/user-attachments/assets/5c4d946e-3c3b-406c-a86b-ed0eb96adc74)

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22vault%2Fconfig%2Fenvironment%22

![image](https://github.com/user-attachments/assets/a2e06fd6-3573-48b9-8f3f-0cc8ed6e543c)

### Additional References:

Handle the duplicate referenced into the PR #10597 