### PR TITLE
Improve Detection Accuracy by Removing Optional Header Matcher from `wordpress-debug-log.yaml`

### DIFF
--- a/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-debug-log.yaml
@@ -2,7 +2,7 @@ id: wp-debug-log
 
 info:
   name: WordPress Debug Log - Exposure
-  author: geraldino2,dwisiswant0,philippedelteil
+  author: geraldino2,dwisiswant0,philippedelteil,FLX
   severity: low
   description: Exposed Wordpress debug log.
   metadata:
@@ -27,13 +27,6 @@ http:
     max-size: 5000
     matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - octet-stream
-          - text/plain
-        condition: or
-
       - type: regex
         part: body
         regex:


### PR DESCRIPTION
**Description**:
I've removed the `header` matcher from the `wordpress-debug-log.yaml` Nuclei template because it's not always set in real-world cases, and the `or` condition within that matcher wasn't sufficient to cover all scenarios.

In multiple live instances, WordPress debug logs were publicly exposed, but the template failed to trigger due to the absence of the `Content-Type` header (specifically `octet-stream` or `text/plain`). Once I removed the header matcher, the template correctly detected the exposed logs.

I believe that the combination of the `regex` in the response body and the status code is sufficient for reliably identifying this exposure. This change improves detection without increasing false positives based on my testing.

**Changes Made**:
- Removed:
  ```yaml
  - type: word
    part: header
    words:
      - octet-stream
      - text/plain
    condition: or
  ```
- Added one more author: `FLX`

Let me know if further validation is needed or if there's a preferred alternative approach.