### PR TITLE
Add header detection to apache-ofbiz-detect.yaml

### DIFF
--- a/http/technologies/apache/apache-ofbiz-detect.yaml
+++ b/http/technologies/apache/apache-ofbiz-detect.yaml
@@ -32,7 +32,14 @@ http:
           - "OFBiz.Visitor="
           - "Apache OFBiz."
         condition: or
-
+        
+      - type: word
+        part: headers
+        words:
+          - "OFBiz.Visitor="
+          - "Apache OFBiz."
+        condition: or
+        
       - type: status
         status:
           - 200


### PR DESCRIPTION
When there is a apache ofbiz server, it can include "OFBiz.Visitor=" or "Apache OFBiz." in response header. So, there need to update code to detect apache ofbiz with response header.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed /http/technologies/apache/apache-ofbiz-detect.yaml
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO



#### Additional Details (leave it blank if not applicable)

![cli_cookie](https://github.com/user-attachments/assets/9ac33b0b-a68f-4047-9f20-c5ccd4e66d2d)
![cli](https://github.com/user-attachments/assets/06857866-551b-40e1-b1e8-b752d5fd3af3)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)