### PR TITLE
Fixed CVE-2023-48023 severity

### DIFF
--- a/http/cves/2023/CVE-2023-48023.yaml
+++ b/http/cves/2023/CVE-2023-48023.yaml
@@ -3,7 +3,7 @@ id: CVE-2023-48023
 info:
   name: Anyscale Ray 2.6.3 and 2.8.0 - Server-Side Request Forgery
   author: cookiehanhoan,harryha
-  severity: high
+  severity: critical
   description: |
     The Ray Dashboard API is affected by a Server-Side Request Forgery (SSRF) vulnerability in the url parameter of the /log_proxy API endpoint. The API does not perform sufficient input validation within the affected parameter and any HTTP or HTTPS URLs are accepted as valid.
   impact: |


### PR DESCRIPTION
As per  https://nvd.nist.gov/vuln/detail/CVE-2023-48023 the base score is set to critical, not high

