### PR TITLE
Update mitel-micollab-panel

### DIFF
--- a/http/exposed-panels/mitel-micollab-panel.yaml
+++ b/http/exposed-panels/mitel-micollab-panel.yaml
@@ -2,7 +2,7 @@ id: mitel-micollab-panel
 
 info:
   name: Mitel MiCollab Login Panel - Detect
-  author: righettod
+  author: righettod,darses
   severity: info
   description: |
     Mitel MiCollab login panel was detected.
@@ -12,11 +12,18 @@ info:
     cpe: cpe:2.3:a:mitel:micollab:*:*:*:*:-:*:*:*
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: mitel
     product: micollab
-    shodan-query: http.html:"MiCollab End User Portal"
+    shodan-query:
+      - http.html:"MiCollab End User Portal"
+      - http.favicon.hash:-1922044295
+    fofa-query:
+      - '"MiCollab End User Portal" && title=="Redirecting..."'
+      - icon_hash="-1922044295"
   tags: panel,mitel,login,detect
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
@@ -26,7 +33,22 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
+          - "status_code == 200"
           - 'contains_any(to_lower(body), "micollab", "mitel_logo", "com.mitel.mas.portal.domain")'
         condition: and
-# digest: 490a00463044022062634f1d54c535a9f90a194bb427664496bbf6a2484168e043534c682f56bc7702207a2fe2be12aa24b680a84a18489bbf30301ed7bb9d9d7cb47b0ac7cd394af2ac:922c64590222798bb761d5b6d8e72950
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/wd/en-us/wapplink.asp"
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "SVR_VER=([\\d\\.\\-]+)"
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/mitel-micollab-panel.yaml
+++ b/http/exposed-panels/mitel-micollab-panel.yaml
@@ -23,32 +23,23 @@ info:
       - icon_hash="-1922044295"
   tags: panel,mitel,login,detect
 
-flow: http(1) && http(2)
-
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/wd/en-us/wapplink.asp"
       - "{{BaseURL}}/portal/"
 
+    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
           - "status_code == 200"
-          - 'contains_any(to_lower(body), "micollab", "mitel_logo", "com.mitel.mas.portal.domain")'
+          - "contains_any(to_lower(body), 'micollab', 'mitel_logo', 'micollab end user portal')"
         condition: and
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/wd/en-us/wapplink.asp"
 
     extractors:
       - type: regex
         name: version
         group: 1
         regex:
-          - "SVR_VER=([\\d\\.\\-]+)"
-
-    matchers:
-      - type: status
-        status:
-          - 200
+          - "SVR_VER=([\\d.\\-]+)"


### PR DESCRIPTION
### Template / PR Information

- Add version extract
- Add more Shodan/Foda queries

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

I was not sure on how to properly add the the version extract to the same page as the panel detect, since the version is only found at another page. Currently the version checks runs only if the panel was found, and then prints the extracted version as a second entry. Example:

```sh
[mitel-micollab-panel] [http] [info] https://SNIP/portal/
[mitel-micollab-panel:version] [http] [info] https://SNIP/wd/en-us/wapplink.asp ["9.8.2.3-1"]
```

Another thing to note is that the current Shodan query has a false negative on pages that redirect to `/server-manager/` instead of `/panel/`, even if the End User Portal is available. The queries add the Mitel favicon, but I expect that this also produces new false positive that were not present before.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)