### PR TITLE
Update CVE-2024-47176.yaml

### DIFF
--- a/javascript/cves/2024/CVE-2024-47176.yaml
+++ b/javascript/cves/2024/CVE-2024-47176.yaml
@@ -58,4 +58,9 @@ javascript:
           - "VulnPrinter"
         condition: and
 
-# digest: 4a0a00473045022100b10c65bc03f4254f1fd76b8451d8aae15d76b7695752b2bc70aa19c581eb60d102201c60cf9a656b34b3ceb555b5065a8c2dc22053c30cd4337bbb4d1e2a33293d4b:922c64590222798bb761d5b6d8e72950
+    extractors:
+      - type: regex
+        group: 1
+        part: interactsh_request
+        regex:
+          - 'User-Agent:\s?(.*)'


### PR DESCRIPTION
Added regex extractor for user-agent of HTTP request. This should contain the cups version as well as the os-version. It's covered in the blog by evilsocket as this is how he retrieved the different kinds of potentially vulnerable devices. 

### Template / PR Information

- Fixed CVE-2024-47176

### Template Validation
I've validated this template locally?
- [ X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
