### PR TITLE
Add cve-2024-5932.yaml - GiveWP <= 3.14.1 - Unauthenticated PHP Object Injection to RCE

### DIFF
--- a/http/cves/2024/cve-2024-5932.yaml
+++ b/http/cves/2024/cve-2024-5932.yaml
@@ -1,0 +1,51 @@
+id: CVE-2024-5932
+
+info:
+  name: GiveWP <= 3.14.1 - Unauthenticated PHP Object Injection to RCE
+  author: Morgan Robertson
+  severity: critical
+  description: |
+    The GiveWP plugin for WordPress is vulnerable to PHP Object Injection leading to Remote Code Execution in all versions up to, and including, 3.14.1 via the 'give_title' parameter. This template tests for the vulnerability via the plugin's readme.txt file which states the currently installed version.
+
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-5932
+    - https://www.wordfence.com/blog/2024/08/4998-bounty-awarded-and-100000-wordpress-sites-protected-against-unauthenticated-remote-code-execution-vulnerability-patched-in-givewp-wordpress-plugin/
+
+  tags: wordpress,givewp,rce,cve-2024-5932,cve,cve2024
+
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2024-5932
+    cwe-id: CWE-502
+
+  metadata:
+    researcher: villu164
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/give"
+    fofa-query: body="/wp-content/plugins/give"
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/give/readme.txt"
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "Stable tag:\\s*([0-9]+\\.[0-9]+\\.[0-9]+)"
+      - type: regex
+        part: body
+        negative: true
+        regex:
+          - "Stable tag:\\s*3\\.14\\.2"
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "Stable tag:\\s*([0-9]+\\.[0-9]+\\.[0-9]+)"


### PR DESCRIPTION
### Template / PR Information

CVE-2024-5932

The GiveWP plugin for WordPress is vulnerable to PHP Object Injection leading to Remote Code Execution in all versions up to, and including, 3.14.1 via the 'give_title' parameter. This template tests for the vulnerability via the plugin's readme.txt file which states the currently installed version.


- Added cve-2024-5932
- References:

    - https://nvd.nist.gov/vuln/detail/CVE-2024-5932
    - https://www.wordfence.com/blog/2024/08/4998-bounty-awarded-and-100000-wordpress-sites-protected-against-unauthenticated-remote-code-execution-vulnerability-patched-in-givewp-wordpress-plugin/


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

    shodan-query: http.html:"/wp-content/plugins/give"
    fofa-query: body="/wp-content/plugins/give"

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)