### PR TITLE
non-destructive CVE-2022-21587

### DIFF
--- a/http/cves/2022/CVE-2022-21587.yaml
+++ b/http/cves/2022/CVE-2022-21587.yaml
@@ -63,17 +63,12 @@ http:
         end
         ------WebKitFormBoundaryZsMro0UsAQYLDZGv--
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - 'text/xml'
-        internal: true
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains(header, "text/xml")'
+          - 'status_code == 200'
+        condition: and
         internal: true
 
   - raw:


### PR DESCRIPTION
### Template / PR Information

The current CVE-2022-21587 template performs a destructive exploitation of the vulnerability by replacing an EBS perl file.
I've tested in field and was able to verify that. 

The pl file replaced is a standard file for mainenance and updates. This templalte overwrites the content of that file.
There is a note on qualys telling exactly that:

```
NOTE: The QID 730670 is a destructive check as the detection would overwrite existing Perl file txkFNDWRR.pl using vulnerable endpoint OA_HTML/BneViewerXMLService?bne:uueupload=TRUE with a malicious payload. 

On successful execution, the uploaded payload will print a string QualysTest: File has been modified for QID 730670 (CVE-2022-21587) in response over endpoint OA_CGI/FNDWRR.exe.
```


https://threatprotect.qualys.com/2023/02/09/oracle-e-business-suite-remote-code-execution-vulnerability-cve-2022-21587/

This vulnerability won't require overwrite the perl file to be verified.

Here is a full analysis that demonstrates a non-destrutive metthod to even upload a JSP file:

https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis?utm_source=rapid7site&utm_medium=referral&utm_campaign=etr_cve-2022-21587

metasploit module uses the same non-destrutive method to deploy a JSP shell:

https://github.com/rapid7/metasploit-framework/blob/35f770997a667fdb3ebc074a2901d9279fc648a3/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb#L4


Was unable to test this version. It needs a double-check

### Template Validation

I've validated this template locally?
- [ ] YES
- [X] NO

