### PR TITLE
Disabling redirects for mixed-active-content template

### DIFF
--- a/http/misconfiguration/mixed-active-content.yaml
+++ b/http/misconfiguration/mixed-active-content.yaml
@@ -20,9 +20,8 @@ http:
     path:
       - "{{BaseURL}}"
 
-    host-redirects: true
-    max-redirects: 3
     matchers-condition: and
+    max-redirects: 0
     matchers:
       - type: regex
         part: body


### PR DESCRIPTION
### Template / PR Information

Sometimes, a website redirects to HTTP version. The previous template mistakenly marked them as having mixed active content - in reality, the whole website is unencrypted.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
