### PR TITLE
CVE-2015-8562 CVSS Fix

### DIFF
--- a/http/cves/2015/CVE-2015-8562.yaml
+++ b/http/cves/2015/CVE-2015-8562.yaml
@@ -10,7 +10,7 @@ info:
     - https://github.com/vulhub/vulhub/tree/master/joomla/CVE-2015-8562
     - https://nvd.nist.gov/vuln/detail/CVE-2015-8562
   classification:
-    cvss-metrics: AV:N/AC:L/Au:N/C:P/I:P/A:P
+    cvss-metrics: CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P
     cvss-score: 7.5
     cve-id: CVE-2015-8562
   metadata:


### PR DESCRIPTION
CVSS score was missing the "`CVSS:2.0/`".