### PR TITLE
CVE-2018-3810-CVE-2018-3811

### DIFF
--- a/dast/cves/2018/CVE-2018-3810-CVE-2018-3811.yaml
+++ b/dast/cves/2018/CVE-2018-3810-CVE-2018-3811.yaml
@@ -10,8 +10,7 @@ info:
     - https://limbenjamin.com/articles/2018/smart-google-code-inserter-wordpress-plugin-authbypass-sqli.html
     - https://wordpress.org/plugins/smart-google-code-inserter/
   classification:
-    cve-id: CVE-2018-3810
-    cve-id: CVE-2018-3811
+    cve-id: CVE-2018-3810 
   metadata:
     verified: false
     max-request: 2


### PR DESCRIPTION
### Template / PR Information

The Smart Google Code Inserter plugin for WordPress before version 3.5 is vulnerable to authentication bypass, allowing unauthenticated users to inject JavaScript site-wide (CVE-2018-3810) and perform SQL injection (CVE-2018-3811).


- CVE-2018-3810-CVE-2018-3811
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [* ] NO

