### PR TITLE
Address false negative in iDRAC 9 Default Login

### DIFF
--- a/http/default-logins/dell/dell-idrac9-default-login.yaml
+++ b/http/default-logins/dell/dell-idrac9-default-login.yaml
@@ -1,10 +1,10 @@
 id: dell-idrac9-default-login
 
 info:
-  name: DELL iDRAC9 Default Login
+  name: DELL iDRAC9 - Default Login
   author: kophjager007,milo2012
   severity: high
-  description: DELL iDRAC9 default login information was discovered. The default iDRAC username and password are widely known, and any user with access to the server could change the default password.
+  description: DELL iDRAC9 default login credentials were discovered.
   reference:
     - https://www.dell.com/support/kbdoc/en-us/000177787/how-to-change-the-default-login-password-of-the-idrac-9
   classification:
@@ -36,8 +36,7 @@ http:
           - 200
         condition: or
 
-      - type: word
-        part: body
-        words:
-          - '"authResult":0'
-# digest: 4a0a00473045022075708871311ecc1e56f7229c666f9e770f4ca9d89aca4d5d21cbedab933ef93702210090257f243ada75b6bb86b4556c103bbbdac1f4f3882f9c2488e9f47a23afbf13:922c64590222798bb761d5b6d8e72950
+      - type: regex
+        name: authresult
+        regex:
+          - '"authResult"\s*:\s*0'

--- a/http/default-logins/dell/dell-idrac9-default-login.yaml
+++ b/http/default-logins/dell/dell-idrac9-default-login.yaml
@@ -4,7 +4,8 @@ info:
   name: DELL iDRAC9 - Default Login
   author: kophjager007,milo2012
   severity: high
-  description: DELL iDRAC9 default login credentials were discovered.
+  description: |
+    DELL iDRAC9 default login credentials was discovered.
   reference:
     - https://www.dell.com/support/kbdoc/en-us/000177787/how-to-change-the-default-login-password-of-the-idrac-9
   classification:
@@ -30,13 +31,12 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 201
-          - 200
-        condition: or
-
       - type: regex
         name: authresult
         regex:
           - '"authResult"\s*:\s*0'
+
+      - type: status
+        status:
+          - 201
+          - 200


### PR DESCRIPTION
### Template / PR Information

This fixes #12697 by switching to a regex that can match arbitrary whitespace.

This also includes some light cosmetic fixes (using ` - Default Login` as the docs recommend).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
