### PR TITLE
Added CVE-2016-8735 Apache Tomcat JMX RCE template

### DIFF
--- a/http/cves/2016/CVE-2016-8735.yaml
+++ b/http/cves/2016/CVE-2016-8735.yaml
@@ -1,0 +1,87 @@
+id: CVE-2016-8735-tomcat-jmx-rce
+
+info:
+  name: Apache Tomcat JMX Remote Code Execution
+  author: your_github_username
+  severity: critical
+  description: Apache Tomcat versions before 6.0.48, 7.x before 7.0.73, 8.x before 8.0.39, 8.5.x before 8.5.7, and 9.x before 9.0.0.M12 are vulnerable to remote code execution if JmxRemoteLifecycleListener is used and the JMX ports are exposed.
+  reference:
+    - http://rhn.redhat.com/errata/RHSA-2017-0457.html
+    - http://www.securityfocus.com/bid/94463
+    - http://tomcat.apache.org/security-9.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2016-8735
+  tags: cve,cve2016,apache,tomcat,rce,jmx
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/manager/status"
+      - "{{BaseURL}}:8080/manager/status"
+      - "{{BaseURL}}:8000/manager/status"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Apache Tomcat"
+        part: body
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "Apache Tomcat/([0-9.]+)"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}:{{jmx_ports}}"
+    attack: batteringram
+    payloads:
+      jmx_ports:
+        - "1099"
+        - "9999"
+        - "8999"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "JMX"
+          - "RMI"
+        condition: and
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: jmx_port
+        group: 1
+        regex:
+          - ":([0-9]+)"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/manager/jmxproxy"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "JMXProxyServlet"
+      - type: dsl
+        dsl:
+          - 'version != "" && jmx_port != "" && (version < "6.0.48" || (version >= "7.0.0" && version < "7.0.73") || (version >= "8.0.0" && version < "8.0.39") || (version >= "8.5.0" && version < "8.5.7") || (version >= "9.0.0" && version < "9.0.0.M12"))'
+
+    extractors:
+      - type: regex
+        name: jmxproxy
+        regex:
+          - "JMXProxyServlet"


### PR DESCRIPTION
### Template / PR Information

Add CVE-2016-8735 Apache Tomcat JMX RCE template

This PR adds a new Nuclei template to detect CVE-2016-8735, a remote code execution vulnerability in Apache Tomcat's JMX implementation.

- Vulnerability: Apache Tomcat JMX Remote Code Execution
- Affected versions: before 6.0.48, 7.x before 7.0.73, 8.x before 8.0.39, 8.5.x before 8.5.7, and 9.x before 9.0.0.M12
- CVSS Score: 10 (Critical)

The template checks for vulnerable versions and the presence of JMXProxyServlet, indicating potential exposure to this vulnerability.

- Added CVE-2016-8735
- References:
  - http://rhn.redhat.com/errata/RHSA-2017-0457.html
  - http://www.securityfocus.com/bid/94463
  - http://tomcat.apache.org/security-9.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="743" alt="Screenshot 2024-10-27 at 12 53 26 AM" src="https://github.com/user-attachments/assets/3024903a-78fc-4a4e-a81c-c649cf39f7ee">


#### Additional Details

N/A

/claim #10893