### PR TITLE
Fix: incorrect CWE classification for CVE-2025-45854

### DIFF
--- a/http/cves/2025/CVE-2025-45854.yaml
+++ b/http/cves/2025/CVE-2025-45854.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2025-45854
-    cwe-id: CWE-869
+    cwe-id: CWE-862,CWE-434
   metadata:
     max-request: 1
     product: jehc-bpm


### PR DESCRIPTION
### Template / PR Information

Fixed incorrect CWE classification for CVE-2025-45854

Changes Made:
- Updated CWE-ID from `CWE-869` to `CWE-862,CWE-434` as per NVD official classification

References:
- https://nvd.nist.gov/vuln/detail/CVE-2025-45854

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)