### PR TITLE
improve typo3-debug-mode.yaml detection

### DIFF
--- a/http/misconfiguration/typo3-debug-mode.yaml
+++ b/http/misconfiguration/typo3-debug-mode.yaml
@@ -2,7 +2,7 @@ id: typo3-debug-mode
 
 info:
   name: TYPO3 Debug Mode Enabled
-  author: tess
+  author: tess,FLX
   severity: low
   description: TYPO3 Debug Mode is enabled.
   classification:
@@ -29,7 +29,7 @@ http:
           - "Uncaught TYPO3 Exception"
         condition: or
 
-      - type: status
-        status:
-          - 500
+      - type: dsl
+        dsl:
+          - "status_code >= 500 && status_code < 600"
 # digest: 4b0a00483046022100afadd26c40c0181eb72c9da56ab9bf27e9219ba68394e0e2391afe09b24ec186022100fe09a24056a8a3cb83cc74a5ce8119b8990d3645e902349ec7cd4fe5dcf4dbb1:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
In some cases (e.g. if the database is not available) the error message is not 500 but 503, so to match any 5xx status code a DSL matcher replaces the simple status code matcher.