### PR TITLE
refactor: fix matchers for CVE-2024-51977

### DIFF
--- a/http/cves/2024/CVE-2024-51977.yaml
+++ b/http/cves/2024/CVE-2024-51977.yaml
@@ -32,12 +32,7 @@ http:
           - '"IP Address"'
         condition: and
 
-      - type: word
-        part: content_type
-        words:
-          - "text/comma-separated-values"
-
-      - type: status
-        status:
-          - 200
-# digest: 4a0a0047304502206acba21c6020a5432ff0cf25085c6ebeba4eb7adfce4cbd2d2622c1130d166cb022100dec80eac34716cfa07b49958ade48247ca9cac54172517ad63180cf8a47a9196:922c64590222798bb761d5b6d8e72950
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - 'contains(content_type, "text/comma-separated-values"")'

--- a/http/cves/2024/CVE-2024-51977.yaml
+++ b/http/cves/2024/CVE-2024-51977.yaml
@@ -35,4 +35,4 @@ http:
       - type: dsl
         dsl:
           - "status_code == 200"
-          - 'contains(content_type, "text/comma-separated-values"")'
+          - 'contains(content_type, "text/comma-separated-values")'

--- a/http/cves/2024/CVE-2024-51977.yaml
+++ b/http/cves/2024/CVE-2024-51977.yaml
@@ -36,3 +36,4 @@ http:
         dsl:
           - "status_code == 200"
           - 'contains(content_type, "text/comma-separated-values")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

The old matcher did not work for some reason? Maybe a bug in nuclei.

So I tweaked the matcher to fix it.  

OLD:
![Screenshot From 2025-07-04 13-59-43](https://github.com/user-attachments/assets/06614f86-efe9-416f-9b72-bcd5fd8d0d8c)
New:
![Screenshot From 2025-07-04 14-04-12](https://github.com/user-attachments/assets/9280c46e-6a1f-41e3-af8b-7a3730c3fad5)

Connected to :
https://github.com/projectdiscovery/nuclei-templates/pull/12489/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)