### PR TITLE
Create apache-activemq-artemis-detect.yaml

### DIFF
--- a/http/technologies/apache/apache-activemq-artemis-detect.yaml
+++ b/http/technologies/apache/apache-activemq-artemis-detect.yaml
@@ -11,7 +11,6 @@ info:
   metadata:
     max-request: 1
     vendor: apache
-    product: activemq artemis
     shodan-query: title:"ActiveMQ Artemis Console"
   tags: tech,activemq,artemis,apache,detect
 

--- a/http/technologies/apache/apache-activemq-artemis-detect.yaml
+++ b/http/technologies/apache/apache-activemq-artemis-detect.yaml
@@ -1,0 +1,30 @@
+id: apache-activemq-artemis-detect
+
+info:
+  name: Apache ActiveMQ Artemis - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache ActiveMQ Artemis Console, the next generation message broker by ActiveMQ.
+  reference:
+    - https://github.com/apache/activemq-artemis/
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: activemq artemis
+    shodan-query: title:"ActiveMQ Artemis Console"
+  tags: tech,activemq,artemis,apache,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/console/hawtconfig.json"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'img/activemq.png'
+          - 'ActiveMQ Artemis'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-activemq-artemis-detect.yaml
+++ b/http/technologies/apache/apache-activemq-artemis-detect.yaml
@@ -14,10 +14,12 @@ info:
     product: activemq artemis
     shodan-query: title:"ActiveMQ Artemis Console"
   tags: tech,activemq,artemis,apache,detect
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/console/hawtconfig.json"
+
     matchers-condition: and
     matchers:
       - type: word
@@ -25,6 +27,7 @@ http:
           - 'img/activemq.png'
           - 'ActiveMQ Artemis'
         condition: and
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache ActiveMQ Artemis Console, the next generation message broker by ActiveMQ.

- References:

https://github.com/apache/activemq-artemis/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache ActiveMQ Artemis Console Docker:**

1. Running container:

`$ git clone https://github.com/apache/activemq-artemis/`
`$ cd activemq-artemis/artemis-docker/`
`$ ./prepare-docker.sh  --from-release --artemis-version 2.40.0`
`$ docker build -f ./docker/Dockerfile-ubuntu-21 -t artemis-ubuntu .`
`$ docker run --detach --name apache-activemq-artemis -p 61616:61616 -p 8161:8161 --rm artemis-ubuntu:latest`

2. Acessing the Apache Kyuubi service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-activemq-artemis`

And the access URL will be http://<obteined_inspect_IP_Address>:8161/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-activemq-artemis-detect.yaml -u "http://<obteined_inspect_IP_Address>:8161/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/6633af44-ca04-4c99-af25-fa07c55aa160)

![image](https://github.com/user-attachments/assets/663d24fa-0fb2-4ee1-a934-b9e8b74071c8)
