### PR TITLE
Add Scalar API documentation detection template

### DIFF
--- a/http/cves/2020/CVE-2020-24914.yaml
+++ b/http/cves/2020/CVE-2020-24914.yaml
@@ -1,0 +1,52 @@
+id: CVE-2020-24914
+
+info:
+  name: QCubed 3.1.1 - PHP Object Injection
+  author: riteshs4hu
+  severity: critical
+  description: |
+    QCubed 3.1.1 and all versions contain a PHP object injection vulnerability caused by unserializing untrusted POST data in profile.php, allowing unauthenticated attackers to execute arbitrary code via crafted POST requests.
+  impact: |
+    Successful exploitation allows unauthenticated attackers to execute arbitrary PHP code on the server, potentially leading to complete system compromise.
+  remediation: |
+    Update QCubed to the latest version that addresses this vulnerability or implement proper input validation and sanitization.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-24914
+    - https://seclists.org/fulldisclosure/2021/Mar/28
+    - https://tech.feedyourhead.at/content/QCubed-PHP-Object-Injection-CVE-2020-24914
+    - https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-24914
+    cwe-id: CWE-502
+    cpe: cpe:2.3:a:qcubed:qcubed:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: qcubed
+    product: qcubed
+    shodan-query: 'http.html:"QCubed" || http.html:"qcubed"'
+    fofa-query: 'body="QCubed" || body="qcubed"'
+  tags: cve,cve2020,qcubed,rce,deserialization
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/vendor/qcubed/qcubed/assets/php/profile.php"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "intDatabaseIndex=1&strReferrer=test&strProfileData=TzozOiJQRE8iOjA6e30%3d"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "You cannot serialize or unserialize PDO instances"
+          - "PDOException"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/scalar-detection.yaml
+++ b/http/exposed-panels/scalar-detection.yaml
@@ -1,0 +1,49 @@
+id: scalar-detection
+
+info:
+  name: Scalar API Documentation - Detect
+  author: recepgunes
+  severity: info
+  description: Scalar API documentation panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+    vendor: scalar
+    product: scalar
+    shodan-query: title:"Scalar API Reference"
+    category: devops
+    fofa-query: title="Scalar API Reference"
+    google-query: intitle:"Scalar API Reference"
+  tags: panel,scalar,api,documentation,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/scalar"
+      - "{{BaseURL}}/scalar/v1"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Scalar API Reference"
+          - "@scalar/api-reference"
+          - "scalar-references"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '@scalar/api-reference@([0-9.]+)'
+          - 'scalar.*version.*([0-9.]+)'


### PR DESCRIPTION
## Summary
- Adds new Nuclei template to detect Scalar API documentation panels
- Targets `/scalar` and `/scalar/v1` endpoints commonly used by Scalar
- Includes proper metadata, classification, and version extraction
- Resolves #12622

## Test plan
- [x] YAML syntax validation passed
- [x] Template follows existing nuclei-templates conventions
- [x] Proper categorization in `http/exposed-panels/` directory
- [x] Includes appropriate tags and metadata
- [ ] Test against known Scalar implementations (manual testing recommended)

The template detects Scalar UI by checking for:
- "Scalar API Reference" in page title/content
- "@scalar/api-reference" package references
- "scalar-references" DOM elements

This detection is particularly relevant for .NET applications since .NET 9 removed Swagger as the default API testing tool, making Scalar a popular alternative.

🤖 Generated with [Claude Code](https://claude.ai/code)