### PR TITLE
Add detection of DOMIBUS instances. 

### DIFF
--- a/http/technologies/domibus-detect.yaml
+++ b/http/technologies/domibus-detect.yaml
@@ -1,0 +1,36 @@
+id: domibus-detect
+
+info:
+  name: Domibus - Detect
+  author: righettod
+  severity: info
+  description: |
+    Domibus was detected.
+  reference:
+    - https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/Domibus
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Domibus"
+  tags: tech,domibus,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/domibus/rest/application/info"
+      - "{{BaseURL}}/domibus/"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>domibus", "domibus-msh")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"versionNumber":\s*"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **DOMIBUS** software.

I did not found any existing templates for this software:

![image](https://github.com/user-attachments/assets/0a685527-2f30-47a1-b1ee-b4206e24d57a)

References:

- https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/Domibus

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/30f3bf6f-035d-4c71-b399-8bee47cccce5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
https://172.104.145.39
https://3.127.133.54
https://3.126.157.123
https://80.82.15.188
https://80.82.3.99
https://212.128.106.176
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Domibus%22

![image](https://github.com/user-attachments/assets/c30740d2-a00c-45f5-83ae-b39730107f1f)

### Additional References

None