### PR TITLE
Update CVE-2025-24813.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-24813.yaml
+++ b/http/cves/2025/CVE-2025-24813.yaml
@@ -14,7 +14,7 @@ info:
     - http://www.openwall.com/lists/oss-security/2025/03/10/5
     - https://nvd.nist.gov/vuln/detail/CVE-2025-24813
   classification:
-    cvss-vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:L
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:L
     cvss-score: 5.5
     cve-id: CVE-2025-24813
     cwe-id: CWE-502


### PR DESCRIPTION
Error detecting the Template with Nuclei due to cvss-vector is not a valid field in Nuclei’s classification schema.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2025-24813


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


##Error 

```
[WRN] Could not load template /root/nuclei-templates/http/cves/2025/CVE-2025-24813.yaml: yaml: unmarshal errors:
  line 17: field cvss-vector not found in type model.Classification
```

##Reason 

```
cvss-vector is not a valid field in Nuclei’s classification schema.

```

