### PR TITLE
Add detection of BMC Control-M MFT login panel instances.

### DIFF
--- a/http/exposed-panels/bmc/bmc-controlm-mft-panel.yaml
+++ b/http/exposed-panels/bmc/bmc-controlm-mft-panel.yaml
@@ -1,0 +1,29 @@
+id: bmc-controlm-mft-panel
+
+info:
+  name: BMC Control-M MFT Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    BMC Control-M MFT products was detected.
+  reference:
+    - https://documents.bmc.com/supportu/9.0.21/en-US/Documentation/Managed_File_Transfer.htm
+    - https://documents.bmc.com/supportu/9.0.21/en-US/Documentation/home.htm
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"File Exchange"
+  tags: panel,bmc,login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "file exchange</title>")'          
+          - 'contains_any(to_lower(body), "main-b2b-icon.png", "fileexchange.ico")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **BMC Control-M MFT** software.

References:

- https://documents.bmc.com/supportu/9.0.21/en-US/Documentation/Managed_File_Transfer.htm
- https://documents.bmc.com/supportu/9.0.21/en-US/Documentation/home.htm

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/ac57ba6b-9a61-4fd9-bb1c-8864f7835964)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://85.233.202.247:7443
https://170.34.80.27:9443
https://162.27.153.230
https://205.138.253.148:9443
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22File+Exchange%22

![image](https://github.com/user-attachments/assets/8c183e60-8328-4bad-b995-74e940f71685)

### Additional References

None