### PR TITLE
Add detection of BESZEL login panel instances.

### DIFF
--- a/http/exposed-panels/beszel-panel.yaml
+++ b/http/exposed-panels/beszel-panel.yaml
@@ -1,0 +1,28 @@
+id: beszel-panel
+
+info:
+  name: Beszel Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Beszel products was detected.
+  reference:
+    - https://github.com/henrygd/beszel
+    - https://beszel.dev/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"beszel"
+  tags: panel,beszel,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>beszel</title>")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **BESZEL** software.

References:

- https://github.com/henrygd/beszel
- https://beszel.dev/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/fa1ade4b-e866-4e09-9160-a23caf44c9f5)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://beszel.mulot.dev
https://178.63.189.51
https://128.140.90.59
http://203.91.237.199
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22beszel%22

![image](https://github.com/user-attachments/assets/203633e4-30d8-4207-905e-5f38406fad59)

### Additional References

None