### PR TITLE
Added Ingress-Nginx Admission detect template

### DIFF
--- a/http/technologies/ingress-nginx-valid-admissionreview-detect.yaml
+++ b/http/technologies/ingress-nginx-valid-admissionreview-detect.yaml
@@ -1,0 +1,54 @@
+id: ingress-nginx-valid-admissionreview
+info:
+  name: Kubernetes Ingress-Nginx Valid AdmissionReview Detection
+  author: burso
+  severity: info
+  description: |
+    Sends a valid minimal AdmissionReview JSON to reliably detect Kubernetes Ingress-Nginx Admission webhook endpoints.
+  tags: tech,kubernetes,ingress-nginx,ingress,nginx,admission-controller
+
+http:
+  - raw:
+      - |
+        POST /validate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "kind": "AdmissionReview",
+          "apiVersion": "admission.k8s.io/v1",
+          "request": {
+            "uid": "{{randstr}}",
+            "kind": {
+              "group": "networking.k8s.io",
+              "version": "v1",
+              "kind": "Ingress"
+            },
+            "operation": "CREATE",
+            "object": {
+              "metadata": {
+                "name": "test-{{randstr}}",
+                "namespace": "default"
+              },
+              "spec": {
+                "rules": [
+                  {
+                    "host": "example.com",
+                    "http": {
+                      "paths": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'AdmissionReview'
+          - 'response'
+          - 'test-{{randstr}}'
+        condition: and


### PR DESCRIPTION
Template / PR Information

This Nuclei template identifies Kubernetes Ingress-Nginx Admission webhook endpoints by sending a valid AdmissionReview JSON payload specifically crafted to interact with Kubernetes admission webhook APIs. Kubernetes Admission Controllers, such as Ingress-Nginx, validate resource creation and updates through AdmissionReview requests. This template leverages that behavior to confirm the presence of the webhook by analyzing structured AdmissionReview responses or validation error messages returned by the endpoint.

Key points:
	•	Sends a minimal but valid AdmissionReview JSON request for an Ingress resource.
	•	Matches responses that explicitly contain Kubernetes AdmissionReview structures or common validation error messages typically returned by Kubernetes webhook endpoints.
	•	Useful for pentesting, security assessments, and Kubernetes infrastructure discovery, specifically for identifying Ingress-Nginx controllers configured as admission controllers.
	•	References:
	•	[Kubernetes Admission Controllers Documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
	•	[AdmissionReview API Reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#admissionreview-v1-admission-k8s-io)

⸻

Template Validation

I’ve validated this template locally?
	•	YES
	•	Tested against Kubernetes ingress-nginx deployments configured with validating admission webhooks.
