### PR TITLE
Add detection of HYPERPLANNING login panel instances.

### DIFF
--- a/http/exposed-panels/hyperplanning-panel.yaml
+++ b/http/exposed-panels/hyperplanning-panel.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: http.title:"HYPERPLANNING"
-  tags: panel,hyperplanning,login
+  tags: panel,hyperplanning,login,detect
 
 http:
   - method: GET
@@ -24,7 +24,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "hyperplanning</title>", "<meta name=\"dc.publisher\" content=\"hyperplanning\"")'
+          - 'contains_any(to_lower(body), "hyperplanning</title>", "content=\"hyperplanning\"")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/hyperplanning-panel.yaml
+++ b/http/exposed-panels/hyperplanning-panel.yaml
@@ -4,7 +4,8 @@ info:
   name: HYPERPLANNING Login Panel - Detect
   author: righettod
   severity: info
-  description: HYPERPLANNING products was detected.
+  description: |
+    HYPERPLANNING products was detected.
   reference:
     - https://www.index-education.com/fr/presentation-hyperplanning.php
   metadata:
@@ -18,6 +19,7 @@ http:
       - "{{BaseURL}}"
 
     host-redirects: true
+
     matchers:
       - type: dsl
         dsl:

--- a/http/exposed-panels/hyperplanning-panel.yaml
+++ b/http/exposed-panels/hyperplanning-panel.yaml
@@ -1,0 +1,33 @@
+id: hyperplanning-panel
+
+info:
+  name: HYPERPLANNING Login Panel - Detect
+  author: righettod
+  severity: info
+  description: HYPERPLANNING System was detected.
+  reference:
+    - https://www.index-education.com/fr/presentation-hyperplanning.php
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"HYPERPLANNING"
+  tags: panel,hyperplanning,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "hyperplanning</title>", "<meta name=\"dc.publisher\" content=\"hyperplanning\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '(?i)Server:\s+HYPERPLANNING\s+([0-9.\s\-]+)'

--- a/http/exposed-panels/hyperplanning-panel.yaml
+++ b/http/exposed-panels/hyperplanning-panel.yaml
@@ -4,7 +4,7 @@ info:
   name: HYPERPLANNING Login Panel - Detect
   author: righettod
   severity: info
-  description: HYPERPLANNING System was detected.
+  description: HYPERPLANNING products was detected.
   reference:
     - https://www.index-education.com/fr/presentation-hyperplanning.php
   metadata:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **HYPERPLANNING** software.

References:

- https://www.index-education.com/fr/presentation-hyperplanning.php

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/bd883bf3-1224-470c-8883-c9d911eb4d1f)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://193.190.94.240
https://213.151.173.118
https://212.71.20.34
https://193.49.236.169
https://146.59.213.5
https://193.54.180.215
https://193.54.176.210
http://194.57.174.201
https://193.52.197.81
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22HYPERPLANNING%22

![image](https://github.com/user-attachments/assets/f67eb799-6331-48e8-98e8-bf7ee7824ea8)

### Additional References

None