### PR TITLE
feat: Update ntlm-directories to detect RDWeb WebFeedLogin

### DIFF
--- a/http/miscellaneous/ntlm-directories.yaml
+++ b/http/miscellaneous/ntlm-directories.yaml
@@ -67,7 +67,7 @@ http:
         - /webticket/webticketservice.svcabs/
         - /adfs/services/trust/2005/windowstransport
         - /internal_windows_authentication/
-        - /RDWeb/FeedLogin/
+        - /RDWeb/FeedLogin/WebFeedLogin.aspx
 
     matchers-condition: and
     matchers:
@@ -83,4 +83,4 @@ http:
       - type: kval
         kval:
           - 'www_authenticate'
-# digest: 490a0046304402207bb66edaa91b28d131d31670f0656d536a7617fa044ccc9c593a796d908e48f30220771745c611f8c32419f1fdd9a6b49ab677725c4df0b96806e523ab8e3c1751e8:1ecbd5a69bbeb8ee6759e78b73274855
+# digest: 4a0a004730450220526421bbc884941343462c749170a962ebebd728dc149478aeb7f8071b50c138022100b467147ed457af8cc6766180e72462d7dcea749b1efc688197088944d32ab76b:1ecbd5a69bbeb8ee6759e78b73274855

--- a/http/miscellaneous/ntlm-directories.yaml
+++ b/http/miscellaneous/ntlm-directories.yaml
@@ -2,12 +2,12 @@ id: ntlm-directories
 
 info:
   name: Discovering directories w/ NTLM
-  author: puzzlepeaches,incogbyte
+  author: puzzlepeaches,incogbyte,missing0x00
   severity: info
   reference:
     - https://medium.com/swlh/internal-information-disclosure-using-hidden-ntlm-authentication-18de17675666
   metadata:
-    max-request: 47
+    max-request: 48
   tags: miscellaneous,misc,fuzz,windows
 
 http:
@@ -67,6 +67,7 @@ http:
         - /webticket/webticketservice.svcabs/
         - /adfs/services/trust/2005/windowstransport
         - /internal_windows_authentication/
+        - /RDWeb/FeedLogin/
 
     matchers-condition: and
     matchers:
@@ -82,4 +83,4 @@ http:
       - type: kval
         kval:
           - 'www_authenticate'
-# digest: 4a0a004730450221009b795bc89897c0faaa1dd1c43b5b70746cec25dd42f7f5db7d6c1ef07f1ecfb702202fe31011b231e5d2ee608bc81fec32373f40e64387fcd73ecfb51213777ba956:922c64590222798bb761d5b6d8e72950
+# digest: 490a0046304402207bb66edaa91b28d131d31670f0656d536a7617fa044ccc9c593a796d908e48f30220771745c611f8c32419f1fdd9a6b49ab677725c4df0b96806e523ab8e3c1751e8:1ecbd5a69bbeb8ee6759e78b73274855


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Add detection for NTLM auth header on /RDWeb/FeedLogin/WebFeedLogin.aspx
- NTLM response discloses server and domain information
- Valid credentials allow:
  - Retrieval of `.ASPXAUTH` cookie (as `application/x-msts-webfeed-login` response)
  - Identification of RemoteApps available to the user
  - Potential cookie reuse for other applications on the IIS server
- Possible NTLM relay target, however attack vectors seem to be limited
- References: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tswp/85306e72-0f6a-41c0-9725-893d8f5aee5c
- Could make this a separate template if preferred


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

The following URLs redirect to `/RDWeb/FeedLogin/WebFeedLogin.aspx` when unauthenticated:
```
/RDWeb/Feed/
/RDWeb/Feed/WebFeed.aspx
/RDWeb/Feed/RDWebService.asmx
/RDWeb/FeedLogin/
/RDWeb/FeedLogin/WebFeedLogin.aspx
```

URLs which allow data retrieval using `.ASPXAUTH` cookie:
```
 POST /RDWeb/Feed/RDWebService.asmx
 GET /RDWeb/Feed/WebFeed.aspx
```