### PR TITLE
Move http/cves/2025/CVE-2025-2825.yaml template to http/cves/2025/CVE-2025-31161.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-31161.yaml
+++ b/http/cves/2025/CVE-2025-31161.yaml
@@ -1,8 +1,8 @@
-id: CVE-2025-2825
+id: CVE-2025-31161
 
 info:
   name: CrushFTP - Authentication Bypass
-  author: parthmalhotra,Ice3man,DhiyaneshDk,pdresearch
+  author: parthmalhotra,Ice3man,DhiyaneshDk,pdresearch,whattheslime
   severity: critical
   description: |
     CrushFTP versions 10.0.0 through 10.8.3 and 11.0.0 through 11.3.0 are affected by a vulnerability that may result in unauthenticated access. Remote and unauthenticated HTTP requests to CrushFTP may allow attackers to gain unauthorized access.
@@ -10,11 +10,11 @@ info:
     - https://projectdiscovery.io/blog/crushftp-authentication-bypass/
     - https://www.rapid7.com/blog/post/2025/03/25/etr-notable-vulnerabilities-in-next-js-cve-2025-29927/
     - https://www.crushftp.com/crush11wiki/Wiki.jsp?page=Update
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-2825
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-31161
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2025-2825
+    cve-id: CVE-2025-31161
     cwe-id: CWE-287
     epss-score: 0.00039
     epss-percentile: 0.08378
@@ -67,4 +67,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 490a00463044022040fadb7bb072c6017cafa22449f56440b96a00a47ddff237bf5bce5a9e083b5902203c677e83121fb11ab6bfe13ba1cefd07aada521c864d14c7bfd59923ef3dc638:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

According to the CVE organization, the CVE record 2025-2825 should no longer be used, as it is a duplicate reservation of CVE-2025-31161.

I therefore thought it would be better to rename this file to avoid any confusion.

- Updated CVE-2025-2825
- References: https://www.cve.org/CVERecord/SearchResults?query=CVE-2025-2825

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)