### PR TITLE
Template missing MFA Check (False Positive)

### DIFF
--- a/cloud/azure/activedirectory/azure-mfa-not-enabled-privileged-users.yaml
+++ b/cloud/azure/activedirectory/azure-mfa-not-enabled-privileged-users.yaml
@@ -11,11 +11,14 @@ info:
     Configure Multi-Factor Authentication for all privileged Azure user accounts to enhance security measures and prevent unauthorized access.
   reference:
     - https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-mfa-howitworks
-  tags: cloud,devops,azure,microsoft,multi-factor-authentication,azure-cloud-config
+    - https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+    - https://docs.microsoft.com/en-us/graph/api/resources/authenticationmethods-overview
+    - https://docs.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-userstates
+  tags: cloud,devops,azure,microsoft,azure-cloud-config,graph-api
 
 flow: |
   code(1);
-  for (let User of iterate(template.userList)) {
+  for (let User of iterate(template.noMfaUsers)) {
     set("userPrincipalName", User);
     code(2);
   }
@@ -26,14 +29,14 @@ code:
       - sh
       - bash
     source: |
-      az ad user list --query '[].{userPrincipalName:userPrincipalName}' --output json
+      az rest --method GET --uri 'https://graph.microsoft.com/v1.0/reports/authenticationMethods/userRegistrationDetails' --query "value[?isMfaRegistered==\`false\`].userPrincipalName"
 
     extractors:
       - type: json
-        name: userList
+        name: noMfaUsers
         internal: true
         json:
-          - '.[].userPrincipalName'
+          - '.[]'
 
   - engine:
       - sh
@@ -41,16 +44,18 @@ code:
     source: |
       az role assignment list --include-classic-administrators true --assignee "$userPrincipalName" --query '[].{roleDefinitionName:roleDefinitionName}' --output json
 
-    matchers-condition: and
     matchers:
       - type: word
         words:
           - 'Owner'
           - 'Contributor'
           - 'Administrator'
+          - 'Reservations Administrator'
+          - 'Role Based Access Control Administrator'
+          - 'User Access Administrator'
 
     extractors:
       - type: dsl
         dsl:
-          - 'userPrincipalName + " is a privileged user without MFA enabled"'
+          - 'userPrincipalName + " is a privileged user without MFA registered"'
 # digest: 4b0a00483046022100ac62c7907ff822f9a0d991f1879f25b4f3d62620f5fa20b030547a2ae093979d022100fd488a6bec4367aeac8a65c1fdc2bde66be3041b2e2d323aae3b0559eb92b362:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Updated azure-mfa-not-enabled-privileged-users template to:
- Added command to check for `isMfaRegistered`
- Added built-in privileged roles (Owner, Contributor, Administrator, Reservations Administrator, RBAC Administrator, User Access Administrator)
- Added reference to Azure RBAC built-in roles documentation

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)