### PR TITLE
add graphql directive overloading detection template

### DIFF
--- a/http/misconfiguration/graphql/graphql-directive-overloading.yaml
+++ b/http/misconfiguration/graphql/graphql-directive-overloading.yaml
@@ -1,0 +1,39 @@
+id: graphql-directive-overloading
+
+info:
+  name: GraphQL Directive Overloading Detection
+  author: shamo0
+  severity: info
+  description: |
+    This template detects directive overloading in GraphQL queries, which can lead to denial of service by allowing multiple duplicated directives in a single query.
+  tags: graphql,denial-of-service
+
+http:
+  - raw:
+      - |
+        POST /graphql HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "query": "query { __typename @aa @aa @aa @aa @aa @aa @aa @aa @aa @aa }"
+        }
+
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "\\\"errors\\\":\\s*\\[.*?\\]"
+      - type: regex
+        part: body
+        regex:
+          - "\\\"message\\\":\\s*\\\".*?@aa.*?\\\""
+
+    extractors:
+      - type: regex
+        name: directive_errors
+        part: body
+        regex:
+          - "\\\"errors\\\":\\s*\\[.*?\\]"


### PR DESCRIPTION
### Template / PR Information

This PR adds a new Nuclei template for detecting GraphQL Directive Overloading, a misconfiguration that can potentially lead to Denial of Service (DoS). The technique involves sending multiple duplicated directives (e.g. @aa) in a single query to test how the GraphQL server handles overload conditions.


### Template Validation

I've validated this template locally?
YES
<img width="1192" height="371" alt="image" src="https://github.com/user-attachments/assets/83a1ca6a-c312-4055-a288-90583da41452" />



#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)