### PR TITLE
Add wordpress-debug-log-detection.yaml

### DIFF
--- a/http/exposures/logs/wordpress-debug-log-detection.yaml
+++ b/http/exposures/logs/wordpress-debug-log-detection.yaml
@@ -1,0 +1,24 @@
+id: wordpress-debug-log-detection
+
+info:
+  name: WordPress Debug Log File Detection
+  author: Morgan Robertson
+  severity: low
+  description: Detects the presence of WordPress debug.log file in the wp-content directory and looks for common WordPress error log entries.
+  tags: wordpress,log,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/debug.log"
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        
+      - type: word
+        words:
+          - 'PHP'
+          - 'WordPress'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Detects the presence of WordPress debug.log file in the wp-content directory and looks for common WordPress error log entries.

e.g.

"Note: if the “Debug Log” setting of the Litespeed Cache plugin is set to “ON”, the security hash will also be leaked to the debug.log file in the /wp-content/ folder on any request with a mismatching security hash." from https://patchstack.com/articles/critical-privilege-escalation-in-litespeed-cache-plugin-affecting-5-million-sites/

- References:
https://patchstack.com/articles/critical-privilege-escalation-in-litespeed-cache-plugin-affecting-5-million-sites/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)