### PR TITLE
Add CVE-2021-31630 and OpenPLC Default Login Checks

### DIFF
--- a/http/cves/2021/CVE-2021-31630.yaml
+++ b/http/cves/2021/CVE-2021-31630.yaml
@@ -1,0 +1,45 @@
+id: CVE-2021-31630
+
+info:
+  name: OpenPLC v3 Authenticated RCE (CVE-2021-31630) - Passive Check
+  author: machevalia
+  severity: high
+  description: >
+    Attempts to login with default credentials and upload a benign custom hardware layer.
+    If upload and compilation succeed, the server is likely vulnerable to CVE-2021-31630.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-31630
+    - https://github.com/thiagorossener/openplc
+  tags: iot,plc,auth,openplc,cve,cve2021,rce
+
+variables:
+  username: "openplc"
+  password: "openplc"
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=openplc&password=openplc
+
+      - |
+        GET /hardware HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    stop-at-first-match: false
+
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Hardware Layer Code Box"
+          - "Save changes"
+        condition: and

--- a/http/default-logins/others/openplc-webserver-v3-default-login.yaml
+++ b/http/default-logins/others/openplc-webserver-v3-default-login.yaml
@@ -1,0 +1,37 @@
+id: openplc-webserver-v3-default-login
+
+info:
+  name: OpenPLC Webserver v3 - Default Login
+  author: machevalia
+  severity: high
+  description: >
+    Checks if OpenPLC is using default credentials (openplc:openplc) by logging in and accessing an authenticated endpoint.
+  tags: iot,openplc,default-login,auth
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=openplc&password=openplc
+
+      - |
+        GET /dashboard HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    stop-at-first-match: false
+
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Dashboard"
+          - "Runtime Logs"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Added two templates for OpenPLC Webserver v3 - 1. default credentials check 2. Defanged RCE check for custom C code loaded into the PLC.

References - 
Original research by Fellipe Oliveira https://packetstorm.news/files/id/162563
My repo with accompanying Python3 script - https://github.com/machevalia/OpenPLC-CVE-2021-31630-RCE/tree/main

### Template Validation

I've validated this template locally?
- [x] YES - validated during real testing
- [ ] NO