### PR TITLE
Update missing-sri.yaml with css checks

### DIFF
--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -2,7 +2,7 @@ id: missing-sri
 
 info:
   name: Missing Subresource Integrity
-  author: lucky0x0d,PulseSecurity.co.nz,sullo
+  author: lucky0x0d,PulseSecurity.co.nz,sullo,danielamar9
   severity: info
   description: |
     Checks if script tags within the HTML response have Subresource Integrity implemented via the integrity attribute.
@@ -11,7 +11,7 @@ info:
     - https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
   metadata:
     max-request: 1
-  tags: compliance,js,sri,misconfig
+  tags: compliance,js,css,sri,misconfig
 
 http:
   - raw:
@@ -22,13 +22,14 @@ http:
     redirects: true
     max-redirects: 5
 
-    matchers-condition: and
+    matchers-condition: or
     matchers:
       - type: xpath
         part: body
         xpath:
           - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-
+          - "//link[contains(@href,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
+      
       - type: word
         words:
           - "text/html"
@@ -39,4 +40,10 @@ http:
         attribute: src
         xpath:
           - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
+     
+      - type: xpath
+        attribute: href
+        xpath:
+          - "//link[contains(@href,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
+
 # digest: 4a0a00473045022035cc74528d4015de4becb701fde9486481cc1755194095f79be9ea515b97f28f022100978e639ff5b38a9be40269679b57d3775c3097ff80a8bdb7ea987b5bcf5f19c3:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -2,7 +2,7 @@ id: missing-sri
 
 info:
   name: Missing Subresource Integrity
-  author: lucky0x0d, PulseSecurity.co.nz, sullo, amarsct
+  author: lucky0x0d,PulseSecurity.co.nz,sullo amarsct
   severity: info
   description: |
     Checks if external script and stylesheet tags in the HTML response are missing the Subresource Integrity (SRI) attribute.
@@ -22,11 +22,11 @@ http:
     redirects: true
     max-redirects: 5
 
-    matchers-condition: or
     matchers:
       - type: xpath
         part: body
         xpath:
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
           - "//script[contains(@src, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
           - "//link[@rel='stylesheet' and contains(@href, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
 
@@ -34,7 +34,13 @@ http:
       - type: xpath
         attribute: src
         xpath:
+          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
+
+      - type: xpath
+        attribute: src
+        xpath:
           - "//script[contains(@src, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
+
       - type: xpath
         attribute: href
         xpath:

--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -29,7 +29,7 @@ http:
         xpath:
           - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
           - "//link[contains(@href,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-      
+ 
       - type: word
         words:
           - "text/html"
@@ -40,7 +40,7 @@ http:
         attribute: src
         xpath:
           - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-     
+
       - type: xpath
         attribute: href
         xpath:

--- a/http/misconfiguration/missing-sri.yaml
+++ b/http/misconfiguration/missing-sri.yaml
@@ -2,10 +2,10 @@ id: missing-sri
 
 info:
   name: Missing Subresource Integrity
-  author: lucky0x0d,PulseSecurity.co.nz,sullo,danielamar9
+  author: lucky0x0d, PulseSecurity.co.nz, sullo, amarsct
   severity: info
   description: |
-    Checks if script tags within the HTML response have Subresource Integrity implemented via the integrity attribute.
+    Checks if external script and stylesheet tags in the HTML response are missing the Subresource Integrity (SRI) attribute.
   reference:
     - https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html#subresource-integrity
     - https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
@@ -27,23 +27,15 @@ http:
       - type: xpath
         part: body
         xpath:
-          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-          - "//link[contains(@href,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
- 
-      - type: word
-        words:
-          - "text/html"
-        part: header
+          - "//script[contains(@src, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
+          - "//link[@rel='stylesheet' and contains(@href, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
 
     extractors:
       - type: xpath
         attribute: src
         xpath:
-          - "//script[contains(@src,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-
+          - "//script[contains(@src, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"
       - type: xpath
         attribute: href
         xpath:
-          - "//link[contains(@href,'//') and not(matches(translate(@integrity,'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=','abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-'))]"
-
-# digest: 4a0a00473045022035cc74528d4015de4becb701fde9486481cc1755194095f79be9ea515b97f28f022100978e639ff5b38a9be40269679b57d3775c3097ff80a8bdb7ea987b5bcf5f19c3:922c64590222798bb761d5b6d8e72950
+          - "//link[@rel='stylesheet' and contains(@href, '//') and (not(@integrity) or not(matches(translate(@integrity, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ+/-=', 'abcdefghijklmnopqrstuvwxyz+/-='), '^sha(256|384|512)-')))]"


### PR DESCRIPTION
Fixes https://github.com/projectdiscovery/nuclei-templates/issues/11337

Template / PR Information
The missing-sri template has been added in PR https://github.com/projectdiscovery/nuclei-templates/pull/8079 but it has an issue that it doesn't identify missing-sri in "link" HTML tags (e.g, in fonts loading, css)

References:
https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
Template Validation
I've validated this template locally?
YES