### PR TITLE
Refactor the "kubelet-metrics" template.

### DIFF
--- a/http/technologies/kubernetes/kubelet/kubelet-metrics.yaml
+++ b/http/technologies/kubernetes/kubelet/kubelet-metrics.yaml
@@ -2,34 +2,28 @@ id: kubelet-metrics
 
 info:
   name: Kubelet Metrics
-  author: sharath
+  author: sharath,righettod
   severity: info
-  description: Scans for kubelet metrics
+  description: |
+    Kube Metrics Server was detected.
+  reference:
+    - https://github.com/kubernetes-sigs/metrics-server
   metadata:
+    verified: true
     max-request: 1
+    shodan-query: http.title:"Kube Metrics Server"
   tags: tech,k8s,kubernetes,devops,kubelet
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/"
       - "{{BaseURL}}/metrics"
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        part: body
-        words:
-          - "# HELP "
-          - "# TYPE "
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>kube metrics server</title>", "kube_configmap_", "kube_pod_", "kube_secret_", "kube_deployment_", "kube_namespace_", "kube_service_")'
         condition: and
-
-      - type: regex
-        part: header
-        regex:
-          - "text/plain"
-
-      - type: status
-        status:
-          - 200
-
-# digest: 4a0a0047304502206304fdefa549420a95e8e8416fa7bbda5e97a730ad45bc39d1f08514ea297377022100b996ee8165fd474d604f554a5ec3768980c2b5c63c8b6edf432767ba64f8778f:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Kube Metrics Server** software.

Reference: https://github.com/kubernetes-sigs/metrics-server

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via shodan:

```text
http://185.206.122.7:8080
http://185.206.122.5:8080
http://104.155.27.248:8080
http://34.79.152.109:8080
http://20.75.102.62:8080
http://52.220.66.236
http://101.132.146.72:8080
http://121.40.126.184:8080
```

![image](https://github.com/user-attachments/assets/9d084dc2-6f5a-4b58-87a9-abd531a33598)

### Additional Details (leave it blank if not applicable)

Shodan query used:  https://www.shodan.io/search?query=http.title%3A%22Kube+Metrics+Server%22

![image](https://github.com/user-attachments/assets/47c40958-9a17-4e14-88d0-51f6240e9853)

### Additional References:

None