### PR TITLE
Create openmetadata-detect.yaml and openmetadata-default-login.yaml

### DIFF
--- a/http/default-logins/openmetadata-default-login.yaml
+++ b/http/default-logins/openmetadata-default-login.yaml
@@ -1,0 +1,51 @@
+id: OpenMetadata-default-login
+
+info:
+  name: OpenMetadata - Detect
+  author: icarot
+  severity: high
+  description: |
+    OpenMetadata server enables default admin credentials. An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/open-metadata/OpenMetadata
+  classification:
+    cpe: cpe:2.3:a:open-metadata:openmetadata:1.7.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: open-metadata
+    product: OpenMetadata
+    shodan-query: title:"OpenMetadata"
+  tags: tech,OpenMetadata,open-metadata,detect
+
+variables:
+  username: admin@open-metadata.org
+  password: admin
+
+http:
+  - raw:
+      - |
+        POST /api/v1/users/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"email":"{{username}}","password": "{{base64("{{password}}")}}"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"accessToken":'
+          - '"refreshToken"'
+          - '"tokenType"'
+          - '"expiryDuration"'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200

--- a/http/technologies/openmetadata-detect.yaml
+++ b/http/technologies/openmetadata-detect.yaml
@@ -1,0 +1,31 @@
+id: OpenMetadata-detect
+
+info:
+  name: OpenMetadata - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a OpenMetadata server, a unified metadata platform for data discovery, data observability, and data governance powered by a central metadata repository, in-depth column level lineage, and seamless team collaboration.
+  reference:
+    - https://github.com/open-metadata/OpenMetadata
+  classification:
+    cpe: cpe:2.3:a:open-metadata:openmetadata:1.7.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: open-metadata
+    product: OpenMetadata
+  tags: tech,OpenMetadata,open-metadata,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>OpenMetadata</title>'
+          - 'OpenMetadata'
+        condition: and
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
These nuclei templates:

* Detects an OpenMetadata web application, a unified metadata platform for data discovery, data observability, and data governance powered by a central metadata repository, in-depth column level lineage, and seamless team collaboration.
* OpenMetadata server enables default admin credentials. An attacker can execute unauthorized operations.


- References:

https://github.com/open-metadata/OpenMetadata

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**OpenMetadata Docker:**

1. Running container:

`$ curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.7.0-release/docker-compose.yml`

OR

`$ curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.8.0-release/docker-compose.yml`

`$ docker compose -f docker-compose.yml up --detach`

2. Acessing the OpenMetadata service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' openmetadata_server`

And the access URL will be http://<obteined_inspect_IP_Address>:8585/

3. Starting a docker container Kali in the same network as the OpenMetadata:

`$ docker run --rm --tty --interactive --network openmetadata_app_net --dns 8.8.8.8 --dns 8.8.4.4 --name container_kali kalilinux/kali-rolling /bin/bash`

**Nuclei execution:**

`$ ~/go/bin/nuclei -t openmetadata-detect.yaml -t openmetadata-default-login.yaml -u "http://<obteined_inspect_IP_Address>:8585" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

![image](https://github.com/user-attachments/assets/da3b644d-7e31-49b9-837b-068a1b47543e)

![image](https://github.com/user-attachments/assets/a1f93ac4-6630-412f-bacc-eb14c5241480)

![image](https://github.com/user-attachments/assets/3093d007-06c6-49eb-bf5d-670cbba7be5c)
