### PR TITLE
Update intercom-identity-misconfiguration.yaml

### DIFF
--- a/http/misconfiguration/intercom-identity-misconfiguration.yaml
+++ b/http/misconfiguration/intercom-identity-misconfiguration.yaml
@@ -28,8 +28,9 @@ http:
       - type: word
         words:
           - "app_id:"
+          - "widget.intercom.io/widget"
         internal: true
-
+    
     extractors:
       - type: regex
         name: intercom_app_id
@@ -37,6 +38,7 @@ http:
         group: 1
         regex:
           - 'app_id:\s*"([a-zA-Z0-9\-]+)"'
+          - "widget\\.intercom\\.io/widget/([^\"']+)"
         internal: true
 
   - method: POST
@@ -55,4 +57,3 @@ http:
       - type: dsl
         dsl:
           - Input
-# digest: 4a0a00473045022028190efeb0390c4eccce2954ac93fda17c5654dce6d0af237bdf7289eb58d178022100caefb1b838e7b59252c17494f76806f25b78a218a5913940996f82c8a394f925:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/intercom-identity-misconfiguration.yaml
+++ b/http/misconfiguration/intercom-identity-misconfiguration.yaml
@@ -30,7 +30,7 @@ http:
           - "app_id:"
           - "widget.intercom.io/widget"
         internal: true
-    
+
     extractors:
       - type: regex
         name: intercom_app_id


### PR DESCRIPTION
### Template / PR Information

This template relied on the `window.intercomSettings = {"app_id":"<redacted>"};` being in the response which may not be the case without using a headless browser. I have added an additional regex "widget\\.intercom\\.io/widget/([^\"']+)" to match `"messengerUrl":"https://widget.intercom.io/widget/<redacted>"` which should be there even in non-headless browsers

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)