### PR TITLE
Create password-warn-age-check.yaml

### DIFF
--- a/code/audit/cis/ubuntu/password-warn-age-check.yaml
+++ b/code/audit/cis/ubuntu/password-warn-age-check.yaml
@@ -1,0 +1,50 @@
+id: password-warn-age-check
+
+info:
+  name: Ensure Password Expiration Warning Days is Configured
+  author: Th3l0newolf
+  severity: medium
+  description: |
+    The PASS_WARN_AGE setting in /etc/login.defs specifies the number of days before password expiration that users are warned. According to CIS Ubuntu Linux Benchmark, this should be set to 7 to provide sufficient notice for users to change their passwords.
+  remediation: |
+    Edit /etc/login.defs and ensure the line reads: PASS_WARN_AGE 7
+    Then verify the change using:
+      grep -Pi -- '^\h*PASS_WARN_AGE\h+\d+\b' /etc/login.defs
+  reference:
+    - https://www.cisecurity.org/benchmark/ubuntu_linux
+  metadata:
+    verified: true
+  tags: cis,linux,password,security,audit,ubuntu,login.defs
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+
+    args:
+      - "-c"
+      - |
+        WARN_AGE_LINE=$(grep -Pi -- '^\h*PASS_WARN_AGE\h+\d+\b' /etc/login.defs | head -n1)
+        if [ -n "$WARN_AGE_LINE" ]; then
+          VALUE=$(echo "$WARN_AGE_LINE" | awk '{print $2}')
+          if [ "$VALUE" -eq 7 ]; then
+            echo "[password-warn-age-check:Policy-Pass] [PASS_WARN_AGE is $VALUE (valid)] [CIS_PASS] [medium]"
+          else
+            echo "[password-warn-age-check:Policy-Fail] [PASS_WARN_AGE is $VALUE (invalid)] [CIS_FAIL] [medium]"
+          fi
+        else
+          echo "[password-warn-age-check:Policy-Fail] [PASS_WARN_AGE not set or malformed] [CIS_FAIL] [medium]"
+        fi
+
+    matchers:
+      - type: word
+        name: policy-pass
+        words:
+          - "Policy-Pass"
+
+      - type: word
+        name: policy-fail
+        words:
+          - "Policy-Fail"
+# digest: 490a00463044022068d8de70afa82a2de9731c1c1ffb0190454d71c7bc7156d52c9408bd5bd253c8022063eba42d3063bea484b7bf05f384098f42b65242546a06b8a64f137b34991d88:a335a84a8b55aca14338a3237976ce9a


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
Ubuntu based checks as per CIS guide for Ubuntu 24.04 LTS v.1.0.0
### Template Validation

I've validated this template locally?
- [x] YES

![password-warn-age-check](https://github.com/user-attachments/assets/3e12a8dc-be3a-46b7-b23c-99d9c83300a5)

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)