### PR TITLE
Add: template of CVE 2022 42475 heap based buffer overflow in fortinet ssl vpn

### DIFF
--- a/http/exposed-panels/fortinet-ssl-vpn-cve-2022-42475.yaml
+++ b/http/exposed-panels/fortinet-ssl-vpn-cve-2022-42475.yaml
@@ -1,0 +1,51 @@
+id: fortinet-ssl-vpn-cve-2022-42475
+
+info:
+  name: Fortinet SSL-VPN CVE-2022-42475 - Heap-based Buffer Overflow
+  author: rogueloop
+  severity: critical
+  description: |
+    A heap-based buffer overflow vulnerability [CWE-122] in FortiOS SSL-VPN (versions 7.2.0 through 7.2.2, 7.0.0 through 7.0.8, 6.4.0 through 6.4.10, 6.2.0 through 6.2.11, 6.0.15 and earlier) and FortiProxy SSL-VPN (versions 7.2.0 through 7.2.1, 7.0.7 and earlier) may allow a remote unauthenticated attacker to execute arbitrary code or commands via specifically crafted requests.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-122
+    cpe:
+      - cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*
+      - cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*
+  reference:
+    - https://fortiguard.com/psirt/FG-IR-22-398
+    - https://github.com/0xhaggis/CVE-2022-42475
+    - https://github.com/CKevens/CVE-2022-42475-RCE-POC
+    - https://github.com/Amir-hy/cve-2022-42475
+    - https://github.com/Mustafa1986/cve-2022-42475-Fortinet
+    - https://github.com/natceil/cve-2022-42475
+    - https://github.com/scrt/cve-2022-42475
+  metadata:
+    shodan-query: |
+      port:10443 http.favicon.hash:945408572
+      cpe:"cpe:2.3:o:fortinet:fortios"
+      http.html:"/remote/login" "xxxxxxxx"
+  tags: fortinet,ssl-vpn,heap-overflow
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/remote/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/remote/login"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "Server: xxxxxxxx-xxxxx"
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/fortinet-ssl-vpn-cve-2022-42475.yaml
+++ b/http/exposed-panels/fortinet-ssl-vpn-cve-2022-42475.yaml
@@ -2,7 +2,7 @@ id: fortinet-ssl-vpn-cve-2022-42475
 
 info:
   name: Fortinet SSL-VPN CVE-2022-42475 - Heap-based Buffer Overflow
-  author: rogueloop
+  author: sambit003
   severity: critical
   description: |
     A heap-based buffer overflow vulnerability [CWE-122] in FortiOS SSL-VPN (versions 7.2.0 through 7.2.2, 7.0.0 through 7.0.8, 6.4.0 through 6.4.10, 6.2.0 through 6.2.11, 6.0.15 and earlier) and FortiProxy SSL-VPN (versions 7.2.0 through 7.2.1, 7.0.7 and earlier) may allow a remote unauthenticated attacker to execute arbitrary code or commands via specifically crafted requests.
@@ -10,9 +10,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cwe-id: CWE-122
-    cpe:
-      - cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*
-      - cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:* cpe:2.3:a:fortinet:fortiproxy:*:*:*:*:*:*:*:*
   reference:
     - https://fortiguard.com/psirt/FG-IR-22-398
     - https://github.com/0xhaggis/CVE-2022-42475


### PR DESCRIPTION
### Template / PR Information
This pull request adds a new vulnerability detection YAML file/template for Fortinet SSL-VPN CVE-2022-42475. The file includes detailed information about the vulnerability, such as its severity, description, and references, as well as the HTTP request and matchers used to detect the vulnerability.

Key changes:

* Added a new YAML file `http/exposed-panels/fortinet-ssl-vpn-cve-2022-42475.yaml` to detect Fortinet SSL-VPN CVE-2022-42475 vulnerability.
* Included metadata such as CVSS score, CWE ID, and CPE for accurate classification of the vulnerability.
* Provided multiple references to external resources for further information and proof of concept.
* Defined HTTP request method, path, and matchers to identify the presence of the vulnerability.

- Added CVE-2022-42475 
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

/claim #10897