### PR TITLE
Added pensando-default-login.yaml Template

### DIFF
--- a/http/default-logins/pensando/pensando-default-login.yaml
+++ b/http/default-logins/pensando/pensando-default-login.yaml
@@ -12,7 +12,7 @@ info:
   metadata:
     verified: true
     fofa-query: icon_hash="1907840597"
-  tags: pensando,default-login,misconfig
+  tags: pensando,default-login
 
 variables:
   username: 'admin'
@@ -45,11 +45,6 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(body, "\"name\":\"admin\"")'
+          - 'contains_all(body, "\"name\":\"admin\"")'
           - 'contains(content_type, "application/json")'
         condition: and
-
-    extractors:
-      - type: dsl
-        dsl:
-          - '"Default login : "+username+" / "+password'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Add a check for default credentials for AMD Pensando PSM
- References: https://arubanetworking.hpe.com/techdocs/Pensando/AMD_Pensando_PSM_for_DSS_Guide-1.72.1-T.pdf

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)