### PR TITLE
Refactor the "Strapi" template.

### DIFF
--- a/http/exposed-panels/strapi-panel.yaml
+++ b/http/exposed-panels/strapi-panel.yaml
@@ -14,7 +14,7 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:strapi:strapi:*:*:*:*:node.js:*:*:*
   metadata:
-    max-request: 4
+    max-request: 2
     vendor: strapi
     product: strapi
     shodan-query: http.title:"strapi"
@@ -24,10 +24,7 @@ http:
   - method: GET
     path:
       - '{{BaseURL}}/admin/auth/login'
-      - '{{BaseURL}}/admin/auth/forgot-password'
-      - '{{BaseURL}}/admin/auth/register'
       - '{{BaseURL}}/admin/plugins/users-permissions/auth/login'
-      - '{{BaseURL}}/admin/plugins/users-permissions/auth/forgot-password'
 
     stop-at-first-match: true
     matchers:

--- a/http/exposed-panels/strapi-panel.yaml
+++ b/http/exposed-panels/strapi-panel.yaml
@@ -1,32 +1,38 @@
 id: strapi-panel
 
 info:
-  name: Strapi Admin Login Panel - Detect
-  author: idealphase
+  name: Strapi Login Panel - Detect
+  author: idealphase,righettod
   severity: info
-  description: Strapi admin login panel was detected.
+  description: |
+    Strapi login panel was detected.
+  reference:
+    - https://github.com/strapi/strapi
+    - https://strapi.io/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
     cpe: cpe:2.3:a:strapi:strapi:*:*:*:*:node.js:*:*:*
   metadata:
-    max-request: 1
+    max-request: 4
     vendor: strapi
     product: strapi
+    shodan-query: http.title:"strapi"
   tags: panel,strapi,login
 
 http:
   - method: GET
     path:
       - '{{BaseURL}}/admin/auth/login'
+      - '{{BaseURL}}/admin/auth/forgot-password'
+      - '{{BaseURL}}/admin/auth/register'
+      - '{{BaseURL}}/admin/plugins/users-permissions/auth/login'
+      - '{{BaseURL}}/admin/plugins/users-permissions/auth/forgot-password'
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        words:
-          - "<title>Strapi Admin</title>"
-
-      - type: status
-        status:
-          - 200
-# digest: 490a0046304402204fa852608b758c09d643f875052abcf70c002105243ce235aed4b2037ebe548e022068123924dfc04550a7d66815b555602772f6ea78bdca0413f4e2279efacb1943:922c64590222798bb761d5b6d8e72950
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>strapi admin</title>", "<title>welcome to your strapi app</title>")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Strapi** login panel software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via shodan:

```text
https://3.124.117.57
https://159.65.58.157
https://38.242.253.82
https://3.79.162.183
https://206.189.52.140
https://51.158.110.104
http://52.210.199.112
https://3.227.115.180
https://18.211.133.180
https://35.153.244.97
https://44.211.47.231
https://13.235.180.116
https://96.126.125.166
https://45.32.129.169
https://3.140.139.26
https://148.135.82.185
https://162.214.125.106
http://44.233.157.85
https://18.181.26.57
```

![image](https://github.com/user-attachments/assets/61cd645c-87e1-4789-a732-68243f0aa653)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22strapi%22

![image](https://github.com/user-attachments/assets/1b1e858d-8b6e-4819-aec4-da11efeb5751)

### Additional References:

None