### PR TITLE
Added Blue Yonder Login Panel Detection

### DIFF
--- a/http/exposed-panels/blue-yonder-login-panel-detection.yaml
+++ b/http/exposed-panels/blue-yonder-login-panel-detection.yaml
@@ -1,0 +1,36 @@
+id: blue-yonder-login-panel-detection
+info:
+  name: Blue Yonder Login Panel Detection
+  author: sorrowx3
+  severity: info
+  description: |
+    Checks for the presence of Blue Yonder login page
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+      verified: true
+      max-request: 1
+  tags: panel,detection,blue-yonder
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/base/"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Blue Yonder"
+          - "Login"
+          - "PGL.Login.initialize();"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/blue-yonder-login-panel-detection.yaml
+++ b/http/exposed-panels/blue-yonder-login-panel-detection.yaml
@@ -10,7 +10,7 @@ info:
     cwe-id: CWE-200
   metadata:
       verified: true
-      max-request: 1
+      max-request: 2
   tags: panel,detection,blue-yonder
 
 http:

--- a/http/exposed-panels/blue-yonder-panel.yaml
+++ b/http/exposed-panels/blue-yonder-panel.yaml
@@ -1,36 +1,31 @@
-id: blue-yonder-login-panel-detection
+id: blue-yonder-panel
+
 info:
   name: Blue Yonder Login Panel Detection
   author: sorrowx3
   severity: info
   description: |
-    Checks for the presence of Blue Yonder login page
+    Blue Yonder login panel was discovered
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
       verified: true
       max-request: 2
-  tags: panel,detection,blue-yonder
+  tags: panel,login,blue-yonder
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
-      - "{{BaseURL}}/base/"
+      - "{{BaseURL}}/base/home"
 
     host-redirects: true
     max-redirects: 2
 
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "Blue Yonder"
-          - "Login"
-          - "PGL.Login.initialize();"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "title=\"blue yonder\"")'
         condition: and
-
-      - type: status
-        status:
-          - 200

--- a/http/exposed-panels/blue-yonder-panel.yaml
+++ b/http/exposed-panels/blue-yonder-panel.yaml
@@ -12,6 +12,7 @@ info:
   metadata:
       verified: true
       max-request: 2
+      shodan-query: html:"title=\"blue yonder\""
   tags: panel,login,blue-yonder
 
 http:

--- a/http/exposed-panels/blue-yonder-panel.yaml
+++ b/http/exposed-panels/blue-yonder-panel.yaml
@@ -1,19 +1,18 @@
 id: blue-yonder-panel
 
 info:
-  name: Blue Yonder Login Panel Detection
+  name: Blue Yonder Panel - Detect
   author: sorrowx3
   severity: info
-  description: |
-    Blue Yonder login panel was discovered
+  description: Blue Yonder login panel was discovered
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-      verified: true
-      max-request: 2
-      shodan-query: html:"title=\"blue yonder\""
-  tags: panel,login,blue-yonder
+    verified: true
+    max-request: 2
+    shodan-query: html:"title=\"blue yonder\""
+  tags: panel,login,blue-yonder,detect
 
 http:
   - method: GET
@@ -21,9 +20,9 @@ http:
       - "{{BaseURL}}"
       - "{{BaseURL}}/base/home"
 
+    stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
-
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Blue Yonder supply chain recently got hacked and this would identify potentially exposed orgs.

Reference login portals:
- https://lnf-aztms-abpp1-pr1.jdadelivers.com/base/
- https://fana.pepsico.com/base/

### Template Validation

I've validated this template locally?
- YES

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)