### PR TITLE
Update Apache Airflow Default Login (v3)

### DIFF
--- a/http/default-logins/apache/airflow-default-login.yaml
+++ b/http/default-logins/apache/airflow-default-login.yaml
@@ -41,12 +41,12 @@ http:
         - airflow
 
     extractors:
-      - type: regex
-        name: csrf_token
-        group: 1
-        internal: true
-        regex:
-          - 'type="hidden" value="(.*?)">'
+    - type: regex
+      name: csrf_token
+      group: 1
+      internal: true
+      regex:
+      - type="hidden" value="(.*?)">
 
     matchers-condition: and
     matchers:

--- a/http/default-logins/apache/airflow-default-login.yaml
+++ b/http/default-logins/apache/airflow-default-login.yaml
@@ -4,7 +4,7 @@ info:
   name: Apache Airflow Default Login
   author: pdteam
   severity: high
-  description: An Apache Airflow default login was discovered.
+  description: Apache Airflow default login credentials were discovered.
   reference:
     - https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html
   classification:
@@ -12,6 +12,8 @@ info:
     cvss-score: 8.3
     cwe-id: CWE-522
   metadata:
+    product: airflow
+    vendor: apache
     max-request: 2
     shodan-query: title:"Sign In - Airflow"
   tags: airflow,default-login,apache

--- a/http/default-logins/apache/airflow-v3-default-login.yaml
+++ b/http/default-logins/apache/airflow-v3-default-login.yaml
@@ -46,7 +46,7 @@ http:
     group: 1
     internal: true
     regex:
-    - 'type="hidden" value="(.*?)">''
+    - type="hidden" value="(.*?)">
 
   matchers-condition: and
   matchers:
@@ -60,3 +60,4 @@ http:
   - type: word
     words:
     - 'You should be redirected automatically'
+# digest: 490a0046304402210096cf86afcc6da7a459ff7282c249845a9d3b65788c3ba773d82042d9c580ac49021f45477719cf33c6ae7eb8b46c995163eb0e96b527744259ce53812242579328:922c64590222798bb761d5b6d8e72950

--- a/http/default-logins/apache/airflow-v3-default-login.yaml
+++ b/http/default-logins/apache/airflow-v3-default-login.yaml
@@ -1,0 +1,62 @@
+id: airflow-v3-default-login
+
+info:
+  name: Apache Airflow v3 Default Login
+  author: pdteam
+  severity: high
+  description: Apache Airflow v3 default login credentials were discovered.
+  reference:
+  - https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cwe-id: CWE-522
+  metadata:
+    product: airflow
+    vendor: apache
+    max-request: 2
+    shodan-query: title:"Airflow"
+  tags: airflow,default-login,apache
+
+http:
+- raw:
+  - |
+    GET /auth/login/ HTTP/1.1
+    Host: {{Hostname}}
+    Origin: {{BaseURL}}
+  - |
+    POST /auth/login/ HTTP/1.1
+    Host: {{Hostname}}
+    Origin: {{BaseURL}}
+    Content-Type: application/x-www-form-urlencoded
+    Referer: {{BaseURL}}/auth/login
+
+    username={{username}}&password={{password}}&_csrf_token={{csrf_token}}
+
+  attack: pitchfork
+  payloads:
+    username:
+    - airflow
+    password:
+    - airflow
+
+  extractors:
+  - type: regex
+    name: csrf_token
+    group: 1
+    internal: true
+    regex:
+    - 'type="hidden" value="(.*?)">''
+
+  matchers-condition: and
+  matchers:
+  - type: dsl
+    dsl:
+    - 'contains(body_1, "Airflow")'
+    - 'contains(body_1, "csrf_token")'
+    - 'status_code_2 == 302'
+    - 'contains(header_2, "session=")'
+    condition: and
+  - type: word
+    words:
+    - 'You should be redirected automatically'


### PR DESCRIPTION
### Template / PR Information

This PR adds a second airflow default login template to handle the v3 console.
Newer versions of airflow have a different HTML title, use different URLs, and have slightly different post-auth page content.

If there is a better way to combine these templates instead, please let me know.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
$ nuclei -duc -debug -t http/default-logins/apache/airflow-v3-default-login.yaml -u http://192.168.40.254:8080

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.4

                projectdiscovery.io

[WRN] Setting thread count to 0 for 1 templates, dynamic extractors are not supported with payloads yet
[INF] Current nuclei version: v3.4.4 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.2.2 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 88
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [airflow-v3-default-login] Dumped HTTP request for http://192.168.40.254:8080/auth/login/

GET /auth/login/ HTTP/1.1
Host: 192.168.40.254:8080
User-Agent: Mozilla/5.0 (ZZ; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36
Connection: close
Origin: http://192.168.40.254:8080
Accept-Encoding: gzip

[DBG] [airflow-v3-default-login] Dumped HTTP response http://192.168.40.254:8080/auth/login/

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Access-Control-Allow-Credentials: true
Cache-Control: no-store, no-cache, must-revalidate, max-age=0
Content-Type: text/html; charset=utf-8
Date: Fri, 13 Jun 2025 04:37:41 GMT
Expires: 0
Pragma: no-cache
Server: uvicorn
Set-Cookie: session=1149a726-20e4-49f8-b9cf-47ab3e5cc1d3.7LhO3kLzD36T3LlKwhP46pVYFwI; Expires=Sun, 13 Jul 2025 04:37:42 GMT; HttpOnly; Path=/
Vary: Accept-Encoding

<!-- extend base layout -->





  


<!DOCTYPE html>
<html>
  <head>
    <title>Airflow
</title>

    ...




    
    
  </body>
</html>
[INF] [airflow-v3-default-login] Dumped HTTP request for http://192.168.40.254:8080/auth/login/

POST /auth/login/ HTTP/1.1
Host: 192.168.40.254:8080
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.3 Safari/605.1.15
Connection: close
Content-Length: 137
Content-Type: application/x-www-form-urlencoded
Cookie: session=1149a726-20e4-49f8-b9cf-47ab3e5cc1d3.7LhO3kLzD36T3LlKwhP46pVYFwI
Origin: http://192.168.40.254:8080
Referer: http://192.168.40.254:8080/auth/login
Accept-Encoding: gzip

username=airflow&password=airflow&_csrf_token=ImEwY2EwOTY2ODVjODk5ZjhhZGM3M2JmMDg5YmZhNjU5YzI4NTI2NjYi.aEurFg.BvfQNdfjDt-yW9gEvQpLQf19vCc
[DBG] [airflow-v3-default-login] Dumped HTTP response http://192.168.40.254:8080/auth/login/

HTTP/1.1 302 Found
Connection: close
Transfer-Encoding: chunked
Access-Control-Allow-Credentials: true
Cache-Control: no-store, no-cache, must-revalidate, max-age=0
Content-Type: text/html; charset=utf-8
Date: Fri, 13 Jun 2025 04:37:41 GMT
Expires: 0
Location: /auth/
Pragma: no-cache
Server: uvicorn
Set-Cookie: session=df70ba0f-46ff-4fd5-b677-7d61fe978bb7.CsxjlqVdakh3XKFoB9J5v0A3B-8; Expires=Sun, 13 Jul 2025 04:37:43 GMT; HttpOnly; Path=/
Vary: Accept-Encoding

<!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="/auth/">/auth/</a>. If not, click the link.
[airflow-v3-default-login:dsl-1] [http] [high] http://192.168.40.254:8080/auth/login/ [password="airflow",username="airflow"]
[airflow-v3-default-login:word-2] [http] [high] http://192.168.40.254:8080/auth/login/ [password="airflow",username="airflow"]
[INF] Scan completed in 384.473041ms. 2 matches found.
