### PR TITLE
Update adcs-certificate.yaml to add more detection

### DIFF
--- a/http/exposures/files/adcs-certificate.yaml
+++ b/http/exposures/files/adcs-certificate.yaml
@@ -1,28 +1,42 @@
 id: adcs-certificate
 
 info:
-  name: Certification Authority Web Enrollment (ADCS) - Detection
-  author: pastaga,defte
+  name: AD CS Web Enrollment and HTTP Interfaces - Detection
+  author: pastaga,defte,atomiczsec
   severity: info
   description: |
-    Web Enrollment is a service that can be installed on an AD CS server to allow users and computers in an Active Directory domain to request a certificate through an interactive web page.
+    Detects the presence of Active Directory Certificate Services (AD CS) Web Enrollment interfaces, including /certenroll/ and /certsrv, which allow users and computers to request certificates through web pages.
   metadata:
     verified: true
     shodan-query: html:"/certenroll"
-  tags: ad,adcs,exposure,files
+  tags: ad,adcs,exposure,files,web-enrollment
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/certenroll/"
       - "{{BaseURL}}/CertEnroll/"
-
+      - "{{BaseURL}}/certsrv"
     host-redirects: true
-    matchers:
-      - type: dsl
-        dsl:
-          - contains(body, ".crl") || contains(body, ".crt")
-          - contains(body, "CertEnroll") || contains(body, "certenroll")
-          - status_code == 200
-        condition: and
-# digest: 4b0a00483046022100834fe22a0cf908f657153bd2278bd1bb581fdb119537ad127e62ec7591c9c4f2022100ae681d05bbfec5621702a57f4bc67cd29afb9878d01c68c2b573086f3b0c6ea6:922c64590222798bb761d5b6d8e72950
+
+matchers-condition: or
+matchers:
+  - type: dsl
+    name: certenroll
+    dsl:
+      - contains(body, ".crl") || contains(body, ".crt")
+      - contains(body, "CertEnroll") || contains(body, "certenroll")
+      - status_code == 200
+    condition: and
+  - type: regex
+    name: certsrv_title
+    part: body
+    regex:
+      - "(?i)<title>.*Certificate Services.*</title>"
+  - type: word
+    name: certsrv_phrases
+    words:
+      - "Microsoft Active Directory Certificate Services"
+      - "Web Enrollment"
+    part: body
+    condition: or


### PR DESCRIPTION
Added detection for AD CS Web Enrollment interfaces across both /certenroll and /certsrv paths, improving its coverage and accuracy.

### Template / PR Information


- Updated detection for AD CS Web Enrollment interfaces across both /certenroll and /certsrv paths
- References:
https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/active-directory-certificate-services-overview

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO


#### Additional Details (leave it blank if not applicable)
