### PR TITLE
Create CVE-2025-27505 - GeoServer - Missing Authorization on REST API Index

### DIFF
--- a/http/cves/2025/CVE-2025-27505.yaml
+++ b/http/cves/2025/CVE-2025-27505.yaml
@@ -4,8 +4,8 @@ info:
   name: GeoServer - Missing Authorization on REST API Index
   author: securitytaters
   severity: medium
-    description: |
-      GeoServer contains a missing authorization vulnerability that allows unauthorized access to the REST API Index page, potentially exposing sensitive configuration information.
+  description: |
+    GeoServer contains a missing authorization vulnerability that allows unauthorized access to the REST API Index page, potentially exposing sensitive configuration information.
   reference:
     - http://geoserver.org/
     - https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html

--- a/http/cves/2025/CVE-2025-27505.yaml
+++ b/http/cves/2025/CVE-2025-27505.yaml
@@ -16,7 +16,7 @@ info:
     cpe: cpe:2.3:a:geoserver:geoserver:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     fofa-query: app="GeoServer"
     vendor: osgeo
     product: geoserver

--- a/http/cves/2025/CVE-2025-27505.yaml
+++ b/http/cves/2025/CVE-2025-27505.yaml
@@ -4,7 +4,8 @@ info:
   name: GeoServer - Missing Authorization on REST API Index
   author: securitytaters
   severity: medium
-  description: GeoServer has authorization issue on its REST API Index page
+    description: |
+      GeoServer contains a missing authorization vulnerability that allows unauthorized access to the REST API Index page, potentially exposing sensitive configuration information.
   reference:
     - http://geoserver.org/
     - https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html
@@ -12,15 +13,17 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
+    cve-id: CVE-2025-27505
     cwe-id: CWE-862
     cpe: cpe:2.3:a:geoserver:geoserver:*:*:*:*:*:*:*:*
   metadata:
     verified: true
     max-request: 2
-    fofa-query: app="GeoServer"
+    fofa-query: app="geoserver"
+    shodan-query: http.title:"geoserver"
     vendor: osgeo
     product: geoserver
-  tags: cve,cve2025,geoserver
+  tags: cve,cve2025,geoserver,misconfig,osgeo
 
 http:
   - method: GET
@@ -35,12 +38,12 @@ http:
       - type: word
         part: body
         words:
-          - Geoserver Configuration API
+          - "Geoserver Configuration API"
 
       - type: word
         part: body
         words:
-          - about/status
+          - "about/status"
 
       - type: status
         status:

--- a/http/cves/2025/CVE-2025-27505.yaml
+++ b/http/cves/2025/CVE-2025-27505.yaml
@@ -25,7 +25,10 @@ info:
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/rest.html"
       - "{{BaseURL}}/geoserver/rest.html"
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:

--- a/http/cves/2025/CVE-2025-27505.yaml
+++ b/http/cves/2025/CVE-2025-27505.yaml
@@ -1,0 +1,44 @@
+id: CVE-2025-27505
+
+info:
+  name: GeoServer - Missing Authorization on REST API Index
+  author: securitytaters
+  severity: medium
+  description: GeoServer has authorization issue on its REST API Index page
+  reference:
+    - http://geoserver.org/
+    - https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-27505
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-862
+    cpe: cpe:2.3:a:geoserver:geoserver:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    fofa-query: app="GeoServer"
+    vendor: osgeo
+    product: geoserver
+  tags: cve,cve2025,geoserver
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/geoserver/rest.html"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - Geoserver Configuration API
+
+      - type: word
+        part: body
+        words:
+          - about/status
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-27505 - GeoServer - Missing Authorization on REST API Index
- References: https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html
- Fixes https://github.com/projectdiscovery/nuclei-templates/issues/12560

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

This PR is based on the issue by @securitytaters.

I modified it a little bit by adding more references, tags and converted the raw request to a regular http request. I also added the base path, as I noticed with the previous vulnerabilities that not all instances are set at the `/geoserver/` path.

Template validated with online system. @securitytaters validated the template locally.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)