### PR TITLE
Add detection of COCKPIT PROJECT login panel instances.

### DIFF
--- a/http/exposed-panels/cockpit-project-panel.yaml
+++ b/http/exposed-panels/cockpit-project-panel.yaml
@@ -29,15 +29,21 @@ http:
 
     extractors:
       - type: regex
-        name: os
         part: body
+        name: os
         group: 1
         regex:
           - '(?i)"PRETTY_NAME"\s*:\s*"(.*?)"'
+        internal: true
 
       - type: regex
-        name: hostname
         part: body
+        name: hostname
         group: 1
         regex:
           - '(?i)"hostname"\s*:\s*"(.*?)"'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"OS: " + os + " | Hostname: " + hostname'

--- a/http/exposed-panels/cockpit-project-panel.yaml
+++ b/http/exposed-panels/cockpit-project-panel.yaml
@@ -29,8 +29,15 @@ http:
 
     extractors:
       - type: regex
+        name: os
         part: body
         group: 1
         regex:
           - '(?i)"PRETTY_NAME"\s*:\s*"(.*?)"'
+
+      - type: regex
+        name: hostname
+        part: body
+        group: 1
+        regex:
           - '(?i)"hostname"\s*:\s*"(.*?)"'

--- a/http/exposed-panels/cockpit-project-panel.yaml
+++ b/http/exposed-panels/cockpit-project-panel.yaml
@@ -1,0 +1,36 @@
+id: cockpit-project-panel
+
+info:
+  name: Cockpit Project Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Cockpit Project products was detected.
+  reference:
+    - https://github.com/cockpit-project/cockpit
+    - https://cockpit-project.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.html:"cockpit/static/login.css"
+  tags: panel,cockpit,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "cockpit/", "is_cockpit_client")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"PRETTY_NAME"\s*:\s*"(.*?)"'
+          - '(?i)"hostname"\s*:\s*"(.*?)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **COCKPIT PROJECT** software.

References:

- https://github.com/cockpit-project/cockpit
- https://cockpit-project.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/5a4ba385-6f03-4ebb-be59-c11c4e8a8bbf)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://172.233.80.157
https://193.57.159.9
https://104.157.61.79
https://38.242.133.34
http://62.210.95.245:9090
http://57.128.166.73:9090
http://54.39.118.54:9090
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.html%3A%22cockpit%2Fstatic%2Flogin.css%22

![image](https://github.com/user-attachments/assets/4066bf98-8183-4367-954c-a85ba5114731)

### Additional References

None