### PR TITLE
Add detection of HUBBLE instances.

### DIFF
--- a/http/technologies/hubble-detect.yaml
+++ b/http/technologies/hubble-detect.yaml
@@ -1,0 +1,29 @@
+id: hubble-detect
+
+info:
+  name: Hubble - Detect
+  author: righettod
+  severity: info
+  description: |
+    Hubble products was detected.
+  reference:
+    - https://github.com/cilium/hubble
+    - https://docs.cilium.io/en/stable/observability/hubble/
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Hubble UI"
+  tags: tech,hubble,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>hubble ui enterprise</title>", "<title>hubble ui</title>")'
+        condition: and

--- a/http/technologies/hubble-detect.yaml
+++ b/http/technologies/hubble-detect.yaml
@@ -25,5 +25,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>hubble ui enterprise</title>", "<title>hubble ui</title>")'
+          - 'contains_any(to_lower(body), "<title>hubble ui enterprise", "<title>hubble ui")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **HUBBLE** software in its free or enterprise version.

💬I did not found any existing template:

![image](https://github.com/user-attachments/assets/202ba8b2-19f6-4219-9fb1-bb501d7ad5bb)

References:
- https://github.com/cilium/hubble
- https://docs.cilium.io/en/stable/observability/hubble/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/2add2f89-2fd1-4168-8b3a-4facbf623a9a)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://35.204.61.62
https://172.179.50.23
http://34.159.17.221
http://81.70.162.171:6002
http://51.8.57.230
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Hubble+UI%22

![image](https://github.com/user-attachments/assets/8a349e31-8390-4068-9340-63abf1076467)

### Additional References

None