### PR TITLE
Add detection of AKUITEO login panel instances.

### DIFF
--- a/http/exposed-panels/akuiteo-panel.yaml
+++ b/http/exposed-panels/akuiteo-panel.yaml
@@ -1,0 +1,35 @@
+id: akuiteo-panel
+
+info:
+  name: Akuiteo Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Akuiteo products was detected.
+  reference:
+    - https://www.akuiteo.com/en/
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Akuiteo"
+  tags: panel,akuiteo,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/akuiteo.collabs/login/login.html"
+      - "{{BaseURL}}/akuiteo/apps/mobile/"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "akuiteo collabs</title>", "/akuiteo.collabs/", "akuiteo mobile</title>")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '(?i)x-akuiteo-masterhash:\s+([0-9a-f]+)'

--- a/http/exposed-panels/akuiteo-panel.yaml
+++ b/http/exposed-panels/akuiteo-panel.yaml
@@ -17,14 +17,14 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/akuiteo.collabs/login/login.html"
-      - "{{BaseURL}}/akuiteo/apps/mobile/"
+      - "{{BaseURL}}/akuiteo/login.html/"
 
     stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "akuiteo collabs</title>", "/akuiteo.collabs/", "akuiteo mobile</title>")'
+          - 'contains_any(to_lower(body), "akuiteo collabs</title>", "/akuiteo.collabs/", "akuiteo mobile</title>", "akuiteo</title>", "/akuiteo/")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/akuiteo-panel.yaml
+++ b/http/exposed-panels/akuiteo-panel.yaml
@@ -9,22 +9,26 @@ info:
   reference:
     - https://www.akuiteo.com/en/
   metadata:
+    verified: true
     max-request: 1
-    shodan-query: http.title:"Akuiteo"
-  tags: panel,akuiteo,login
+    shodan-query: title:"Akuiteo"
+  tags: panel,akuiteo,login,detect
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}"
       - "{{BaseURL}}/akuiteo.collabs/login/login.html"
       - "{{BaseURL}}/akuiteo/login.html/"
+
+    redirects: true
+    max-redirects: 2
 
     stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_any(to_lower(body), "akuiteo collabs</title>", "/akuiteo.collabs/", "akuiteo mobile</title>", "akuiteo</title>", "/akuiteo/")'
+          - 'contains_any(to_lower(body), "akuiteo collabs</title>", "akuiteo mobile</title>", "akuiteo</title>", "<title>[akuiteo]")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **AKUITEO** software.

💬I do not found any existing template:

![image](https://github.com/user-attachments/assets/d17a7d01-f22c-4b43-a5ec-60132a474e36)


References:

- https://www.akuiteo.com/en/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/a6946fa3-9133-486e-ab98-ade7dfb9b0a8)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://98.66.217.177
https://213.44.176.19
https://213.44.176.22
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Akuiteo%22

![image](https://github.com/user-attachments/assets/5a691103-e944-4edd-8187-b743e456373f)

### Additional References

None