### PR TITLE
Add detection of OPENOBSERVE login panel instances.

### DIFF
--- a/http/exposed-panels/openobserve-panel.yaml
+++ b/http/exposed-panels/openobserve-panel.yaml
@@ -1,0 +1,27 @@
+id: openobserve-panel
+
+info:
+  name: OpenObserve Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    OpenObserve products was detected.
+  reference:
+    - https://github.com/openobserve/openobserve
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"OpenObserve"
+  tags: panel,openobserve,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "openobserve</title>")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **OPENOBSERVE** software.

References:

- https://github.com/openobserve/openobserve

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/f93401e5-7143-4455-9ae7-dd8e211d39c5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://54.248.81.76
https://143.244.222.232
http://23.22.221.3
https://52.199.122.87
https://52.54.215.176
https://101.132.80.249
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22OpenObserve%22

![image](https://github.com/user-attachments/assets/70ede4f8-795f-408e-80c1-b361e5173646)

### Additional References

None