### PR TITLE
Add detection of VAULTWARDEN login panel instances. 

### DIFF
--- a/http/exposed-panels/vaultwarden-panel.yaml
+++ b/http/exposed-panels/vaultwarden-panel.yaml
@@ -1,0 +1,27 @@
+id: vaultwarden-panel
+
+info:
+  name: Vaultwarden Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Vaultwarden products was detected.
+  reference:
+    - https://github.com/dani-garcia/vaultwarden
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"vaultwarden"
+  tags: panel,vaultwarden,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/#/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "vaultwarden web</title>")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **VAULTWARDEN** software.

References:

- https://github.com/dani-garcia/vaultwarden

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/fb577ec2-d8bc-4b8a-bec4-19f646347864)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://116.203.62.121
https://109.147.146.223
https://51.15.227.62
https://65.21.147.197
https://54.144.142.47
https://208.184.105.20
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22vaultwarden%22

![image](https://github.com/user-attachments/assets/30d94c2f-e2cb-45e2-883a-b313354d10bd)

### Additional References

None