### PR TITLE
Detection of Discord invites

### DIFF
--- a/http/miscellaneous/discord-invite-detect.yaml
+++ b/http/miscellaneous/discord-invite-detect.yaml
@@ -1,0 +1,30 @@
+id: discord-invite-detect
+
+info:
+  name: Detect Discord Invites for users, bots and servers
+  author: rxerium
+  severity: info
+  description: Detect Discord Invites for users, bots and servers
+  reference: https://discord.com
+  tags: exposure,discord,info,osint
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    extractors:
+      - type: regex
+        name: discord-server-invite
+        regex:
+          - "https?:\\/\\/(?:www\\.)?discord\\.gg\\/([a-zA-Z0-9-]+)"
+
+      - type: regex
+        name: discord-user-invite
+        regex:
+          - "https?:\\/\\/discord\\.com\\/users\\/([0-9]+)"
+
+      - type: regex
+        name: discord-bot-invite
+        regex:
+          - "https?:\\/\\/discord\\.com\\/oauth2\\/authorize\\?client_id=([0-9]+)[^\\s\"']*"


### PR DESCRIPTION
This template detects server, user and bot invites.

![image](https://github.com/user-attachments/assets/7eca697d-4063-44e8-a932-71c81450f712)

I'm not sure if there is a folder better suited to place this template in? Perhaps `osint`? Do let me know :)

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)