### PR TITLE
add zabbix login panel detection template

### DIFF
--- a/http/exposed-panels/zabbix-login.yaml
+++ b/http/exposed-panels/zabbix-login.yaml
@@ -1,0 +1,27 @@
+id: zabbix-login
+
+info:
+  name: Zabbix Login Panel Detection
+  author: rifatartiran
+  severity: info
+  description: Detects exposed Zabbix login panels
+  reference:
+    - https://www.zabbix.com/
+  tags: panel,zabbix,login,exposed
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/zabbix"
+      - "{{BaseURL}}/zabbix/index.php"
+
+    matchers:
+      - type: word
+        words:
+          - "<title>Zabbix</title>"
+          - "name=\"enter\""
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Zabbix Login Panel Detection Template

This template detects exposed login pages of the Zabbix monitoring system by checking for specific HTML elements and page titles.

- The template is located under: `http/exposed-panels/zabbix-login.yaml`
- Matchers include title content `<title>Zabbix</title>` and login form input.
- HTTP status code 200 is also validated.

### Template Validation

I've validated this template locally:
- [x] YES
- [ ] NO

### Additional Details

This panel is commonly exposed at `/zabbix/` or `/zabbix/index.php`, and identification of such panels can indicate potential unauthorized access points. 

### References

- https://www.zabbix.com/