### PR TITLE
Added new template to detect MCP SSE endpoint

### DIFF
--- a/http/exposures/apis/exposed-mcp-sse-server.yaml
+++ b/http/exposures/apis/exposed-mcp-sse-server.yaml
@@ -1,18 +1,17 @@
 id: exposed-mcp-sse-server
 
 info:
-  name: Exposed MCP SSE API Detection
+  name: MCP SSE API Exposed - Detect
   author: domwhewell-sage
   severity: unknown
   description: |
-    Detects exposed Model Context Protocol (MCP) servers through the SSE API.
-    MCP servers often provide administrative access to AI tools, LLM systems, or other automation infrastructure.
-    Exposed MCP interfaces can lead to unauthorized access, information disclosure, and potential system compromise.
-    This template detects a SSE server event stream and returns the messages endpoint which can be used to POST JSON-RPC 2.0 requests.
-  metadata:
-    verified: true
+    Detects exposed Model Context Protocol (MCP) servers through the SSE API. MCP servers often provide administrative access to AI tools, LLM systems, or other automation infrastructure. Exposed MCP interfaces can lead to unauthorized access, information disclosure, and potential system compromise. This template detects a SSE server event stream and returns the messages endpoint which can be used to POST JSON-RPC 2.0 requests.
   reference:
     - https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse
+  metadata:
+    verified: true
+    max-requests: 2
+    shodan-query: "text/event-stream"
   tags: mcp,devtools,exposure,api,ai,llm
 
 http:
@@ -20,23 +19,21 @@ http:
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/sse"
-    max-size: 100
 
-    matchers-condition: and
+    stop-at-first-match: true
+
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "status_code == 200 && contains(content_type, 'text/event-stream')"
+          - "status_code == 406 && contains(content_type, 'application/json')"
+        condition: or
 
-      - type: word
-        part: header
-        words:
-          - "text/event-stream"
-
-      - type: word
-        part: body
-        words:
-          - "event: endpoint"
+      - type: dsl
+        dsl:
+          - "contains(body, 'event: endpoint')"
+          - "contains(body, 'Not Acceptable: Client must accept text/event-stream')"
+        condition: or
 
     extractors:
       - type: regex

--- a/http/exposures/apis/exposed-mcp-sse-server.yaml
+++ b/http/exposures/apis/exposed-mcp-sse-server.yaml
@@ -27,7 +27,7 @@ http:
       - type: status
         status:
           - 200
-      
+
       - type: word
         part: header
         words:

--- a/http/exposures/apis/exposed-mcp-sse-server.yaml
+++ b/http/exposures/apis/exposed-mcp-sse-server.yaml
@@ -1,0 +1,45 @@
+id: exposed-mcp-sse-server
+
+info:
+  name: Exposed MCP SSE API Detection
+  author: domwhewell-sage
+  severity: unknown
+  description: |
+    Detects exposed Model Context Protocol (MCP) servers through the SSE API.
+    MCP servers often provide administrative access to AI tools, LLM systems, or other automation infrastructure.
+    Exposed MCP interfaces can lead to unauthorized access, information disclosure, and potential system compromise.
+    This template detects a SSE server event stream and returns the messages endpoint which can be used to POST JSON-RPC 2.0 requests.
+  metadata:
+    verified: true
+  reference:
+    - https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse
+  tags: mcp,devtools,exposure,api,ai,llm
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/sse"
+    max-size: 100
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      
+      - type: word
+        part: header
+        words:
+          - "text/event-stream"
+
+      - type: word
+        part: body
+        words:
+          - "event: endpoint"
+
+    extractors:
+      - type: regex
+        name: message_endpoint
+        regex:
+          - 'data: ([/?_=a-zA-Z0-9-]+)'


### PR DESCRIPTION
### Template / PR Information

I've been having trouble getting the [MCP template](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposures/apis/exposed-mcp-server.yaml) to detect the MCP servers I have tested it with. This is because you have to obtain the session_id first before sending the POST requests and those endpoints always returned a 202 response.

This template detects the HTTP with SSE in the old spec, typically on the /sse endpoint. As it is a streaming response I have set the response size to 100 to capture the first message, the spec states "When a client connects, the server MUST send an endpoint event containing a URI for the client to use for sending messages." so the matchers ensure it is an event stream and that the first event is an endpoint, the extractor then extracts the data in that first event which will be the endpoint you may send the JSON-RPC to.

- References: https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse

This protocol is depreciated now which is why I have added this as a separate template

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

For validation I used the [damn-vulnerable-MCP-server](https://github.com/harishsg993010/damn-vulnerable-MCP-server/tree/main/docs) and [bbot-server](https://github.com/blacklanternsecurity/bbot-server)

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)