### PR TITLE
Add detection of DocuWare login panel instances.

### DIFF
--- a/http/exposed-panels/docuware-panel.yaml
+++ b/http/exposed-panels/docuware-panel.yaml
@@ -1,0 +1,27 @@
+id: docuware-panel
+
+info:
+  name: DocuWare - Detect
+  author: righettod
+  severity: info
+  description: |
+    DocuWare panel was detected.
+  reference:
+    - https://start.docuware.com/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Docuware"
+  tags: panel,docuware,detect,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/DocuWare/Identity/Account/Login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "docuware</title>", "/docuware/identity/")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **DocuWare** software.

References:

- https://start.docuware.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/37fa7246-ad1d-43b9-a52f-f227c4999d30)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://dw75.meylly.com
http://51.75.192.3
https://209.10.72.56
http://200.196.247.5
https://98.129.81.24
http://87.98.221.103
http://200.57.52.66
http://141.94.166.243
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Docuware%22

![image](https://github.com/user-attachments/assets/377ef19d-5785-4c3c-b136-3b1cf2ed3f75)

### Additional References

None