### PR TITLE
Add detection of OPENTEXT CONTENT SERVER login panel instances.

### DIFF
--- a/http/exposed-panels/opentext-contentserver-panel.yaml
+++ b/http/exposed-panels/opentext-contentserver-panel.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-    shodan-query: http.title:"Content Server Log-in"
+    shodan-query: http.title:"Content Server"
   tags: panel,opentext,login
 
 http:

--- a/http/exposed-panels/opentext-contentserver-panel.yaml
+++ b/http/exposed-panels/opentext-contentserver-panel.yaml
@@ -1,0 +1,38 @@
+id: opentext-contentserver-panel
+
+info:
+  name: OpenText Content Server Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    OpenText Content Server products was detected.
+  reference:
+    - https://www.opentext.com/products/document-management
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Content Server Log-in"
+  tags: panel,opentext,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 4
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "opentext content server", "opentext content suite")'
+          - 'contains_any(to_lower(body), "login", "log-in", "signin")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)login\.js\?v=([0-9.]+)'
+          - '(?i)OpenText\s+Content\s+Server\s+version\s+([0-9.]+)'

--- a/http/exposed-panels/opentext-contentserver-panel.yaml
+++ b/http/exposed-panels/opentext-contentserver-panel.yaml
@@ -26,7 +26,6 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains_any(to_lower(body), "opentext content server", "opentext content suite")'
-          - 'contains_any(to_lower(body), "login", "log-in", "signin")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **OPENTEXT CONTENT SERVER** software.

References:

- https://www.opentext.com/products/document-management

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/47a880d8-1d6d-4c02-96dd-aaf2f9b96f0f)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://20.166.22.100
https://support.syntergy.com
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Content+Server%22

![image](https://github.com/user-attachments/assets/ef3ab31d-5ce9-4efe-9f1f-03f4350992a2)

### Additional References

None