### PR TITLE
Fix CVE-2025-4427 false-negative detection

### DIFF
--- a/http/cves/2025/CVE-2025-4427.yaml
+++ b/http/cves/2025/CVE-2025-4427.yaml
@@ -40,9 +40,14 @@ http:
       - type: word
         part: body
         words:
-          - "Format 'Process[pid="
           - "localizedMessage"
-        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "Format 'Process\\[pid="
+          - "Format 'java\\.lang\\.UNIXProcess@[0-9a-f]+'"
+        condition: or
 
       - type: word
         part: interactsh_protocol


### PR DESCRIPTION
## Summary
- Fixed false-negative detection in CVE-2025-4427 template for Ivanti Endpoint Manager Mobile RCE
- Updated matchers to handle both process ID and UNIXProcess object response formats
- Added regex matcher for `java.lang.UNIXProcess@[hash]` pattern

## Changes
- Reorganized matchers with OR condition for better detection coverage
- Added regex patterns to catch UNIXProcess object responses that were causing false-negatives

## References
- Fixes #12209
- Addresses false-negative reported by xcr-19