### PR TITLE
Fixed dsl matcher on server-private-keys. Added ed25519 to detections

### DIFF
--- a/http/exposures/configs/server-private-keys.yaml
+++ b/http/exposures/configs/server-private-keys.yaml
@@ -2,7 +2,7 @@ id: server-private-keys
 
 info:
   name: SSL/SSH/TLS/JWT Keys - Detect
-  author: geeknik,R12W4N,j4vaovo
+  author: geeknik,R12W4N,j4vaovo,VulnSCOUT
   severity: high
   description: Private SSL, SSH, TLS, and JWT keys were detected.
   classification:
@@ -10,7 +10,7 @@ info:
     cvss-score: 7.5
     cwe-id: CWE-200
   metadata:
-    max-request: 45
+    max-request: 47
   tags: config,exposure
 
 http:
@@ -35,12 +35,14 @@ http:
         - "/id_rsa_2048"
         - "/id_rsa_3072"
         - "/id_rsa_4096"
+        - "/id_ed25519"
         - "/.ssh/id_rsa"
         - "/.ssh/id_dsa"
         - "/.ssh/id_rsa_1024"
         - "/.ssh/id_rsa_2048"
         - "/.ssh/id_rsa_3072"
         - "/.ssh/id_rsa_4096"
+        - "/.ssh/id_ed25519"
         - "/{{Hostname}}.key"
         - "/{{Hostname}}.pem"
         - "/config/jwt/private.pem"
@@ -86,7 +88,7 @@ http:
 
       - type: dsl
         dsl:
-          - '!contains(body_2, "<html")'
-          - '!contains(body_2, "<HTML")'
+          - '!contains(body, "<html")'
+          - '!contains(body, "<HTML")'
         condition: and
 # digest: 4b0a004830460221009ca568df0aece57cb81ee17d79df5541de166d5796d0d0af5737cb60dd82a027022100f0661182bac9c94ef6c8d23c25b8db56ad8fad22eb877c4f58c72f4035ce9ee9:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

- Fixed `server-private-keys.yaml` to properly detect these keys. Previously, the template was trying to DSL match on `body_2` instead of `body`, resulting in false negative detections. 
- Added `id_ed25519` to detections as well.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
I noticed that I wasn't getting any detections on this template at all, which led to me investigating this template closer. Changing the DSL matcher from `body_2` to `body` (based on documentation) gave the desired detections.

![image](https://github.com/user-attachments/assets/12b47940-bfc3-4b76-9f09-1a3f62eef810)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)