### PR TITLE
Add "web.core.windows.net" to azure-takeover-detection.yaml

### DIFF
--- a/dns/azure-takeover-detection.yaml
+++ b/dns/azure-takeover-detection.yaml
@@ -47,6 +47,7 @@ dns:
           - 'contains(cname, "servicebus.windows.net")'
           - 'contains(cname, "trafficmanager.net")'
           - 'contains(cname, "visualstudio.com")'
+          - 'contains(cname, "web.core.windows.net")'
     extractors:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Adding "web.core.windows.net" string to Azure subdomain takeover detection.

- References:
  - I was only find this [link](https://falconforce.nl/arbitrary-1-click-azure-tenant-takeover-via-ms-application/) which briefly mentions this type of Azure resource for subdomain takeover. However, it is possible.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
