### PR TITLE
Add detection of  IRISNext login panel instances.

### DIFF
--- a/http/exposed-panels/irisnext-panel.yaml
+++ b/http/exposed-panels/irisnext-panel.yaml
@@ -1,0 +1,34 @@
+id: irisnext-panel
+
+info:
+  name: IRISNext Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    IRISNext products was detected.
+  reference:
+    - https://www.irislink.com/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"irisnext"
+  tags: panel,irisnext,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dblang.dcw"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>irisnext")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'IRISNext\s+-\s+V([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **IRISNext** software.

References:

- https://www.irislink.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/6b92a746-e04e-45b2-b72d-b19770dc39ec)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://217.31.75.151
https://91.238.31.238
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22irisnext%22

![image](https://github.com/user-attachments/assets/bf7ccb0e-e08a-47a1-81b3-27b2f5a93df5)

### Additional References

None