### PR TITLE
Remove unneeded elements from standard requests

### DIFF
--- a/http/exposed-panels/saltgui-panel.yaml
+++ b/http/exposed-panels/saltgui-panel.yaml
@@ -17,7 +17,6 @@ http:
     path:
       - "{{BaseURL}}"
 
-    unsafe: true
     host-redirects: true
     max-redirects: 2
 

--- a/http/exposed-panels/wildix-collaboration-panel.yaml
+++ b/http/exposed-panels/wildix-collaboration-panel.yaml
@@ -21,7 +21,6 @@ http:
     path:
       - "{{BaseURL}}"
 
-    stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
 


### PR DESCRIPTION
This should help make those requests "clusterable" with requests from other templates.
