### PR TITLE
[swagger-api] check /docs/ with trailing slash

### DIFF
--- a/http/exposures/apis/swagger-api.yaml
+++ b/http/exposures/apis/swagger-api.yaml
@@ -72,6 +72,7 @@ http:
         - "/api/swagger_doc.json"
         - "/docu"
         - "/docs"
+        - "/docs/"
         - "/swagger"
         - "/api-doc"
         - "/doc/"


### PR DESCRIPTION
the template did not find swagger on a target where URL path = /docs/ 

(with trailing slash).

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)