### PR TITLE
Enrich the "THANOS" template.

### DIFF
--- a/http/misconfiguration/thanos-prometheus-exposure.yaml
+++ b/http/misconfiguration/thanos-prometheus-exposure.yaml
@@ -2,11 +2,16 @@ id: thanos-prometheus-exposure
 
 info:
   name: Thanos Prometheus Setup - Exposure
-  author: DhiyaneshDk
+  author: DhiyaneshDk,righettod
   severity: high
+  description: |
+    Thanos graph endpoint was detected.
+  reference:
+    - https://thanos.io/
+    - https://github.com/thanos-io/thanos
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     shodan-query: title:"Thanos | Highly available Prometheus setup"
     fofa-query: icon_hash="29632872"
   tags: thanos,prometheus,exposure,setup,misconfig
@@ -15,17 +20,12 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/graph"
+      - "{{BaseURL}}/classic/graph"
 
-    matchers-condition: and
+    stop-at-first-match: true
     matchers:
-      - type: word
-        words:
-          - "THANOS_COMPONENT"
-          - "THANOS_QUERY_URL"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "THANOS_COMPONENT", "THANOS_QUERY_URL") || contains_all(body, "<title>Thanos", "href=\"/classic/\">Thanos</a>")'
         condition: and
-
-        part: body
-      - type: status
-        status:
-          - 200
-# digest: 4a0a00473045022100d9e1e7479593315b55f53fd69afbc820f042cce7a4a60701e873063a1ff59ac0022000ce3370054049d410c3c2e5bf66ae61582e6d5e1255ab4808a62e399d219a3e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little enhancement of the template to make it more generic to detect the presence of an instance of the **THANOS** software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

💡I have just inverted the following 2 paths in the template for my test:

![image](https://github.com/user-attachments/assets/26cb9ce6-d552-4d68-8322-ae36a42d5e7d)

Tested against the following hosts found via shodan:

```text
http://35.205.54.99:9090
```

![image](https://github.com/user-attachments/assets/86c608b4-d2e8-4e9f-8b4b-80e6bc09ce32)


### Additional Details (leave it blank if not applicable)

None

### Additional References:

None