### PR TITLE
Update waf-detect:securesphere to filter False Positive from OPNSense error page

### DIFF
--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -679,7 +679,6 @@ http:
         name: securesphere
         regex:
           - '(?i)<h2>error<.h2>'
-          - '(?i)<title>error<.title>'
           - '(?i)<b>error<.b>'
           - '(?i)<td.class="(errormessage|error)".height="[0-9]{1,3}".width="[0-9]{1,3}">'
           - '(?i)the.incident.id.(is|number.is).'


### PR DESCRIPTION
### Template / PR Information

- Remove one matcher of `waf-detect:securesphere` due to false positive on OPNSense error page

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

I did not validate on an actual SecureSphere install to check if the template still matches. Considering the words are all `condition: or`, I expect this to still be true.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)