### PR TITLE
Add detection of Twenty CRM instances. 

### DIFF
--- a/http/technologies/twenty-detect.yaml
+++ b/http/technologies/twenty-detect.yaml
@@ -23,5 +23,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_all(to_lower(body), "<title>twenty</title>", "a modern open-source crm")'
+          - 'contains_all(to_lower(body), "<title>twenty</title>", "open-source crm")'
         condition: and

--- a/http/technologies/twenty-detect.yaml
+++ b/http/technologies/twenty-detect.yaml
@@ -1,0 +1,27 @@
+id: twenty-detect
+
+info:
+  name: Twenty - Detect
+  author: righettod
+  severity: info
+  description: |
+    Twenty products was detected.
+  reference:
+    - https://github.com/twentyhq/twenty
+    - https://twenty.com/
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Twenty"
+  tags: tech,twenty,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/welcome"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "<title>twenty</title>", "a modern open-source crm")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **Twenty** CRM software.

References:

- https://github.com/twentyhq/twenty
- https://twenty.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/b93a7a91-a4d7-4bd5-8f0a-ed85566328aa)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://139.185.53.196:3000
http://167.235.152.25:3000
https://13.200.0.92
http://154.23.255.194:3000
https://demo.twenty.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Twenty%22

![image](https://github.com/user-attachments/assets/521c6b21-4ca5-439a-9d81-4387407abb95)

### Additional References

None