### PR TITLE
implement Unify HiPath Cordless IP Default Login detection template

### DIFF
--- a/http/default-logins/unify/unify-hipath-default-login.yaml
+++ b/http/default-logins/unify/unify-hipath-default-login.yaml
@@ -27,7 +27,7 @@ info:
 http:
   - method: GET
     path:
-      - "/"
+      - "{{BaseURL}}"
 
     matchers:
       - type: word

--- a/http/default-logins/unify/unify-hipath-default-login.yaml
+++ b/http/default-logins/unify/unify-hipath-default-login.yaml
@@ -1,7 +1,7 @@
 id: unify-hipath-default-login
 
 info:
-  name: Unify HiPath Cordless IP Default Login
+  name: Unify HiPath Cordless IP - Default Login
   author: FLX
   severity: high
   description: |
@@ -22,7 +22,7 @@ info:
     max-request: 2
     product: hipath
     vendor: unify
-  tags: default-login, unify, hipath
+  tags: default-login,unify,hipath
 
 http:
   - method: GET

--- a/http/default-logins/unify/unify-hipath-default-login.yaml
+++ b/http/default-logins/unify/unify-hipath-default-login.yaml
@@ -1,0 +1,61 @@
+id: unify-hipath-default-login
+
+info:
+  name: Unify HiPath Cordless IP Default Login
+  author: FLX
+  severity: high
+  description: |
+    Default login credentials on the Unify HiPath Cordless IP admin center were discovered.
+  impact: |
+    An attacker could gain unauthorized access to the admin center and potentially change the configuration of the devices configured on the service.
+  remediation: |
+    Change the default password to a strong password.
+  reference: 
+    - https://wiki.unify.com/images/d/dd/HiPath_Cordless_IP_V1,_Administrator_Documentation.pdf
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-522
+    cpe:  cpe:2.3:a:unify:hipath:*:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    product: hipath
+    vendor: unify
+  tags: default-login, unify, hipath
+
+http:
+  - method: GET
+    path:
+      - "/"
+    
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/html/wbm_login.html"
+
+  - raw:
+      - |
+        POST /cgi-bin/ikon_button.exe?page=1500&button=51&line=0&eventid=0&WbmSessionId=nosession&Username={{user}}&Password={{pass}}&CountryCode=en&NoSessionTimeout=false&SwitchLanguage=false HTTP/1.1
+        Host: {{Hostname}}
+
+    attack: pitchfork
+    payloads:
+      user:
+        - Unify
+      pass:
+        - 1q21q2
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "{\"success\":true"
+          - "There is another user logged in"
+        condition: or

--- a/http/default-logins/unify/unify-hipath-default-login.yaml
+++ b/http/default-logins/unify/unify-hipath-default-login.yaml
@@ -10,13 +10,13 @@ info:
     An attacker could gain unauthorized access to the admin center and potentially change the configuration of the devices configured on the service.
   remediation: |
     Change the default password to a strong password.
-  reference: 
+  reference:
     - https://wiki.unify.com/images/d/dd/HiPath_Cordless_IP_V1,_Administrator_Documentation.pdf
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
     cwe-id: CWE-522
-    cpe:  cpe:2.3:a:unify:hipath:*:*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:unify:hipath:*:*:*:*:*:*:*:*:*
   metadata:
     verified: true
     max-request: 2
@@ -28,7 +28,7 @@ http:
   - method: GET
     path:
       - "/"
-    
+
     matchers:
       - type: word
         part: body


### PR DESCRIPTION
### Template / PR Information

Implementation of default credential detection template for Unifi HiPath Cordless IP which uses `Unify`:`1q21q2`. The first request should validate that there is a real instance which results in less requests when doing on a larger scale. If a user is already logged in with the credentials the response is different so I have added another matcher word.

Reference:
https://wiki.unify.com/images/d/dd/HiPath_Cordless_IP_V1,_Administrator_Documentation.pdf

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Shodan queries are not useful for this type of application because its often found in internal networks.