### PR TITLE
Add detection of DUFS instances.

### DIFF
--- a/http/technologies/dufs-detect.yaml
+++ b/http/technologies/dufs-detect.yaml
@@ -1,0 +1,35 @@
+id: dufs-detect
+
+info:
+  name: DUFS - Detect
+  author: righettod
+  severity: info
+  description: |
+    DUFS software was detected.
+  reference:
+    - https://github.com/sigoden/dufs
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"Dufs"
+  tags: tech,dufs,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "__dufs_v", "allow_upload")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)__dufs_v([0-9.]+)_'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **DUFS** software.

💬I did not found any existing template:

![image](https://github.com/user-attachments/assets/e7b60e03-11a2-41f7-bbba-a5bf27b1f682)

References:
- https://github.com/sigoden/dufs

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/6efa058b-8c18-4e74-94ea-f35173fa3350)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://111.47.113.232:5000
http://217.182.200.97:5000
http://47.108.185.75:5000
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Dufs%22

![image](https://github.com/user-attachments/assets/2334a7fe-2c92-4ebe-b122-54cb5ea98d69)

### Additional References

None