### PR TITLE
Add templates for account lockout and password aging policy checks (PR1)

### DIFF
--- a/misconfiguration/linux/account-lockout-threshold-not-configured.yaml
+++ b/misconfiguration/linux/account-lockout-threshold-not-configured.yaml
@@ -1,0 +1,40 @@
+id: account-lockout-threshold-not-configured
+
+info:
+  name: Linux Account Lockout Threshold Not Configured
+  author: songyaeji
+  severity: high
+  description: >
+    The system does not enforce an account lockout threshold. Without this control,
+    repeated login attempts are not restricted, leaving the system vulnerable to brute-force attacks.
+    This template checks whether account lockout settings are configured in PAM modules.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,pam,auth,misconfiguration,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 3
+  classification:
+    cwe-id: CWE-307
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 5.5
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      grep -E 'pam_tally2.so|pam_faillock.so' /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/common-auth 2>/dev/null || echo "no-lockout-config"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "no-lockout-config"
+      - type: regex
+        part: code_1_response
+        regex:
+          - 'pam_tally2.so(?!.*deny=)'
+          - 'pam_faillock.so(?!.*deny=)'

--- a/misconfiguration/linux/password-max-days-not-configured.yaml
+++ b/misconfiguration/linux/password-max-days-not-configured.yaml
@@ -1,0 +1,47 @@
+id: password-max-days-not-configured
+
+info:
+  name: Linux Password Maximum Usage Period Not Configured
+  author: songyaeji
+  severity: medium
+  description: >
+    If password expiration is not enforced, compromised passwords may remain valid indefinitely,
+    posing a security risk. This template checks whether PASS_MAX_DAYS is configured properly (≤ 90)
+    and whether individual user shadow entries exceed acceptable limits.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,local,misconfiguration,password,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-284
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L
+    cvss-score: 4.6
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      grep "^PASS_MAX_DAYS" /etc/login.defs 2>/dev/null || echo "no-passmaxdays"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - 'PASS_MAX_DAYS\s*([9][1-9]|[1-9][0-9]{2,})'
+          - 'PASS_MAX_DAYS\s*0'
+          - 'no-passmaxdays'
+
+  - engine:
+      - bash
+    source: |
+      awk -F: '$5 >= 91 { print $1 ":" $5 }' /etc/shadow 2>/dev/null || echo "no-shadow-entry"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '.*:[9][1-9]|[1-9][0-9]{2,}'


### PR DESCRIPTION
### Template / PR Information

This PR adds new nuclei templates focused on **Linux account security policies**, based on the **2024 Cloud Vulnerability Assessment Guide** published by [KISA (Korea Internet & Security Agency)](https://isms.kisa.or.kr/main/csap/notice/).

1. `account-lockout-threshold-not-configured.yaml`  
   - Detects if PAM modules (`pam_tally2.so`, `pam_faillock.so`) are missing lockout thresholds (`deny=`).
2. `password-max-days-not-configured.yaml`  
   - Checks if password expiration settings (`PASS_MAX_DAYS`) are properly set in `/etc/login.defs`.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2300" height="960" alt="pr1_screenshot" src="https://github.com/user-attachments/assets/cc469105-23d9-4b55-b3dc-5210356d3439" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)