### PR TITLE
Add new title support for jenkins-openuser-register.yaml

### DIFF
--- a/http/misconfiguration/jenkins/jenkins-openuser-register.yaml
+++ b/http/misconfiguration/jenkins/jenkins-openuser-register.yaml
@@ -29,6 +29,8 @@ http:
         part: body
         words:
           - "Create an account! [Jenkins]"
+          - "Register [Jenkins]"
+          - "Register - Jenkins"
 
       - type: word
         part: header


### PR DESCRIPTION
### Template / PR Information

Jenkins repository registration page title was updated multiple times since `jenkins-openuser-register` template was created.
I modified it to reflect these changes, so we keep detecting opened registration pages.

- Updated  "Jenkins Open User registration" detection
- References:
    - https://github.com/jenkinsci/jenkins/pull/7872 "Create an account! [Jenkins]" -> "Register [Jenkins]"
    - https://github.com/jenkinsci/jenkins/pull/10178 "Register [Jenkins]" -> "Register - Jenkins"

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)