### PR TITLE
Create CVE-2025-53624 - docusaurus-plugin-content-gists < 4.0.0 - GitHub Personal Access Token Exposure

### DIFF
--- a/http/cves/2025/CVE-2025-53624.yaml
+++ b/http/cves/2025/CVE-2025-53624.yaml
@@ -1,0 +1,79 @@
+id: CVE-2025-53624
+
+info:
+  name: docusaurus-plugin-content-gists < 4.0.0 - GitHub Personal Access Token Exposure
+  author: darses
+  severity: high
+  description: |
+    The Docusaurus gists plugin adds a page to your Docusaurus instance, displaying all public gists of a GitHub user. docusaurus-plugin-content-gists versions prior to 4.0.0 are vulnerable to exposing GitHub Personal Access Tokens in production build artifacts when passed through plugin configuration options. The token, intended for build-time API access only, is inadvertently included in client-side JavaScript bundles, making it accessible to anyone who can view the website's source code.
+  impact: |
+    A GitHub personal access token exposure vulnerability can grant an attacker unauthorized access to your repositories and organization resources, potentially leading to data exfiltration, code injection, and supply chain attacks.
+  remediation: |
+    Update docusaurus-plugin-content-gists to version 4.0.0+. Revoke access to the GitHub PAT that was used: https://github.com/settings/tokens.
+  reference:
+    - https://github.com/webbertakken/docusaurus-plugin-content-gists/commit/8d4230b82412edb215ddfa9e609d178510a5fe31
+    - https://github.com/webbertakken/docusaurus-plugin-content-gists/security/advisories/GHSA-qf34-qpr4-5pph
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-53624
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    vendor: webbertakken
+    product: docusaurus_plugin_content_gists
+    shodan-query:
+      - http.html:"Docusaurus"
+    fofa-query:
+      - body="Docusaurus"
+  tags: cve,cve2025,docusaurus,exposure
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        internal: true
+        words:
+          - 'name="generator" content="Docusaurus'
+        part: body
+
+      - type: status
+        internal: true
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: js_file_url
+        internal: true
+        group: 1
+        regex:
+          - '<script src="/(assets/js/main\.[^"]*\.js)"'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}{{js_file_url}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "personalAccessToken"
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: github_token
+        group: 1
+        regex:
+          - ',personalAccessToken:"([^"]*)"}'

--- a/http/cves/2025/CVE-2025-53624.yaml
+++ b/http/cves/2025/CVE-2025-53624.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-53624
 
 info:
-  name: docusaurus-plugin-content-gists < 4.0.0 - GitHub Personal Access Token Exposure
+  name: Docusaurus Gists Plugin < 4.0.0 - GitHub Personal Access Token Exposure
   author: darses
   severity: high
   description: |
@@ -13,12 +13,14 @@ info:
   reference:
     - https://github.com/webbertakken/docusaurus-plugin-content-gists/commit/8d4230b82412edb215ddfa9e609d178510a5fe31
     - https://github.com/webbertakken/docusaurus-plugin-content-gists/security/advisories/GHSA-qf34-qpr4-5pph
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-53624
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-    cvss-score: 10.0
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
+    cvss-score: 8.6
     cve-id: CVE-2025-53624
     cwe-id: CWE-200
   metadata:
+    max-request: 2
     verified: true
     vendor: webbertakken
     product: docusaurus_plugin_content_gists
@@ -36,7 +38,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code == 200"
+          - 'status_code == 200'
           - 'contains(body, "docusaurus_locale")'
         condition: and
         internal: true
@@ -44,25 +46,21 @@ http:
     extractors:
       - type: regex
         name: js_file_url
-        internal: true
         group: 1
         regex:
           - '<script src="/(assets/js/main\.[^"]*\.js)"'
+        internal: true
 
   - method: GET
     path:
       - "{{BaseURL}}/{{js_file_url}}"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "personalAccessToken"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "personalAccessToken")'
+        condition: and
 
     extractors:
       - type: regex

--- a/http/cves/2025/CVE-2025-53624.yaml
+++ b/http/cves/2025/CVE-2025-53624.yaml
@@ -22,10 +22,8 @@ info:
     verified: true
     vendor: webbertakken
     product: docusaurus_plugin_content_gists
-    shodan-query:
-      - http.html:"Docusaurus"
-    fofa-query:
-      - body="Docusaurus"
+    shodan-query: http.html:"Docusaurus"
+    fofa-query: body="Docusaurus"
   tags: cve,cve2025,docusaurus,exposure
 
 flow: http(1) && http(2)
@@ -33,20 +31,15 @@ flow: http(1) && http(2)
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
-    matchers-condition: and
     matchers:
-      - type: word
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - 'contains(body, "docusaurus_locale")'
+        condition: and
         internal: true
-        words:
-          - 'name="generator" content="Docusaurus'
-        part: body
-
-      - type: status
-        internal: true
-        status:
-          - 200
 
     extractors:
       - type: regex
@@ -58,14 +51,14 @@ http:
 
   - method: GET
     path:
-      - "{{BaseURL}}{{js_file_url}}"
+      - "{{BaseURL}}/{{js_file_url}}"
 
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - "personalAccessToken"
-        part: body
 
       - type: status
         status:


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-53624
- References: https://github.com/webbertakken/docusaurus-plugin-content-gists/security/advisories/GHSA-qf34-qpr4-5pph

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)