### PR TITLE
Add detection of IBM Spectrum products instances. 

### DIFF
--- a/http/technologies/ibm/ibm-spectrum-detect.yaml
+++ b/http/technologies/ibm/ibm-spectrum-detect.yaml
@@ -22,8 +22,6 @@ http:
       - "{{BaseURL}}/JNLP"
 
     stop-at-first-match: true
-    redirects: true
-    max-redirects: 2
     matchers:
       - type: dsl
         dsl:

--- a/http/technologies/ibm/ibm-spectrum-detect.yaml
+++ b/http/technologies/ibm/ibm-spectrum-detect.yaml
@@ -1,0 +1,40 @@
+id: ibm-spectrum-detect
+
+info:
+  name: IBM Spectrum - Detect
+  author: righettod
+  severity: info
+  description: |
+    IBM Spectrum products was detected.
+  reference:
+    - https://www.ibm.com/docs/en/products?filter=spectrum
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"IBM Spectrum"
+  tags: tech,ibm
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"    
+      - "{{BaseURL}}/BACLIENT"
+      - "{{BaseURL}}/JNLP"
+
+    stop-at-first-match: true
+    redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "ibm spectrum", "com.ibm.")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"guiVersion"\s*:\s*"([0-9.\-]+)"'
+          - '(?i)name="?version"?\s+value="?([0-9.\-]+)"?'

--- a/http/technologies/ibm/ibm-spectrum-detect.yaml
+++ b/http/technologies/ibm/ibm-spectrum-detect.yaml
@@ -17,7 +17,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"    
+      - "{{BaseURL}}/"
       - "{{BaseURL}}/BACLIENT"
       - "{{BaseURL}}/JNLP"
 

--- a/http/technologies/ibm/ibm-spectrum-detect.yaml
+++ b/http/technologies/ibm/ibm-spectrum-detect.yaml
@@ -12,7 +12,7 @@ info:
     max-request: 1
     verified: true
     shodan-query: http.title:"IBM Spectrum"
-  tags: tech,ibm
+  tags: tech,ibm,spectrum
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **IBM Spectrum** software.

References:

- https://www.ibm.com/docs/en/products?filter=spectrum

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/9e0c17c8-fe6e-46b4-9673-784064aa8749)

Hosts used for the test found via Shodan and/or https://crt.sh :

```
https://147.32.87.124
https://52.116.109.132
https://101.42.169.57
http://182.79.33.172:1588
http://131.94.83.82:1500
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22IBM+Spectrum%22

![image](https://github.com/user-attachments/assets/a768910d-aa69-4391-80ed-ee8b803e69d1)

### Additional References

None