### PR TITLE
Update anmelden-panel.yaml

### DIFF
--- a/http/exposed-panels/anmelden-panel.yaml
+++ b/http/exposed-panels/anmelden-panel.yaml
@@ -1,17 +1,17 @@
-id: anmelden-panel
+id: opnsense-panel
 
 info:
-  name: Anmelden | OPNsense Panel - Detect
-  author: Splint3r7
+  name: OPNsense Panel - Detect
+  author: Splint3r7,johnk3r
   severity: info
   description: |
-    Anmelden | OPNsense panel was detected.
+    OPNsense panel was detected.
   classification:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-    shodan-query: http.title:"Anmelden | OPNsense"
-  tags: panel,anmelden,login,detect
+    shodan-query: http.title:"OPNsense"
+  tags: panel,login,detect,opnsense
 
 http:
   - method: GET
@@ -21,7 +21,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "<title>Anmelden | OPNsense")'
+          - 'contains(body, "OPNsense")'
           - 'status_code == 200'
         condition: and
 # digest: 4a0a0047304502210089c7598d6072d2a436626f9f539336c56cb43dc3980103ffb9d255a5cfe39fd5022028f32bbf6fe5302245e43328192c381d15e24745c9bad97937c523aeefe957e1:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/opnsense-panel.yaml
+++ b/http/exposed-panels/opnsense-panel.yaml
@@ -10,7 +10,7 @@ info:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-    shodan-query: http.title:"OPNsense"
+    shodan-query: http.favicon.hash: -1148190371
   tags: panel,login,detect,opnsense
 
 http:

--- a/http/exposed-panels/opnsense-panel.yaml
+++ b/http/exposed-panels/opnsense-panel.yaml
@@ -10,7 +10,7 @@ info:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-    shodan-query: http.favicon.hash: -1148190371
+    shodan-query: http.favicon.hash:"-1148190371"
   tags: panel,login,detect,opnsense
 
 http:
@@ -21,7 +21,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "OPNsense")'
+          - 'contains(body, "| OPNsense</title>")'
           - 'status_code == 200'
         condition: and
-# digest: 4a0a0047304502210089c7598d6072d2a436626f9f539336c56cb43dc3980103ffb9d255a5cfe39fd5022028f32bbf6fe5302245e43328192c381d15e24745c9bad97937c523aeefe957e1:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Rule change because:

**anmelden** = German word for 'login'

Therefore the rule only looked at panels in 'German'.

I've validated this template locally?
- [Y] YES
- [ ] NO
![image](https://github.com/user-attachments/assets/442eeaa7-9b90-45f5-bd62-1dd6a1a4c4fa)
![image](https://github.com/user-attachments/assets/b5771b29-8f80-4d74-aaa1-e0e53d65cebe)
