### PR TITLE
Add detection of REPOSILITE login panel instances.

### DIFF
--- a/http/exposed-panels/reposilite-panel.yaml
+++ b/http/exposed-panels/reposilite-panel.yaml
@@ -1,0 +1,28 @@
+id: reposilite-panel
+
+info:
+  name: Reposilite Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Reposilite products was detected.
+  reference:
+    - https://reposilite.com/
+    - https://github.com/dzikoysk/reposilite
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"reposilite"
+  tags: panel,reposilite,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "reposilite repository", "reposilite description", "hosted through the reposilite")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **REPOSILITE** software.

References:

* https://reposilite.com/
* https://github.com/dzikoysk/reposilite

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/6f0f465c-1497-4262-af5f-82713950037a)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://45.81.233.189:8080
http://3.73.82.225
https://116.202.172.247
http://20.218.210.97:8080
http://84.247.138.132:8080
http://51.79.55.183
https://3.6.19.125
https://143.110.180.175
https://34.150.74.188
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22reposilite%22

![image](https://github.com/user-attachments/assets/62c84eb2-20ca-46e6-9e65-9bbb70749550)

### Additional References

None