### PR TITLE
Add VMware Workspace One UEM SSP Login Panel Template

### DIFF
--- a/http/exposed-panels/workspace-one-uem-ssp.yaml
+++ b/http/exposed-panels/workspace-one-uem-ssp.yaml
@@ -1,0 +1,37 @@
+id: workspace-one-uem-ssp
+
+info:
+  name: VMware Workspace ONE UEM Airwatch Self-Service Portal (SSP) Login Panel - Detect
+  author: KoratSec
+  severity: info
+  description: VMware Workspace ONE UEM Airwatch Self-Service Portal (SSP) login panel was detected.
+  reference:
+    - https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/2209/UEM_ConsoleBasics/GUID-AWT-SELFSERVICEPORTALOVERVIEW.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:vmware:workspace_one_uem:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: vmware
+    product: workspace_one_uem
+    shodan-query: 
+      - http.favicon.hash:"321909464"
+      - http.html:"Self-Service Portal"
+    fofa-query: body="ssp loginscreen"
+  tags: panel,workspaceone,vmware,airwatch,ssp
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/MyDevice/Login"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Self-Service Portal"
+          - "/MyDevice/Login"
+          - "AirWatch"
+        condition: and

--- a/http/exposed-panels/workspace-one-uem-ssp.yaml
+++ b/http/exposed-panels/workspace-one-uem-ssp.yaml
@@ -17,7 +17,7 @@ info:
     max-request: 1
     vendor: vmware
     product: workspace_one_uem
-    shodan-query: 
+    shodan-query:
       - http.favicon.hash:"321909464"
       - http.html:"Self-Service Portal"
     fofa-query: body="ssp loginscreen"

--- a/http/exposed-panels/workspace-one-uem-ssp.yaml
+++ b/http/exposed-panels/workspace-one-uem-ssp.yaml
@@ -1,10 +1,11 @@
 id: workspace-one-uem-ssp
 
 info:
-  name: VMware Workspace ONE UEM Airwatch Self-Service Portal (SSP) Login Panel - Detect
+  name: VMware Workspace ONE UEM Airwatch Self-Service Portal - Detect
   author: KoratSec
   severity: info
-  description: VMware Workspace ONE UEM Airwatch Self-Service Portal (SSP) login panel was detected.
+  description: |
+    VMware Workspace ONE UEM Airwatch Self-Service Portal (SSP) login panel was detected.
   reference:
     - https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/2209/UEM_ConsoleBasics/GUID-AWT-SELFSERVICEPORTALOVERVIEW.html
   classification:
@@ -20,7 +21,7 @@ info:
       - http.favicon.hash:"321909464"
       - http.html:"Self-Service Portal"
     fofa-query: body="ssp loginscreen"
-  tags: panel,workspaceone,vmware,airwatch,ssp
+  tags: panel,workspaceone,vmware,airwatch,ssp,login,detect
 
 http:
   - method: GET
@@ -32,6 +33,6 @@ http:
         part: body
         words:
           - "Self-Service Portal"
-          - "/MyDevice/Login"
           - "AirWatch"
         condition: and
+        case-insensitive: true


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added VMware Workspace One UEM Self-Service Portal (SSP) Login Panel Template. It is complimentary to the existing Nuclei Workspace One login panel template, referencing a different path.
- References: https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/2209/UEM_ConsoleBasics/GUID-AWT-SELFSERVICEPORTALOVERVIEW.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

HTTP Matched Data Response Snippet Example 1:
```
<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" /><meta name="apple-mobile-web-app-title" content="AirWatch" /><title>
	


        Self-Service Portal
        
</title>
```
HTTP Matched Data Response Snippet Example 2:
```
 <div class="main">
        <form action="/MyDevice/Login" autocomplete="off" id="form0" method="post">
        <div>
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)