### PR TITLE
Add detection of the LUXTRUST COSI product.

### DIFF
--- a/http/technologies/luxtrust-cosi-detect.yaml
+++ b/http/technologies/luxtrust-cosi-detect.yaml
@@ -1,0 +1,26 @@
+id: luxtrust-cosi-detect
+
+info:
+  name: LuxTrust COSI - Detect
+  author: righettod
+  severity: info
+  description: |
+     LuxTrust COSI was detected.
+  reference:
+    - https://luxtrust.com/en/professionals/our-digital-solutions/sign-electronically
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,luxtrust,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web/thanks"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "plateforme de signature", "esign-web")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect the **LUXTRUST COSI** product.

[LUXTRUST](https://luxtrust.com/en) is a Luxembourgish company and its is a Certificate Authority.

COSI is a product to sign document that is commonly used in Luxembourg:

https://luxtrust.com/en/professionals/our-digital-solutions/sign-electronically

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against https://esign.post.lu

![image](https://github.com/user-attachments/assets/2cb2d6b3-528c-42c6-9a7c-3f71bd696063)


#### Additional Details (leave it blank if not applicable)

None

#### Additional References:

None