### PR TITLE
Fix Huawei WAF detection rule: server header returns elb in most cases

### DIFF
--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -743,9 +743,9 @@ http:
         name: huaweicloud
         condition: and
         regex:
-          - '(?)content="CloudWAF"'
-          - 'Server: CloudWAF'
+          - '(?i)content="CloudWAF"'
           - 'Set-Cookie: HWWAFSESID='
+          - 'Set-Cookie: HWWAFSESTIME='
 
       - type: word
         name: safe3webfirewall


### PR DESCRIPTION
### Template / PR Information

Huawei WAF detection template didn't detect an app behind CloudWAF, problem relates to response header not returning Server: CloudWAF, but Server: elb in the cases I've tried, so changed that alongside with the (?) typo in - '(?)content="CloudWAF"' regex to (?i) too.

- Updated http/technologies/waf-detect/huaweicloud patterns
- References: used https://consumer.huawei.com/tr/ (yes /tr/ is behind CloudWAF while original site isn't) to test CloudWAF pattern alongside some others, this correctly detects CloudWAF while older version didn't.

I've validated this template locally?
- [ x] YES
- [ ] NO
