### PR TITLE
Umbraco Login Panel - Detect Template Update

### DIFF
--- a/http/exposed-panels/umbraco-login.yaml
+++ b/http/exposed-panels/umbraco-login.yaml
@@ -24,10 +24,10 @@ info:
   tags: panel,umbraco,detect
 
 http:
-  # Umbraco before 13.0.0
   - method: GET
     path:
       - "{{BaseURL}}/umbraco"
+      - "{{BaseURL}}/umbraco/login"
 
     host-redirects: true
     max-redirects: 3
@@ -38,29 +38,11 @@ http:
         part: body
         words:
           - 'Umbraco.Sys'
+          - '<umb-auth'
+        condition: or
 
       - type: status
         status:
           - 200
 
-  # Umbraco 13.x.x
-  - method: GET
-    path:
-      - "{{BaseURL}}/umbraco/login"
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "<umb-auth"
-
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        words:
-          - "text/html"
-        part: header
 # digest: 490a00463044022043d53ad53a8ce98369cf2c3d9afa9e86bddfbb30d08e66a7c57bec1da1733fcb022011b45272a7ae99406f1177d25efc434690c7fdc11eb2c9d6d9d6bea357c3682d:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/umbraco-login.yaml
+++ b/http/exposed-panels/umbraco-login.yaml
@@ -2,7 +2,7 @@ id: umbraco-login
 
 info:
   name: Umbraco Login Panel - Detect
-  author: ola456
+  author: ola456,stvnhrlnd
   severity: info
   description: Umbraco login panel was detected.
   reference:
@@ -24,6 +24,7 @@ info:
   tags: panel,umbraco,detect
 
 http:
+  # Umbraco before 13.0.0
   - method: GET
     path:
       - "{{BaseURL}}/umbraco"
@@ -41,4 +42,25 @@ http:
       - type: status
         status:
           - 200
+
+  # Umbraco 13.x.x
+  - method: GET
+    path:
+      - "{{BaseURL}}/umbraco/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<umb-auth"
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "text/html"
+        part: header
 # digest: 490a00463044022043d53ad53a8ce98369cf2c3d9afa9e86bddfbb30d08e66a7c57bec1da1733fcb022011b45272a7ae99406f1177d25efc434690c7fdc11eb2c9d6d9d6bea357c3682d:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

- The Umbraco Login Panel - Detect template does not work on Umbraco version 13.0.0 and above.
- In Umbraco 13.0.0 the login page moved from `/umbraco` to `/umbraco/login` and `Umbraco.Sys` no longer appears in the response.
- This update adds a new path for `/umbraco/login` and matches `<umb-auth` in the response (the Umbraco custom element for authentication).
- References:
  - <https://github.com/umbraco/Umbraco-CMS/blob/8d81c7039175ffbf9c3d877cc4c8f2b2567cb9db/src/Umbraco.Web.UI.Login/index.html#L49>

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO