### PR TITLE
Added CVE-2021-3287 Template

### DIFF
--- a/http/cves/2021/CVE-2021-3287.yaml
+++ b/http/cves/2021/CVE-2021-3287.yaml
@@ -10,7 +10,10 @@ info:
   reference:
     - https://haxolot.com/posts/2021/manageengine_opmanager_pre_auth_rce/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-3287
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb
   tags: rce,java,deserialization,opmanager,cve,cve2021
+  metadata:
+    verified: false
 
 http:
   - raw:
@@ -32,3 +35,8 @@ http:
         part: body
         binary:
           - "aced0005" # Java serialization stream header
+
+      - type: word
+        part: header
+        words:
+          - "Set-Cookie: JSESSIONID="

--- a/http/cves/2021/CVE-2021-3287.yaml
+++ b/http/cves/2021/CVE-2021-3287.yaml
@@ -1,0 +1,34 @@
+id: CVE-2021-3287
+
+info:
+  name: ManageEngine OpManager Deserialization RCE - CVE-2021-3287
+  author: tomaquet18
+  severity: critical
+  description: |
+    ManageEngine OpManager is vulnerable to a pre-authentication Java deserialization vulnerability
+    that allows for remote code execution. This template tests for CVE-2021-3287 patch bypass behavior.
+  reference:
+    - https://haxolot.com/posts/2021/manageengine_opmanager_pre_auth_rce/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-3287
+  tags: rce,java,deserialization,opmanager,cve,cve2021
+
+http:
+  - raw:
+      - |
+        POST /servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/octet-stream
+        Content-Length: 10
+
+        {{hex_decode("aced00057704000003ea")}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: binary
+        part: body
+        binary:
+          - "aced0005" # Java serialization stream header

--- a/http/cves/2021/CVE-2021-3287.yaml
+++ b/http/cves/2021/CVE-2021-3287.yaml
@@ -1,19 +1,38 @@
 id: CVE-2021-3287
 
 info:
-  name: ManageEngine OpManager Deserialization RCE - CVE-2021-3287
+  name: ManageEngine OpManager SumPDU - Java Deserialization
   author: tomaquet18
   severity: critical
   description: |
-    ManageEngine OpManager is vulnerable to a pre-authentication Java deserialization vulnerability
-    that allows for remote code execution. This template tests for CVE-2021-3287 patch bypass behavior.
+    Zoho ManageEngine OpManager before 12.5.329 allows unauthenticated Remote Code Execution due to a general bypass in the deserialization class.
   reference:
     - https://haxolot.com/posts/2021/manageengine_opmanager_pre_auth_rce/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-3287
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb
-  tags: rce,java,deserialization,opmanager,cve,cve2021
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-3287
+    cwe-id: CWE-502
+    epss-score: 0.71116
+    epss-percentile: 0.9861
+    cpe: cpe:2.3:a:zohocorp:manageengine_opmanager:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
+    vendor: zohocorp
+    product: manageengine_opmanager
+    shodan-query:
+      - http.title:"opmanager plus"
+      - http.title:"opmanager"
+    fofa-query:
+      - title="opmanager plus"
+      - title="opmanager"
+    google-query:
+      - intitle:"opmanager plus"
+      - intitle:"opmanager"
+    verified: true
+    max-request: 1
+  tags: cve,cve2021,rce,java,deserialization,opmanager,kev
 
 http:
   - raw:
@@ -21,22 +40,21 @@ http:
         POST /servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/octet-stream
-        Content-Length: 10
 
         {{hex_decode("aced00057704000003ea")}}
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: binary
         part: body
         binary:
           - "aced0005" # Java serialization stream header
 
       - type: word
-        part: header
+        part: set_cookie
         words:
-          - "Set-Cookie: JSESSIONID="
+          - "JSESSIONID="
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

- **Added CVE-2021-3287** — ManageEngine OpManager Deserialization RCE
- This template sends a serialized Java integer (`1002`) to the vulnerable `SUMHandShakeServlet` endpoint. If the response includes a valid Java serialized stream header (`0xaced0005`), the system is likely vulnerable to unauthenticated Java deserialization (CVE-2021-3287).

- References:
  - https://haxolot.com/posts/2021/manageengine_opmanager_pre_auth_rce/
  - https://nvd.nist.gov/vuln/detail/CVE-2021-3287

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.5

                projectdiscovery.io

[INF] Current nuclei version: v3.4.5 (latest)
[INF] Current nuclei-templates version: v10.2.3 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 105
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] [CVE-2021-3287] Dumped HTTP request for http://192.168.31.102:8060/servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet

POST /servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet HTTP/1.1
Host: 192.168.31.102:8060
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15        
Connection: close
Content-Length: 10
Content-Type: application/octet-stream
Accept-Encoding: gzip

��w�
[DBG] [CVE-2021-3287] Dumped HTTP response http://192.168.31.102:8060/servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet

HTTP/1.1 200
Connection: close
Transfer-Encoding: chunked
Date: Thu, 26 Jun 2025 10:49:45 GMT
Set-Cookie: JSESSIONID=16D93DD06E361B48F5193432F2D1A52D; Path=/; HttpOnly
Vary: Accept-Encoding


00000000  ac ed 00 05                                       |....|
[CVE-2021-3287:status-1] [http] [critical] http://192.168.31.102:8060/servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet       
[CVE-2021-3287:binary-2] [http] [critical] http://192.168.31.102:8060/servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet       
[INF] Scan completed in 22.190292ms. 2 matches found.
```


#### Additional Details (leave it blank if not applicable)

/claim #12474

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)