### PR TITLE
Add detection of OPENSIGN login panel instances.

### DIFF
--- a/http/exposed-panels/opensign-panel.yaml
+++ b/http/exposed-panels/opensign-panel.yaml
@@ -5,7 +5,7 @@ info:
   author: righettod
   severity: info
   description: |
-    The login panel of the OpenSign software was identified.
+    OpenSign Login panel was discovered.
   reference:
     - https://www.opensignlabs.com/
     - https://github.com/OpenSignLabs/OpenSign


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **OPENSIGN** software.

References:

- https://www.opensignlabs.com/
- https://github.com/OpenSignLabs/OpenSign

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

![image](https://github.com/user-attachments/assets/09f25208-c6eb-4a1d-bad2-84477c6d3cac)

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://54.81.230.107
https://180.232.31.183
http://162.19.106.174:3030
http://46.20.242.155:3000
http://192.141.172.78:3000
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22opensign%22

![image](https://github.com/user-attachments/assets/edcf2fb4-0654-4f0c-9180-284795779279)

### Additional References

None