### PR TITLE
Fix jwk-json-leak template matcher

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1489,5 +1489,15 @@
             "website": "https://hassankhanyusufzai.com/",
             "email": ""
     }
+    },
+    {
+        "author": "seqre",
+        "links": {
+            "github": "https://github.com/seqre",
+            "twitter": "https://twitter.com/grzelakmarek",
+            "linkedin": "https://www.linkedin.com/in/marek-grzelak/",
+            "website": "https://seqre.dev",
+            "email": "contact@seqre.dev"
+        }
     }
 ]

--- a/http/exposures/tokens/jwk-json-leak.yaml
+++ b/http/exposures/tokens/jwk-json-leak.yaml
@@ -35,7 +35,7 @@ http:
       - type: word
         part: body
         words:
-          - '"kid":'
+          - '"kty":'
 
       - type: word
         part: content_type


### PR DESCRIPTION
### Template / PR Information

According to the [RFC 7517 section 4.5](https://www.rfc-editor.org/rfc/rfc7517#section-4.5):
> The "kid" value is a case-sensitive string.  Use of this member is **OPTIONAL**.

On the other hand, [section 4.1](https://www.rfc-editor.org/rfc/rfc7517#section-4.1) mentions:
> The "kty" value is a case-sensitive string.  This member **MUST** be present in a JWK.

With that in mind, I've changed the `kid` from the template's matcher to `kty` as there is a higher chance that this field will be present.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Example `jwks.json` file from [Appendix A of the RFC](https://www.rfc-editor.org/rfc/rfc7517#appendix-A.1):
```json
{"keys":
 [
   {"kty":"EC",
    "crv":"P-256",
    "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
    "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
    "use":"enc",
    "kid":"1"},

   {"kty":"RSA",
    "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
    "e":"AQAB",
    "alg":"RS256",
    "kid":"2011-04-29"}
 ]
}
```
I hosted this file locally as visible and then with the `kid` fields removed. The new template matches the file in both cases.