### PR TITLE
Add CVE-2025-8286 - Güralp Systems FMUS

### DIFF
--- a/http/cves/2025/CVE-2025-8286.yaml
+++ b/http/cves/2025/CVE-2025-8286.yaml
@@ -1,13 +1,16 @@
 id: CVE-2025-8286
 
 info:
-  name: Güralp Systems FMUS Series Seismic Monitoring Devices - Missing Authentication for Critical Function
+  name: Güralp Systems FMUS Series - Missing Authentication for Critical Function
   severity: critical
   author: darses
   description: |
-    The affected products expose an unauthenticated Telnet-based command line interface that could allow an attacker to modify hardware configurations, manipulate data, or factory reset the device.
+    Güralp Systems FMUS Series Seismic Monitoring Devices expose an unauthenticated Telnet-based command line interface that allows attackers to modify hardware configurations, manipulate data, or factory reset the device.
   impact: |
     Successful exploitation of this vulnerability could allow an attacker to modify hardware configurations, manipulate data, or factory reset the device.
+  reference:
+    - https://www.cisa.gov/news-events/ics-advisories/icsa-25-212-01
+    - https://www.cve.org/CVERecord?id=CVE-2025-8286
   remediation: |
     Update to the latest firmware version or apply vendor recommended patches to secure Telnet access.
   classification:
@@ -17,15 +20,10 @@ info:
     cvss-score: 9.8
   metadata:
     vendor: guralp_systems
-    product: guralp_fmus_series_seismic_monitoring_devices
-    shodan-query:
-      - '"Welcome to " "list of available commands" port:4244'
-    fofa-query:
-      - '"Welcome to " && "list of available commands" && port="4244"'
-  reference:
-    - https://www.cisa.gov/news-events/ics-advisories/icsa-25-212-01
-    - https://www.cve.org/CVERecord?id=CVE-2025-8286
-  tags: ics,cve,cve2025,tcp,telnet
+    product: fmus_series_seismic_monitoring_devices
+    shodan-query: '"Welcome to " "list of available commands" port:4244'
+    fofa-query: '"Welcome to " && "list of available commands" && port="4244"'
+  tags: ics,cve,cve2025,tcp,telnet,guralp
 
 tcp:
   - host:

--- a/http/cves/2025/CVE-2025-8286.yaml
+++ b/http/cves/2025/CVE-2025-8286.yaml
@@ -35,7 +35,7 @@ tcp:
 
     inputs:
       - data: "\n"
-        read: 128
+        read: 256
         name: banner
 
       - data: "system info\n"

--- a/http/cves/2025/CVE-2025-8286.yaml
+++ b/http/cves/2025/CVE-2025-8286.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-8286
 
 info:
-  name: Güralp Systems FMUS Series - Missing Authentication for Critical Function
+  name: Güralp Systems FMUS Series - Unauthenticated Access
   severity: critical
   author: darses
   description: |
@@ -19,11 +19,12 @@ info:
     cvss-metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
     cvss-score: 9.8
   metadata:
+    verified: true
     vendor: guralp_systems
     product: fmus_series_seismic_monitoring_devices
     shodan-query: '"Welcome to " "list of available commands" port:4244'
     fofa-query: '"Welcome to " && "list of available commands" && port="4244"'
-  tags: ics,cve,cve2025,tcp,telnet,guralp
+  tags: cve,cve2025,tcp,network,telnet,guralp,ics
 
 tcp:
   - host:

--- a/http/cves/2025/CVE-2025-8286.yaml
+++ b/http/cves/2025/CVE-2025-8286.yaml
@@ -1,0 +1,72 @@
+id: CVE-2025-8286
+
+info:
+  name: Güralp Systems FMUS Series Seismic Monitoring Devices - Missing Authentication for Critical Function
+  severity: critical
+  author: darses
+  description: |
+    The affected products expose an unauthenticated Telnet-based command line interface that could allow an attacker to modify hardware configurations, manipulate data, or factory reset the device.
+  impact: |
+    Successful exploitation of this vulnerability could allow an attacker to modify hardware configurations, manipulate data, or factory reset the device.
+  remediation: |
+    Update to the latest firmware version or apply vendor recommended patches to secure Telnet access.
+  classification:
+    cwe-id: CWE-306
+    cve-id: CVE-2025-8286
+    cvss-metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    cvss-score: 9.8
+  metadata:
+    vendor: guralp_systems
+    product: guralp_fmus_series_seismic_monitoring_devices
+    shodan-query:
+      - '"Welcome to " "list of available commands" port:4244'
+    fofa-query:
+      - '"Welcome to " && "list of available commands" && port="4244"'
+  reference:
+    - https://www.cisa.gov/news-events/ics-advisories/icsa-25-212-01
+    - https://www.cve.org/CVERecord?id=CVE-2025-8286
+  tags: ics,cve,cve2025,tcp,telnet
+
+tcp:
+  - host:
+      - "{{Hostname}}"
+
+    port: 4244
+
+    inputs:
+      - data: "\n"
+        read: 128
+        name: banner
+
+      - data: "system info\n"
+        read: 256
+        name: system_info
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: banner
+        words:
+          - "Welcome to "
+          - 'type "help" for a list of available commands'
+        condition: and
+
+      - type: word
+        part: system_info
+        words:
+          - "Host Name: "
+          - "Firmware Version: "
+        condition: and
+
+    extractors:
+      - type: regex
+        part: system_info
+        group: 1
+        regex:
+          - "Host\\s+Name:\\s+([\\w\\d\\.\\-]+)"
+
+      - type: regex
+        part: system_info
+        group: 1
+        regex:
+          - "Firmware\\s+Version:\\s+([\\d\\.\\-]+)"


### PR DESCRIPTION
### Template / PR Information

- Add CVE-2025-8286 - Güralp Systems FMUS Series Seismic Monitoring Devices - Missing Authentication for Critical Function

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

In essence this is just an exposed telnet service. With public search engines there are some false positives on just the 'help' text and the `FMUS` hostname is not a given. So I added a `system info` command to double check and also extract version information.

Based on the CISA description, this is a WONTFIX by the vendor.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)