### PR TITLE
feat: add rdp default port check

### DIFF
--- a/code/windows/audit/remote-desktop-default-port.yaml
+++ b/code/windows/audit/remote-desktop-default-port.yaml
@@ -1,0 +1,35 @@
+id: remote-desktop-default-port
+
+info:
+  name: Remote Desktop Listening on Default Port 3389
+  author: asteria121
+  severity: high
+  description: Checks if rdp is listening on default port 3389
+  impact: |
+    Can be scanned from massive rdp target scanner. May be subject to future attacks.
+  remediation: |
+    Change rdp connection port from default 3389 or disable rdp if you are not using.
+  tags: windows,rdp,port
+
+self-contained: true
+
+code:
+  - pre-condition: |
+      IsWindows();
+    engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+    pattern: "*.ps1"
+    source: |
+      $rdpService = Get-Service -Name TermService;
+      $rdpPort = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp").PortNumber;
+      if ($rdpService.Status -eq 'Running' -and $rdpPort -eq 3389) { Write-Host "True" } else { Write-Host "False" }
+
+    matchers:
+      - type: word
+        words:
+          - "True"
+# digest: 4a0a00473045022100c91ba8156b57be0ccf27c1c81923567a22cd64f4571a74103df3427a20565ab702206249c327ec7457d70d485bd8af7a6575aab5348738a750d45ee94680be261cd8:1080a639ff2c294f8df9be5858df76f1

--- a/code/windows/audit/remote-desktop-default-port.yaml
+++ b/code/windows/audit/remote-desktop-default-port.yaml
@@ -1,15 +1,16 @@
 id: remote-desktop-default-port
 
 info:
-  name: Remote Desktop Listening on Default Port 3389
+  name: Remote Desktop Listening Default Port - Detect
   author: asteria121
   severity: info
-  description: Checks if rdp is listening on default port 3389
+  description: |
+    The Remote Desktop Protocol (RDP) service listens on a default port (TCP 3389), which is commonly targeted by attackers.
   impact: |
-    Can be scanned from massive rdp target scanner. May be subject to future attacks.
+    Exposure of the default RDP port (TCP 3389) increases the risk of brute-force attacks and unauthorized access. This can lead to system compromise, data breaches, and ransomware deployment.
   remediation: |
-    Change rdp connection port from default 3389 or disable rdp if you are not using.
-  tags: windows,rdp,port
+    Change the default RDP listening port to a non-standard port to reduce exposure.
+  tags: windows,rdp,audit
 
 self-contained: true
 
@@ -32,4 +33,3 @@ code:
       - type: word
         words:
           - "True"
-# digest: 4a0a00473045022100c91ba8156b57be0ccf27c1c81923567a22cd64f4571a74103df3427a20565ab702206249c327ec7457d70d485bd8af7a6575aab5348738a750d45ee94680be261cd8:1080a639ff2c294f8df9be5858df76f1

--- a/code/windows/audit/remote-desktop-default-port.yaml
+++ b/code/windows/audit/remote-desktop-default-port.yaml
@@ -3,7 +3,7 @@ id: remote-desktop-default-port
 info:
   name: Remote Desktop Listening on Default Port 3389
   author: asteria121
-  severity: high
+  severity: info
   description: Checks if rdp is listening on default port 3389
   impact: |
     Can be scanned from massive rdp target scanner. May be subject to future attacks.


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Created RDP default port checker
- References:

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
I use my desktop outside via Wake on LAN and RDP. So I use rdp in non-server Windows OS. But using rdp on default port could lead to port scan by attackers. So I made a script which checks rdp is running on default port TCP 3389. If rdp is running and port is not 3389, it is not detected.

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)