### PR TITLE
Match both server-info and server-status

### DIFF
--- a/http/misconfiguration/apache/apache-server-status.yaml
+++ b/http/misconfiguration/apache/apache-server-status.yaml
@@ -24,7 +24,6 @@ http:
       - "{{BaseURL}}/server-info"
       - "{{BaseURL}}/server-status"
 
-    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Removed "stop-at-first-match" which would flag /server-info but not /server-status
- Would lead to false negative on /server-status

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Before:
```
$ echo https://xyz | nuclei -id apache-server-status -silent
[apache-server-status] [http] [low] https://xyz/server-info
```

After:
```
$ echo https://xyz | nuclei -id apache-server-status -silent
[apache-server-status] [http] [low] https://xyz/server-info
[apache-server-status] [http] [low] https://xyz/server-status
```