### PR TITLE
Add detection of Wiki.js instances.

### DIFF
--- a/http/technologies/wiki-js-detect.yaml
+++ b/http/technologies/wiki-js-detect.yaml
@@ -1,0 +1,27 @@
+id: wiki-js-detect
+
+info:
+  name: Wiki.js - Detect
+  author: righettod
+  severity: info
+  description: |
+    Wiki.js was detected.
+  reference:
+    - https://js.wiki/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"wiki.js"
+  tags: tech,wiki-js,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/_assets/js/app.js"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "wiki.js - wiki.js.org", "window.wiki")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **Wiki.js** software.

References:

- https://js.wiki/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/bb20db43-4349-43cb-8187-95c95fb4b4d5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
https://18.193.88.99
https://77.90.59.34
https://146.179.108.96
http://64.226.107.198
https://130.235.92.68
http://46.249.53.113
https://5.75.142.113
http://23.254.225.239:8080
https://85.214.135.112
https://54.225.130.124
https://64.227.24.9
https://207.229.67.80
https://20.158.56.188
https://142.103.94.46
http://64.227.5.116
https://144.22.59.63
https://187.1.161.134
http://15.152.37.122
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22wiki.js%22

![image](https://github.com/user-attachments/assets/ee1fc9d6-1151-497c-8c66-f9408f608c51)

### Additional References

None