### PR TITLE
Checking HTTP TRACE method directly to identify whether it's enabled

### DIFF
--- a/http/miscellaneous/http-trace.yaml
+++ b/http/miscellaneous/http-trace.yaml
@@ -21,15 +21,3 @@ http:
         part: body
         words:
           - "TRACE / HTTP"
-
-  - method: OPTIONS
-    path:
-      - "{{BaseURL}}"
-
-    matchers:
-      - type: regex
-        name: options-request
-        part: header
-        regex:
-          - "(?i)Allow: [A-Z,]*TRACE"
-# digest: 4b0a00483046022100f9c42bf24e52d5c2931151045443dab9c60868bbc296777a74f7d21be18a2395022100faff47f82942b010ec7c2296ac7e7b7dec44cc809fb24354686bbaa5729add90:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

At CERT PL, we've identified websites that show that HTTP TRACE is enabled when performing an OPTIONS request, but in reality, TRACE returns 405. Let's skip these FPs.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO
