### PR TITLE
Add beyondtrust-remotesupport-version

### DIFF
--- a/http/technologies/beyondtrust-remotesupport-version.yaml
+++ b/http/technologies/beyondtrust-remotesupport-version.yaml
@@ -5,7 +5,7 @@ info:
   author: missing0x00
   severity: info
   description: |
-    BeyondTrust Remote Support version and timestamp extraction from /get_rdf endpoint
+    Detects and extracts version information from BeyondTrust Remote Support installations by querying the /get_rdf endpoint.
   classification:
     cpe: cpe:2.3:a:beyondtrust:remote_support:*:*:*:*:*:*:*:*
   metadata:

--- a/http/technologies/beyondtrust-remotesupport-version.yaml
+++ b/http/technologies/beyondtrust-remotesupport-version.yaml
@@ -1,0 +1,61 @@
+id: beyondtrust-remotesupport-version
+
+info:
+  name: BeyondTrust Remote Support Version - Detect
+  author: missing0x00
+  severity: info
+  description: |
+    BeyondTrust Remote Support version and timestamp extraction from /get_rdf endpoint
+  classification:
+    cpe: cpe:2.3:a:beyondtrust:remote_support:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: beyondtrust
+    product: remote_support
+    shodan-query:
+      - title:"Remote Support Portal"
+      - http.favicon.hash:-694003434
+      - http.html:"BeyondTrust Remote Support"
+  tags: tech,beyondtrust,version,detect
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/get_rdf?comp=sdcust&locale_code=en-us'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        name: successful
+        part: body
+        regex:
+          - 'BeyondTrust'
+
+    extractors:
+      - type: regex
+        name: extracted_unix_timestamp
+        part: body
+        group: 1
+        regex:
+          - 'en-us\n(.*)\n'
+        internal: true
+
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '\x07.([\.\d]+)\x00'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"Version: " + version'
+          - '"Timestamp: " + extracted_unix_timestamp'
+          - '"Release Date: " + date_time("%Y-%M-%D", extracted_unix_timestamp)'
+# digest: 4a0a0047304502204d3cc1c5b4b59edb702dcdc72aa8857ec11280515a47afa6ab4bb418d1d661cd022100fd12207238bad8efb54b9537dc37c3fb34906dbaa4138d62ced089a05b34e8b0:1ecbd5a69bbeb8ee6759e78b73274855

--- a/http/technologies/beyondtrust-remotesupport-version.yaml
+++ b/http/technologies/beyondtrust-remotesupport-version.yaml
@@ -30,10 +30,9 @@ http:
         status:
           - 200
 
-      - type: regex
-        name: successful
-        part: body
-        regex:
+      - type: word
+        part: response
+        words:
           - 'BeyondTrust'
 
     extractors:


### PR DESCRIPTION
### Template / PR Information

- Extracts version number and timestamp from application/octet-stream response
- Timestamp appears to be either the installation or last patch date
- Response size between 800-900kb
- Credit for technique to [Jorren Geurts]( 
https://www.resillion.com/latest-news/beyondtrust-remote-support-how-template-injection-can-lead-to-remote-code-execution/)

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Example response format:
<img width="642" alt="image" src="https://github.com/user-attachments/assets/71e339e2-fe1b-4284-b9f6-fc689829b9a5" />

Alternate Python script:
```python
import sys
import requests
import re
import datetime

target = sys.argv[1]

r = requests.get(f"https://{target}/get_rdf?comp=sdcust&locale_code=en-us")
r_split = re.split("[^\w.-]", r.text.strip())

timestamp = r_split[3]
version = r_split[10]

builddate = datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S')

print(f"Install Date: {builddate} \nVersion: {version}")
```

Both regex methods work consistently against tested versions.