### PR TITLE
Added new template to detect exposed .env files

### DIFF
--- a/file/env-file-exposure.yaml
+++ b/file/env-file-exposure.yaml
@@ -1,0 +1,26 @@
+id: env-file-exposure
+
+info:
+  name: Exposed .env File
+  author: Basit2002
+  severity: high
+  description: Detects publicly exposed .env files containing environment variables like DB credentials or app secrets.
+  tags: exposure, env, config, sensitive
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.env"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "DB_PASSWORD"
+          - "APP_KEY"
+          - "DB_HOST"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/file/env-file-exposure.yaml
+++ b/file/env-file-exposure.yaml
@@ -5,7 +5,12 @@ info:
   author: Basit2002
   severity: high
   description: Detects publicly exposed .env files containing environment variables like DB credentials or app secrets.
-  tags: exposure, env, config, sensitive
+  reference:
+    - https://book.hacktricks.xyz/pentesting-web/dotenv-env-files
+    - https://github.com/dolevf/Damn-Vulnerable-Webhook-Application/issues/1
+  metadata:
+    verified: false
+  tags: exposure, env, config, sensitive, file
 
 requests:
   - method: GET
@@ -24,3 +29,9 @@ requests:
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: regex
+        regex:
+          - "DB_PASSWORD=.*"
+          - "APP_KEY=.*"


### PR DESCRIPTION
### Template / PR Information

This Nuclei template detects publicly exposed `.env` files which may contain sensitive environment variables such as `DB_PASSWORD`, `APP_KEY`, or `DB_HOST`. These are commonly left behind in misconfigured deployments and can lead to serious information leakage.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

You can find `.env` files using:
- Google Dork: `intitle:"index of" ".env"`
- Shodan Query: `http.favicon.hash:-354153108`
- Manual inspection of exposed endpoints

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
