### PR TITLE
Add detection of HULY login panel instances.

### DIFF
--- a/http/exposed-panels/huly-panel.yaml
+++ b/http/exposed-panels/huly-panel.yaml
@@ -1,0 +1,27 @@
+id: huly-panel
+
+info:
+  name: Huly Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Huly products was detected.
+  reference:
+    - https://huly.io/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"Huly"
+  tags: panel,huly,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login%3Acomponent%3ALoginApp"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>huly</title>")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **HULY** software.

References:

- https://huly.io/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/7cbb522b-8e2a-4903-8bde-14e603752b47)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://188.245.174.188
http://176.9.166.44
https://82.118.22.50
http://94.228.168.196
https://3.147.213.163
https://149.56.201.139
http://217.77.6.22
http://5.78.94.86
https://42.1.66.167
http://35.241.101.180
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22Huly%22

![image](https://github.com/user-attachments/assets/5ae07b69-8f4f-4492-ad2a-4aaf073d5034)

### Additional References

None