### PR TITLE
Add detection of ZORAXY login panel instances.

### DIFF
--- a/http/exposed-panels/zoraxy-panel.yaml
+++ b/http/exposed-panels/zoraxy-panel.yaml
@@ -24,5 +24,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "zoraxy</title>", "zoraxy.csrf.Token")'
+          - 'contains_any(to_lower(body), "zoraxy</title>", "zoraxy.csrf.token")'
         condition: and

--- a/http/exposed-panels/zoraxy-panel.yaml
+++ b/http/exposed-panels/zoraxy-panel.yaml
@@ -1,0 +1,28 @@
+id: zoraxy-panel
+
+info:
+  name: Zoraxy Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Zoraxy products was detected.
+  reference:
+    - https://github.com/tobychui/zoraxy
+    - https://zoraxy.aroz.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Login | Zoraxy"
+  tags: panel,zoraxy,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web/login.html"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "zoraxy</title>", "zoraxy.csrf.Token")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **ZORAXY** software.

References:

- https://github.com/tobychui/zoraxy
- https://zoraxy.aroz.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/ae136f79-102c-4dfb-b4a4-9f58ab9a6da6)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://142.132.194.137:8000
http://84.182.146.239:3000
http://170.210.44.231:8000
http://45.76.99.161:8000
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Login+%7C+Zoraxy%22

![image](https://github.com/user-attachments/assets/b3eb9b3c-dc08-42f2-93b0-7f6d3584ef45)

### Additional References

None