### PR TITLE
Fixed FP - s3-bucket-policy-public-access.yaml

### DIFF
--- a/cloud/aws/s3/s3-bucket-policy-public-access.yaml
+++ b/cloud/aws/s3/s3-bucket-policy-public-access.yaml
@@ -27,7 +27,7 @@ code:
       aws s3api list-buckets --query 'Buckets[*].Name'
 
     extractors:
-      - type: json # type of the extractor
+      - type: json
         internal: true
         name: buckets
         json:
@@ -39,21 +39,13 @@ code:
     source: |
       aws s3api get-bucket-policy --bucket $bucket --query Policy --output text
 
-    matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - '"Effect":"Allow"'
-
-      - type: word
-        part: body
-        words:
-          - '"Principal":"*"'
-          - '"AWS":"*"'
+        regex:
+          - '\{[^}]*?(?:(?:"Effect"\s*:\s*"Allow"[^}]*?"Principal"\s*:\s*(?:"\*"|\{\s*"AWS"\s*:\s*"\*"\s*\}))|(?:"Principal"\s*:\s*(?:"\*"|\{\s*"AWS"\s*:\s*"\*"\s*\})[^}]*?"Effect"\s*:\s*"Allow"))[^}]*?\}'
 
     extractors:
       - type: dsl
         dsl:
           - '"The S3 bucket " + bucket +" is publicly accessible via Policy"'
-# digest: 4a0a00473045022100c62712d0155b3a6ab8cad4c8d7a87284079288e840855539a4186055949e17f2022061849f7af633798a71f6769172339151da4f05799827c15cc680ee59bfbbf55d:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Updated the template with a regex that ensures that both `"Effect":"Allow"` and a public principal (like `"Principal":"*"` or `{"AWS":"*"})` are found within the same policy statement (i.e., within the same `{...}` block in the JSON policy string). It does this by checking for both required substrings in either order, bounded by the statement's curly braces.

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)