### PR TITLE
feat: detect greatpages.com.br domain takeover

### DIFF
--- a/http/takeovers/greatpages-takeover.yaml
+++ b/http/takeovers/greatpages-takeover.yaml
@@ -15,6 +15,8 @@ info:
     cvss-score: 7.2
     cwe-id: CWE-284
   metadata:
+    verified: true
+    fofa-query: 'cname="cname.greatpages.com.br"'
     max-request: 2
   tags: takeover,dns,greatpages
 

--- a/http/takeovers/greatpages-takeover.yaml
+++ b/http/takeovers/greatpages-takeover.yaml
@@ -1,0 +1,58 @@
+id: greatpages-takeover
+
+info:
+  name: GreatPages.com.br - Takeover Detection
+  author: juliosmelo
+  severity: high
+  description: |
+    Detects potential domain takeover vulnerability for domains pointing to greatpages.com.br service.
+    The vulnerability occurs when a DNS record points to cname.greatpages.com.br but returns HTTP 404,
+    indicating the domain is unclaimed and can be taken over.
+  reference:
+    - https://github.com/EdOverflow/can-i-take-over-xyz
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cwe-id: CWE-284
+  metadata:
+    max-request: 2
+  tags: takeover,dns,greatpages
+
+dns:
+  - name: "{{FQDN}}"
+    type: CNAME
+    class: IN
+    recursion: true
+    retries: 3
+    matchers:
+      - type: word
+        words:
+          - "cname.greatpages.com.br"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 404
+      
+      - type: word
+        words:
+          - "404"
+          - "not found"
+          - "page not found"
+          - "não encontrada"
+          - "página não encontrada"
+        condition: or
+        case-insensitive: true
+    
+    extractors:
+      - type: dsl
+        dsl:
+          - 'host'
+          - 'status_code'
+          - 'len(body)'

--- a/http/takeovers/greatpages-takeover.yaml
+++ b/http/takeovers/greatpages-takeover.yaml
@@ -33,13 +33,11 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
-    
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 404
-      
       - type: word
         words:
           - "404"
@@ -49,7 +47,6 @@ http:
           - "página não encontrada"
         condition: or
         case-insensitive: true
-    
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/greatpages-takeover.yaml
+++ b/http/takeovers/greatpages-takeover.yaml
@@ -33,11 +33,13 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 404
+
       - type: word
         words:
           - "404"
@@ -47,6 +49,7 @@ http:
           - "página não encontrada"
         condition: or
         case-insensitive: true
+
     extractors:
       - type: dsl
         dsl:

--- a/http/takeovers/greatpages-takeover.yaml
+++ b/http/takeovers/greatpages-takeover.yaml
@@ -1,35 +1,18 @@
 id: greatpages-takeover
 
 info:
-  name: GreatPages.com.br - Takeover Detection
+  name: GreatPages - Takeover Detection
   author: juliosmelo
   severity: high
   description: |
-    Detects potential domain takeover vulnerability for domains pointing to greatpages.com.br service.
-    The vulnerability occurs when a DNS record points to cname.greatpages.com.br but returns HTTP 404,
-    indicating the domain is unclaimed and can be taken over.
+    Detects potential subdomain takeover on GreatPages.com.br by identifying the default error message shown on unclaimed pages.
   reference:
-    - https://github.com/EdOverflow/can-i-take-over-xyz
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
-    cvss-score: 7.2
-    cwe-id: CWE-284
+    - https://greatpages.com.br
   metadata:
     verified: true
-    fofa-query: 'cname="cname.greatpages.com.br"'
-    max-request: 2
-  tags: takeover,dns,greatpages
-
-dns:
-  - name: "{{FQDN}}"
-    type: CNAME
-    class: IN
-    recursion: true
-    retries: 3
-    matchers:
-      - type: word
-        words:
-          - "cname.greatpages.com.br"
+    fofa-query: cname="cname.greatpages.com.br"
+    max-request: 1
+  tags: takeover,greatpages
 
 http:
   - method: GET
@@ -38,23 +21,15 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 404
+      - type: dsl
+        dsl:
+          - Host != ip
 
       - type: word
         words:
-          - "404"
-          - "not found"
-          - "page not found"
-          - "não encontrada"
-          - "página não encontrada"
-        condition: or
-        case-insensitive: true
+          - "Página não encontrada (Erro 404)"
 
     extractors:
       - type: dsl
         dsl:
-          - 'host'
-          - 'status_code'
-          - 'len(body)'
+          - cname


### PR DESCRIPTION
### Template / PR Information

Add GreatPages.com.br subdomain takeover detection

This PR adds a new Nuclei template to detect domain takeover vulnerabilities for the GreatPages.com.br hosting service in Brazil.

Template Details

Service: GreatPages.com.br (Brazilian hosting service)
Vulnerability Type: Subdomain/Domain Takeover
Detection Method: DNS CNAME + HTTP 404 verification
Severity: High

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:
[GreatPages Official Documentation](https://greatpages.com.br/)
[Can I Take Over XYZ - Community Project](https://github.com/EdOverflow/can-i-take-over-xyz)
[OWASP Subdomain Takeover Prevention](https://owasp.org/www-community/attacks/Subdomain_Takeover)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)