### PR TITLE
Add detection of FRAPPE FRAMEWORK instances. 

### DIFF
--- a/http/technologies/frappe-framework-detect.yaml
+++ b/http/technologies/frappe-framework-detect.yaml
@@ -1,0 +1,29 @@
+id: frappe-framework-detect
+
+info:
+  name: Frappe Framework - Detect
+  author: righettod
+  severity: info
+  description: |
+    Frappe Framework products was detected.
+  reference:
+    - https://frappe.io/framework
+    - https://docs.frappe.io/framework/user/en/introduction
+    - https://github.com/frappe/frappe
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"window.frappe"
+  tags: panel,frappe,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/about"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "frappe.csrf_token", "frappe.boot", "frappe-web.bundle")'
+        condition: and

--- a/http/technologies/frappe-framework-detect.yaml
+++ b/http/technologies/frappe-framework-detect.yaml
@@ -19,8 +19,12 @@ info:
 http:
   - method: GET
     path:
+      - "{{BaseURL}}"
       - "{{BaseURL}}/about"
 
+    host-redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **FRAPPE FRAMEWORK** software.

References:

* https://frappe.io/framework
* https://docs.frappe.io/framework/user/en/introduction
* https://github.com/frappe/frappe

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/a5edad66-e5ce-4d93-9244-36bba370bd51)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
http://165.227.129.50
https://51.12.52.37
https://144.24.218.197
http://20.123.73.151
https://3.109.36.231
http://165.22.182.90
https://37.27.84.97
https://102.222.177.6
https://134.209.124.162
http://209.126.8.100
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22window.frappe%22

![image](https://github.com/user-attachments/assets/43498860-5d17-447f-8b23-b4363af8ab13)

### Additional References

None