### PR TITLE
Update Tumblr and SmugMug OSINT Templates with Improved Username Validation

### DIFF
--- a/http/osint/user-enumeration/smugmug.yaml
+++ b/http/osint/user-enumeration/smugmug.yaml
@@ -15,10 +15,13 @@ info:
 
 self-contained: true
 
+variables:
+  - valid_username: "{{user | regex_search('^[^\\.]+$')}}"
+
 http:
   - method: GET
     path:
-      - "https://{{user}}.smugmug.com"
+      - "https://{{valid_username}}.smugmug.com"
 
     matchers-condition: and
     matchers:
@@ -30,5 +33,3 @@ http:
         part: body
         words:
           - "schema.org/Person"
-
-# digest: 4b0a00483046022100c0e245709f2115865834573d39f4b56cc534939732ce4ac151bd44ea3eb8697b022100b3ef873c060c289e274ffc10994f3323ed42cf8b7061ffba6d9beaf0e78f01a7:922c64590222798bb761d5b6d8e72950

--- a/http/osint/user-enumeration/smugmug.yaml
+++ b/http/osint/user-enumeration/smugmug.yaml
@@ -16,7 +16,7 @@ info:
 self-contained: true
 
 variables:
-  valid_username: "{{replace('{{user}}', '.', '')}}"
+  valid_username: "{{replace(user, '.', '')}}"
 
 http:
   - method: GET

--- a/http/osint/user-enumeration/smugmug.yaml
+++ b/http/osint/user-enumeration/smugmug.yaml
@@ -16,7 +16,7 @@ info:
 self-contained: true
 
 variables:
-  - valid_username: "{{user | regex_search('^[^\\.]+$')}}"
+  valid_username: "{{replace('{{user}}', '.', '')}}"
 
 http:
   - method: GET

--- a/http/osint/user-enumeration/tumblr.yaml
+++ b/http/osint/user-enumeration/tumblr.yaml
@@ -15,10 +15,13 @@ info:
 
 self-contained: true
 
+variables:
+  - valid_username: "{{user | regex_search('^[^\\.]+$')}}"
+
 http:
   - method: GET
     path:
-      - "https://{{user}}.tumblr.com"
+      - "https://{{valid_username}}.tumblr.com"
 
     matchers-condition: and
     matchers:
@@ -30,5 +33,3 @@ http:
         part: body
         words:
           - "avatar"
-
-# digest: 490a00463044022064bbfbad5abc7147d797d127c98a222e0cb8e2195bb5947b2bc603b6d4276f0302204cb6bb6e10819dedce9c126ddfa567ad206666b370c9b01e319307eb5946027f:922c64590222798bb761d5b6d8e72950

--- a/http/osint/user-enumeration/tumblr.yaml
+++ b/http/osint/user-enumeration/tumblr.yaml
@@ -16,7 +16,7 @@ info:
 self-contained: true
 
 variables:
-  valid_username: "{{replace('{{user}}', '.', '')}}"
+  valid_username: "{{replace(user, '.', '')}}"
 
 http:
   - method: GET

--- a/http/osint/user-enumeration/tumblr.yaml
+++ b/http/osint/user-enumeration/tumblr.yaml
@@ -16,7 +16,7 @@ info:
 self-contained: true
 
 variables:
-  - valid_username: "{{user | regex_search('^[^\\.]+$')}}"
+  valid_username: "{{replace('{{user}}', '.', '')}}"
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

• Added templates to detect user profile information for Tumblr and SmugMug using OSINT techniques.

• The templates validate usernames and avoid false positives for cases where periods (.) are incorrectly interpreted as subdomain separators.

• References: N/A

### Template Validation

I've validated this template locally?
- [ x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)