### PR TITLE
Create apache-doris-default-login.yaml

### DIFF
--- a/http/default-logins/apache/apache-doris-default-login.yaml
+++ b/http/default-logins/apache/apache-doris-default-login.yaml
@@ -20,7 +20,7 @@ http:
         Host: {{Hostname}}
         Authorization: Basic {{basicAuth}}
         Content-Type: application/json; charset=utf-8
-    
+
     payloads:
       basicAuth:
         - YWRtaW46

--- a/http/default-logins/apache/apache-doris-default-login.yaml
+++ b/http/default-logins/apache/apache-doris-default-login.yaml
@@ -1,0 +1,33 @@
+id: apache-doris-default-login
+
+info:
+  name: Apache Doris Default Login - Default Login
+  author: icarot
+  severity: high
+  description: |
+    Tests if Apache Doris Panel, it is an easy-to-use, high performance and unified analytics database, is using the default password on root/admin user accounts.
+  metadata:
+    max-request: 2
+    vendor: apache
+    product: doris
+    shodan-query: title:"doris"
+  tags: tech,doris,apache,default-login,misconfig
+
+http:
+  - raw:
+      - |
+        POST /rest/v1/login HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{basicAuth}}
+        Content-Type: application/json; charset=utf-8
+    
+    payloads:
+      basicAuth:
+        - YWRtaW46
+        - cm9vdDo=
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/http/default-logins/apache/doris-default-login.yaml
+++ b/http/default-logins/apache/doris-default-login.yaml
@@ -34,7 +34,7 @@ http:
       - type: word
         part: body
         words:
-          - '"Login success!"'
+          - 'msg":"Login success!"'
 
       - type: word
         part: content_type

--- a/http/default-logins/apache/doris-default-login.yaml
+++ b/http/default-logins/apache/doris-default-login.yaml
@@ -1,17 +1,19 @@
-id: apache-doris-default-login
+id: doris-default-login
 
 info:
-  name: Apache Doris Default Login - Default Login
+  name: Apache Doris - Default Login
   author: icarot
   severity: high
   description: |
     Tests if Apache Doris Panel, it is an easy-to-use, high performance and unified analytics database, is using the default password on root/admin user accounts.
   metadata:
+    verified: true
     max-request: 2
     vendor: apache
     product: doris
-    shodan-query: title:"doris"
-  tags: tech,doris,apache,default-login,misconfig
+    shodan-query: http.favicon.hash:"24048806"
+    fofa-query: icon_hash=24048806
+  tags: apache,default-login,doris
 
 http:
   - raw:
@@ -26,8 +28,19 @@ http:
         - YWRtaW46
         - cm9vdDo=
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
+      - type: word
+        part: body
+        words:
+          - '"Login success!"'
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
This nuclei template:

* Tests if Apache Doris Panel, it is an easy-to-use, high performance and unified analytics database, is using the default password on root/admin users account.

- References:

https://github.com/apache/doris

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Doris Docker:**

1. Creating the docker network to Doris:
`docker network create --driver bridge --subnet=172.20.80.0/24 doris-network`

2. Running container Doris frontend:
`$ docker run -itd --name=fe --env FE_SERVERS="fe1:172.20.80.2:9010" --env FE_ID=1 -p 8030:8030 -p 9030:9030 -v /data/fe/doris-meta:/opt/apache-doris/fe/doris-meta -v /data/fe/conf:/opt/apache-doris/fe/conf -v /data/fe/log:/opt/apache-doris/fe/log --network=doris-network --ip=172.20.80.2 apache/doris:1.2.1-fe-x86_64`

3. Running container Doris backend:
`$ docker run -itd --name=be --env FE_SERVERS="fe1:172.20.80.2:9010" --env BE_ADDR="172.20.80.3:9050" -p 8040:8040 -v /data/be/storage:/opt/apache-doris/be/storage -v /data/be/conf:/opt/apache-doris/be/conf -v /data/be/log:/opt/apache-doris/be/log --network=doris-network --ip=172.20.80.3 apache/doris:1.2.1-be-x86_64`

4. Get the IP Address of Apache Doris frontend:
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' fe`

5.And the access URL will be http://<doris-fe-obteined_inspect_IP_Address>:8030/

**Nuclei execution:**

`$ nuclei -t apache-doris-default-login.yaml -u "http://172.20.80.2:8030/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/704aa79f-6b98-461b-bc20-652da4f5ac3e)

![image](https://github.com/user-attachments/assets/94fdfc91-553e-4d85-8943-62dbaf548225)
