### PR TITLE
Add detection of FRAPPE HELPDESK login panel instances.

### DIFF
--- a/http/exposed-panels/frappe-helpdesk-panel.yaml
+++ b/http/exposed-panels/frappe-helpdesk-panel.yaml
@@ -1,0 +1,35 @@
+id: frappe-helpdesk-panel
+
+info:
+  name: Frappe Helpdesk Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Frappe Helpdesk products was detected.
+  reference:
+    - https://frappe.io/helpdesk
+    - https://github.com/frappe/helpdesk
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"window.frappe_version"
+  tags: panel,frappe,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/helpdesk/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "/helpdesk/", "frappe")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)helpdesk_version\s*=\s*"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **FRAPPE HELPDESK** software.

References:

* https://frappe.io/helpdesk
* https://github.com/frappe/helpdesk

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/dac30110-3f67-41b9-97e3-05c5ed10682a)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://41.76.172.138
https://95.111.203.32
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22window.frappe_version%22

![image](https://github.com/user-attachments/assets/e1b3c169-6ce7-4a74-acb9-dbd50f6962e4)

### Additional References

None