### PR TITLE
Update CVE-2018-7314 tags

### DIFF
--- a/http/cves/2018/CVE-2018-7314.yaml
+++ b/http/cves/2018/CVE-2018-7314.yaml
@@ -27,7 +27,7 @@ info:
     fofa-query:
       - app="Joomla!-网站安装"
       - app="joomla!-网站安装"
-  tags: cve,cve2018,joomla,sqli,joomla\!,mlwebtechnologies
+  tags: cve,cve2018,joomla,sqli,mlwebtechnologies
 variables:
   num: "{{rand_int(800000000, 1000000000)}}"
 


### PR DESCRIPTION
Some templates have the same tags:
- https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2019/CVE-2019-9922.yaml#L31
- https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2018/CVE-2018-6605.yaml#L29
- https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2020/CVE-2020-23972.yaml#L33
- etc.

And there are many more, I can't list them all here, I believe the problem starts from these commit:

https://github.com/projectdiscovery/nuclei-templates/commit/bdd749d390e7731873ff8e63190d699a27d25d91