### PR TITLE
fix(xss): use `waitdialog` in dom-xss

### DIFF
--- a/dast/vulnerabilities/xss/dom-xss.yaml
+++ b/dast/vulnerabilities/xss/dom-xss.yaml
@@ -2,7 +2,7 @@ id: dom-xss
 
 info:
   name: DOM Cross Site Scripting
-  author: theamanrawat,AmirHossein Raeisi
+  author: theamanrawat,AmirHossein Raeisi,dwisiswant0
   severity: medium
   description: |
     Detects DOM-based Cross Site Scripting (XSS) vulnerabilities.
@@ -11,25 +11,29 @@ info:
   remediation: |
     Sanitize and validate user input to prevent script injection.
   tags: xss,dom,dast,headless
+
 variables:
   num: "{{rand_int(10000, 99999)}}"
+
 headless:
   - steps:
       - action: navigate
         args:
           url: "{{BaseURL}}"
 
-      - action: waitload
+      - action: waitdialog
+        name: reflected
+
     payloads:
       reflection:
-        - "'\"><h1>{{num}}</h1>"
+        - "'\"><script>alert({{num}})</script>"
 
     fuzzing:
       - part: query
         type: postfix
         mode: single
         fuzz:
-          - "{{reflection}}"
+          - "{{url_encode(reflection)}}"
 
       - part: path
         type: postfix
@@ -38,15 +42,8 @@ headless:
           - "{{reflection}}"
 
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "<h1>{{num}}</h1>"
-
-      - type: word
-        part: header
-        words:
-          - "text/html"
-# digest: 4a0a00473045022100a376112ac616c2d38a2243a8543d3497e3882c834b51e2c47b289e43a5b7134e022075dbb9f4451bec92b6385d4db956aec9812f5548795500b322831abd67f03bd7:922c64590222798bb761d5b6d8e72950
+      - type: dsl
+        dsl:
+          - reflected == true
+          - reflected_message == num

--- a/dast/vulnerabilities/xss/dom-xss.yaml
+++ b/dast/vulnerabilities/xss/dom-xss.yaml
@@ -47,3 +47,4 @@ headless:
         dsl:
           - reflected == true
           - reflected_message == num
+        condition: and


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed dom-xss.yaml

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


**Proof:**

HTML:

```html
<html>
<head>
    <title>Nuclei Test Page</title>
</head>
<body>
<script type="text/javascript">
const urlParams = new URLSearchParams(window.location.search);
const nameContent = urlParams.get('name');
if (nameContent) document.write(nameContent);
</script>
</body>
</html>
```

Usage:

```bash
nuclei -t ./dast/vulnerabilities/xss/dom-xss.yaml -dast -headless -u "http://127.0.0.1:8080/?name=John"
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)