### PR TITLE
add CVE-2024-44000

### DIFF
--- a/http/cves/2024/CVE-2024-44000.yaml
+++ b/http/cves/2024/CVE-2024-44000.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-44000
 
 info:
-  name: LiteSpeed Cache <= 6.4.1 - Sensitive Information Exposure via Log Files
+  name: LiteSpeed Cache <= 6.4.1 - Sensitive Information Exposure
   author: s4e-io
   severity: high
   description: |
@@ -9,6 +9,7 @@ info:
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/litespeed-cache/litespeed-cache-641-unauthenticated-sensitive-information-exposure-via-log-files
     - https://github.com/absholi7ly/CVE-2024-44000-LiteSpeed-Cache
+    - https://github.com/gbrsh/CVE-2024-44000
     - https://thehackernews.com/2024/09/critical-security-flaw-found-in.html
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
   classification:
@@ -30,16 +31,13 @@ flow: http(1) && http(2)
 http:
   - raw:
       - |
-        GET /wp-content/plugins/litespeed-cache/readme.txt HTTP/1.1
+        GET / HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "LiteSpeed Cache")'
-          - 'contains(content_type,"text/plain")'
-          - 'status_code == 200'
-        condition: and
+          - 'contains(body, "/wp-content/plugins/litespeed-cache")'
         internal: true
 
   - raw:
@@ -50,7 +48,7 @@ http:
     matchers-condition: and
     matchers:
       - type: regex
-        part: body
+        part: response
         regex:
           - "(wordpress(_logged_in)?_[a-f0-9]{32}=[^;]+)"
 

--- a/http/cves/2024/CVE-2024-44000.yaml
+++ b/http/cves/2024/CVE-2024-44000.yaml
@@ -1,0 +1,73 @@
+id: CVE-2024-44000
+
+info:
+  name: LiteSpeed Cache <= 6.4.1 - Sensitive Information Exposure via Log Files
+  author: s4e-io
+  severity: high
+  description: |
+    The LiteSpeed Cache plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 6.4.1 through the debug.log file that is publicly exposed. This makes it possible for unauthenticated attackers to view potentially sensitive information contained in the exposed log file. The log file may contain user cookies making it possible for an attacker to log in with any session that is actively valid and exposed in the log file. Note: the debug feature must be enabled for this to be a concern and this feature is disabled by default.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/litespeed-cache/litespeed-cache-641-unauthenticated-sensitive-information-exposure-via-log-files
+    - https://github.com/absholi7ly/CVE-2024-44000-LiteSpeed-Cache
+    - https://thehackernews.com/2024/09/critical-security-flaw-found-in.html
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2024-44000
+    cwe-id: CWE-532
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: liteSpeed-technologies
+    product: liteSpeed-cache
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/litespeed-cache"
+  tags: cve,cve2024,info-leak,takeover,wordpress
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/litespeed-cache/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "LiteSpeed Cache")'
+          - 'contains(content_type,"text/plain")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-content/debug.log HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "(wordpress(_logged_in)?_[a-f0-9]{32}=[^;]+)"
+
+      - type: word
+        part: body
+        words:
+          - 'get_role: administrator'
+          - 'Set-Cookie'
+          - '_logged_in'
+          - 'expires'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'text/plain'
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2024/CVE-2024-44000.yaml
+++ b/http/cves/2024/CVE-2024-44000.yaml
@@ -23,7 +23,7 @@ info:
     product: liteSpeed-cache
     framework: wordpress
     publicwww-query: "/wp-content/plugins/litespeed-cache"
-  tags: cve,cve2024,info-leak,takeover,wordpress
+  tags: cve,cve2024,info-leak,takeover,wordpress,wp-plugin,litespeed-cache,wp
 
 flow: http(1) && http(2)
 
@@ -53,15 +53,6 @@ http:
         part: body
         regex:
           - "(wordpress(_logged_in)?_[a-f0-9]{32}=[^;]+)"
-
-      - type: word
-        part: body
-        words:
-          - 'get_role: administrator'
-          - 'Set-Cookie'
-          - '_logged_in'
-          - 'expires'
-        condition: and
 
       - type: word
         part: content_type


### PR DESCRIPTION
CVE-2024-44000

The LiteSpeed Cache plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 6.4.1 through the debug.log file that is publicly exposed. This makes it possible for unauthenticated attackers to view potentially sensitive information contained in the exposed log file. The log file may contain user cookies making it possible for an attacker to log in with any session that is actively valid and exposed in the log file. Note: the debug feature must be enabled for this to be a concern and this feature is disabled by default.


<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)