### PR TITLE
Fix MCP templates

### DIFF
--- a/http/exposures/apis/exposed-mcp-server.yaml
+++ b/http/exposures/apis/exposed-mcp-server.yaml
@@ -22,8 +22,10 @@ http:
   - method: POST
     path:
       - "{{BaseURL}}"
+      - "{{BaseURL}}/mcp/"
 
     headers:
+      Accept: application/json, text/event-stream
       Content-Type: application/json
 
     payloads:
@@ -75,4 +77,3 @@ http:
         part: body
         regex:
           - "\"name\"\\s*:\\s*\"([^\"]+)\""
-# digest: 4a0a004730450220028c4c6a08f3ccc58b8d2149744f67c3ba451ada7eda43b0fec10ac1887e2cf8022100c369ed55029cf8d1a9c5a7bff7ec73d12a6f036b12118c355a91bfc8292189ba:922c64590222798bb761d5b6d8e72950

--- a/http/exposures/apis/exposed-mcp-sse-server.yaml
+++ b/http/exposures/apis/exposed-mcp-sse-server.yaml
@@ -19,7 +19,7 @@ http:
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/sse"
-
+    max-size: 100
     stop-at-first-match: true
 
     matchers:
@@ -40,4 +40,3 @@ http:
         name: message_endpoint
         regex:
           - 'data: ([/?_=a-zA-Z0-9-]+)'
-# digest: 4b0a00483046022100c14ef80d514d8da664ee7653359f4dd6c7d4806e82dcb2af060aef4ae66eead302210093e6eaca613d798af47ddb3933dc9c7995eeaccdc4ebff473d03de9793c4034f:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

- Fixed http/exposures/apis/exposed-mcp-sse-server.yaml
- Fixed http/exposures/apis/exposed-mcp-server.yaml

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

You can validate with https://github.com/projectdiscovery/nuclei-templates-labs/pull/17 and https://github.com/projectdiscovery/nuclei-templates-labs/pull/18

#### Additional Details (leave it blank if not applicable)

##### Fixed http/exposures/apis/exposed-mcp-sse-server.yaml

The template requires a `max-size` parameter. As the response is streamed nuclei times out waiting for the server to close the connection. I experimented with smaller `max-size` parameters such as `max-size: 50` but it cut off the session_id message returned by the server.

##### Fixed http/exposures/apis/exposed-mcp-server.yaml

The spec [requires](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http:~:text=the%20MCP%20endpoint.-,The%20client%20MUST%20include%20an%20Accept%20header,-%2C%20listing%20both%20application) an accept header :/.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)