### PR TITLE
Add templates to check cron ownership and DoS-vulnerable services

### DIFF
--- a/misconfiguration/linux/linux-cron-ownership-perms-check.yaml
+++ b/misconfiguration/linux/linux-cron-ownership-perms-check.yaml
@@ -1,0 +1,55 @@
+id: linux-cron-file-permissions
+
+info:
+  name: Cron File Ownership and Permissions Check
+  author: songyaeji
+  severity: high
+  description: >
+    Checks whether /etc/cron.allow and /etc/cron.deny files have proper ownership (root)
+    and permission (640). Misconfigured cron access files may allow unauthorized users
+    to schedule cron jobs, which could result in system compromise or denial of service.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,cron,permissions,misconfiguration,local
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      result=""
+      if [ -f /etc/cron.allow ]; then
+        owner=$(stat -c "%U" /etc/cron.allow)
+        perm=$(stat -c "%a" /etc/cron.allow)
+        if [ "$owner" != "root" ] || [ "$perm" -gt 640 ]; then
+          result+="[WARN] /etc/cron.allow misconfigured\n"
+        fi
+      fi
+      if [ -f /etc/cron.deny ]; then
+        owner=$(stat -c "%U" /etc/cron.deny)
+        perm=$(stat -c "%a" /etc/cron.deny)
+        if [ "$owner" != "root" ] || [ "$perm" -gt 640 ]; then
+          result+="[WARN] /etc/cron.deny misconfigured\n"
+        fi
+      fi
+      if [ -n "$result" ]; then
+        echo -e "$result"
+      else
+        echo "[OK] cron files properly configured"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[WARN] /etc/cron.allow misconfigured"
+          - "[WARN] /etc/cron.deny misconfigured"

--- a/misconfiguration/linux/linux-dos-vulnerable-services-disabled.yaml
+++ b/misconfiguration/linux/linux-dos-vulnerable-services-disabled.yaml
@@ -1,0 +1,44 @@
+id: linux-dos-vulnerable-services-disabled
+
+info:
+  name: DoS Vulnerable Services Disabled (echo, discard, daytime, chargen)
+  author: songyaeji
+  severity: high
+  description: >
+    If services such as echo, discard, daytime, and chargen are enabled on the system, 
+    attackers may exploit them to extract system information or launch denial-of-service (DoS) attacks. 
+    These legacy services should be disabled if not explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,misconfiguration,xinetd,DoS,legacy
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 5.5
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      vulnerable=""
+      for svc in echo discard daytime chargen; do
+        if grep -iq 'disable[[:space:]]*=[[:space:]]*no' "/etc/xinetd.d/$svc" 2>/dev/null; then
+          echo "[VULNERABLE] $svc service is enabled in /etc/xinetd.d/$svc"
+          vulnerable="yes"
+        fi
+      done
+      if [ -z "$vulnerable" ]; then
+        echo "[SAFE] All DoS-related services are properly disabled"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"


### PR DESCRIPTION
### Template / PR Information

This PR adds new nuclei templates to identify insecure configurations related to **cron file permissions** and **DoS-vulnerable services**, based on the 2024 Cloud Vulnerability Assessment Guide published by [KISA (Korea Internet & Security Agency)](https://isms.kisa.or.kr/main/csap/notice/).

1. `linux-cron-ownership-perms-check.yaml`  
   - Verifies that critical cron files (e.g., `/etc/cron.allow`, `/etc/cron.deny`, `/etc/crontab`) are owned by `root` and have proper permissions.
   
2. `linux-dos-vulnerable-services-disabled.yaml`  
   - Checks if legacy DoS-prone services such as `chargen`, `daytime`, `discard`, and `echo` are disabled.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2303" height="960" alt="image" src="https://github.com/user-attachments/assets/07f918e3-2e21-49d5-8fa0-3545b40a74be" />


I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)