### PR TITLE
Create trust-center.yaml (Detection of Trust Center Pages/Subdomains)

### DIFF
--- a/http/miscellaneous/trust-center-detect.yaml
+++ b/http/miscellaneous/trust-center-detect.yaml
@@ -29,13 +29,6 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - '(?i)<title>\s*([^<]*trust center[^<]*)<\/title>'
-          - '(?i)<title>\s*([^<]*trust portal[^<]*)<\/title>'
-        condition: or
-
       - type: word
         words:
           - "Trust Center"

--- a/http/miscellaneous/trust-center-detect.yaml
+++ b/http/miscellaneous/trust-center-detect.yaml
@@ -1,7 +1,7 @@
 id: trust-center-detect
 
 info:
-  name: Trust Center Page - Detection
+  name: Trust Center Page - Detect
   author: ajdumanhug
   severity: info
   description: |
@@ -23,7 +23,6 @@ http:
       - "{{BaseURL}}/compliance"
 
     stop-at-first-match: true
-
     redirects: true
     max-redirects: 2
 

--- a/http/miscellaneous/trust-center-detect.yaml
+++ b/http/miscellaneous/trust-center-detect.yaml
@@ -1,16 +1,16 @@
-id: trust-center
+id: trust-center-detect
 
 info:
-  name: Trust Center Page
+  name: Trust Center Page - Detection
   author: ajdumanhug
   severity: info
   description: |
-    Detects presence of Trust Center pages or subdomains provided by Safebase, Vanta, TrustCloud
+    Detected the presence of Trust Center pages or subdomains provided by Safebase, Vanta, or TrustCloud.
   metadata:
     verified: true
     max-request: 6
     shodan-query: http.title:"Trust Center"
-  tags: miscellaneous,misc,generic,trust-center,reconnaissance
+  tags: misc,trust,center,generic
 
 http:
   - method: GET
@@ -23,15 +23,12 @@ http:
       - "{{BaseURL}}/compliance"
 
     stop-at-first-match: true
+
     redirects: true
     max-redirects: 2
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: regex
         part: body
         regex:
@@ -47,3 +44,7 @@ http:
           - "static.vanta.com/static/entry-trust-report.js"
         condition: or
         case-insensitive: true
+
+      - type: status
+        status:
+          - 200

--- a/http/miscellaneous/trust-center.yaml
+++ b/http/miscellaneous/trust-center.yaml
@@ -1,0 +1,49 @@
+id: trust-center
+
+info:
+  name: Trust Center Page
+  author: ajdumanhug
+  severity: info
+  description: |
+    Detects presence of Trust Center pages or subdomains provided by Safebase, Vanta, TrustCloud
+  metadata:
+    verified: true
+    max-request: 6
+    shodan-query: http.title:"Trust Center"
+  tags: miscellaneous,misc,generic,trust-center,reconnaissance
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/trust"
+      - "{{BaseURL}}/trust-center"
+      - "{{BaseURL}}/trust-center.html"
+      - "{{BaseURL}}/security"
+      - "{{BaseURL}}/compliance"
+
+    stop-at-first-match: true
+    redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - '(?i)<title>\s*([^<]*trust center[^<]*)<\/title>'
+          - '(?i)<title>\s*([^<]*trust portal[^<]*)<\/title>'
+        condition: or
+
+      - type: word
+        words:
+          - "Trust Center"
+          - "Powered by Safebase"
+          - "TrustShare Overview"
+          - "static.vanta.com/static/entry-trust-report.js"
+        condition: or
+        case-insensitive: true


### PR DESCRIPTION
### Template / PR Information
This template detects presence of Trust Center pages or subdomains provided by Safebase, Vanta, TrustCloud

I used the following URLs for test purposes:
- https://trust.openai.com/
- https://trust.offsec.com/
- https://trust.gitlab.com/
- https://security.crossbeam.com/
- https://security.abnormal.ai
- https://security.asana.com/
- https://trust.dedupe.ly/
- https://www.trellix.com/
- https://www.thomsonreuters.com/
- https://www.onetrust.com/
- https://www.atlassian.com/
- https://aws.amazon.com/
- https://cloud.google.com/
- https://www.docusign.com/
- https://www.articulate.com/
- https://www.canva.com/

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

![image](https://github.com/user-attachments/assets/a8867e5e-b644-45cb-b05b-1cd31052e292)

Based on the results, there are some URLs from the list that weren't detected. This is likely because a few of them have Cloudflare challenges in place.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)