### PR TITLE
Enrich the JUMPSERVER template.

### DIFF
--- a/http/exposed-panels/jumpserver-panel.yaml
+++ b/http/exposed-panels/jumpserver-panel.yaml
@@ -2,29 +2,33 @@ id: jumpserver-panel
 
 info:
   name: JumpServer Login Panel - Detect
-  author: lu4nx
+  author: lu4nx,righettod
   severity: info
   description: |
     JumpServer Open Source Bastion Host login panel was detected.
   reference:
     - https://www.jumpserver.org/
+    - https://github.com/jumpserver/jumpserver
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
     cpe: cpe:2.3:a:fit2cloud:jumpserver:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     shodan-query: http.title:'JumpServer'
     zoomeye-query: title:'JumpServer'
     product: jumpserver
     vendor: fit2cloud
-  tags: panel,jumpserver
+  tags: panel,jumpserver,login
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/core/auth/login/"
+      - "{{BaseURL}}/users/login/"
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
@@ -33,9 +37,17 @@ http:
         regex:
           - "(?i)<title>(\n.*)JumpServer Open Source Bastion Host(\n.*)</title>"
           - "(?i)<title>(\n.*)JumpServer 开源堡垒机(\n.*)</title>"
+          - "(?i)<title>\n*Jumpserver.*?\n*</title>"
+          - "(?i)>Welcome to the Jumpserver.*?</h2>"
         condition: or
 
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100b0193aa901be83a2ee7aafbab1feec0611ebec1452df27b4f5100ff7f8836230022036e989243081a687b79eacfb03c7122b2bf99a93424b58da49f9298dbf1f71d1:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)&copy;\s+([0-9-]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose to add some patterns to detect the instance of the **JumpServer** software.

🚩I respected the initial structure of the template.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via shodan:

```text
https://39.105.54.219
https://3.209.220.238
http://36.99.188.164:8080
```

![image](https://github.com/user-attachments/assets/2b8817a1-2472-4faf-a7af-10a8e28c880f)

![image](https://github.com/user-attachments/assets/8bfe9560-fdfa-4466-92f1-aa13a9a8ce67)


### Additional Details (leave it blank if not applicable)

Shodan query used (one present into the template): https://www.shodan.io/search?query=http.title%3A%22JumpServer%22

![image](https://github.com/user-attachments/assets/bee8c845-e680-45c6-8ca9-bf20c0b62cee)

### Additional References:

None