### PR TITLE
Create apache-jspwiki-detect.yaml and apache-jspwiki-IP-userenum.yaml

### DIFF
--- a/http/exposures/configs/apache-jspwiki-IP-userenum.yaml
+++ b/http/exposures/configs/apache-jspwiki-IP-userenum.yaml
@@ -1,0 +1,37 @@
+id: apache-jspwiki-IP-userenum
+
+info:
+  name: Apache JSPWiki - Active User IP Enumeration
+  author: icarot
+  severity: low 
+  description: |
+    Enumerates the IP Address and users that is currently accessing an Apache JSPWiki web application, leading open source WikiWiki engine, feature-rich and built around standard JEE components (Java, servlets, JSP).
+  classification:
+    cpe: cpe:2.3:a:apache:jspwiki:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: jspwiki
+  tags: tech,jspwiki,apache,enumeration
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Wiki.jsp?page=SystemInfo"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<b>Active Wiki Users</b>'
+        condition: and
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: user and IP address enumeration
+        group: 1
+        part: body
+        regex:
+          - "(?i)\\<\\/td\\>\\<td\\> ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}.+)\\<\\/td><\\/tr\\>"

--- a/http/exposures/configs/apache-jspwiki-ip-userenum.yaml
+++ b/http/exposures/configs/apache-jspwiki-ip-userenum.yaml
@@ -1,7 +1,7 @@
 id: apache-jspwiki-ip-userenum
 
 info:
-  name: Apache JSPWiki - Active User IP Enumeration
+  name: Apache JSPWiki - User IP Enumeration
   author: icarot
   severity: low
   description: |
@@ -10,9 +10,10 @@ info:
     cpe: cpe:2.3:a:apache:jspwiki:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    verified: true
     vendor: apache
     product: jspwiki
-  tags: tech,jspwiki,apache,enumeration
+  tags: jspwiki,apache,enumeration
 
 http:
   - method: GET
@@ -22,17 +23,12 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - '<b>Active Wiki Users</b>'
+          - 'Number of active sessions'
         condition: and
+
       - type: status
         status:
           - 200
-
-    extractors:
-      - type: regex
-        name: user and IP address enumeration
-        group: 1
-        part: body
-        regex:
-          - "(?i)\\<\\/td\\>\\<td\\> ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}.+)\\<\\/td><\\/tr\\>"

--- a/http/exposures/configs/apache-jspwiki-ip-userenum.yaml
+++ b/http/exposures/configs/apache-jspwiki-ip-userenum.yaml
@@ -1,9 +1,9 @@
-id: apache-jspwiki-IP-userenum
+id: apache-jspwiki-ip-userenum
 
 info:
   name: Apache JSPWiki - Active User IP Enumeration
   author: icarot
-  severity: low 
+  severity: low
   description: |
     Enumerates the IP Address and users that is currently accessing an Apache JSPWiki web application, leading open source WikiWiki engine, feature-rich and built around standard JEE components (Java, servlets, JSP).
   classification:
@@ -28,6 +28,7 @@ http:
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         name: user and IP address enumeration

--- a/http/technologies/apache/apache-jspwiki-detect.yaml
+++ b/http/technologies/apache/apache-jspwiki-detect.yaml
@@ -26,6 +26,7 @@ http:
           - 'contains_any(body, "JSPWiki: Main", "JSPWiki: Login")'
           - 'contains(body, "/jspwiki")'
           - 'status_code == 200'
+        condition: and
 
     extractors:
       - type: regex

--- a/http/technologies/apache/apache-jspwiki-detect.yaml
+++ b/http/technologies/apache/apache-jspwiki-detect.yaml
@@ -1,0 +1,37 @@
+id: apache-jspwiki-detect
+
+info:
+  name: Apache JSPWiki - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache JSPWiki web application, leading open source WikiWiki engine, feature-rich and built around standard JEE components (Java, servlets, JSP).
+  classification:
+    cpe: cpe:2.3:a:apache:jspwiki:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: jspwiki
+    shodan-query: title:"JSPWiki"
+  tags: tech,jspwiki,apache,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Wiki.jsp"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'JSPWiki: Main</title>'
+          - 'jspwiki'
+        condition: and
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - "JSPWiki v[0-9]+\\.[0-9]+\\.[0-9]+"

--- a/http/technologies/apache/apache-jspwiki-detect.yaml
+++ b/http/technologies/apache/apache-jspwiki-detect.yaml
@@ -18,17 +18,15 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/Wiki.jsp"
-    matchers-condition: and
+      - "{{BaseURL}}"
+
     matchers:
-      - type: word
-        words:
-          - 'JSPWiki: Main</title>'
-          - 'jspwiki'
-        condition: and
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains_any(body, "JSPWiki: Main", "JSPWiki: Login")'
+          - 'contains(body, "/jspwiki")'
+          - 'status_code == 200'
+
     extractors:
       - type: regex
         name: version


### PR DESCRIPTION
**This nuclei templates:**

* Detects a Apache JSPWiki web application, leading open source WikiWiki engine, feature-rich and built around standard JEE components (Java, servlets, JSP).
* Enumerates the IP Address of the users that is acessing an Apache JSPWiki web application, leading open source WikiWiki engine, feature-rich and built around standard JEE components (Java, servlets, JSP).

**References:**

https://github.com/apache/jspwiki

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Execute Docker Container:**

`$ docker run -d -p 8080:8080 --name jspwiki apache/jspwiki`
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' jspwiki`

**Docker Kali container:**

`# nuclei -t apache-jspwiki-detect.yaml -t apache-jspwiki-IP-userenum.yaml -u "http://<IP_obtained_Docker_Inspect>:8080/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`
![image](https://github.com/user-attachments/assets/93f61dd3-056c-4904-aad6-8ef18cc533f4)
