### PR TITLE
Update phpmyadmin-server-import

### DIFF
--- a/http/misconfiguration/phpmyadmin/phpmyadmin-server-import.yaml
+++ b/http/misconfiguration/phpmyadmin/phpmyadmin-server-import.yaml
@@ -21,7 +21,6 @@ http:
       paths:
         - "/pma/server_import.php"
         - "/phpmyadmin/server_import.php"
-        - "/phpMyAdmin 2/server_import.php"
         - "/db/server_import.php"
         - "/server_import.php"
         - "/PMA/server_import.php"
@@ -31,7 +30,6 @@ http:
         - "/admin/phpMyAdmin/server_import.php"
 
     stop-at-first-match: true
-
     matchers-condition: and
     matchers:
       - type: word
@@ -41,10 +39,10 @@ http:
 
       - type: word
         part: body
-        condition: or
         words:
           - "Location of the text file"
           - "Browse your computer"
+        condition: or
 
       - type: status
         status:

--- a/http/misconfiguration/phpmyadmin/phpmyadmin-server-import.yaml
+++ b/http/misconfiguration/phpmyadmin/phpmyadmin-server-import.yaml
@@ -35,10 +35,16 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        condition: and
+        part: body
         words:
           - "File to import"
+
+      - type: word
+        part: body
+        condition: or
+        words:
           - "Location of the text file"
+          - "Browse your computer"
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

* **Updated** PhpMyAdmin `server_import.php` exposure template.

* Improved matcher logic to support detection of multiple UI strings in phpMyAdmin 5.x (e.g., `"Browse your computer"` introduced in newer UI).

* Tested locally using `phpMyAdmin-5.0.1-all-languages`.

* References:

  * [https://github.com/phpmyadmin/phpmyadmin/releases/tag/RELEASE\_5\_0\_1](https://github.com/phpmyadmin/phpmyadmin/releases/tag/RELEASE_5_0_1)
  * [https://www.phpmyadmin.net/](https://www.phpmyadmin.net/)


### Template Validation

I've validated this template locally?

* [x] YES
* [ ] NO



#### Additional Details

* **Matched string**: `"Browse your computer"` found in response body of `server_import.php` in phpMyAdmin 5.0.1.
* Verified 200 status code with authenticated session (if applicable).
* Tested on localhost in Dockerized phpMyAdmin environment.



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)