### PR TITLE
Adding WCF Detect

### DIFF
--- a/http/technologies/windows-communication-foundation-detect.yaml
+++ b/http/technologies/windows-communication-foundation-detect.yaml
@@ -1,0 +1,38 @@
+id: windows-communication-foundation
+
+info:
+  name: Windows Communication Foundation Detect
+  author: r3naissance
+  severity: info
+  metadata:
+    max-request: 1
+    vendor: windows
+    product: wcf
+    shodan-query: http.title:"Service"
+  tags: tech,wcf,windows
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        case-insensitive: true
+        words:
+          - 'Endpoint not found.'
+          - 'class="heading1">Service'
+          - 'This is a Windows&#169; Communication Foundation service.'
+        condition: or
+
+      - type: word
+        part: body
+        case-insensitive: true
+        words:
+          - '<title>Service</title>'
+
+      - type: status
+        status:
+          - 200

--- a/http/technologies/windows-communication-foundation-detect.yaml
+++ b/http/technologies/windows-communication-foundation-detect.yaml
@@ -1,7 +1,7 @@
 id: windows-communication-foundation-detect
 
 info:
-  name: Windows Communication Foundation Detect
+  name: Windows Communication Foundation - Detect
   author: r3naissance
   severity: info
   metadata:
@@ -14,18 +14,18 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/'
+      - '{{BaseURL}}'
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
-        case-insensitive: true
         words:
           - 'Endpoint not found.'
           - 'class="heading1">Service'
           - 'This is a Windows&#169; Communication Foundation service.'
         condition: or
+        case-insensitive: true
 
       - type: word
         part: body

--- a/http/technologies/windows-communication-foundation-detect.yaml
+++ b/http/technologies/windows-communication-foundation-detect.yaml
@@ -1,4 +1,4 @@
-id: windows-communication-foundation
+id: windows-communication-foundation-detect
 
 info:
   name: Windows Communication Foundation Detect


### PR DESCRIPTION
### Template / PR Information

Detects WCF. The service page is displayed when the ServiceMetadataBehavior.httpHelpPageEnabled=True in the web.config.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

From Nuclei debug output:
```
HTTP/1.1 200 OK
Connection: close
Content-Length: 6437
Content-Type: text/html; charset=UTF-8
Date: Thu, 26 Sep 2024 03:04:01 GMT
Server: Microsoft-HTTPAPI/2.0

<HTML><HEAD><STYLE type="text/css">#content{ FONT-SIZE: 0.7em; PADDING-BOTTOM: 2em; MARGIN-LEFT: 30px}BODY{MARGIN-TOP: 0px; MARGIN-LEFT: 0px; COLOR: #000000; FONT-FAMILY: Verdana; BACKGROUND-COLOR: white}P{MARGIN-TOP: 0px; MARGIN-BOTTOM: 12px; COLOR: #000000; FONT-FAMILY: Verdana}PRE{BORDER-RIGHT: #f0f0e0 1px solid; PADDING-RIGHT: 5px; BORDER-TOP: #f0f0e0 1px solid; MARGIN-TOP: -5px; PADDING-LEFT: 5px; FONT-SIZE: 1.2em; PADDING-BOTTOM: 5px; BORDER-LEFT: #f0f0e0 1px solid; PADDING-TOP: 5px; BORDER-BOTTOM: #f0f0e0 1px solid; FONT-FAMILY: Courier New; BACKGROUND-COLOR: #e5e5cc}.heading1{MARGIN-TOP: 0px; PADDING-LEFT: 15px; FONT-WEIGHT: normal; FONT-SIZE: 26px; MARGIN-BOTTOM: 0px; PADDING-BOTTOM: 3px; MARGIN-LEFT: -30px; WIDTH: 100%; COLOR: #ffffff; PADDING-TOP: 10px; FONT-FAMILY: Tahoma; BACKGROUND-COLOR: #003366}.intro{MARGIN-LEFT: -15px}</STYLE>
<TITLE>Service</TITLE></HEAD><BODY>
<DIV id="content">
<P class="heading1">Service</P>
<BR/>
<P class="intro">This is a Windows&#169; Communication Foundation service.<BR/><BR/><B>Metadata publishing for this service is currently disabled.</B><BR/><BR/>If you have access to the service, you can enable metadata publishing by completing the following steps to modify your web or application configuration file:<BR/><BR/>1. Create the following service behavior configuration, or add the &lt;serviceMetadata&gt; element to an existing service behavior configuration:</P>
SNIP
```