### PR TITLE
Add permission checks for logging and service config files

### DIFF
--- a/misconfiguration/linux/etc-rsyslogconf-permission-check.yaml
+++ b/misconfiguration/linux/etc-rsyslogconf-permission-check.yaml
@@ -1,0 +1,44 @@
+id: etc-rsyslogconf-permission-check
+
+info:
+  name: /etc/(r)syslog.conf File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/syslog.conf or /etc/rsyslog.conf file is not owned by root or has insecure permissions,
+    attackers may manipulate logging settings to avoid detection.
+  reference:
+    - https://isms.kisa.or.kr
+    - KISA Cloud Vulnerability Assessment Guide (2024)
+  tags: linux,configuration,logging,permissions,rsyslog,syslog
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/rsyslog.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'
+
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/syslog.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/etc-services-permission-check.yaml
+++ b/misconfiguration/linux/etc-services-permission-check.yaml
@@ -1,0 +1,34 @@
+id: etc-services-permission-check
+
+info:
+  name: /etc/services File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/services file is not owned by root or has excessive permissions,
+    an attacker may alter port assignments to redirect services or open unauthorized ports.
+  reference:
+    - https://isms.kisa.or.kr
+    - KISA Cloud Vulnerability Assessment Guide (2024)
+  tags: linux,configuration,services,permissions,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/services 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'

--- a/misconfiguration/linux/etc-xinetdconf-permission-check.yaml
+++ b/misconfiguration/linux/etc-xinetdconf-permission-check.yaml
@@ -1,0 +1,43 @@
+id: etc-xinetdconf-permission-check
+
+info:
+  name: /etc/(x)inetd.conf File Owner and Permission Check
+  author: songyaeji
+  severity: high
+  description: >
+    If the /etc/xinetd.conf or /etc/inetd.conf file is writable by non-root users, they may register malicious services that run with root privileges. This check ensures the file is owned by root and has secure permissions.
+  reference:
+    - https://isms.kisa.or.kr/main/csap/notice/
+    - Cloud Vulnerability Assessment Guide (2024) by KISA
+  tags: linux,local,configuration,file,ownership,permission,xinetd,inetd
+  metadata:
+    verified: true
+    os: linux
+    max-request: 2
+  classification:
+    cwe-id: CWE-732
+    cvss-metrics: CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/xinetd.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_1_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'
+
+  - engine:
+      - bash
+    source: |
+      stat -c "%U %G %a" /etc/inetd.conf 2>/dev/null || echo "not-found"
+    matchers:
+      - type: regex
+        part: code_2_response
+        regex:
+          - '^root\s+root\s+([0-5]?[0-9]{2}|644)$'


### PR DESCRIPTION
### Template / PR Information

This PR adds nuclei templates that audit permission settings for key system configuration files related to logging and services on Linux systems. Improper permissions on these files may lead to unauthorized modifications or information disclosure.

1. `etc-rsyslogconf-permission-check.yaml`  
   - Checks whether `/etc/rsyslog.conf` has secure permission settings.
2. `etc-services-permission-check.yaml`  
   - Verifies if `/etc/services` is not world-writable to prevent unauthorized service configuration manipulation.
3. `etc-xinetdconf-permission-check.yaml`  
   - Ensures that `/etc/xinetd.conf` is properly secured against unauthorized access.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2297" height="1442" alt="image" src="https://github.com/user-attachments/assets/a06ca61c-b373-4e07-a0e8-008493731f00" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)