### PR TITLE
Add password file protection and root path check templates

### DIFF
--- a/misconfiguration/linux/password-file-not-protected.yaml
+++ b/misconfiguration/linux/password-file-not-protected.yaml
@@ -1,0 +1,44 @@
+id: password-file-not-protected
+
+info:
+  name: Linux Password File Not Properly Protected
+  author: songyaeji
+  severity: high
+  description: >
+    If password hashes are stored in /etc/passwd, which is world-readable, they can be exposed to non-privileged users.
+    Proper configurations should ensure password hashes are stored only in /etc/shadow, which is restricted.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,misconfiguration,passwd,shadow,password,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-256
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 5.5
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      ls -l /etc/shadow 2>/dev/null || echo "no-shadow-file"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "no-shadow-file"
+
+  - engine:
+      - bash
+    source: |
+      awk -F: '$2 !~ /^x$/ { print $0 }' /etc/passwd 2>/dev/null || echo "all-x-field"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^[^:]+:[^x]:'

--- a/misconfiguration/linux/root-path-includes-current-dir.yaml
+++ b/misconfiguration/linux/root-path-includes-current-dir.yaml
@@ -1,0 +1,35 @@
+id: root-path-includes-current-dir
+
+info:
+  name: Root PATH Environment Variable Includes Current Directory (".")
+  author: songyaeji
+  severity: high
+  description: >
+    If the root user's PATH variable includes the current directory (".") at the beginning or middle,
+    unauthorized scripts or binaries in the current working directory could be executed with root privileges,
+    potentially leading to privilege escalation or unintended behavior.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,misconfiguration,path,privilege-escalation
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-427
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 6.7
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      echo $PATH | grep -q '\.:.*' && echo "dot-in-path" || echo "safe-path"
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "dot-in-path"


### PR DESCRIPTION
### Template / PR Information

This PR adds two new nuclei templates for detecting security misconfigurations related to **password file protection and environment path hygiene**. These checks help identify insecure file permissions and execution behavior on Linux systems.

1. `password-file-not-protected.yaml`
   - Detects if critical authentication files such as `/etc/passwd` and `/etc/shadow` are improperly permissioned (e.g., world-readable).
2. `root-path-includes-current-dir.yaml`
   - Checks if the root user’s `$PATH` variable includes `.` or empty elements, which can be exploited to execute malicious binaries.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2307" height="961" alt="image" src="https://github.com/user-attachments/assets/86c58504-4450-40fb-b100-52841f51cc6b" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)