### PR TITLE
Create file-disable-directory-listing.yaml

### DIFF
--- a/http/misconfiguration/tomcat-directory-listing.yaml
+++ b/http/misconfiguration/tomcat-directory-listing.yaml
@@ -30,6 +30,7 @@ http:
         words:
           - "Directory Listing For"
           - "<a href="
+        condition: and
 
       - type: regex
         part: header


### PR DESCRIPTION
This PR adds a template to detect directory listing enabled on Apache Tomcat servers.
It works by inspecting the HTTP response body for directory index patterns such as "Directory Listing For" and "<a href=", and confirms the content type is text/html. The Accept-Language: en header ensures consistent response parsing.

### Template / PR Information
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- References: 
    - https://isms.kisa.or.kr/main/csap/notice/
    - Cloud Vulnerability Assessment Guide(2024) by KISA
    - [Cloud_Vuln_Assessment_Guide(2024).zip](https://github.com/user-attachments/files/21496322/Cloud_Vuln_Assessment_Guide.2024.zip)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)