### PR TITLE
add: EC2 CNAME-based subdomain takeover detection template

### DIFF
--- a/http/takeovers/aws-ec2-cname-takeover.yaml
+++ b/http/takeovers/aws-ec2-cname-takeover.yaml
@@ -9,9 +9,13 @@ info:
     (e.g., ec2-xx-xx-xx-xx.compute.amazonaws.com), and where the target appears
     unclaimed or inactive — a potential subdomain takeover scenario.
   reference:
-    - https://docs.projectdiscovery.io
     - https://github.com/EdOverflow/can-i-take-over-xyz
-  tags: takeover,aws,ec2,cname,subdomain
+    - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html
+    - https://blog.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/
+  metadata:
+    verified: true
+    max-request: 2
+  tags: takeover,aws,ec2,cname,subdomain,dns
 
 dns:
   - name: "{{FQDN}}"


### PR DESCRIPTION
Adds a new Nuclei template to detect CNAME-based subdomain takeover opportunities involving AWS EC2 instances.

Template name: aws-ec2-cname-takeover.yaml
Location: http/takeovers/

This template identifies subdomains that explicitly CNAME to AWS EC2 public hostnames (*.compute.amazonaws.com) and respond with known error signatures that suggest the EC2 instance is inactive, unclaimed, or deallocated.
	•	Detects dangling EC2 CNAMEs via DNS query (type: CNAME)
	•	Uses HTTP probing to match common AWS error pages (e.g., 404, timeout, “Sorry, we couldn’t find that page”)
	•	Extracts target EC2 hostname from DNS/HTTP response

Template Validation

I’ve validated this template locally?
	•	YES

Additional Details
	•	DNS regex covers EC2 hostnames in both classic and regional formats
	•	Useful for cloud hygiene, bug bounty, and external attack surface audits

Additional References:
	•	[Nuclei Template Guide](https://nuclei.projectdiscovery.io/templating-guide/)
	•	[AWS EC2 Public DNS Format](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html)