### PR TITLE
Create unquoted service path

### DIFF
--- a/code/windows/unquoted-service-pathcheck.yaml
+++ b/code/windows/unquoted-service-pathcheck.yaml
@@ -1,0 +1,51 @@
+id: unquoted-service-pathcheck
+
+info:
+  name: Unquoted Service PathCheck
+  author: pussycat0x
+  severity: high
+  description: |
+    The Unquoted Service Path vulnerability in Windows occurs when services are installed using paths containing spaces without proper quotation marks. If attackers obtain write permissions in the service's installation directory, they can execute malicious code with elevated privileges.
+  tags: code,windows,privesc,ps
+
+self-contained: true
+code:
+  - engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+      - -File
+    pattern: "*.ps1"
+    source: |
+      Write-Host "Fetching the list of services, this may take a while...";
+
+      # Get the list of services that meet the criteria
+       $services = Get-WmiObject -Class Win32_Service | 
+      Where-Object { 
+      $_.PathName -inotmatch "`"" -and # Service path does not contain quotes
+      $_.PathName -inotmatch ":\\Windows\\" -and 
+      ($_.StartMode -eq "Auto" -or $_.StartMode -eq "Manual") -and 
+      ($_.State -eq "Running" -or $_.State -eq "Stopped")
+      };
+
+      # Check if any services meet the criteria
+      if ($($services | Measure-Object).Count -lt 1) {
+      Write-Host "No unquoted service paths were found.";
+        } else {
+       Write-Host "Unquoted service paths were found:";
+
+
+       foreach ($service in $services) {
+        Write-Host "Service Name: $($service.Name)";
+        Write-Host "Display Name: $($service.DisplayName)";
+        Write-Host "Path: $($service.PathName)";
+        Write-Host "----------------------------------";
+         }
+         }
+    
+    extractors:
+      - type: dsl
+        dsl:
+          - response


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

```
.\nuclei.exe  -t D:\nuclei\win\fxx.yaml -svd  -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.1

                projectdiscovery.io

[WRN] Found 32 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.0.1 (outdated)
[INF] Current nuclei-templates version: v10.0.1 (latest)
[INF] New templates added in latest release: 86
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from test
[VER] [get-hotfix] Executed code on local machine
[DBG] Code Protocol request variables:
        1. Hostname =>
        2. Input =>

[DBG] Code Protocol response variables:
        1. input =>
        2. interactsh-server =>
        3. response => Fetching the list of serv .... -------------------------
        4. template-id => unquoted-service-pathcheck
        5. template-info => {unquoted-service-pathcheck pussycat0x co .... nil> {info} map[] <nil> }
        6. template-path => D:\nuclei\win\fxx.yaml
        7. type => code

[unquoted-service-pathcheck] [code] [info]  [Fetching the list of services, this may take a while...
Unquoted service paths were found:
Service Name: elasticsearch-service-x64
Display Name: Elasticsearch 8.9.1 (elasticsearch-service-x64)
Path: C:\Users\Admin\Downloads\elasticsearch-8.9.1-windows-x86_64\elasticsearch-8.9.1\bin\elasticsearch-service-x64.exe //RS//elasticsearch-service-x64
```
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)