### PR TITLE
Add detection of IBM API Connect login panel instances.

### DIFF
--- a/http/exposed-panels/ibm/ibm-api-connect-panel.yaml
+++ b/http/exposed-panels/ibm/ibm-api-connect-panel.yaml
@@ -9,17 +9,25 @@ info:
     - https://www.ibm.com/products/api-connect/developer-portal
   metadata:
     max-request: 1
-  tags: panel,ibm,detect,login
+  tags: panel,ibm,api,detect,login
 
 http:
   - method: GET
     path:
       - '{{BaseURL}}/auth/manager/sign-in/'
+      - '{{BaseURL}}'
 
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(to_lower(body), "ibm api connect")'
-          - 'contains(to_lower(body), "window.apiconnectcfg")'
-        condition: and
+          - 'status_code == 200 || status_code == 404'
+
+      - type: dsl
+        dsl:
+          - 'contains_any(to_lower(body), "content=\"ibm api connect", "ibm api connect</title>")'
+          - 'contains_all(to_lower(body), "window.apiConnectCfg", "ibm-cloud", "<title>api connect")'
+        condition: or

--- a/http/exposed-panels/ibm/ibm-api-connect-panel.yaml
+++ b/http/exposed-panels/ibm/ibm-api-connect-panel.yaml
@@ -1,0 +1,25 @@
+id: ibm-api-connect-panel
+
+info:
+  name: IBM API Connect Panel - Detect
+  author: righettod
+  severity: info
+  description: IBM API Connect login panel was detected.
+  reference:
+    - https://www.ibm.com/products/api-connect/developer-portal
+  metadata:
+    max-request: 1
+  tags: panel,ibm,detect,login
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/auth/manager/sign-in/'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "ibm api connect")'
+          - 'contains(to_lower(body), "window.apiconnectcfg")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **IBM API Connect** software.

References:

- https://www.ibm.com/products/api-connect

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

✅I tested it against a online trial of the software as well as another private instance:

https://api-manager.us-east-a.apiconnect.automation.ibm.com

![image](https://github.com/user-attachments/assets/60bf2fc8-9199-43fc-b473-1ea2b1820f96)

![image](https://github.com/user-attachments/assets/61196d87-8166-412c-8378-0d420202bad0)

🤔I did not achieved to find a effective Shodan query:

* Using the title gave many false positive:

![image](https://github.com/user-attachments/assets/669f911b-592a-42da-8bd3-16580ddf8a13)

* Using the favicon (it is a image on path `/assets/favicon-32x32.png`) gave nothing:
* Using `http.html` on string like `IBM API Connect` gave non useful hits:

![image](https://github.com/user-attachments/assets/23228579-c497-403f-a63d-be66e0689d3e)

👓This template is not the same than #10678 : This template detect the IBM API Connect **management portal** and not the **developer portal**.

### Additional Details (leave it blank if not applicable)

None

### Additional References

None