### PR TITLE
Fixed False Negative on CVE-2023-39650

### DIFF
--- a/http/cves/2023/CVE-2023-39650.yaml
+++ b/http/cves/2023/CVE-2023-39650.yaml
@@ -36,7 +36,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(body, "tvcmsblog")'
+          - 'contains_any(tolower(response), "prestashop", "tvcmsblog")'
         internal: true
 
   - raw:


### PR DESCRIPTION
### Template / PR Information

- Fixed CVE-2023-39650
- References: Its gives False Negative due not matching tvcmsblog on main page

### Template Validation

I've validated this template locally?
- [X ] YES
- [ ] NO

