### PR TITLE
Use a bigger number to reduce false positives

### DIFF
--- a/http/vulnerabilities/other/bagisto-csti.yaml
+++ b/http/vulnerabilities/other/bagisto-csti.yaml
@@ -21,14 +21,14 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/bagisto-common/search?query={{228*'98'}}"
+      - "{{BaseURL}}/bagisto-common/search?query={{2288*'9876'}}"
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "22344"
+          - "22596288"
           - "bagisto"
         condition: and
 
@@ -36,4 +36,3 @@ http:
         part: content_type
         words:
           - "text/html"
-# digest: 4a0a004730450220136bcb4efbcb0850cd5b5266d892e7bbdbe76b108a05029cf87f25ac5e29c246022100f4aca5114b1f1a8f93f374b33fdbccf245f20c38d161b9594e94ad9d093b12bd:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

False positives were detected due to `bagisto` matching from the URL path sometimes and the smaller number. Larger number would be better to reduce false positives.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO