### PR TITLE
Create apache-kyuubi-detect.yaml and apache-kyuubi-config.yaml

### DIFF
--- a/http/exposures/configs/apache-kyuubi-config.yaml
+++ b/http/exposures/configs/apache-kyuubi-config.yaml
@@ -1,7 +1,7 @@
 id: apache-kyuubi-config
 
 info:
-  name: Apache Kyuubi - Exposure
+  name: Apache Kyuubi - Configuration Exposure
   author: icarot
   severity: medium
   description: |
@@ -18,6 +18,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/engine-ui/0.0.0.0:4040/environment/"
+
     matchers-condition: and
     matchers:
       - type: word
@@ -26,6 +27,7 @@ http:
           - 'kyuubi'
           - '/opt/apache-kyuubi'
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/exposures/configs/apache-kyuubi-config.yaml
+++ b/http/exposures/configs/apache-kyuubi-config.yaml
@@ -25,7 +25,6 @@ http:
         words:
           - 'Environment</title>'
           - 'kyuubi'
-          - '/opt/apache-kyuubi'
         condition: and
 
       - type: status

--- a/http/exposures/configs/apache-kyuubi-config.yaml
+++ b/http/exposures/configs/apache-kyuubi-config.yaml
@@ -1,0 +1,31 @@
+id: apache-kyuubi-config
+
+info:
+  name: Apache Kyuubi - Exposure
+  author: icarot
+  severity: medium
+  description: |
+    Detects if path Appconfigs of Apache Kyuubi web application is exposed, getting internal information about the configuration made.
+  classification:
+    cpe: cpe:2.3:a:apache:kyuubi:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: kyuubi
+  tags: config,exposure,kyuubi,apache
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/engine-ui/0.0.0.0:4040/environment/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Environment</title>'
+          - 'kyuubi'
+          - '/opt/apache-kyuubi'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-kyuubi-detect.yaml
+++ b/http/technologies/apache/apache-kyuubi-detect.yaml
@@ -1,7 +1,7 @@
 id: apache-kyuubi-detect
 
 info:
-  name: Apache Kyuubi - Detection
+  name: Apache Kyuubi - Detect
   author: icarot
   severity: info
   description: |
@@ -15,16 +15,18 @@ info:
     vendor: apache
     product: kyuubi
   tags: tech,kyuubi,apache,detect
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/ui/"
+
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - '<title>Apache Kyuubi Dashboard</title>'
-        condition: and
+          - '<title>Apache Kyuubi Dashboard'
+
       - type: status
         status:
           - 200

--- a/http/technologies/apache/apache-kyuubi-detect.yaml
+++ b/http/technologies/apache/apache-kyuubi-detect.yaml
@@ -1,0 +1,30 @@
+id: apache-kyuubi-detect
+
+info:
+  name: Apache Kyuubi - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Kyuubi server, a distributed and multi-tenant gateway to provide serverless SQL on data warehouses and lakehouses.
+  reference:
+    - https://github.com/apache/kyuubi/
+  classification:
+    cpe: cpe:2.3:a:apache:kyuubi:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: kyuubi
+  tags: tech,kyuubi,apache,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Apache Kyuubi Dashboard</title>'
+        condition: and
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache Kyuubi web application, a distributed and multi-tenant gateway to provide serverless SQL on data warehouses and lakehouses.
* Detects if path Appconfigs of Apache Kyuubi web application is exposed, getting internal information about the configuration made.

- References:

https://github.com/apache/kyuubi/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Kyuubi Docker:**

1. Running container:

`$ git clone https://github.com/apache/kyuubi/`
`$ cd kyuubi/docker/playground/`
`$ docker compose up -d`

2. Acessing the Apache Kyuubi service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kyuubi`

3. Starting a docker container Kali in the same network as the Apache Kyuubi:

`$ docker run --rm --tty --interactive --network playground_default --dns 8.8.8.8 --dns 8.8.4.4 --name container_kali kalilinux/kali-rolling /bin/bash`

And the access URL will be http://<obteined_inspect_IP_Address>:10099/

4. Execute a SQL on the SQL Editor:
Access "http://<obteined_inspect_IP_Address>:10099/ui/editor" and execute the following SQL Query "select version();".

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-kyuubi-detect.yaml -t apache-kyuubi-config.yaml -u "http://<obteined_inspect_IP_Address>:10099" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/9c7e8ac8-68f7-4a55-ad51-fc7da4960758)

![image](https://github.com/user-attachments/assets/eb149cf1-d7b7-402d-895e-cfb071ca53e9)

![image](https://github.com/user-attachments/assets/e29602dd-e4bd-4003-9a95-bcfeded9f736)
