### PR TITLE
Add ASP.NET Core Development Environment Exposure

### DIFF
--- a/http/misconfiguration/microsoft/aspnetcore-dev-env.yaml
+++ b/http/misconfiguration/microsoft/aspnetcore-dev-env.yaml
@@ -1,0 +1,33 @@
+id: aspnetcore-dev-env
+
+info:
+  name: ASP.NET Core Development Environment Exposure
+  author: Mys7ic
+  severity: info
+  tags: misconfig,aspnetcore,exposure
+  description: |
+    The ASP.NET Core application is running in Development mode, which could exposes detailed error messages and stack traces on the '/Error' page.
+  impact: |
+    Exposing detailed error messages and stack traces can reveal sensitive information such as server configurations, file paths, source code snippets, and other debug information. Attackers can use this information to identify vulnerabilities and compromise the application or underlying systems.  
+  remediation: |
+    Set the 'ASPNETCORE_ENVIRONMENT' environment variable to 'Production' and ensure that detailed error messages are not exposed to end-users.
+  reference:
+    - https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
+  metadata:
+    max-request: 1
+    vendor: Microsoft
+    product: ASP.NET Core
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Error"
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - "<strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>"
+      - type: word
+        condition: and
+        words:
+          - "ASPNETCORE_ENVIRONMENT"
+          - "<environment include=\"Development\">"

--- a/http/misconfiguration/microsoft/aspnetcore-dev-env.yaml
+++ b/http/misconfiguration/microsoft/aspnetcore-dev-env.yaml
@@ -1,33 +1,40 @@
 id: aspnetcore-dev-env
 
 info:
-  name: ASP.NET Core Development Environment Exposure
+  name: ASP.NET Core Development Environment - Exposure
   author: Mys7ic
   severity: info
-  tags: misconfig,aspnetcore,exposure
   description: |
     The ASP.NET Core application is running in Development mode, which could exposes detailed error messages and stack traces on the '/Error' page.
   impact: |
-    Exposing detailed error messages and stack traces can reveal sensitive information such as server configurations, file paths, source code snippets, and other debug information. Attackers can use this information to identify vulnerabilities and compromise the application or underlying systems.  
+    Exposing detailed error messages and stack traces can reveal sensitive information such as server configurations, file paths, source code snippets, and other debug information. Attackers can use this information to identify vulnerabilities and compromise the application or underlying systems.
   remediation: |
     Set the 'ASPNETCORE_ENVIRONMENT' environment variable to 'Production' and ensure that detailed error messages are not exposed to end-users.
   reference:
     - https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments
   metadata:
     max-request: 1
-    vendor: Microsoft
-    product: ASP.NET Core
-requests:
+    vendor: microsoft
+    product: asp.net-core
+    shodan-query: html:"ASPNETCORE_ENVIRONMENT"
+    verified: true
+  tags: misconfig,aspnetcore,exposure
+
+http:
   - method: GET
     path:
       - "{{BaseURL}}/Error"
+
     matchers-condition: or
     matchers:
       - type: word
+        part: body
         words:
           - "<strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>"
+
       - type: word
-        condition: and
+        part: body
         words:
           - "ASPNETCORE_ENVIRONMENT"
           - "<environment include=\"Development\">"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Added a new template to detect when an ASP.NET Core application is running in Development mode, exposing detailed error messages on the /Error page.

References:
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
