### PR TITLE
Add haliteroglu25 admin panel exposure detection template

### DIFF
--- a/templates/student-submissions/haliteroglu25/haliteroglu25-exposed-admin-panels.yaml
+++ b/templates/student-submissions/haliteroglu25/haliteroglu25-exposed-admin-panels.yaml
@@ -1,0 +1,28 @@
+id: haliteroglu25-admin-panels
+
+info:
+  name: Admin Panel Exposure Detector by haliteroglu25
+  author: Halit Eroğlu
+  severity: low
+  description: |
+    This nuclei template checks for exposed admin or dashboard panels such as /admin, /panel, or /dashboard.
+    Created by haliteroglu25 as part of a software security course assignment.
+
+  tags: exposure,admin,misconfiguration,haliteroglu25
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin"
+      - "{{BaseURL}}/panel"
+      - "{{BaseURL}}/dashboard"
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "Login"
+          - "Admin"
+        condition: or


### PR DESCRIPTION
### Template / PR Information

This pull request adds a custom Nuclei template developed by **haliteroglu25 (Halit Eroğlu)** for detecting exposed admin or management panels such as `/admin`, `/panel`, and `/dashboard`.

The purpose of this template is to assist in identifying weakly protected web interfaces, and was written as part of a **Software Security course assignment**.

- File Path: `templates/student-submissions/haliteroglu25/haliteroglu25-exposed-admin-panels.yaml`

### Template Validation

I've validated this template locally:
- [x] YES
- [ ] NO

### Additional Details

This is a basic informational scan for HTTP 200 responses and common keywords like "Login" or "Admin".

There is no CVE reference; this template is for educational purposes and targets misconfiguration detection.

### How to use

You can test this template locally with the following command:

```bash
nuclei -u https://example.com -t templates/student-submissions/haliteroglu25/haliteroglu25-exposed-admin-panels.yaml
```