### PR TITLE
Added additional status code matching rules for sap-redirect.yaml

### DIFF
--- a/http/vulnerabilities/other/sap-redirect.yaml
+++ b/http/vulnerabilities/other/sap-redirect.yaml
@@ -23,6 +23,8 @@ http:
       - type: status
         status:
           - 302
+          - 301
+          - 307
 
       - type: word
         words:


### PR DESCRIPTION
### Template / PR Information

- Fixed sap-redirect.yaml
- References: https://userapps.support.sap.com/sap/support/knowledge/en/3143650

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Some SAP NetWeaver instances use status codes different from 302 when performing the redirection.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)