### PR TITLE
Update Jenkins Default Login to support newer versions

### DIFF
--- a/http/default-logins/jenkins/jenkins-default.yaml
+++ b/http/default-logins/jenkins/jenkins-default.yaml
@@ -36,11 +36,12 @@ http:
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
+        Taco: time
 
     matchers:
       - type: dsl
         dsl:
           - 'contains(body_3, "/logout")'
-          - 'contains(body_3, "<title>Dashboard") || contains(body_3, "Dashboard [Jenkins]")'
+          - 'contains(body_3, "<title>Dashboard -") || contains(body_3, "Dashboard [Jenkins]")'
         condition: and
 # digest: 4a0a00473045022100b2ef4112c325676d60c6228f0761f52f145aae1ab1e077af549eab06a3ac6e70022060af315b91477afc05380248bb4bed1b3a1c8e97ac084057ff3407477c164634:922c64590222798bb761d5b6d8e72950

--- a/http/default-logins/jenkins/jenkins-default.yaml
+++ b/http/default-logins/jenkins/jenkins-default.yaml
@@ -1,15 +1,24 @@
 id: jenkins-weak-password
 
 info:
-  name: Jenkins Default Login
+  name: Jenkins - Default Login
   author: Zandros0
   severity: high
-  description: Jenkins default admin login information was discovered.
+  description: Jenkins credentials of admin:admin were discovered.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
     cwe-id: CWE-522
+    cpe: cpe:2.3:a:jenkins:jenkins:*:*:*:*:*:*:*:*
   metadata:
+    product: jenkins
+    vendor: jenkins
+    shodan-query:
+      - cpe:"cpe:2.3:a:jenkins:jenkins"
+      - http.favicon.hash:"81586312"
+      - product:"jenkins"
+      - x-jenkins
+      - title:"Jenkins"   
     max-request: 3
   tags: jenkins,default-login
 
@@ -32,6 +41,6 @@ http:
       - type: dsl
         dsl:
           - 'contains(body_3, "/logout")'
-          - 'contains(body_3, "Dashboard [Jenkins]")'
+          - 'contains(body_3, "<title>Dashboard") || contains(body_3, "Dashboard [Jenkins]")'
         condition: and
 # digest: 4a0a00473045022100b2ef4112c325676d60c6228f0761f52f145aae1ab1e077af549eab06a3ac6e70022060af315b91477afc05380248bb4bed1b3a1c8e97ac084057ff3407477c164634:922c64590222798bb761d5b6d8e72950

--- a/http/default-logins/jenkins/jenkins-default.yaml
+++ b/http/default-logins/jenkins/jenkins-default.yaml
@@ -36,7 +36,6 @@ http:
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
-        Taco: time
 
     matchers:
       - type: dsl

--- a/http/default-logins/jenkins/jenkins-default.yaml
+++ b/http/default-logins/jenkins/jenkins-default.yaml
@@ -18,7 +18,7 @@ info:
       - http.favicon.hash:"81586312"
       - product:"jenkins"
       - x-jenkins
-      - title:"Jenkins"   
+      - title:"Jenkins"
     max-request: 3
   tags: jenkins,default-login
 

--- a/http/default-logins/jenkins/jenkins-default.yaml
+++ b/http/default-logins/jenkins/jenkins-default.yaml
@@ -1,7 +1,7 @@
 id: jenkins-weak-password
 
 info:
-  name: Jenkins - Default Login
+  name: Jenkins Default Login
   author: Zandros0
   severity: high
   description: Jenkins credentials of admin:admin were discovered.


### PR DESCRIPTION
### PR Information

This updates the Jenkins Default login template so that it works with Jenkins 2.513. The main change is the update to the dashboard pattern match to handle both old and new versions. In addition to string match fix, this update includes more metadata, a reference to the admin:admin credential used in the description, and a small tweak to the name for consistency.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
```
$ nuclei -duc -debug -t ./http/default-logins/jenkins/jenkins-default.yaml -u http://192.168.40.254:8081

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.4

                projectdiscovery.io

[INF] Current nuclei version: v3.4.4 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.2.2 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 65
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [jenkins-weak-password] Dumped HTTP request for http://192.168.40.254:8081

GET / HTTP/1.1
Host: 192.168.40.254:8081
User-Agent: Mozilla/5.0 (Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [jenkins-weak-password] Dumped HTTP response http://192.168.40.254:8081

HTTP/1.1 403 Forbidden
Connection: close
Content-Type: text/html;charset=utf-8
Date: Fri, 13 Jun 2025 04:08:54 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Server: Jetty(12.0.21)
Set-Cookie: JSESSIONID.a3ce9856=node01nwnadzs6e99nxpsudep2tpxu201694.node0; Path=/; HttpOnly; SameSite=Lax
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Hudson: 1.395
X-Jenkins: 2.513
X-Jenkins-Session: 6c7010a7

<html><head><meta http-equiv='refresh' content='1;url=/login?from=%2F'/><script id='redirect' data-redirect-url='/login?from=%2F' src='/static/6c7010a7/scripts/redirect.js'></script></head><body style='background-color:white; color:white;'>
Authentication required
<!--
-->

</body></html>                                                                                                                                                                                                                                                                                                            
[INF] [jenkins-weak-password] Dumped HTTP request for http://192.168.40.254:8081/j_spring_security_check

POST /j_spring_security_check HTTP/1.1
Host: 192.168.40.254:8081
User-Agent: Mozilla/5.0 (Knoppix; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36
Connection: close
Content-Length: 57
Content-Type: application/x-www-form-urlencoded
Cookie: JSESSIONID.a3ce9856=node01nwnadzs6e99nxpsudep2tpxu201694.node0
Accept-Encoding: gzip

j_username=admin&j_password=admin&from=%2F&Submit=Sign+in
[DBG] [jenkins-weak-password] Dumped HTTP response http://192.168.40.254:8081/j_spring_security_check

HTTP/1.1 302 Found
Connection: close
Content-Length: 0
Date: Fri, 13 Jun 2025 04:08:54 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Location: /
Server: Jetty(12.0.21)
Set-Cookie: JSESSIONID.a3ce9856=node0afr4bwaavfetqa2kfr686qea201695.node0; Path=/; HttpOnly; SameSite=Lax
Vary: Accept-Encoding
X-Content-Type-Options: nosniff

[INF] [jenkins-weak-password] Dumped HTTP request for http://192.168.40.254:8081

GET / HTTP/1.1
Host: 192.168.40.254:8081
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20100101 Firefox/127.0
Connection: close
Cookie: JSESSIONID.a3ce9856=node0afr4bwaavfetqa2kfr686qea201695.node0
Taco: time
Accept-Encoding: gzip

[DBG] [jenkins-weak-password] Dumped HTTP response http://192.168.40.254:8081

HTTP/1.1 200 OK
Connection: close
Cache-Control: no-cache,no-store,must-revalidate
Content-Type: text/html;charset=utf-8
Cross-Origin-Opener-Policy: same-origin
Date: Fri, 13 Jun 2025 04:08:54 GMT
Expires: 0
Referrer-Policy: same-origin
Server: Jetty(12.0.21)
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: sameorigin
X-Hudson: 1.395
X-Hudson-Theme: default
X-Instance-Identity: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1SpC0UpUYQWUE3ZPkvfqge3iy4NB4+Z0TLVW1puziKrPfyRGXClcSr0q1zsJ3Gdi1CWBdBMB9XJrQ+4Uy0GptrJaEh7GiadVdh+0NFI4j5lOVJxxqQrMzMDhOwtI2mERC3ACcqn2jIqTs1RMR8OG/Rui53Ltd084sVX0n/iVx+QF94bsjeRoX/Zrma1rn0KvayWZRnlMCqeIzsaJb+sY/wU7fX2cjWP60Ns3H9Jx4i+Gt5yS3y+bM59VXvGdgSBsug8fZEriOq8PVHnJPAj6G1F5eWcGHk0BSrQP9X5Qlld02lElhdygVf2jYWz3b/kRnIvjKlJgC4VvgYjggCF7uQIDAQAB
X-Jenkins: 2.513
X-Jenkins-Session: 6c7010a7


  
  <!DOCTYPE html><html><head resURL="/static/6c7010a7" data-rooturl="" data-resurl="/static/6c7010a7" data-extensions-available="true" data-unit-test="false" data-imagesurl="/static/6c7010a7/images" data-crumb-header="Jenkins-Crumb" data-crumb-value="36d3f9fcdb62700237a86219abedd6982b2783dcaec9503cd5c6fca96c4196cc">
    
    

    <title>Dashboard - Jenkins</title><link rel="stylesheet" 
.....

width=&quot;32&quot;/&gt;&lt;/svg&gt;" data-dropdown-text="Website" data-dropdown-type="ITEM" data-dropdown-href="https://www.jenkins.io/"></template></div></template></div></div></footer></body></html>
[jenkins-weak-password:dsl-1] [http] [high] http://192.168.40.254:8081
[INF] Scan completed in 255.966917ms. 1 matches found.
```