### PR TITLE
Add detection of Maestro LISTSERV login panel instances.

### DIFF
--- a/http/exposed-panels/maestro-listserv-panel.yaml
+++ b/http/exposed-panels/maestro-listserv-panel.yaml
@@ -4,7 +4,8 @@ info:
   name: Maestro LISTSERV - Detect
   author: righettod
   severity: info
-  description: Maestro LISTSERV panel was detected.
+  description: |
+    Maestro LISTSERV panel was detected.
   reference:
     - https://www.lsoft.com/
     - https://www.lsoft.com/products/maestro_11.1.asp

--- a/http/exposed-panels/maestro-listserv-panel.yaml
+++ b/http/exposed-panels/maestro-listserv-panel.yaml
@@ -1,0 +1,35 @@
+id: maestro-listserv-panel
+
+info:
+  name: Maestro LISTSERV - Detect
+  author: righettod
+  severity: info
+  description: Maestro LISTSERV panel was detected.
+  reference:
+    - https://www.lsoft.com/
+    - https://www.lsoft.com/products/maestro_11.1.asp
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"LISTSERV Maestro"
+  tags: panel,maestro,detect,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/lui/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "listserv", "maestro")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)<title>[\n\r\t\s]*LISTSERV\s+Maestro[\n\r\t\s]*([0-9.-]+)[\n\r\t\s]*</title>'
+          - '(?i)uniqvp=([0-9.-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Maestro LISTSERV** software.

References:
- https://www.lsoft.com/
- https://www.lsoft.com/products/maestro_11.1.asp

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/3f5a34c4-b6e8-4ce7-9b73-d45a8547d8e7)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://20.7.123.140
https://128.146.217.22
http://64.190.174.87
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22LISTSERV+Maestro%22

![image](https://github.com/user-attachments/assets/3e2de465-946c-42eb-95a5-9938732987b7)

### Additional References

None