### PR TITLE
Update crxde-lite.yaml

### DIFF
--- a/http/exposed-panels/crxde-lite.yaml
+++ b/http/exposed-panels/crxde-lite.yaml
@@ -3,14 +3,14 @@ id: crxde-lite
 info:
   name: CRXDE Lite Panel - Detect
   author: nadino
-  severity: info
+  severity: high
   description: CRXDE Lite panel was detected.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
     max-request: 1
-  tags: panel
+  tags: aem,crxde,panel
 
 http:
   - method: GET


### PR DESCRIPTION
Based on this docs https://github.com/AdobeDocs/experience-manager-65.en/blob/main/help/sites-developing/developing-with-crxde-lite.md

```
From AEM 6.5.5.0 onwards, anonymous access of CRXDE Lite is not possible anymore. Users are redirected to the login screen.
```