### PR TITLE
Add detection of OLYMPIC Banking System login panel instances.

### DIFF
--- a/http/exposed-panels/olympic-panel.yaml
+++ b/http/exposed-panels/olympic-panel.yaml
@@ -1,0 +1,34 @@
+id: olympic-panel
+
+info:
+  name: OLYMPIC Banking System Login Panel - Detect
+  author: righettod
+  severity: info
+  description: OLYMPIC Banking System was detected.
+  reference:
+    - https://www.olympicbankingsystem.com/en/
+  metadata:
+    max-request: 2
+    shodan-query: http.title:"olympic banking system"
+  tags: panel,olympic,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Connect.do"
+      - "{{BaseURL}}/javaScript/responsive/portal.js"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "olympic banking system", "olympic.action=")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '&#169;([0-9]+)-'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **OLYMPIC Banking System** software.

References:

- https://www.olympicbankingsystem.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/c7b954c1-5081-404d-9d0d-4a112be4e4d4)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://212.203.105.43:51443
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22olympic+banking+system%22

![image](https://github.com/user-attachments/assets/112e8ed9-b9a2-4bfa-b24c-3162ddd04ea2)

### Additional References

None