### PR TITLE
Add detection of  PGHERO instances.

### DIFF
--- a/http/technologies/pghero-detect.yaml
+++ b/http/technologies/pghero-detect.yaml
@@ -1,0 +1,27 @@
+id: pghero-detect
+
+info:
+  name: PgHero - Detect
+  author: righettod
+  severity: info
+  description: |
+    PgHero products was detected.
+  reference:
+    - https://github.com/ankane/pghero
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"PgHero"
+  tags: tech,pghero,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>pghero", "/assets/pghero/", ">pghero</a>")'
+        condition: and

--- a/http/technologies/pghero-detect.yaml
+++ b/http/technologies/pghero-detect.yaml
@@ -17,8 +17,9 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
+    host-redirects: true
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **PgHero** software.

💬There is already an template for PgHero in the section `http/misconfiguration/` ([ref](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/misconfiguration/pghero-dashboard-exposure.yaml)) . However, this PR propose a generic detection of PgHero.

References:

- https://github.com/ankane/pghero

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/c052eeb3-7725-44aa-a132-251295b36f4f)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://13.126.146.41
http://194.195.114.110
http://95.216.241.92
http://144.22.176.247:8080
http://144.22.251.188:8080
http://164.152.35.160:8080
http://144.22.243.194:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22PgHero%22

![image](https://github.com/user-attachments/assets/c76ccb39-28f3-471c-88d9-522218aeb43b)

### Additional References

None