### PR TITLE
Create api-intigriti.yaml

### DIFF
--- a/http/token-spray/api-intigriti.yaml
+++ b/http/token-spray/api-intigriti.yaml
@@ -1,0 +1,46 @@
+id: api-intigriti-researcher
+
+info:
+  name: Intigriti-Researcher API Test
+  author: 0xpugal
+  severity: info
+  description: The Intigriti researcher API can be used to query information about Programs you have access to via our platform and Program activities you have access to via our platform
+  reference:
+    - https://kb.intigriti.com/en/articles/8529303-intigriti-researcher-api
+  metadata:
+    verified: true
+    max-request: 1
+  tags: token-spray,intigriti
+
+self-contained: true
+
+http:
+  - method: GET
+    path:
+      - "https://api.intigriti.com/external/researcher/v1/programs"
+
+    headers:
+      Authorization: Bearer {{token}}
+      Content-Type: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"records"'
+          - '"webLinks"'
+          - '"detail"'
+          - '"handle"'
+          - '"value"'
+          - '"status"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information
The Intigriti researcher API can be used to query information about Programs you have access to via our platform and Program activities you have access to via our platform.

### Template Validation
```
GET /external/researcher/v1/programs HTTP/1.1
Host: api.intigriti.com
User-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Authorization: Bearer D39BC4C04AEF86692ED26184E0BC3A741D410C4F8FAE3CB4494B1F3C06E7331E-1
Content-Type: application/json
Accept-Encoding: gzip

[DBG] [api-intigriti] Dumped HTTP response https://api.intigriti.com/external/researcher/v1/programs

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Api-Supported-Versions: 1.0
Cache-Control: no-store, max-age=0
Content-Type: application/json; charset=utf-8
Date: Thu, 03 Oct 2024 14:51:01 GMT
Server: Hidden
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Vary: Accept-Encoding
Vary: Origin
Via: 1.1 779d4a38a8a0cdb82e507946739e9fe8.cloudfront.net (CloudFront)
X-Amz-Cf-Id: mlywUqqo6IqsfHLMJW-E5iaYxwnCW4Asjwoc43lyJCd54zGcEU9C9g==
X-Amz-Cf-Pop: MAA51-C1
X-Cache: Miss from cloudfront
X-Content-Type-Options: nosniff
X-Frame-Options: deny

{.........}

[api-intigriti:word-1] [http] [info] https://api.intigriti.com/external/researcher/v1/programs
[api-intigriti:word-2] [http] [info] https://api.intigriti.com/external/researcher/v1/programs
[api-intigriti:status-3] [http] [info] https://api.intigriti.com/external/researcher/v1/programs                                                                                                                                                                                                                                                                                                                                                                                                                                                                         ```
```

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
+ https://kb.intigriti.com/en/articles/8529303-intigriti-researcher-api
+ https://intigriti-researcher-api.readme.io/reference/introduction-to-intigritis-researcher-api

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)