### PR TITLE
X-Powered-By: Zope (use capital Z)

### DIFF
--- a/http/technologies/fingerprinthub-web-fingerprints.yaml
+++ b/http/technologies/fingerprinthub-web-fingerprints.yaml
@@ -14986,7 +14986,7 @@ http:
         part: header
         name: zope
         words:
-          - "X-Powered-By: zope"
+          - "X-Powered-By: Zope"
 
       - type: word
         condition: and


### PR DESCRIPTION
### Template / PR Information

Zope seems to use a capital Z in the X-Powered-By header. Tested it on two Zope 5 setups.

Zope production setup:

```
> GET / HTTP/1.1
> Host: 192.168.122.152:8080
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 Ok
< Server: TwistedWeb/24.3.0
< Date: Fri, 24 Jan 2025 15:22:13 GMT
< X-Powered-By: Zope (www.zope.org), Python (www.python.org)
```

Zope local setup:
```
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 855
< Content-Type: text/html; charset=utf-8
< Date: Fri, 24 Jan 2025 14:34:48 GMT
< Server: waitress
< Via: waitress
< X-Powered-By: Zope (www.zope.dev), Python (www.python.org)
```

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


### Additional References:

- https://zope.readthedocs.io/en/latest/index.html