### PR TITLE
Refactor the "NETDATA" template.

### DIFF
--- a/http/exposed-panels/netdata-panel.yaml
+++ b/http/exposed-panels/netdata-panel.yaml
@@ -2,12 +2,13 @@ id: netdata-panel
 
 info:
   name: Netdata Panel - Detect
-  author: TechbrunchFR
+  author: TechbrunchFR,righettod
   severity: info
   description: |
     Netdata panel was detected.
   reference:
     - https://github.com/netdata/netdata
+    - https://www.netdata.cloud/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -18,6 +19,7 @@ info:
     product: netdata
     shodan-query:
       - http.title:"netdata dashboard"
+      - http.title:"Netdata Console"
       - "server: netdata embedded http server"
     fofa-query: title="netdata dashboard"
     google-query: intitle:"netdata dashboard"
@@ -27,20 +29,33 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/api/v1/info"
+      - "{{BaseURL}}/sign-in"
 
-    matchers-condition: and
+    stop-at-first-match: true
+    matchers-condition: or
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(header), "application/json")'
+          - 'contains(to_lower(body), "netdata")'
+        condition: and
 
-      - type: word
-        part: header
-        words:
-          - "application/json"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>netdata console</title>")'
+        condition: and
 
-      - type: word
+    extractors:
+      - type: regex
         part: body
-        words:
-          - "netdata"
-# digest: 490a004630440220107e0c1ce2e2424cd68b93f784568312fe8d84448148720720ea5ed979db99d4022005f922ca23a057fcd5940737054c03f7eba088b631ef2739ca1dff80263b9880:922c64590222798bb761d5b6d8e72950
+        group: 1
+        regex:
+          - '(?i)version:\s+"([0-9.]+)"'
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)nodeEnv:\s+"([a-z0-9]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **NETDATA** software.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/9b55f562-c265-41c4-a5d7-2704a92f0efa)

Tested against the following hosts found via shodan:

```text
http://184.73.164.241:80
http://27.126.189.15:19999
```

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Netdata+Console%22

![image](https://github.com/user-attachments/assets/074014e9-7935-4762-a36a-a01ee4367288)

### Additional References:

None