### PR TITLE
Added HP printer default credentials template.

### DIFF
--- a/network/default-login/hp-printer-default-credentials.yaml
+++ b/network/default-login/hp-printer-default-credentials.yaml
@@ -1,0 +1,55 @@
+id: hp-printer-default-admin-login
+
+info:
+  name: Hewlett Packard LaserJet Printer Firmware Version 5.8.1.1 - Default Credentials
+  author: John Osborn (Summit Security Group, LLC)
+  severity: high
+  description: HP printers do not use a password when authenticating as the Administrator user by default. This template detects HP printers that allow this administrative login without a password.
+  reference: https://h30434.www3.hp.com/t5/Printing-Errors-or-Lights-Stuck-Print-Jobs/What-is-the-user-name-and-password-in-Embedded-Web-Server/td-p/6165417
+  tags: hp,printer,network,default-login,misconfig
+  metadata:
+    verified: true
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/hp/device/SignIn/Index"
+    headers:
+      User-Agent: Mozilla/5.0
+      Accept-Encoding: identity
+
+    extractors:
+      - type: regex
+        name: token
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - 'id="CSRFToken" name="CSRFToken" value="([^"]+)"'
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/hp/device/SignIn/Index"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      Referer: "{{BaseURL}}/hp/device/SignIn/Index"
+      Origin: "{{BaseURL}}"
+      User-Agent: Mozilla/5.0
+      Accept-Encoding: identity
+    body: |
+      CSRFToken={{token}}&agentIdSelect=hp_EmbeddedPin_v1&PinDropDown=AdminItem&PasswordTextBox=&signInOk=Sign+In
+    cookie-reuse: true
+    redirects: true
+    max-redirects: 2
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "User: Administrator"
+          - "Sign out"
+      - type: regex
+        part: header
+        regex:
+          - 'Set-Cookie: .*session.*'


### PR DESCRIPTION
### Template / PR Information

I created a template that detected certain HP printer installations that use default credentials (Administrator:blank).

- Added hp-printer-default-credentials.yaml
- References: https://h30434.www3.hp.com/t5/Printing-Errors-or-Lights-Stuck-Print-Jobs/What-is-the-user-name-and-password-in-Embedded-Web-Server/td-p/6165417

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
Below, is the verified output confirming that the template works as intended and the matchers catch the vulnerability accurately. 

The screenshots illustrate the initial GET request needed to access the login page, and the subsequent POST request made to the server using the default credentials and regex'd CSRF token. Lastly, the template matchers in the last screenshot show the template matched the words "User: Administrator" which is only present when successfully logged in as the administrator user, as well as the new cookies that are set with the Set-Cookie header in the response from the web server.

In total, the template is configured to match either the words "User: Administrator" or catch the new cookie that is offered by the server.

![HP Default Creds Poc 1 ](https://github.com/user-attachments/assets/b31f405b-1344-4520-b77d-2bf4280134fa)
![HP Default Creds Poc 2](https://github.com/user-attachments/assets/2680799b-a043-4286-b612-99a2ac824cbb)
![HP Default Creds Poc 3](https://github.com/user-attachments/assets/0ca9bca9-7b1e-4ec5-abdd-f4bfa4fe2ea1)
![HP Default Creds Poc 4](https://github.com/user-attachments/assets/b4a9a605-3388-4c82-9387-05973a7fe38b)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

