### PR TITLE
Add detection of NGSURVEY login panel instances.

### DIFF
--- a/http/exposed-panels/ngsurvey-panel.yaml
+++ b/http/exposed-panels/ngsurvey-panel.yaml
@@ -1,0 +1,27 @@
+id: ngsurvey-panel
+
+info:
+  name: ngSurvey Login Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    ngSurvey products was detected.
+  reference:
+    - https://www.ngsurvey.com/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"ngSurvey enterprise survey software"
+  tags: panel,ngsurvey,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/home/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "<title>ngsurvey enterprise survey software</title>", "ngsconfig.js")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **NGSURVEY** software.

References:

- https://www.ngsurvey.com/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/77658c85-f1ba-4d39-bb6f-3b8b8edaab49)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://5.195.28.3:4443
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22ngSurvey+enterprise+survey+software%22

![image](https://github.com/user-attachments/assets/27187887-fc24-4847-991d-bbc5a6af7ee0)

### Additional References

None