### PR TITLE
Add CVE-2021-32677.yaml

### DIFF
--- a/http/cves/2021/CVE-2021-32677.yaml
+++ b/http/cves/2021/CVE-2021-32677.yaml
@@ -1,0 +1,41 @@
+id: CVE-2021-32677
+
+info:
+  name: FastAPI < 0.65.2 - CSRF via text/plain
+  author: oxqnd
+  severity: medium
+  description: |
+    FastAPI versions before 0.65.2 parse JSON bodies even when the content-type is text/plain.
+    This allows CSRF attacks due to CORS bypass with simple requests.
+  impact: |
+    Attacker can send forged requests via cross-site forms or scripts to perform unauthorized actions.
+  remediation: |
+    Upgrade to FastAPI 0.65.2 or later.
+  reference:
+    - https://github.com/advisories/GHSA-8h2j-cgx8-6xv7
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-32677
+  classification:
+    cve-id: CVE-2021-32677
+    cwe-id: CWE-352
+    cvss-score: 4.3
+  tags: cve,cve2021,fastapi,csrf
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain
+
+        {"username":"csrf_test","password":"csrf_test"}
+
+    matchers:
+      - type: word
+        words:
+          - '"username":"csrf_test"'
+          - '"password":"csrf_test"'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Hello,

I'm submitting this PR to contribute a detection template for CVE-2021-32677, which affects FastAPI < 0.65.2 due to unsafe JSON parsing with content-type set to `text/plain`.

Thanks!

---

### Template / PR Information

- Added **CVE-2021-32677** detection template for FastAPI versions prior to 0.65.2
- The vulnerability exists because FastAPI parsed JSON request bodies even when the `Content-Type` was set to `text/plain`, which allows CSRF attacks by bypassing CORS preflight.
- The template sends a `POST` request with a `text/plain` content-type and a JSON body, and checks for reflection of that JSON as confirmation of the issue.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional Details

- Verified on FastAPI 0.65.1 running locally with `uvicorn`
- Detection is based on reflected JSON response from an endpoint with `text/plain` content
- Exploitable in cookie-auth scenarios with unprotected POST endpoints

### References:

- https://github.com/advisories/GHSA-8h2j-cgx8-6xv7
- https://nvd.nist.gov/vuln/detail/CVE-2021-32677
- https://github.com/fastapi/fastapi/pull/2118

---

### Additional References:
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
