### PR TITLE
Add SATO printers default login

### DIFF
--- a/http/default-logins/sato/sato-default-login.yaml
+++ b/http/default-logins/sato/sato-default-login.yaml
@@ -4,11 +4,13 @@ info:
   name: Sato - Default Login
   author: y0no
   severity: high
+  description: |
+    Sato using default credentials was discovered.
   metadata:
     verified: true
     max-request: 1
     shodan-query: title:"Sato"
-  tags: sato,default-login,misconfig,printer
+  tags: sato,default-login,printer
 
 http:
   - raw:
@@ -21,6 +23,7 @@ http:
         group={{username}}&pw={{password}}
 
     attack: pitchfork
+
     payloads:
       username:
         - 'settings'
@@ -30,6 +33,7 @@ http:
         - '6677'
 
     stop-at-first-match: true
+
     matchers-condition: and
     matchers:
       - type: word

--- a/http/default-logins/sato/sato-default-login.yaml
+++ b/http/default-logins/sato/sato-default-login.yaml
@@ -32,8 +32,6 @@ http:
         - '0310'
         - '6677'
 
-    stop-at-first-match: true
-
     matchers-condition: and
     matchers:
       - type: word

--- a/http/default-logins/sato/sato-printer-default-login.yaml
+++ b/http/default-logins/sato/sato-printer-default-login.yaml
@@ -1,0 +1,51 @@
+id: sato-default-login
+
+info:
+  name: Sato - Default Login
+  author: y0no
+  severity: medium
+  metadata:
+    verified: true
+    max-request: 1
+  tags: sato,default-login,misconfig,printer
+
+
+http:
+  - raw:
+    - |
+      POST /WebConfig/lua/auth.lua HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded
+      Referer: {{BaseURL}}
+
+      group={{username}}&pw={{password}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - 'settings'
+        - 'service'
+      password:
+        - '0310'
+        - '6677'
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"r":0'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        name: groups
+        json:
+          - '.groups[]'

--- a/http/default-logins/sato/sato-printer-default-login.yaml
+++ b/http/default-logins/sato/sato-printer-default-login.yaml
@@ -3,12 +3,12 @@ id: sato-default-login
 info:
   name: Sato - Default Login
   author: y0no
-  severity: medium
+  severity: high
   metadata:
     verified: true
     max-request: 1
+    shodan-query: title:"Sato"
   tags: sato,default-login,misconfig,printer
-
 
 http:
   - raw:
@@ -29,23 +29,21 @@ http:
         - '0310'
         - '6677'
 
-    headers:
-      Content-Type: application/x-www-form-urlencoded
-
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - '"r":0'
+          - 'groups":["user'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
 
       - type: status
         status:
           - 200
-
-    extractors:
-      - type: json
-        part: body
-        name: groups
-        json:
-          - '.groups[]'

--- a/http/default-logins/sato/sato-printer-default-login.yaml
+++ b/http/default-logins/sato/sato-printer-default-login.yaml
@@ -12,13 +12,13 @@ info:
 
 http:
   - raw:
-    - |
-      POST /WebConfig/lua/auth.lua HTTP/1.1
-      Host: {{Hostname}}
-      Content-Type: application/x-www-form-urlencoded
-      Referer: {{BaseURL}}
+      - |
+        POST /WebConfig/lua/auth.lua HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Referer: {{BaseURL}}
 
-      group={{username}}&pw={{password}}
+        group={{username}}&pw={{password}}
 
     attack: pitchfork
     payloads:


### PR DESCRIPTION
### Template / PR Information

This template add a check to test if a SATO printer is configured with default logins.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### References :

- https://www.satoamerica.com/support/tech-tips/sato-printer-setting-and-configuration-webpage-login