### PR TITLE
Add detection of PRONOTE login panel instances.

### DIFF
--- a/http/exposed-panels/pronote-panel.yaml
+++ b/http/exposed-panels/pronote-panel.yaml
@@ -1,0 +1,33 @@
+id: pronote-panel
+
+info:
+  name: PRONOTE Login Panel - Detect
+  author: righettod
+  severity: info
+  description: PRONOTE products was detected.
+  reference:
+    - https://www.index-education.com/fr/logiciel-gestion-vie-scolaire.php
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"PRONOTE"
+  tags: panel,pronote,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>pronote", "<meta name=\"dc.publisher\" content=\"pronote\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '(?i)Server:\s+PRONOTE\s+([0-9.\s\-]+)'

--- a/http/exposed-panels/pronote-panel.yaml
+++ b/http/exposed-panels/pronote-panel.yaml
@@ -24,7 +24,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>pronote", "<meta name=\"dc.publisher\" content=\"pronote\"")'
+          - 'contains_any(to_lower(body), "<title>pronote", "content=\"pronote\"")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/pronote-panel.yaml
+++ b/http/exposed-panels/pronote-panel.yaml
@@ -4,7 +4,8 @@ info:
   name: PRONOTE Login Panel - Detect
   author: righettod
   severity: info
-  description: PRONOTE products was detected.
+  description: |
+    PRONOTE products was detected.
   reference:
     - https://www.index-education.com/fr/logiciel-gestion-vie-scolaire.php
   metadata:
@@ -18,6 +19,7 @@ http:
       - "{{BaseURL}}"
 
     host-redirects: true
+
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **PRONOTE** software.

References:

- https://www.index-education.com/fr/logiciel-gestion-vie-scolaire.php

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/9ada7d78-f16b-4d61-98d2-a91e6dda1256)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://92.133.126.122
http://130.93.113.109:8080
https://37.71.132.197
https://50.234.157.164
http://128.199.196.65
https://200.40.51.189
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22PRONOTE%22

![image](https://github.com/user-attachments/assets/6450de24-799d-494c-a027-254f060accfd)


### Additional References

None