### PR TITLE
Create apache-inlong-detect.yaml and apache-inlong-default-login.yaml

### DIFF
--- a/http/default-logins/apache/apache-inlong-default-login.yaml
+++ b/http/default-logins/apache/apache-inlong-default-login.yaml
@@ -1,0 +1,56 @@
+id: apache-inlong-default-login
+
+info:
+  name: Apache InLong - Default Login
+  author: icarot
+  severity: high
+  description: |
+    Apache InLong server enables default admin credentials. An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/apache/inlong/
+  classification:
+    cpe: cpe:2.3:a:apache:inlong:1.13.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: inlong
+  tags: apache,inlong,default-login,misconfig
+
+variables:
+  username: admin
+  password: inlong
+
+http:
+  - raw:
+      - |
+        POST /inlong/manager/api/anno/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        
+        {"username":"{{username}}","password":"{{password}}"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"success":true'
+          - '"errMsg":null'
+          - '"data":true'
+        condition: and
+
+      - type: word
+        part: set_cookie
+        words:
+          - 'JSESSIONID'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/default-logins/apache/apache-inlong-default-login.yaml
+++ b/http/default-logins/apache/apache-inlong-default-login.yaml
@@ -27,7 +27,7 @@ http:
         POST /inlong/manager/api/anno/login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        
+
         {"username":"{{username}}","password":"{{password}}"}
 
     matchers-condition: and

--- a/http/default-logins/apache/apache-inlong-default-login.yaml
+++ b/http/default-logins/apache/apache-inlong-default-login.yaml
@@ -14,6 +14,7 @@ info:
     max-request: 1
     vendor: apache
     product: inlong
+    fofa-query: icon_hash="1155196680"
   tags: apache,inlong,default-login,misconfig
 
 variables:
@@ -40,16 +41,9 @@ http:
         condition: and
 
       - type: word
-        part: set_cookie
-        words:
-          - 'JSESSIONID'
-        condition: and
-
-      - type: word
         part: content_type
         words:
           - 'application/json'
-        condition: and
 
       - type: status
         status:

--- a/http/technologies/apache/apache-inlong-detect.yaml
+++ b/http/technologies/apache/apache-inlong-detect.yaml
@@ -1,0 +1,32 @@
+id: apache-inlong-detect
+
+info:
+  name: Apache InLong - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache InLong server, a one-stop, full-scenario integration framework for massive data.
+  reference:
+    - https://github.com/apache/inlong/
+  classification:
+    cpe: cpe:2.3:a:apache:inlong:1.13.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: inlong
+  tags: tech,apache,inlong,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>InLong</title>'
+        condition: and
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-inlong-detect.yaml
+++ b/http/technologies/apache/apache-inlong-detect.yaml
@@ -1,7 +1,7 @@
 id: apache-inlong-detect
 
 info:
-  name: Apache InLong - Detection
+  name: Apache InLong - Detect
   author: icarot
   severity: info
   description: |
@@ -14,17 +14,21 @@ info:
     max-request: 1
     vendor: apache
     product: inlong
+    fofa-query: icon_hash="1155196680"
   tags: tech,apache,inlong,detect
+
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
+
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - '<title>InLong</title>'
-        condition: and
+          - 'InLong</title>'
+          - 'webpackJsonpinlong'
+        condition: or
         case-insensitive: true
 
       - type: status


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache InLong, a one-stop, full-scenario integration framework for massive data.
* Apache InLong server enables default admin credentials. An attacker can execute unauthorized operations.

- References:

https://github.com/apache/inlong

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache InLong Docker:**

1. Running container:

`$ git clone https://github.com/apache/inlong`
`$ cd docker/docker-compose/`
`$ docker compose up -d`

2. Acessing the Apache InLong service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dashboard`

And the access URL will be http://<obteined_inspect_IP_Address>/ or http://<host_IP_Address>/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-inlong-detect.yaml -t apache-inlong-default-login.yaml -u "http://<obteined_inspect_IP_Address>" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="727" height="519" alt="image" src="https://github.com/user-attachments/assets/957cdc5e-c66e-42c0-9cb7-54a6c757f755" />

<img width="776" height="881" alt="image" src="https://github.com/user-attachments/assets/32234414-791b-4b8d-98fc-9545b3fafcf9" />

<img width="1626" height="343" alt="image" src="https://github.com/user-attachments/assets/1d19dd92-2026-4033-a106-376fcfde4a33" />
