### PR TITLE
add xphoneconnect admin panel detection

### DIFF
--- a/http/exposed-panels/xphoneconnect-admin-panel.yaml
+++ b/http/exposed-panels/xphoneconnect-admin-panel.yaml
@@ -1,7 +1,7 @@
 id: xphoneconnect-admin-panel
 
 info:
-  name: XPhone Connect Admin Interface Detection
+  name: XPhone Connect Admin Interface - Detect
   author: FLX
   severity: info
   description: |
@@ -13,24 +13,29 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:3cx:3cx:*:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
     vendor: c4b
     product: xphone
-    verified: true
     fofa-query: icon_hash="516202656"
-  tags: panel,xphone,login
+  tags: panel,xphone,login,detect
 
 http:
   - method: GET
     path:
+      - '{{BaseURL}}'
       - '{{BaseURL}}/xphoneconnect/admin/Login.aspx'
 
+    host-redirects: true
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "XPhone Connect server - Logon"
+          - "XPhone Web-Meeting"
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

Add detection for xphoneconnect admin panel. These panels are often not detected as they do not appear in normal word lists. They are often misconfigured with insecure/default passwords and lead to compromise of internal domain systems as they are typically connected to internal Active Directory systems.

- References: https://www.c4b.com/en/xphone-connect/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

![image](https://github.com/user-attachments/assets/a007c5f3-44bb-4578-a7de-9593b91671fd)
no google dork, because these pages are not indexed