### PR TITLE
fix: update printer info leak template to print more context

### DIFF
--- a/network/misconfig/printers-info-leak.yaml
+++ b/network/misconfig/printers-info-leak.yaml
@@ -6,11 +6,20 @@ info:
   severity: info
   description: |
     Unauthorized access to printers allows attackers to print, eavesdrop sensitive documents.
+  impact: |
+     Attackers can gain access to sensitive printed documents, manipulate print jobs, and potentially compromise printer security
+  remediation: |
+     Implement proper network segmentation, disable unnecessary printer services, and ensure printers are not directly accessible from untrusted networks.
   reference:
     - https://book.hacktricks.xyz/pentesting/9100-pjl
+    - https://en.wikipedia.org/wiki/Printer_Job_Language
   metadata:
     max-request: 1
-  tags: network,iot,printer,misconfig,tcp
+    vendor: generic
+    product: printer
+    shodan-query: port:9100
+  tags: network,iot,printer,misconfig,tcp,pjl
+
 tcp:
   - inputs:
       - data: "@PJL INFO ID\n"

--- a/network/misconfig/printers-info-leak.yaml
+++ b/network/misconfig/printers-info-leak.yaml
@@ -2,7 +2,7 @@ id: printers-info-leak
 
 info:
   name: Unauthorized Printer Access
-  author: pussycat0x
+  author: pussycat0x,matejsmycka
   severity: info
   description: |
     Unauthorized access to printers allows attackers to print, eavesdrop sensitive documents.

--- a/network/misconfig/printers-info-leak.yaml
+++ b/network/misconfig/printers-info-leak.yaml
@@ -13,15 +13,18 @@ info:
   tags: network,iot,printer,misconfig,tcp
 tcp:
   - inputs:
-      - data: "@PJL INFO STATUS\n"
+      - data: "@PJL INFO ID\n"
     host:
       - "{{Hostname}}"
     port: 9100
 
     matchers:
-      - type: word
-        words:
-          - "CODE="
-          - "PJL INFO STATUS"
-        condition: and
-# digest: 4a0a00473045022100e5cd3caafcba367256fc02a088505cf294ceb9eba20a33e032ce2aca6b16c8110220510d9b154b7130143030f9f441ed0a1ea44c52053a2fb945d9a603d59c122f95:922c64590222798bb761d5b6d8e72950
+      - type: binary
+        binary:
+          - "40504a4c20494e464f2049440d0a22"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"([^"]+)"'


### PR DESCRIPTION
### Template / PR Information

This PR makes the printer port 9100 template better for asset discovery.
It uses different PJL command. Matcher had to be tweaked for binary chars so no FP or FN emerge.

It was tested on multiple hosts.

Before:
<img width="723" height="454" alt="Screenshot From 2025-07-14 17-25-26" src="https://github.com/user-attachments/assets/454d4ea7-bbac-43b4-9346-aeff4f11114b" />
After:
<img width="827" height="457" alt="Screenshot From 2025-07-14 18-00-17" src="https://github.com/user-attachments/assets/6be1712d-d107-40e6-868f-3ac3ae1b02d0" />

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)