### PR TITLE
Add detection of HUGINN login panel instances.

### DIFF
--- a/http/exposed-panels/huginn-panel.yaml
+++ b/http/exposed-panels/huginn-panel.yaml
@@ -1,0 +1,26 @@
+id: huginn-panel
+
+info:
+  name: Huginn Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Huginn products was detected.
+  reference:
+    - https://github.com/huginn/huginn
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,huginn,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/users/sign_in"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "huginn</title>", "huginn</a>")'
+        condition: and

--- a/http/exposed-panels/huginn-panel.yaml
+++ b/http/exposed-panels/huginn-panel.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    shodan-query: http.favicon.hash:-1951475503
   tags: panel,huginn,login
 
 http:
@@ -22,5 +23,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "huginn</title>", "huginn</a>")'
+          - 'contains_any(to_lower(body), "huginn</title>", "huginn</a>", "Huginn monitors")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **HUGINN** software.

References:

- https://github.com/huginn/huginn

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/6cc6a40a-aac7-49b6-8ac3-c25a630b66d0)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://138.201.27.184
http://207.180.211.128
https://104.248.238.70
https://134.209.43.164
https://44.230.93.73
https://74.48.185.35
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22huginn%22

![image](https://github.com/user-attachments/assets/b8591291-132b-4cbc-91a5-d5c561d91bff)

### Additional References

None