### PR TITLE
Fixed CVSS scoring on CVE-2024-43919

### DIFF
--- a/http/cves/2024/CVE-2024-43919.yaml
+++ b/http/cves/2024/CVE-2024-43919.yaml
@@ -13,7 +13,7 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-43919
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
+    cvss-score: 5.3
     cve-id: CVE-2024-43919
     cwe-id: CWE-862
     epss-score: 0.00091

--- a/http/cves/2024/CVE-2024-43919.yaml
+++ b/http/cves/2024/CVE-2024-43919.yaml
@@ -3,7 +3,7 @@ id: CVE-2024-43919
 info:
   name: YARPP <= 5.30.10 - Missing Authorization
   author: s4e-io
-  severity: critical
+  severity: medium
   description: |
     The YARPP Yet Another Related Posts Plugin plugin for WordPress is vulnerable to unauthorized access due to a missing capability check in the ~/includes/yarpp_pro_set_display_types.php file in all versions up to, and including, 5.30.10. This makes it possible for unauthenticated attackers to set display types.
   reference:
@@ -12,12 +12,12 @@ info:
     - https://patchstack.com/database/vulnerability/yet-another-related-posts-plugin/wordpress-yet-another-related-posts-plugin-yarpp-plugin-5-30-10-broken-access-control-vulnerability?_s_id=cve
     - https://nvd.nist.gov/vuln/detail/CVE-2024-43919
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
     cvss-score: 5.3
     cve-id: CVE-2024-43919
     cwe-id: CWE-862
-    epss-score: 0.00091
-    epss-percentile: 0.40377
+    epss-score: 0.16372
+    epss-percentile: 0.95977
     cpe: cpe:2.3:a:yarpp:yet_another_related_posts_plugin:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
@@ -26,6 +26,7 @@ info:
     product: yet_another_related_posts_plugin
     framework: wordpress
     fofa-query: body="wp-content/plugins/yet-another-related-posts-plugin/"
+    shodan-query: http.html:"wp-content/plugins/yet-another-related-posts-plugin/"
   tags: cve,cve2024,wp,wordpress,wp-plugin,auth-bypass,yet-another-related-posts-plugin
 
 http:


### PR DESCRIPTION
Fixed incorrect cvss score

### Template / PR Information

The template gave a CVSS score of 9.8 when in fact it is 5.3

- Fixed CCVE-2024-43919
- References: https://patchstack.com/database/wordpress/plugin/yet-another-related-posts-plugin/vulnerability/wordpress-yet-another-related-posts-plugin-yarpp-plugin-5-30-10-broken-access-control-vulnerability?_s_id=cve