### PR TITLE
fix(exposed-pki-cert): tighten matchers and remove root path to reduc…

### DIFF
--- a/http/exposures/files/exposed-pki-cert.yaml
+++ b/http/exposures/files/exposed-pki-cert.yaml
@@ -1,7 +1,7 @@
 id: exposed-pki-cert
 
 info:
-  name: Exposed Internal PKI Infrastructure - Detect
+  name: Exposed Internal PKI Infrastructure – Detect
   author: nullenc0de
   severity: high
   description: |
@@ -9,53 +9,49 @@ info:
   metadata:
     verified: true
     max-request: 10
-  tags: pki,exposure,misconfig
+  tags:
+    - pki
+    - exposure
+    - misconfig
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/{{paths}}"
-
     payloads:
       paths:
-        - ""
-        - "certsrv/"
-        - "pki/"
-        - "PKI/"
-        - "crl/"
-        - "CRL/"
-        - ".well-known/pki-validation/"
-        - "ocsp/"
-        - "CertEnroll/"
-        - "CertSrv/"
-
+        - "/certsrv/"
+        - "/pki/"
+        - "/PKI/"
+        - "/crl/"
+        - "/CRL/"
+        - "/.well-known/pki-validation/"
+        - "/ocsp/"
+        - "/CertEnroll/"
+        - "/CertSrv/"
     stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
-    matchers-condition: or
+
+    # Require both a keyword match and a PKI-specific indicator
+    matchers-condition: and
     matchers:
+      # DSL matcher: must mention PKI services but not be the default OCSP stub
       - type: dsl
         dsl:
           - 'contains_any(body, "Certificate Services", "CRL Distribution Point", "OCSP Responder")'
-          - '!regex("^This is an OCSP responder.$", body)'
-        condition: and
+          - '!regex("(?i)^\\s*This is an OCSP responder\\.?\\s*$", body)'
 
+      # Regex matcher: look for CA Common Name or direct links to cert/crl bundles
       - type: regex
         regex:
-          - 'CN=[A-Za-z0-9-]+-CA'
-          - '(?i)<a\s+href="([^"]+\.crl)"[^>]*>[^<]*\.crl<\/a>'
-          - '(?i)<a\s+href="([^"]+\.cer)"[^>]*>[^<]*\.cer<\/a>'
-          - '(?i)<a\s+href="([^"]+\.p7b)"[^>]*>[^<]*\.p7b<\/a>'
-          - '(?i)href="([^"]+\.crl)"'
-          - '(?i)href="([^"]+\.cer)"'
-          - '(?i)href="([^"]+\.p7b)"'
-        condition: or
+          - '\\bCN=[A-Za-z0-9-]+-CA\\b'
+          - '(?i)href="[^"]+\\.(?:crl|cer|p7b)"'
 
     extractors:
       - type: regex
         name: certificate_details
         regex:
-          - "CN=[A-Za-z0-9-]+-CA"
-          - "O=[A-Za-z0-9 ]+"
-          - "OU=[A-Za-z0-9 ]+"
-# digest: 490a004630440220275be7e096b281697f76f09c5b0b199aa3e8c66ff5351c343c51fec6e72a06fa02207e610a9715c8c54515e2184c68d6a49d3abbcc8869e9718dfe62c0186a8e5ddf:922c64590222798bb761d5b6d8e72950
+          - 'CN=[A-Za-z0-9-]+-CA'
+          - 'O=[A-Za-z0-9 ]+'
+          - 'OU=[A-Za-z0-9 ]+'


### PR DESCRIPTION
…e false-positives

- Changed matchers-condition from `or` to `and` to require both keyword and regex matches
- Removed the empty payload path (`""`) to avoid scanning the root URL
- Prefixed all `paths` entries with `/` for consistency
- Simplified and strengthened regex patterns for `CN` and `.crl/.cer/.p7b` links
- Enhanced OCSP stub exclusion using a more precise regex

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)