### PR TITLE
Add detection of IBM API Connect Developer Portal instances. 

### DIFF
--- a/http/technologies/ibm/ibm-api-connect-developer-portal-detect.yaml
+++ b/http/technologies/ibm/ibm-api-connect-developer-portal-detect.yaml
@@ -1,0 +1,36 @@
+id: ibm-api-connect-developer-portal-detect
+
+info:
+  name: IBM API Connect Developer Portal Detect
+  author: righettod
+  severity: info
+  description: IBM API Connect Developer Portal was detected.
+  reference:
+    - https://github.com/ibm-apiconnect/devportal
+    - https://www.ibm.com/products/api-connect/developer-portal
+  metadata:
+    max-request: 1
+    shodan-query: http.favicon.hash:"801517258"
+  tags: tech,ibm
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+      - '{{BaseURL}}/favicon.ico'
+      - '{{BaseURL}}/modules/ibm_apim/ibm_apim.info.yml'
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "ibm developer portal is ready to create sites", "package: ibm api developer portal", "modules\\/ibm_apim\\/") || ("801517258" == mmh3(base64_py(body)))'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)version:\s+([0-9a-z\-_.]+)'

--- a/http/technologies/ibm/ibm-api-connect-developer-portal-detect.yaml
+++ b/http/technologies/ibm/ibm-api-connect-developer-portal-detect.yaml
@@ -1,7 +1,7 @@
-id: ibm-api-connect-developer-portal-detect
+id: ibm-api-connect-detect
 
 info:
-  name: IBM API Connect Developer Portal Detect
+  name: IBM API Connect Developer Portal - Detect
   author: righettod
   severity: info
   description: IBM API Connect Developer Portal was detected.
@@ -9,9 +9,10 @@ info:
     - https://github.com/ibm-apiconnect/devportal
     - https://www.ibm.com/products/api-connect/developer-portal
   metadata:
-    max-request: 1
+    verified: true
+    max-request: 3
     shodan-query: http.favicon.hash:"801517258"
-  tags: tech,ibm
+  tags: tech,ibm,detect
 
 http:
   - method: GET
@@ -24,9 +25,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_any(to_lower(body), "ibm developer portal is ready to create sites", "package: ibm api developer portal", "modules\\/ibm_apim\\/") || ("801517258" == mmh3(base64_py(body)))'
-        condition: and
+          - 'contains_any(to_lower(body), "ibm developer portal is ready", "package: ibm api developer", "modules\\/ibm_apim\\/")'
+          - '("801517258" == mmh3(base64_py(body)))'
+        condition: or
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **IBM API Connect Developer Portal** software.

References:

- https://github.com/ibm-apiconnect/devportal
- https://www.ibm.com/products/api-connect/developer-portal

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/89977fc3-7a2e-416f-a2a2-fd70d9348022)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
https://194.78.26.205:9091
https://194.78.189.215:55553
https://200.23.139.211:4443
https://165.253.64.23
https://192.193.104.142
https://192.193.103.42
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.favicon.hash%3A%22801517258%22

![image](https://github.com/user-attachments/assets/8dcfcb28-2893-4a9c-ad40-bbe88c92fb0a)

### Additional References

None