### PR TITLE
Update Token spray README.md

### DIFF
--- a/http/token-spray/README.md
+++ b/http/token-spray/README.md
@@ -8,10 +8,10 @@ token-spray are **self-contained** template and does not requires URLs as input 
 
 ```console
 # Running token-spray templates against a single token to test
-nuclei -t token-spray/ -var token=random-token-to-test
+nuclei -t token-spray/ -var token=random-token-to-test -esc
 
 # Running token-spray templates against a file containing multiple new line delimited tokens
-nuclei -t token-spray/ -var token=file_with_tokens.txt
+nuclei -t token-spray/ -var token=file_with_tokens.txt -esc
 ```
 
 ## Credits


### PR DESCRIPTION
Templates dont run as written in the Readme anymore. requires -esc for these to run on my side.

### Template / PR Information

Updated token spray readme to account for the change for -esc flag for self contained files

### Template Validation

I've validated this template locally?
n/a

#### Additional Details (leave it blank if not applicable)
[WRN] Excluded 247 self-contained template[s] (disabled as default), use -esc option to run self-contained templates.