### PR TITLE
Create inactive-password-lock-default-check.yaml

### DIFF
--- a/code/audit/cis/ubuntu/inactive-password-lock-default-check.yaml
+++ b/code/audit/cis/ubuntu/inactive-password-lock-default-check.yaml
@@ -1,0 +1,44 @@
+id: inactive-password-lock-default-check
+
+info:
+  name: Ensure Inactive Password Lock is Configured (Default Setting)
+  author: Th3l0newolf
+  severity: high
+  description: |
+    Checks if the default user inactivity lock is configured properly.
+    The system should disable user accounts that remain inactive for more than 45 days after password expiration.
+  remediation: |
+    Run: sudo useradd -D -f 45
+    This sets the default INACTIVE parameter for new user accounts.
+  reference:
+    - https://www.cisecurity.org/benchmark/ubuntu_linux
+  metadata:
+    verified: true
+  tags: cis,linux,password,inactive,useradd,audit,ubuntu
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    args:
+      - "-c"
+      - |
+        INACTIVE_DAYS=$(useradd -D | grep -i INACTIVE | awk -F= '{print $2}')
+        if [ -z "$INACTIVE_DAYS" ] || [ "$INACTIVE_DAYS" -gt 45 ]; then
+          echo "[inactive-password-lock-default-check:Policy-Fail] [INACTIVE=$INACTIVE_DAYS (invalid)] [CIS_FAIL] [high]"
+        else
+          echo "[inactive-password-lock-default-check:Policy-Pass] [INACTIVE=$INACTIVE_DAYS (valid)] [CIS_PASS] [high]"
+        fi
+
+    matchers:
+      - type: word
+        name: policy-pass
+        words:
+          - "Policy-Pass"
+
+      - type: word
+        name: policy-fail
+        words:
+          - "Policy-Fail"
+# digest: 4a0a00473045022100815788db6bfa9a571f3ce360efa3ea8d3df25787748a70b84e37682a29949971022000a7194afc6e6032178bfb52ec0c3dd80d25be8c7a3d189e80a4028b5c195a30:a335a84a8b55aca14338a3237976ce9a


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Ubuntu based checks as per CIS guide for Ubuntu 24.04 LTS v.1.0.0

### Template Validation

I've validated this template locally?
- [x] YES

![inactive-password-lock-default-check](https://github.com/user-attachments/assets/cd85205f-b5af-4a60-8ddf-68049a89f1c7)


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)