### PR TITLE
add misconfiguration of linux

### DIFF
--- a/misconfiguration/linux/account-lockout-threshold-not-configured.yaml
+++ b/misconfiguration/linux/account-lockout-threshold-not-configured.yaml
@@ -1,0 +1,40 @@
+id: account-lockout-threshold-not-configured
+
+info:
+  name: Linux Account Lockout Threshold Not Configured
+  author: songyaeji
+  severity: high
+  description: >
+    The system does not enforce an account lockout threshold. Without this control,
+    repeated login attempts are not restricted, leaving the system vulnerable to brute-force attacks.
+    This template checks whether account lockout settings are configured in PAM modules.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,pam,auth,misconfiguration,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 3
+  classification:
+    cwe-id: CWE-307
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 5.5
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      grep -E 'pam_tally2.so|pam_faillock.so' /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-auth 2>/dev/null || echo "no-lockout-config"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "no-lockout-config"
+      - type: regex
+        part: code_1_response
+        regex:
+          - 'pam_tally2.so(?!.*deny=)'
+          - 'pam_faillock.so(?!.*deny=)'

--- a/misconfiguration/linux/check-sendmail-postfix-version.yaml
+++ b/misconfiguration/linux/check-sendmail-postfix-version.yaml
@@ -1,0 +1,79 @@
+id: check-sendmail-postfix-version
+
+info:
+  name: Sendmail and Postfix Version Vulnerability Check
+  author: songyaeji
+  severity: medium
+  description: >
+    This template checks if the versions of Sendmail and Postfix are being used and whether they are likely outdated.
+    Unpatched versions may contain critical vulnerabilities such as buffer overflows, privilege escalation, or information disclosure.
+    It checks process presence and version indicators to help determine patch status.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,sendmail,postfix,version,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 3
+  classification:
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-937
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      ps -ef | grep sendmail | grep -v grep || echo "sendmail-not-running"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "sendmail"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      cat /etc/mail/sendmail.cf 2>/dev/null | grep "^DZ" || echo "no-dz-entry"
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "DZ"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      systemctl status postfix 2>/dev/null | grep "postfix" || echo "postfix-not-running"
+    matchers:
+      - type: word
+        part: code_3_response
+        words:
+          - "postfix"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      postfix status 2>/dev/null | grep "postfix-script" || echo "no-script"
+    matchers:
+      - type: word
+        part: code_4_response
+        words:
+          - "postfix-script"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      postconf -d 2>/dev/null | grep mail_version || echo "no-mail-version"
+    matchers:
+      - type: word
+        part: code_5_response
+        words:
+          - "mail_version"
+        condition: contains

--- a/misconfiguration/linux/dns-bind-version-check.yaml
+++ b/misconfiguration/linux/dns-bind-version-check.yaml
@@ -1,0 +1,45 @@
+id: dns-bind-version-patch
+
+info:
+  name: BIND DNS Version - Security Patch Check
+  author: songyaeji
+  severity: high
+  description: >
+    Older versions of the BIND DNS server may contain vulnerabilities such as Service Denial Attacks,
+    Buffer Overflows, and remote code execution risks. This template checks if the BIND service (named) is running
+    and retrieves its version to determine whether security patches have been applied.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,dns,bind,patch,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-1104
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      ps -ef | grep named | grep -v grep || echo "named-not-running"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "named"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      named -v 2>/dev/null || echo "version-not-found"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - "BIND\\s+([0-9]+\\.[0-9]+\\.[0-9]+)"

--- a/misconfiguration/linux/dns-zone-transfer-check.yaml
+++ b/misconfiguration/linux/dns-zone-transfer-check.yaml
@@ -1,0 +1,35 @@
+id: dns-zone-transfer-check
+
+info:
+  name: DNS Zone Transfer - Configuration Check
+  author: songyaeji
+  severity: high
+  description: >
+    If DNS Zone Transfer is allowed to all hosts, it may expose sensitive information such as hostnames, 
+    network structure, and system data. This template checks whether the BIND DNS server restricts 
+    zone transfers via allow-transfer directive in /etc/named.conf.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,dns,bind,zonetransfer,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-200
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      cat /etc/named.conf 2>/dev/null | grep -E 'allow-transfer' || echo "no-allow-transfer"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "allow-transfer"
+        condition: contains

--- a/misconfiguration/linux/etc-hosts-permission-check.yaml
+++ b/misconfiguration/linux/etc-hosts-permission-check.yaml
@@ -1,0 +1,33 @@
+id: etc-hosts-permission-check
+
+info:
+  name: /etc/hosts File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/hosts file is writable by non-root users, attackers may register malicious DNS mappings and redirect legitimate domains to malicious sites (pharming attacks). This check ensures /etc/hosts is owned by root and has appropriate permissions.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,hosts,file,permission,ownership,misconfiguration
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/hosts 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/etc-passwd-permission-check.yaml
+++ b/misconfiguration/linux/etc-passwd-permission-check.yaml
@@ -1,0 +1,33 @@
+id: etc-passwd-permission-check
+
+info:
+  name: /etc/passwd File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If a user other than root can modify the /etc/passwd file, it may allow unauthorized shell access or privilege escalation. This template checks that the file is owned by root and has permission 644 or less.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,permission,file,passwd,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.0
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/passwd 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+(6[0-4][0-4]|64[0-4]|[0-5][0-9]{2}|[0-9]{1,2})$'

--- a/misconfiguration/linux/etc-rsyslogconf-permission-check.yaml
+++ b/misconfiguration/linux/etc-rsyslogconf-permission-check.yaml
@@ -1,0 +1,44 @@
+id: etc-rsyslogconf-permission-check
+
+info:
+  name: /etc/(r)syslog.conf File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/syslog.conf or /etc/rsyslog.conf file is not owned by root or has insecure permissions,
+    attackers may manipulate logging settings to avoid detection.
+  reference:
+    - https://isms.kisa.or.kr
+    - KISA Cloud Vulnerability Assessment Guide (2024)
+  tags: linux,configuration,logging,permissions,rsyslog,syslog
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/rsyslog.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'
+
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/syslog.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/etc-services-permission-check.yaml
+++ b/misconfiguration/linux/etc-services-permission-check.yaml
@@ -1,0 +1,34 @@
+id: etc-services-permission-check
+
+info:
+  name: /etc/services File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/services file is not owned by root or has excessive permissions,
+    an attacker may alter port assignments to redirect services or open unauthorized ports.
+  reference:
+    - https://isms.kisa.or.kr
+    - KISA Cloud Vulnerability Assessment Guide (2024)
+  tags: linux,configuration,services,permissions,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/services 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/etc-shadow-permission-check.yaml
+++ b/misconfiguration/linux/etc-shadow-permission-check.yaml
@@ -1,0 +1,33 @@
+id: etc-shadow-permission-check
+
+info:
+  name: /etc/shadow File Owner and Permission Check
+  author: songyaeji
+  severity: critical
+  description: >
+    The /etc/shadow file must only be readable by root. If its permissions or ownership are misconfigured, it can lead to exposure of password hashes, allowing offline cracking or privilege escalation.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,shadow,permission,file,misconfiguration
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/shadow 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+shadow\s+([0-3][0-9]{2}|400)$'

--- a/misconfiguration/linux/etc-xinetdconf-permission-check.yaml
+++ b/misconfiguration/linux/etc-xinetdconf-permission-check.yaml
@@ -1,0 +1,43 @@
+id: etc-xinetdconf-permission-check
+
+info:
+  name: /etc/(x)inetd.conf File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/xinetd.conf or /etc/inetd.conf file is writable by non-root users, they may register malicious services that run with root privileges. This check ensures the file is owned by root and has secure permissions.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,configuration,file,ownership,permission,xinetd,inetd
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/xinetd.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'
+
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/inetd.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/file-or-dir-without-owner.yaml
+++ b/misconfiguration/linux/file-or-dir-without-owner.yaml
@@ -1,0 +1,35 @@
+id: file-or-dir-without-owner
+
+info:
+  name: Files or Directories Without Valid Owner or Group
+  author: songyaeji
+  severity: medium
+  description: >
+    Files or directories without a valid owner or group may result from improper user/group deletion or administrative errors.
+    These files could be exploited or misused if not properly reviewed and removed or reassigned.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,ownership,compliance,file-permissions
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L
+    cvss-score: 4.6
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      find /etc /tmp /bin /sbin \( -nouser -o -nogroup \) -xdev -exec ls -al {} \; 2>/dev/null | head -n 1 || echo "no-unowned"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - " /"
+        condition: contains

--- a/misconfiguration/linux/home-env-permission-check.yaml
+++ b/misconfiguration/linux/home-env-permission-check.yaml
@@ -1,0 +1,40 @@
+id: home-env-permission-check
+
+info:
+  name: User Home Directory and Shell Environment File Ownership & Permission Check
+  author: songyaeji
+  severity: medium
+  description: >
+    If shell startup and environment files (e.g. .bashrc, .bash_profile, .bash_logout) are not owned by the user or root,
+    or have insecure write permissions, malicious users can manipulate environment variables or inject malicious commands.
+  tags: linux,local,permissions,home,shell,compliance
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  metadata:
+    os: linux
+    verified: true
+    max-request: 1
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      for user in $(awk -F: '$6 ~ /^\/home/ {print $1}' /etc/passwd); do
+        HOME_DIR=$(eval echo ~$user)
+        find "$HOME_DIR" -maxdepth 1 -type f \( -name ".bashrc" -o -name ".bash_profile" -o -name ".bash_logout" \) -exec ls -l {} \;
+      done
+    matchers:
+      - type: regex
+        name: insecure-perms
+        part: code_1_response
+        regex:
+          - "^-..w..w..w"
+          - "^-.{2}w.{2}w.{2}w"
+      - type: negative-word
+        name: not-owned-by-user
+        words:
+          - "root"
+        part: code_1_response

--- a/misconfiguration/linux/linux-anonymous-ftp-disabled.yaml
+++ b/misconfiguration/linux/linux-anonymous-ftp-disabled.yaml
@@ -1,0 +1,54 @@
+id: linux-anonymous-ftp-disabled
+
+info:
+  name: Linux Anonymous FTP Access Enabled - Security Misconfiguration
+  author: songyaeji
+  severity: high
+  description: >
+    If the anonymous FTP account is enabled, malicious users may exploit it to log in anonymously
+    and write to directories, potentially gaining unauthorized access or executing local exploits
+    against the system. This template checks for signs that anonymous FTP is enabled
+    via /etc/passwd, vsFTPD, or ProFTPD configuration files.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,ftp,anonymous,vsftpd,proftpd,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:H
+    cvss-score: 8.6
+    cwe-id: CWE-200
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      ftp_user=$(grep -E '^ftp:' /etc/passwd)
+      vsftp_enabled=$(grep -i 'anonymous_enable' /etc/vsftpd/vsftpd.conf 2>/dev/null | grep -i yes)
+      proftp_alias=$(grep -i 'UserAlias[[:space:]]\+anonymous' /etc/proftpd/proftpd.conf 2>/dev/null)
+
+      if [ -n "$ftp_user" ]; then
+        echo "[VULNERABLE] FTP user exists in /etc/passwd"
+      fi
+
+      if [ -n "$vsftp_enabled" ]; then
+        echo "[VULNERABLE] anonymous_enable=YES is set in vsftpd.conf"
+      fi
+
+      if [ -n "$proftp_alias" ]; then
+        echo "[VULNERABLE] 'UserAlias anonymous ftp' found in proftpd.conf"
+      fi
+
+      if [ -z "$ftp_user" ] && [ -z "$vsftp_enabled" ] && [ -z "$proftp_alias" ]; then
+        echo "[SAFE] Anonymous FTP is properly disabled"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-automountd-enabled.yaml
+++ b/misconfiguration/linux/linux-automountd-enabled.yaml
@@ -1,0 +1,38 @@
+id: linux-automountd-enabled
+
+info:
+  name: Automountd Service Running - Privilege Escalation Risk
+  author: songyaeji
+  severity: high
+  description: >
+    If the automountd service is enabled, a local attacker may execute arbitrary commands using root privileges
+    by exploiting automatic mount options. This misconfiguration can lead to local privilege escalation.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,automountd,service,privilege-escalation,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-269
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if ps -ef | grep -v grep | grep -q automountd; then
+        echo "[VULNERABLE] automountd service is running"
+      else
+        echo "[SAFE] automountd service is not running"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE] automountd service is running"

--- a/misconfiguration/linux/linux-cron-ownership-perms-check.yaml
+++ b/misconfiguration/linux/linux-cron-ownership-perms-check.yaml
@@ -1,0 +1,57 @@
+id: linux-cron-file-permissions
+
+info:
+  name: Cron File Ownership and Permissions Check
+  author: songyaeji
+  severity: high
+  description: >
+    Checks whether /etc/cron.allow and /etc/cron.deny files have proper ownership (root)
+    and permission (640). Misconfigured cron access files may allow unauthorized users
+    to schedule cron jobs, which could result in system compromise or denial of service.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,cron,permissions,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      result=""
+      if [ -f /etc/cron.allow ]; then
+        owner=$(stat -c "%U" /etc/cron.allow)
+        perm=$(stat -c "%a" /etc/cron.allow)
+        if [ "$owner" != "root" ] || [ "$perm" -gt 640 ]; then
+          result+="[WARN] /etc/cron.allow misconfigured\n"
+        fi
+      fi
+
+      if [ -f /etc/cron.deny ]; then
+        owner=$(stat -c "%U" /etc/cron.deny)
+        perm=$(stat -c "%a" /etc/cron.deny)
+        if [ "$owner" != "root" ] || [ "$perm" -gt 640 ]; then
+          result+="[WARN] /etc/cron.deny misconfigured\n"
+        fi
+      fi
+
+      if [ -n "$result" ]; then
+        echo -e "$result"
+      else
+        echo "[OK] cron files properly configured"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[WARN] /etc/cron.allow misconfigured"
+          - "[WARN] /etc/cron.deny misconfigured"

--- a/misconfiguration/linux/linux-dos-vulnerable-services-disabled.yaml
+++ b/misconfiguration/linux/linux-dos-vulnerable-services-disabled.yaml
@@ -1,0 +1,45 @@
+id: linux-dos-vulnerable-services-disabled
+
+info:
+  name: DoS Vulnerable Services Disabled (echo, discard, daytime, chargen)
+  author: songyaeji
+  severity: high
+  description: >
+    If services such as echo, discard, daytime, and chargen are enabled on the system, 
+    attackers may exploit them to extract system information or launch denial-of-service (DoS) attacks. 
+    These legacy services should be disabled if not explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,misconfiguration,xinetd,DoS,legacy
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 5.5
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      vulnerable=""
+      for svc in echo discard daytime chargen; do
+        if grep -iq 'disable[[:space:]]*=[[:space:]]*no' "/etc/xinetd.d/$svc" 2>/dev/null; then
+          echo "[VULNERABLE] $svc service is enabled in /etc/xinetd.d/$svc"
+          vulnerable="yes"
+        fi
+      done
+
+      if [ -z "$vulnerable" ]; then
+        echo "[SAFE] All DoS-related services are properly disabled"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-hosts-access-control.yaml
+++ b/misconfiguration/linux/linux-hosts-access-control.yaml
@@ -1,0 +1,43 @@
+id: linux-hosts-access-control
+
+info:
+  name: Check TCP Wrapper IP-based access control configuration
+  author: songyaeji
+  severity: high
+  description: >
+    Detects if IP and port restrictions are properly applied using TCP Wrapper (/etc/hosts.allow and /etc/hosts.deny).
+    If unrestricted, systems are vulnerable to unauthorized remote access (e.g. Telnet, RSH, SSH).
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,misconfig,access-control,tcpwrapper,ssh
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      echo "[*] Checking /etc/hosts.deny"
+      if grep -q "^ALL:ALL" /etc/hosts.deny; then
+        echo "[OK] /etc/hosts.deny has ALL:ALL policy"
+      else
+        echo "[WARN] /etc/hosts.deny is missing ALL:ALL (default deny)"
+      fi
+
+      echo "[*] Checking sshd allow policy in /etc/hosts.allow"
+      grep -Ei "sshd" /etc/hosts.allow || echo "[WARN] No sshd-specific allow policy found"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "/etc/hosts.deny"
+          - "/etc/hosts.allow"

--- a/misconfiguration/linux/linux-nfs-everyone-access.yaml
+++ b/misconfiguration/linux/linux-nfs-everyone-access.yaml
@@ -1,0 +1,40 @@
+id: linux-nfs-everyone-access
+
+info:
+  name: NFS Access Control Misconfiguration - Everyone Shared
+  author: songyaeji
+  severity: high
+  description: >
+    If access control is not properly configured on NFS, unauthorized users can mount shared directories without authentication. 
+    This can result in exposure or tampering of sensitive files.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,nfs,access-control,misconfiguration
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if grep -E '\(.*all_squash.*\)' /etc/exports; then
+        echo "[VULNERABLE] NFS allows everyone access with all_squash"
+      elif grep -E '\*' /etc/exports; then
+        echo "[VULNERABLE] NFS allows access to all (*) hosts"
+      else
+        echo "[SAFE] NFS access is restricted to specific IPs/subnets"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-nfs-service-disabled.yaml
+++ b/misconfiguration/linux/linux-nfs-service-disabled.yaml
@@ -1,0 +1,38 @@
+id: linux-nfs-service-disabled
+
+info:
+  name: NFS Service Daemon Should Be Disabled
+  author: songyaeji
+  severity: high
+  description: >
+    If the NFS service is running, unauthorized users may exploit it to access, modify, or delete system files.
+    It is recommended to ensure the NFS daemon is disabled when not explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,nfs,misconfiguration,daemon
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if ps -ef | grep -v grep | grep -q nfsd; then
+        echo "[VULNERABLE] NFS service is active (nfsd is running)"
+      else
+        echo "[SAFE] NFS service is not running"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-nis-nisplus-service-running.yaml
+++ b/misconfiguration/linux/linux-nis-nisplus-service-running.yaml
@@ -1,0 +1,41 @@
+id: linux-nis-nisplus-service-running
+
+info:
+  name: NIS/NIS+ Service Enabled
+  author: songyaeji
+  severity: high
+  description: >
+    If insecure NIS or NIS+ services are running, attackers may gain root privileges or harvest sensitive user information. 
+    It is strongly recommended to disable these services unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,nis,nisplus,misconfiguration,privilege-escalation,service
+  metadata:
+    verified: true
+    os: linux
+    category: nis
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      running=$(ps -ef | egrep "ypserv|ypbind|ypxfrd|rpc.yppasswdd|rpc.yppupdated" | grep -v grep)
+      if [ -n "$running" ]; then
+        echo "[VULNERABLE] NIS or NIS+ service is running"
+        echo "$running"
+      else
+        echo "[SAFE] NIS and NIS+ services are not running"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-os-kernel-eol-check.yaml
+++ b/misconfiguration/linux/linux-os-kernel-eol-check.yaml
@@ -1,0 +1,46 @@
+id: linux-os-kernel-eol-check
+
+info:
+  name: Linux OS or Kernel End of Life (EOL) Version Check
+  author: songyaeji
+  severity: high
+  description: >
+    Systems running outdated or EOL (End-of-Life) versions of Linux OS or Kernel may be vulnerable to
+    known exploits due to lack of vendor support and patch updates. This template checks the current OS
+    and Kernel version to assess patch compliance status.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,patch,eol,os,kernel,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-1104
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      cat /etc/os-release 2>/dev/null | grep -E '^VERSION_ID=' || echo "os-version-not-found"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "VERSION_ID="
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      uname -r 2>/dev/null || echo "kernel-version-not-found"
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "generic"
+        condition: contains

--- a/misconfiguration/linux/linux-r-command-services-disabled.yaml
+++ b/misconfiguration/linux/linux-r-command-services-disabled.yaml
@@ -1,0 +1,51 @@
+id: linux-r-command-services-disabled
+
+info:
+  name: r-command Services Disabled (rlogin, rsh, rexec)
+  author: songyaeji
+  severity: high
+  description: >
+    If r-command services (rlogin, rsh, rexec) are enabled, unauthorized users may access or extract sensitive information,
+    or disrupt the system through open ports. These legacy services should be disabled unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,misconfiguration,rlogin,rsh,rexec,xinetd
+  metadata:
+    verified: true
+    os: linux
+    category: configuration
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      rlogin_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rlogin 2>/dev/null)
+      rsh_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rsh 2>/dev/null)
+      rexec_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rexec 2>/dev/null)
+
+      if [ -n "$rlogin_check" ]; then
+        echo "[VULNERABLE] rlogin service is enabled"
+      fi
+      if [ -n "$rsh_check" ]; then
+        echo "[VULNERABLE] rsh service is enabled"
+      fi
+      if [ -n "$rexec_check" ]; then
+        echo "[VULNERABLE] rexec service is enabled"
+      fi
+
+      if [ -z "$rlogin_check" ] && [ -z "$rsh_check" ] && [ -z "$rexec_check" ]; then
+        echo "[SAFE] All r-command services are properly disabled"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-rhosts-hostsequiv-check.yaml
+++ b/misconfiguration/linux/linux-rhosts-hostsequiv-check.yaml
@@ -1,0 +1,50 @@
+id: linux-rhosts-hostsequiv-check
+
+info:
+  name: Detect presence or misconfiguration of .rhosts and hosts.equiv
+  author: songyaeji
+  severity: high
+  description: >
+    Presence or misconfiguration of .rhosts or /etc/hosts.equiv files can allow unauthorized remote command execution (rlogin, rsh).
+    This template detects existence and improper permissions or unsafe "+" usage in these files.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+    - https://linux.die.net/man/5/hosts.equiv
+  tags: linux,local,misconfig,rhosts,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      # Check if /etc/hosts.equiv exists
+      if [ -f /etc/hosts.equiv ]; then
+        echo "[FOUND] /etc/hosts.equiv exists"
+        ls -l /etc/hosts.equiv
+        echo "[CONTENT]"
+        cat /etc/hosts.equiv
+      fi
+
+      # Check if any .rhosts files exist under home directories
+      find /home -maxdepth 2 -name ".rhosts" 2>/dev/null | while read rhost; do
+        echo "[FOUND] $rhost"
+        ls -l "$rhost"
+        echo "[CONTENT]"
+        cat "$rhost"
+      done
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "/etc/hosts.equiv"
+          - ".rhosts"

--- a/misconfiguration/linux/linux-unnecessary-rpc-enabled.yaml
+++ b/misconfiguration/linux/linux-unnecessary-rpc-enabled.yaml
@@ -1,0 +1,42 @@
+id: linux-unnecessary-rpc-enabled
+
+info:
+  name: Unnecessary RPC Service (rstatd) Enabled
+  author: songyaeji
+  severity: high
+  description: >
+    If unnecessary RPC services like rstatd are enabled, attackers may exploit buffer overflow, DoS, or remote execution vulnerabilities to gain root privileges and compromise the system.
+    These services should be disabled unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux, misconfiguration, rpc, xinetd, rstatd, privilege-escalation
+  metadata:
+    verified: true
+    os: linux
+    category: rpc
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if [ -f /etc/xinetd.d/rstatd ]; then
+        if grep -qE 'disable\s*=\s*no' /etc/xinetd.d/rstatd; then
+          echo "[VULNERABLE] rstatd RPC service is enabled in xinetd"
+        else
+          echo "[SAFE] rstatd RPC service is disabled"
+        fi
+      else
+        echo "[SAFE] rstatd service not found"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-world-writable-file-check.yaml
+++ b/misconfiguration/linux/linux-world-writable-file-check.yaml
@@ -1,7 +1,7 @@
 id: linux-world-writable-file-check
 
 info:
-  name: World Writable File Permission Check
+  name: Linux World Writable File Permission Check
   author: songyaeji
   severity: high
   description: >
@@ -13,6 +13,10 @@ info:
   metadata:
     verified: true
     os: linux
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
 
 self-contained: true
 
@@ -26,4 +30,4 @@ code:
         name: world-writable-files
         part: code_1_response
         regex:
-          - "^-rw.{3}rw.{3}.*"
+          - "^-..w..w..w.*"

--- a/misconfiguration/linux/linux-world-writable-file-check.yaml
+++ b/misconfiguration/linux/linux-world-writable-file-check.yaml
@@ -1,0 +1,29 @@
+id: linux-world-writable-file-check
+
+info:
+  name: World Writable File Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If important system files are configured with world writable (chmod o+w) permissions, malicious users may arbitrarily modify them, leading to privilege escalation, system backdoors, or service disruption.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,misconfig,permission,compliance
+  metadata:
+    verified: true
+    os: linux
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      find / -type f -perm -2 ! -path "/tmp/*" -exec ls -l {} \; 2>/dev/null
+    matchers:
+      - type: regex
+        name: world-writable-files
+        part: code_1_response
+        regex:
+          - "^-rw.{3}rw.{3}.*"

--- a/misconfiguration/linux/linux-xinetd-finger-disabled.yaml
+++ b/misconfiguration/linux/linux-xinetd-finger-disabled.yaml
@@ -1,0 +1,44 @@
+id: linux-xinetd-finger-disabled
+
+info:
+  name: Linux Finger Service Disabled - xinetd Misconfiguration
+  author: songyaeji
+  severity: high
+  description: >
+    If the Finger service is enabled, it may expose user information to unauthorized users,
+    leading to potential password-based attacks. This template checks whether the Finger
+    service is properly disabled by inspecting the 'disable' directive in /etc/xinetd.d/finger.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,finger,xinetd,misconfiguration,local
+  metadata:
+    os: linux
+    category: configuration
+    verified: true
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.5
+    cwe-id: CWE-200
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if [ -f /etc/xinetd.d/finger ]; then
+        disable_status=$(grep -i 'disable' /etc/xinetd.d/finger | grep -v '^#' | awk -F '=' '{print $2}' | xargs)
+        if [ "$disable_status" = "no" ]; then
+          echo "[VULNERABLE] Finger service is enabled (disable = no)"
+        else
+          echo "[SAFE] Finger service is disabled"
+        fi
+      else
+        echo "[SAFE] /etc/xinetd.d/finger does not exist"
+      fi
+
+    matchers:
+      - type: word
+        words:
+          - "[VULNERABLE] Finger service is enabled"

--- a/misconfiguration/linux/linux-xinetd-tftp-talk-disabled.yaml
+++ b/misconfiguration/linux/linux-xinetd-tftp-talk-disabled.yaml
@@ -1,0 +1,45 @@
+id: linux-xinetd-tftp-talk-disabled
+
+info:
+  name: Linux tftp, talk, ntalk Services Should Be Disabled
+  author: songyaeji
+  severity: high
+  description: >
+    Unused services like tftp, talk, or ntalk may have known vulnerabilities.
+    If these are enabled, they could be targeted by attackers.
+    This template checks if they are properly disabled in the xinetd configuration.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,tftp,talk,ntalk,xinetd,service,misconfiguration
+  metadata:
+    os: linux
+    category: system
+    verified: true
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
+    cvss-score: 6.2
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      for svc in tftp talk ntalk; do
+        file="/etc/xinetd.d/$svc"
+        if [ -f "$file" ]; then
+          if grep -q "disable[[:space:]]*=[[:space:]]*yes" "$file"; then
+            echo "[SAFE] $svc is disabled."
+          else
+            echo "[VULNERABLE] $svc is not disabled in $file."
+          fi
+        else
+          echo "[SAFE] $svc service config file not found. Assuming not installed."
+        fi
+      done
+    matchers:
+      - type: word
+        words:
+          - "[VULNERABLE] $svc is not disabled in"

--- a/misconfiguration/linux/password-complexity-not-enforced.yaml
+++ b/misconfiguration/linux/password-complexity-not-enforced.yaml
@@ -5,11 +5,20 @@ info:
   author: songyaeji
   severity: high
   description: >
-    Password complexity requirements are not enforced on this system. This allows weak passwords, making user accounts more susceptible to brute-force and dictionary attacks.
+    Password complexity requirements are not enforced on this system. This allows weak passwords,
+    making user accounts more susceptible to brute-force and dictionary attacks.
   reference:
     - https://isms.kisa.or.kr/main/csap/notice/
     - Cloud Vulnerability Assessment Guide(2024) by KISA
   tags: linux,local,configuration,auth,weak-password,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-521
 
 self-contained: true
 code:
@@ -17,7 +26,6 @@ code:
       - bash
     source: |
       cat /etc/security/pwquality.conf 2>/dev/null || true
-
     matchers:
       - type: regex
         part: code_1_response
@@ -27,18 +35,19 @@ code:
           - 'ucredit\s*=\s*0'
           - 'lcredit\s*=\s*0'
           - 'ocredit\s*=\s*0'
+        condition: or
 
   - engine:
       - bash
     source: |
       grep pam_pwquality.so /etc/pam.d/system-auth /etc/pam.d/common-password 2>/dev/null || true
-
     matchers:
       - type: word
         part: code_2_response
         words:
           - "pam_pwquality.so"
-      - type: negative_word
+      - type: word
         part: code_2_response
         words:
           - "enforce_for_root"
+        negative: true

--- a/misconfiguration/linux/password-complexity-not-enforced.yaml
+++ b/misconfiguration/linux/password-complexity-not-enforced.yaml
@@ -1,0 +1,44 @@
+id: password-complexity-not-enforced
+
+info:
+  name: Linux Password Complexity Not Enforced
+  author: songyaeji
+  severity: high
+  description: >
+    Password complexity requirements are not enforced on this system. This allows weak passwords, making user accounts more susceptible to brute-force and dictionary attacks.
+  reference:
+    - https://access.redhat.com/solutions/13090
+    - https://wiki.debian.org/PasswordStrength
+  tags: linux,local,configuration,auth,weak-password,compliance
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      cat /etc/security/pwquality.conf 2>/dev/null || true
+
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - 'minlen\s*=\s*[0-7]'               # 길이 8자 미만
+          - 'dcredit\s*=\s*0'                  # 숫자 없음
+          - 'ucredit\s*=\s*0'                  # 대문자 없음
+          - 'lcredit\s*=\s*0'                  # 소문자 없음
+          - 'ocredit\s*=\s*0'                  # 특수문자 없음
+
+  - engine:
+      - bash
+    source: |
+      grep pam_pwquality.so /etc/pam.d/system-auth /etc/pam.d/common-password 2>/dev/null || true
+
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "pam_pwquality.so"
+      - type: negative_word
+        part: code_2_response
+        words:
+          - "enforce_for_root"                # root 계정에 강제 적용 없음

--- a/misconfiguration/linux/password-complexity-not-enforced.yaml
+++ b/misconfiguration/linux/password-complexity-not-enforced.yaml
@@ -7,8 +7,8 @@ info:
   description: >
     Password complexity requirements are not enforced on this system. This allows weak passwords, making user accounts more susceptible to brute-force and dictionary attacks.
   reference:
-    - https://access.redhat.com/solutions/13090
-    - https://wiki.debian.org/PasswordStrength
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
   tags: linux,local,configuration,auth,weak-password,compliance
 
 self-contained: true
@@ -22,11 +22,11 @@ code:
       - type: regex
         part: code_1_response
         regex:
-          - 'minlen\s*=\s*[0-7]'               # 길이 8자 미만
-          - 'dcredit\s*=\s*0'                  # 숫자 없음
-          - 'ucredit\s*=\s*0'                  # 대문자 없음
-          - 'lcredit\s*=\s*0'                  # 소문자 없음
-          - 'ocredit\s*=\s*0'                  # 특수문자 없음
+          - 'minlen\s*=\s*[0-7]'
+          - 'dcredit\s*=\s*0'
+          - 'ucredit\s*=\s*0'
+          - 'lcredit\s*=\s*0'
+          - 'ocredit\s*=\s*0'
 
   - engine:
       - bash
@@ -41,4 +41,4 @@ code:
       - type: negative_word
         part: code_2_response
         words:
-          - "enforce_for_root"                # root 계정에 강제 적용 없음
+          - "enforce_for_root"

--- a/misconfiguration/linux/password-file-not-protected.yaml
+++ b/misconfiguration/linux/password-file-not-protected.yaml
@@ -1,0 +1,44 @@
+id: password-file-not-protected
+
+info:
+  name: Linux Password File Not Properly Protected
+  author: songyaeji
+  severity: high
+  description: >
+    If password hashes are stored in /etc/passwd, which is world-readable, they can be exposed to non-privileged users.
+    Proper configurations should ensure password hashes are stored only in /etc/shadow, which is restricted.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,misconfiguration,passwd,shadow,password,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-256
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 5.5
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      ls -l /etc/shadow 2>/dev/null || echo "no-shadow-file"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "no-shadow-file"
+
+  - engine:
+      - bash
+    source: |
+      awk -F: '$2 !~ /^x$/ { print $0 }' /etc/passwd 2>/dev/null || echo "all-x-field"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^[^:]+:[^x]:'

--- a/misconfiguration/linux/password-max-days-not-configured.yaml
+++ b/misconfiguration/linux/password-max-days-not-configured.yaml
@@ -1,0 +1,47 @@
+id: password-max-days-not-configured
+
+info:
+  name: Linux Password Maximum Usage Period Not Configured
+  author: songyaeji
+  severity: medium
+  description: >
+    If password expiration is not enforced, compromised passwords may remain valid indefinitely,
+    posing a security risk. This template checks whether PASS_MAX_DAYS is configured properly (≤ 90)
+    and whether individual user shadow entries exceed acceptable limits.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,misconfiguration,password,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-284
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L
+    cvss-score: 4.6
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      grep "^PASS_MAX_DAYS" /etc/login.defs 2>/dev/null || echo "no-passmaxdays"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - 'PASS_MAX_DAYS\s*([9][1-9]|[1-9][0-9]{2,})'
+          - 'PASS_MAX_DAYS\s*0'
+          - 'no-passmaxdays'
+
+  - engine:
+      - bash
+    source: |
+      awk -F: '$5 >= 91 { print $1 ":" $5 }' /etc/shadow 2>/dev/null || echo "no-shadow-entry"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '.*:[9][1-9]|[1-9][0-9]{2,}'

--- a/misconfiguration/linux/root-path-includes-current-dir.yaml
+++ b/misconfiguration/linux/root-path-includes-current-dir.yaml
@@ -1,0 +1,35 @@
+id: root-path-includes-current-dir
+
+info:
+  name: Root PATH Environment Variable Includes Current Directory (".")
+  author: songyaeji
+  severity: high
+  description: >
+    If the root user's PATH variable includes the current directory (".") at the beginning or middle,
+    unauthorized scripts or binaries in the current working directory could be executed with root privileges,
+    potentially leading to privilege escalation or unintended behavior.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,misconfiguration,path,privilege-escalation
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-427
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 6.7
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      echo $PATH | grep -q '\.:.*' && echo "dot-in-path" || echo "safe-path"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "dot-in-path"

--- a/misconfiguration/linux/root-remote-login.yaml
+++ b/misconfiguration/linux/root-remote-login.yaml
@@ -2,13 +2,14 @@ id: root-remote-login
 
 info:
   name: Linux Root Remote Login - Security Misconfiguration
-  author: yaeji-song
-  severity: high
+  author: songyaeji
+  severity: critical
   description: >
-    Root 계정의 telnet 또는 ssh 원격 접속이 허용된 경우, 보안상 매우 위험합니다. 
-    본 템플릿은 `/etc/securetty`와 `sshd_config` 내 root 계정 접속 설정을 검사합니다.
+    Allowing remote access via Telnet or SSH for the root account poses a serious security risk.
+    This template checks the configuration of /etc/securetty and sshd_config to determine whether root login is permitted.
   reference:
-    - https://book.hacktricks.xyz/linux-hardening/privilege-escalation
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
   tags: linux,ssh,root,misconfiguration,local
   metadata:
     verified: true

--- a/misconfiguration/linux/root-remote-login.yaml
+++ b/misconfiguration/linux/root-remote-login.yaml
@@ -14,6 +14,11 @@ info:
   metadata:
     verified: true
     os: linux
+    max-request: 2
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-306
 
 self-contained: true
 code:

--- a/misconfiguration/linux/root-remote-login.yaml
+++ b/misconfiguration/linux/root-remote-login.yaml
@@ -1,0 +1,38 @@
+id: root-remote-login
+
+info:
+  name: Linux Root Remote Login - Security Misconfiguration
+  author: yaeji-song
+  severity: high
+  description: >
+    Root 계정의 telnet 또는 ssh 원격 접속이 허용된 경우, 보안상 매우 위험합니다. 
+    본 템플릿은 `/etc/securetty`와 `sshd_config` 내 root 계정 접속 설정을 검사합니다.
+  reference:
+    - https://book.hacktricks.xyz/linux-hardening/privilege-escalation
+  tags: linux,ssh,root,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+
+self-contained: true
+code:
+  - engine:
+      - bash
+    source: |
+      cat /etc/securetty 2>/dev/null | grep -E 'pts/[0-9]+' || echo "no-securetty"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "pts/"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      cat /etc/ssh/sshd_config 2>/dev/null | grep -E '^PermitRootLogin\s+yes' || echo "no-root-ssh"
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "PermitRootLogin yes"

--- a/misconfiguration/linux/sendmail-user-execution-prevention.yaml
+++ b/misconfiguration/linux/sendmail-user-execution-prevention.yaml
@@ -1,0 +1,56 @@
+id: sendmail-user-execution-prevention
+
+info:
+  name: Sendmail Execution Restriction for General Users
+  author: songyaeji
+  severity: medium
+  description: >
+    This template checks whether general users are restricted from executing Sendmail using the 'q' option,
+    and whether the Postfix binary is restricted to root or appropriate group members.
+    Lack of restriction could allow unauthorized users to manipulate the mail queue or disrupt mail delivery.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,sendmail,postfix,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 3
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
+    cvss-score: 5.5
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      grep -i restrictqrun /etc/mail/sendmail.cf 2>/dev/null || echo "[MISSING] restrictqrun not found in sendmail.cf"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "restrictqrun"
+        condition: contains
+
+  - engine:
+      - bash
+    source: |
+      stat -c "%A" /usr/sbin/postfix 2>/dev/null
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - "^-rwxr-x---"
+
+  - engine:
+      - bash
+    source: |
+      getent group postfix | awk -F ':' '{print $4}' | grep -qw root || echo "[MISSING] root not in postfix group"
+    matchers:
+      - type: word
+        part: code_3_response
+        words:
+          - "root"

--- a/misconfiguration/linux/smtp-open-relay-check.yaml
+++ b/misconfiguration/linux/smtp-open-relay-check.yaml
@@ -1,0 +1,62 @@
+id: smtp-open-relay-check
+
+info:
+  name: Linux SMTP Open Relay Configuration Check (Sendmail/Postfix)
+  author: songyaeji
+  severity: high
+  description: >
+    If the SMTP server does not restrict mail relaying, attackers may exploit it to use the mail server for spam or denial-of-service (DoS) attacks.
+    This template checks whether sendmail and postfix are configured to deny unauthorized relay attempts.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,smtp,sendmail,postfix,misconfiguration,relay
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-305
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if ps -ef | grep -v grep | grep -q sendmail; then
+        if grep -q 'R\$.\* \$#error \$@ 5.7.1 \$: "550 Relaying denied"' /etc/mail/sendmail.cf 2>/dev/null; then
+          echo "[SAFE] Sendmail relay restriction is configured."
+        else
+          echo "[VULNERABLE] Sendmail relay restriction is missing."
+        fi
+      else
+        echo "[INFO] Sendmail is not active."
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE] Sendmail relay restriction is missing."
+
+  - engine:
+      - bash
+    source: |
+      if systemctl is-active postfix | grep -q running; then
+        mynetworks=$(grep -E '^\s*mynetworks\s*=' /etc/postfix/main.cf 2>/dev/null)
+        relay_restrict=$(grep -E '^\s*smtpd_relay_restrictions\s*=.*permit_mynetworks' /etc/postfix/main.cf 2>/dev/null)
+        if [[ -z "$mynetworks" || -z "$relay_restrict" ]]; then
+          echo "[VULNERABLE] Postfix relay restrictions are missing or misconfigured."
+        else
+          echo "[SAFE] Postfix relay restrictions are properly configured."
+        fi
+      else
+        echo "[INFO] Postfix is not active."
+      fi
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "[VULNERABLE] Postfix relay restrictions are missing or misconfigured."

--- a/misconfiguration/linux/smtp-relay-restriction-check.yaml
+++ b/misconfiguration/linux/smtp-relay-restriction-check.yaml
@@ -1,0 +1,64 @@
+id: smtp-relay-restriction-check
+
+info:
+  name: SMTP Relay Restriction Check (Sendmail/Postfix)
+  author: songyaeji
+  severity: medium
+  description: >
+    Checks whether SMTP relay restrictions are properly configured for sendmail and postfix.
+    Unrestricted SMTP relay may be exploited by attackers to distribute spam or perform denial-of-service (DoS) attacks.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,smtp,sendmail,postfix,relay,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 5.5
+    cwe-id: CWE-305
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      ps -ef | grep sendmail | grep -v grep || echo "[INFO] sendmail process not found"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "sendmail"
+
+  - engine:
+      - bash
+    source: |
+      grep 'R$ *' /etc/mail/sendmail.cf 2>/dev/null | grep 'Relaying denied' || echo "[MISSING] Relay restriction not found in sendmail.cf"
+    matchers:
+      - type: word
+        part: code_2_response
+        words:
+          - "Relaying denied"
+
+  - engine:
+      - bash
+    source: |
+      grep 'mynetworks' /etc/postfix/main.cf 2>/dev/null || echo "[MISSING] mynetworks setting not found"
+    matchers:
+      - type: word
+        part: code_3_response
+        words:
+          - "mynetworks"
+
+  - engine:
+      - bash
+    source: |
+      grep 'permit_mynetworks' /etc/postfix/main.cf 2>/dev/null || echo "[MISSING] permit_mynetworks setting not found"
+    matchers:
+      - type: word
+        part: code_4_response
+        words:
+          - "permit_mynetworks"

--- a/misconfiguration/linux/suid-sgid-stickybit-check.yaml
+++ b/misconfiguration/linux/suid-sgid-stickybit-check.yaml
@@ -1,20 +1,24 @@
 id: suid-sgid-stickybit-check
 
 info:
-  name: SUID/SGID/Sticky Bit Permission Check on Root-Owned Files
+  name: SUID/SGID Permission Check on Root-Owned Files
   author: songyaeji
   severity: high
   description: >
-    Files with SUID or SGID bits owned by root may lead to privilege escalation if improperly set.
-    This template detects files with suspicious SUID/SGID permissions and flags them for review.
-  tags: linux,permission,misconfiguration,compliance,filesystem,local
+    Files owned by root with SUID or SGID permissions may lead to privilege escalation
+    if misconfigured. This template detects such files for further review.
   reference:
     - https://isms.kisa.or.kr
-    - CIS Benchmark - Linux File Permissions
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,permission,misconfiguration,compliance,filesystem,local
   metadata:
-    os: linux
     verified: true
+    os: linux
     max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-276
 
 self-contained: true
 
@@ -24,9 +28,7 @@ code:
     source: |
       find / -user root -type f \( -perm -4000 -o -perm -2000 \) -exec ls -lg {} \; 2>/dev/null | head -n 10
     matchers:
-      - type: word
-        words:
-          - "r-s"
-          - "rws"
+      - type: regex
         part: code_1_response
-        condition: or
+        regex:
+          - "^.*[-rwx]{4}s[-rwx]{5}.*"

--- a/misconfiguration/linux/suid-sgid-stickybit-check.yaml
+++ b/misconfiguration/linux/suid-sgid-stickybit-check.yaml
@@ -1,0 +1,32 @@
+id: suid-sgid-stickybit-check
+
+info:
+  name: SUID/SGID/Sticky Bit Permission Check on Root-Owned Files
+  author: songyaeji
+  severity: high
+  description: >
+    Files with SUID or SGID bits owned by root may lead to privilege escalation if improperly set.
+    This template detects files with suspicious SUID/SGID permissions and flags them for review.
+  tags: linux,permission,misconfiguration,compliance,filesystem,local
+  reference:
+    - https://isms.kisa.or.kr
+    - CIS Benchmark - Linux File Permissions
+  metadata:
+    os: linux
+    verified: true
+    max-request: 1
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      find / -user root -type f \( -perm -4000 -o -perm -2000 \) -exec ls -lg {} \; 2>/dev/null | head -n 10
+    matchers:
+      - type: word
+        words:
+          - "r-s"
+          - "rws"
+        part: code_1_response
+        condition: or


### PR DESCRIPTION
This PR introduces a series of custom Nuclei templates based on the Linux security inspection items defined in the official Korean Cloud Vulnerability Assessment Guide (2024) published by KISA(Korea Internet & Security Agency).

These templates help automate misconfiguration checks and insecure service detection across Linux systems, enhancing cloud baseline hardening and compliance assessments.

- References
  https://isms.kisa.or.kr/main/csap/notice/
  Cloud Vulnerability Assessment Guide(2024) by KISA
[Cloud_Vuln_Assessment_Guide(2024).zip](https://github.com/user-attachments/files/21496322/Cloud_Vuln_Assessment_Guide.2024.zip)


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)