### PR TITLE
Refactor the "Django Admin Panel" template.

### DIFF
--- a/http/exposed-panels/django-admin-panel.yaml
+++ b/http/exposed-panels/django-admin-panel.yaml
@@ -2,7 +2,7 @@ id: django-admin-panel
 
 info:
   name: Python Django Admin Login Panel - Detect
-  author: pdteam
+  author: pdteam,righettod
   severity: info
   description: Python Django admin login panel was detected.
   classification:
@@ -10,21 +10,29 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:djangoproject:django:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 1
+    max-request: 2
     vendor: djangoproject
     product: django
-    shodan-query: cpe:"cpe:2.3:a:djangoproject:django"
-  tags: panel,django,python,djangoproject
+    shodan-query: cpe:"cpe:2.3:a:djangoproject:django" || http.title:"Django administration"
+  tags: panel,django,python,djangoproject,login
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/admin/login/?next=/admin/"
+      - "{{BaseURL}}/admin/login/"
 
+    redirects: true
+    max-redirects: 2
     matchers:
-      - type: word
-        words:
-          - "<a href=\"/admin/\">Django administration</a>"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "| django administration", "| django-administration", "django-admin-interface", "<span>django administration</span>")'
         condition: and
+
+    extractors:
+      - type: regex
         part: body
-# digest: 4a0a00473045022100ac02c54225e975d3158eb41af01a31c5140aed18e7d38914fc03d73c3f52e4f1022046df2c0f2c1ac45625152b39485a91c7dc569d88b0b24fc5349d458d836c7961:922c64590222798bb761d5b6d8e72950
+        group: 1
+        regex:
+          - '(?i)django-admin-interface\s+([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Django Admin Panel** software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via shodan:

```text
https://116.203.205.250
https://167.235.77.196
https://5.75.145.75
http://207.154.216.213
https://65.109.142.73
http://52.6.169.57
https://13.234.129.104
```

![image](https://github.com/user-attachments/assets/5ce5d6b0-e86f-4cb7-806f-baa95fc3ae18)

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Django+administration%22

![image](https://github.com/user-attachments/assets/9898ab67-7617-4ce6-8e9e-c146be9fcacd)

### Additional References:

None