### PR TITLE
ADDED CVE-2020-24881

### DIFF
--- a/http/cves/2020/CVE-2020-24881.yaml
+++ b/http/cves/2020/CVE-2020-24881.yaml
@@ -1,0 +1,49 @@
+id: CVE-2020-24881
+
+info:
+  name: osTicket <1.14.3 - Server-Side Request Forgery (SSRF)
+  author: harshtech123
+  severity: critical
+  description: osTicket before version 1.14.3 contains a Server-Side Request Forgery (SSRF) vulnerability, which allows attackers to perform internal port scans and potentially add malicious files by manipulating requests.
+  impact: |
+    An attacker can leverage this vulnerability to perform unauthorized network scans, potentially exposing internal services or delivering malicious content.
+  remediation: |
+    Update osTicket to version 1.14.3 or later to mitigate this vulnerability.
+  reference:
+    - https://blackbatsec.medium.com/cve-2020-24881-server-side-request-forgery-in-osticket-eea175e147f0
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-24881
+    - https://github.com/ARPSyndicate/kenzer-templates
+    - https://github.com/osTicket/osTicket
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.4
+    cve-id: CVE-2020-24881
+    cwe-id: CWE-918
+    epss-score: 0.02672
+    epss-percentile: 0.94526
+    cpe: cpe:2.3:a:osticket:osticket:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: osTicket
+    product: osTicket
+  tags: cve2020,cve,ssrf,osticket,oss
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/path/to/vulnerable/endpoint?target=http://127.0.0.1:80"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "Expected content or response indicating SSRF vulnerability"
+
+    extractors:
+      - type: regex
+        regex:
+          - "(desired information from the response)"


### PR DESCRIPTION
 /claim #11184
/closes #11184 
added a CVE-2020-24881 template

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2020-24881

- References:
-  https://blackbatsec.medium.com/cve-2020-24881-server-side-request-forgery-in-osticket-eea175e147f0
-  https://nvd.nist.gov/vuln/detail/CVE-2020-24881
- https://github.com/ARPSyndicate/kenzer-templates
- https://github.com/osTicket/osTicket
   
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)