### PR TITLE
Add detection of RICOH Web Image Monitor devices

### DIFF
--- a/http/exposed-panels/ricoh-webimagemonitor-panel.yaml
+++ b/http/exposed-panels/ricoh-webimagemonitor-panel.yaml
@@ -1,4 +1,4 @@
-id: ricoh-webimagemonitor-detect
+id: ricoh-webimagemonitor-panel
 
 info:
   name: Ricoh Web Image Monitor - Detect

--- a/http/exposed-panels/ricoh-webimagemonitor-panel.yaml
+++ b/http/exposed-panels/ricoh-webimagemonitor-panel.yaml
@@ -9,9 +9,9 @@ info:
   reference:
     - https://support.ricoh.com/bb_v1oi/pub_e/oi_view/0001082/0001082137/view/intro/int/wim.htm
   metadata:
+    verified: true
     max-request: 1
     shodan-query: http.html:"Web Image Monitor"
-    verified: true
   tags: panel,ricoh,detect
 
 http:

--- a/http/technologies/ricoh-webimagemonitor-panel.yaml
+++ b/http/technologies/ricoh-webimagemonitor-panel.yaml
@@ -1,0 +1,34 @@
+id: ricoh-webimagemonitor-detect
+
+info:
+  name: Ricoh Web Image Monitor - Detect
+  author: righettod
+  severity: info
+  description: |
+    Ricoh Web Image Monitor device was detected.
+  reference:
+    - https://support.ricoh.com/bb_v1oi/pub_e/oi_view/0001082/0001082137/view/intro/int/wim.htm
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"Web Image Monitor"
+    verified: true
+  tags: panel,ricoh,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web/guest/en/websys/webArch/header.cgi"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "web image monitor</h3", "ricoh")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)<h2 id="modelName" style="z-index:1;">([A-Z0-9\s]+)</h2>'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of **RICOH Web Image Monitor** devices.

References:

- https://support.ricoh.com/bb_v1oi/pub_e/oi_view/0001082/0001082137/view/intro/int/wim.htm

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/3d6966c9-d2b3-4e2c-a1b5-84c26b994e45)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://212.89.9.92
https://139.179.164.120
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Web+Image+Monitor%22

![image](https://github.com/user-attachments/assets/1017a84c-4640-43ac-b037-df4af7fcd298)

### Additional References

None