### PR TITLE
feat: add YSoft SafeQ panel exposure template

### DIFF
--- a/http/exposed-panels/ysoft/safeq-panel.yaml
+++ b/http/exposed-panels/ysoft/safeq-panel.yaml
@@ -1,0 +1,43 @@
+id: ysoft-safeq-panel
+
+info:
+  name: SafeQ Panel - Exposure
+  author: matejsmycka
+  severity: info
+  description: |
+    The YSoft SafeQ panel is umbrella printer management software used by many printer vendors. This should not be exposed to the public internet.
+  reference:
+    - https://www.ysoft.com/safeq
+    - https://1617882505.rsc.cdn77.org/YSoft_SAFEQ_Cloud_documentation.pdf
+  tags: panel,ysoft,login,safeq
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/login"
+
+    stop-at-first-match: true
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "YSoft SafeQ"
+          - "Y Soft Corporation, a.s."
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'YSoft SafeQ ([0-9\.]+)'
+        name: version


### PR DESCRIPTION
### Template / PR Information

After identifying multiple [Ysoft](https://www.ysoft.com/) SafeQ instances pointing to the internet, I have decided to create a template for this vendor. Multiple printer companies are using hardware from YSoft, which develops management server for these. We have not found any vulnerabilities for the server however it is bad practise to expose hardware controllers to the internet.

This template was tested on safeq 5 and 6.

<img width="832" height="527" alt="image" src="https://github.com/user-attachments/assets/29c25213-3d0a-4b14-aa77-f48823d65ba9" />



### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)