### PR TITLE
domain update

### DIFF
--- a/http/osint/user-enumeration/threads.yaml
+++ b/http/osint/user-enumeration/threads.yaml
@@ -19,7 +19,7 @@ self-contained: true
 http:
   - method: GET
     path:
-      - "https://www.threads.net/@{{user}}"
+      - "https://www.threads.com/@{{user}}"
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
threads.net redirects to threads.com but redirects is not supported in this template so I figured it would be easier to just update the domain

Example user:
https://www.threads.com/@rxerium

- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)