### PR TITLE
Update apache-hertzbeat-default-login.yaml

### DIFF
--- a/http/default-logins/apache/apache-hertzbeat-default-login.yaml
+++ b/http/default-logins/apache/apache-hertzbeat-default-login.yaml
@@ -8,9 +8,10 @@ info:
     Apache HertzBeat enables default admin (and others) credentials. An attacker can execute unauthorized operations.
   reference:
     - https://github.com/apache/hertzbeat
-  tags: apache,hertzbeat,default-login
   metadata:
     max-request: 4
+    verified: true
+  tags: apache,hertzbeat,default-login
 
 variables:
   password: hertzbeat
@@ -31,7 +32,7 @@ http:
         - tom
         - guest
         - lili
-        
+
     matchers-condition: and
     matchers:
       - type: word

--- a/http/default-logins/apache/apache-hertzbeat-default-login.yaml
+++ b/http/default-logins/apache/apache-hertzbeat-default-login.yaml
@@ -2,7 +2,7 @@ id: apache-hertzbeat-default-login
 
 info:
   name: Apache HertzBeat - Default Credentials
-  author: securitytaters, icarot
+  author: securitytaters,icarot
   severity: high
   description: |
     Apache HertzBeat enables default admin (and others) credentials. An attacker can execute unauthorized operations.

--- a/http/default-logins/apache/apache-hertzbeat-default-login.yaml
+++ b/http/default-logins/apache/apache-hertzbeat-default-login.yaml
@@ -11,6 +11,7 @@ info:
   metadata:
     max-request: 4
     verified: true
+    shodan-query: title:"HertzBeat"
   tags: apache,hertzbeat,default-login
 
 variables:

--- a/http/default-logins/apache/apache-hertzbeat-default-login.yaml
+++ b/http/default-logins/apache/apache-hertzbeat-default-login.yaml
@@ -2,16 +2,17 @@ id: apache-hertzbeat-default-login
 
 info:
   name: Apache HertzBeat - Default Credentials
-  author: securitytaters
+  author: securitytaters, icarot
   severity: high
   description: |
-    Apache HertzBeat enables default admin credentials. An attacker can execute unauthorized operations.
+    Apache HertzBeat enables default admin (and others) credentials. An attacker can execute unauthorized operations.
   reference:
     - https://github.com/apache/hertzbeat
   tags: apache,hertzbeat,default-login
+  metadata:
+    max-request: 4
 
 variables:
-  username: admin
   password: hertzbeat
 
 http:
@@ -23,6 +24,14 @@ http:
 
         {"type":0,"identifier":"{{username}}","credential":"{{password}}"}
 
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+        - tom
+        - guest
+        - lili
+        
     matchers-condition: and
     matchers:
       - type: word
@@ -41,4 +50,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4b0a004830460221009949033b0a7fba568acf760259bd61eb07d2220643edb3115900cabc0d21e413022100ff9fed9547e59471e313b853999791fc87568962fc935ef65523f10dc1885211:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This nuclei template:

* Adding three more verification of default accounts in the Hertzbeat Web Application.

- References:

https://github.com/apache/hertzbeat

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache HertzBeat Docker:**

1. Running container Hertzbeat:
`$ docker run -d -p 1157:1157 -p 1158:1158 --name apache-hertzbeat apache/hertzbeat`

2. Get the IP Address of Apache Hertzbeat frontend:
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-hertzbeat`

3.And the access URL will be http://<obtained_IP_address>:1157

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-hertzbeat-default-login.yaml -u "http://172.17.0.3:1157/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/0a7fd625-ca05-49cd-b872-786abbe2e22d)

![image](https://github.com/user-attachments/assets/1c450804-11e0-47e7-82d9-7966835f889f)
