### PR TITLE
Add port 6835/tcp to check for CVE-2023-46604

### DIFF
--- a/javascript/cves/2023/CVE-2023-46604.yaml
+++ b/javascript/cves/2023/CVE-2023-46604.yaml
@@ -2,7 +2,7 @@ id: CVE-2023-46604
 
 info:
   name: Apache ActiveMQ - Remote Code Execution
-  author: Ice3man,Mzack9999,pdresearch
+  author: Ice3man,Mzack9999,pdresearch,ret2src
   severity: critical
   description: |
     Apache ActiveMQ is vulnerable to Remote Code Execution.The vulnerability may allow a remote attacker with network access to a broker to run arbitrary shell commands by manipulating serialized class types in the OpenWire protocol to cause the broker to instantiate any class on the classpath.
@@ -38,7 +38,8 @@ variables:
 
 javascript:
   - pre-condition: |
-      isPortOpen(Host,Port);
+      Ports.some(port => isPortOpen(Host, port));
+      
     code: |
       let m1 = require('nuclei/net');
       let m2 = require('nuclei/bytes');
@@ -57,7 +58,7 @@ javascript:
 
     args:
       Host: "{{Host}}"
-      Port: "61616"
+      Ports: ["61616", "6835"]
       oob: "{{interactsh-url}}"
 
     matchers:

--- a/javascript/cves/2023/CVE-2023-46604.yaml
+++ b/javascript/cves/2023/CVE-2023-46604.yaml
@@ -44,7 +44,8 @@ javascript:
       let m1 = require('nuclei/net');
       let m2 = require('nuclei/bytes');
       let b = m2.Buffer();
-      let name=Host+':'+Port;
+      let openPort = Ports.find(port => isPortOpen(Host, port));
+      let name = Host + ':' + openPort;
       let conn = m1.Open('tcp', name);
       let randomvar = '{{randstr}}'.toLowerCase();
       var Base64={encode: btoa}


### PR DESCRIPTION
### PR Information

This adds the additional port from PR #11237 to the vulnerability check for CVE-2023-46604.
See #11237 for additional details.

**IMPORTANT:** Please make sure that my `javascript` `pre-condition` is valid. Since this is my first template contribution, I'm not sure if my code works as intended. There might be a better way to check multiple ports; network templates already support this through PR [#4401](https://github.com/projectdiscovery/nuclei/pull/4401).

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO