### PR TITLE
hotfix: missing input to setup nuclei in workflows

### DIFF
--- a/.github/workflows/template-sign.yml
+++ b/.github/workflows/template-sign.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/nuclei@v1
+        with:
+          token: '${{ secrets.GITHUB_TOKEN}}'
       - run: nuclei -lfa -duc -sign -ud $GITHUB_WORKSPACE -t .
         env:
           NUCLEI_USER_CERTIFICATE: ${{ secrets.NUCLEI_USER_CERTIFICATE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/nuclei@v1
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Validate templates
         run: nuclei -duc -validate -lfa -ud $GITHUB_WORKSPACE -w workflows/ -et .github/
 
@@ -51,6 +53,8 @@ jobs:
             changed:
               - added|modified: *templates
       - uses: projectdiscovery/actions/setup/nuclei@v1
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
       - run: bash weak-matcher-checks.sh
         id: check
         if: steps.filter.outputs.changed == 'true'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed https://github.com/projectdiscovery/nuclei-templates/actions/runs/12437311343/job/34727026669?pr=11399
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)