### PR TITLE
Create chirpstack-default-login.yaml

### DIFF
--- a/http/default-logins/chirpstack/chirpstack-default-login.yaml
+++ b/http/default-logins/chirpstack/chirpstack-default-login.yaml
@@ -1,0 +1,35 @@
+id: chirpstack-default-login
+
+info:
+  name: ChirpStack - Default Login
+  author: t3l3machus
+  severity: high
+  description: Fresh ChirpStack installations use the default credentials (admin/admin), allowing attackers to easily access the admin console.
+  reference:
+    - https://www.chirpstack.io/docs/chirpstack/use/login.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-1392
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"ChirpStack LoRaWAN"
+    fofa-query: title="ChirpStack LoRaWAN"
+  tags: default-login,chirpstack
+
+http:
+  - raw:
+      - |
+        POST /api.InternalService/Login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/grpc-web-text
+        Accept: application/grpc-web-text
+
+        AAAAAA4KBWFkbWluEgVhZG1pbg==
+
+    matchers-condition: and
+    matchers:
+    - type: dsl
+      dsl:
+        - "len(body)>4 && status_code==200 && contains(all_headers, 'application/grpc-web-text+proto')"

--- a/http/default-logins/chirpstack/chirpstack-default-login.yaml
+++ b/http/default-logins/chirpstack/chirpstack-default-login.yaml
@@ -4,7 +4,8 @@ info:
   name: ChirpStack - Default Login
   author: t3l3machus
   severity: high
-  description: Fresh ChirpStack installations use the default credentials (admin/admin), allowing attackers to easily access the admin console.
+  description: |
+    Fresh ChirpStack installations use the default credentials (admin/admin), allowing attackers to easily access the admin console.
   reference:
     - https://www.chirpstack.io/docs/chirpstack/use/login.html
   classification:
@@ -28,8 +29,12 @@ http:
 
         AAAAAA4KBWFkbWluEgVhZG1pbg==
 
-    matchers-condition: and
+      # AAAAAA4KBWFkbWluEgVhZG1pbg== is proto buffer encoded string for admin admin
+
     matchers:
       - type: dsl
         dsl:
-          - "len(body)>4 && status_code==200 && contains(all_headers, 'application/grpc-web-text+proto')"
+          - "contains(content_type, 'application/grpc-web-text+proto')"
+          - "status_code==200"
+          - "contains(body, 'AAAAA')"
+        condition: and

--- a/http/default-logins/chirpstack/chirpstack-default-login.yaml
+++ b/http/default-logins/chirpstack/chirpstack-default-login.yaml
@@ -30,6 +30,6 @@ http:
 
     matchers-condition: and
     matchers:
-    - type: dsl
-      dsl:
-        - "len(body)>4 && status_code==200 && contains(all_headers, 'application/grpc-web-text+proto')"
+      - type: dsl
+        dsl:
+          - "len(body)>4 && status_code==200 && contains(all_headers, 'application/grpc-web-text+proto')"

--- a/http/exposed-panels/chirpstack-login.yaml
+++ b/http/exposed-panels/chirpstack-login.yaml
@@ -8,10 +8,6 @@ info:
     Detects the presence of ChirpStack LoRaWAN Network-Server by identifying unique page characteristics in the HTML response.
   reference:
     - https://www.chirpstack.io/docs/chirpstack/use/login.html
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
-    cvss-score: 8.3
-    cwe-id: CWE-1392
   metadata:
     verified: true
     max-request: 1

--- a/http/exposed-panels/chirpstack-login.yaml
+++ b/http/exposed-panels/chirpstack-login.yaml
@@ -1,0 +1,31 @@
+id: chirpstack-login
+
+info:
+  name: ChirpStack LoRaWAN Detection
+  author: ProjectDiscoveryAI
+  severity: info
+  description: |
+    Detects the presence of ChirpStack LoRaWAN Network-Server by identifying unique page characteristics in the HTML response.
+  reference:
+    - https://www.chirpstack.io/docs/chirpstack/use/login.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-1392
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"ChirpStack LoRaWAN"
+    fofa-query: title="ChirpStack LoRaWAN"
+  tags: panel,chirpstack
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "ChirpStack LoRaWAN"


### PR DESCRIPTION
### Template / PR Information

Added ChirpStack default login credentials check.
Fresh ChirpStack installations use the default credentials (admin/admin), allowing attackers to easily access the admin console.

- References:
https://www.chirpstack.io/docs/chirpstack/use/login.html

### Template Validation

I've validated this template locally?
YES

Command used for testing:
```
.\nuclei.exe -u https://chirpstack.redacted.net/ -t .\chirpstack-default-login.yaml -v -duc -debug
```

### Testing the template with valid default credentials (admin : admin):
![valid](https://github.com/user-attachments/assets/330383b5-a42f-4fa1-b2f5-a53a2552e904)


### Testing the template with intentionally invalid credentials:
![invalid](https://github.com/user-attachments/assets/bc1a3ca3-0021-4518-9be3-75607319cc66)


The matcher checks for:
- the response body size (len(body) > 4 characters, the minimum length for non-empty base64 strings), as failed login attempts return an empty response AND 
- the status code being 200 AND
- The uncommon value `application/grpc-web-text+proto` in `all_headers` that is returned by the server via the `Content-Type` response header.

An additional matcher could be added regarding the existence of the response header-value `Grpc-Message: Invalid%20username%20or%20password` that only appears if the login request fails.

#### Additional Details 
There's hundreds, possibly thousands of servers running with default creds, easily traceable with shodan / fofa, etc
**shodan-query**: http.title:"ChirpStack LoRaWAN"
**fofa-query**: title="ChirpStack LoRaWAN"

### Preview of valid and invalid request and response for clarity:

#### Valid
![image](https://github.com/user-attachments/assets/67e836d8-2e8a-41a7-80d9-0383c1cfc984)

#### Invalid
![image](https://github.com/user-attachments/assets/c16f323a-a6bb-4caa-bf15-ce89d8e4971a)

