### PR TITLE
CVE-2024-28000 - LiteSpeed Cache <= 6.3.0.1 - Unauthenticated Privilege Escalation

### DIFF
--- a/http/cves/2024/cve-2024-28000.yaml
+++ b/http/cves/2024/cve-2024-28000.yaml
@@ -1,0 +1,52 @@
+id: CVE-2024-28000
+
+info:
+  name: LiteSpeed Cache <= 6.3.0.1 - Unauthenticated Privilege Escalation
+  author: Morgan Robertson
+  severity: critical
+  description: |
+    The LiteSpeed Cache plugin for WordPress is vulnerable to privilege escalation in versions <= 6.3.0.1, allowing unauthenticated attackers to spoof their user ID, leading to the potential creation of new administrative user accounts via the REST API. This template tests for the vulnerability via the plugin's readme.txt file which states the currently installed version.
+
+  reference:
+    - https://patchstack.com/articles/critical-privilege-escalation-in-litespeed-cache-plugin-affecting-5-million-sites/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-28000
+    - https://www.wordfence.com/blog/2024/08/over-5000000-site-owners-affected-by-critical-privilege-escalation-vulnerability-patched-in-litespeed-cache-plugin/
+
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-28000
+    cwe-id: CWE-266
+
+  metadata:
+    framework: wordpress
+    researcher: John Blackbourn
+    shodan-query: http.html:"/wp-content/plugins/litespeed-cache"
+    fofa-query: body="/wp-content/plugins/litespeed-cache"
+
+  tags: wordpress,plugin,litespeed,privilege-escalation,cve-2024-28000,cve2024,cve
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/litespeed-cache/readme.txt"
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "Stable tag:\\s*([0-9]+\\.[0-9]+(?:\\.[0-9]+)*)"
+      - type: regex
+        part: body
+        negative: true
+        regex:
+          - "Stable tag:\\s*(6\\.[4-9]|[7-9]\\.\\d|6\\.3\\.0\\.[2-9]|6\\.3\\.[1-9]\\d*)"
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "Stable tag:\\s*([0-9]+\\.[0-9]+(?:\\.[0-9]+)*)"


### PR DESCRIPTION
### Template / PR Information

The LiteSpeed Cache plugin for WordPress is vulnerable to privilege escalation in versions <= 6.3.0.1, allowing unauthenticated attackers to spoof their user ID, leading to the potential creation of new administrative user accounts via the REST API. This template tests for the vulnerability via the plugin's readme.txt file which states the currently installed version.

- Added CVE-2024-28000
- References:
    - https://patchstack.com/articles/critical-privilege-escalation-in-litespeed-cache-plugin-affecting-5-million-sites/
    - https://nvd.nist.gov/vuln/detail/CVE-2024-28000
    - https://www.wordfence.com/blog/2024/08/over-5000000-site-owners-affected-by-critical-privilege-escalation-vulnerability-patched-in-litespeed-cache-plugin/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)




### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)