### PR TITLE
Create apache-hertzbeat-detect.yaml

### DIFF
--- a/http/technologies/apache/apache-hertzbeat-detect.yaml
+++ b/http/technologies/apache/apache-hertzbeat-detect.yaml
@@ -19,6 +19,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/assets/app-data.json"
+
     matchers-condition: and
     matchers:
       - type: word
@@ -26,6 +27,7 @@ http:
           - '"name": "HertzBeat"'
           - 'hertzbeat.apache.org'
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/technologies/apache/apache-hertzbeat-detect.yaml
+++ b/http/technologies/apache/apache-hertzbeat-detect.yaml
@@ -1,0 +1,31 @@
+id: apache-hertzbeat-detect
+
+info:
+  name: Apache Hertzbeat - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Hertzbeat web application is in use, that is a real-time monitoring system with agentless, performance cluster, prometheus-compatible, custom monitoring and status page building capabilities.
+  classification:
+    cpe: cpe:2.3:a:apache:hertzbeat:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: hertzbeat
+    shodan-query: title:"HertzBeat"
+  tags: tech,hertzbeat,apache,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/assets/app-data.json"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"name": "HertzBeat"'
+          - 'hertzbeat.apache.org'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-hertzbeat-detect.yaml
+++ b/http/technologies/apache/apache-hertzbeat-detect.yaml
@@ -26,7 +26,7 @@ http:
         words:
           - '"name": "HertzBeat"'
           - 'hertzbeat.apache.org'
-        condition: and
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
This nuclei template:

* Tests if Apache HertzBeat is in use, a real-time monitoring system with agentless, performance cluster, prometheus-compatible, custom monitoring and status page building capabilities.

- References:

https://github.com/apache/hertzbeat

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache HertzBeat Docker:**

1. Running container Doris backend:
`$ docker run -d -p 1157:1157 -p 1158:1158 --name apache-hertzbeat apache/hertzbeat`

2. Get the IP Address of Apache Doris frontend:
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-hertzbeat`

3. And the access URL will be http://<obtained_IP_address>:1157

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-hertzbeat-detect.yaml -u "http://172.17.0.3:1157/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/07b58f8a-8f8f-48df-9347-bdb3219c8c6e)

![image](https://github.com/user-attachments/assets/0cfb79b0-fb91-4f0b-ac8b-daee5ffdedc7)
