### PR TITLE
Add templates to check NIS/NIS+ services and R-command configurations

### DIFF
--- a/misconfiguration/linux/linux-nis-nisplus-service-running.yaml
+++ b/misconfiguration/linux/linux-nis-nisplus-service-running.yaml
@@ -1,0 +1,41 @@
+id: linux-nis-nisplus-service-running
+
+info:
+  name: NIS/NIS+ Service Enabled
+  author: songyaeji
+  severity: high
+  description: >
+    If insecure NIS or NIS+ services are running, attackers may gain root privileges or harvest sensitive user information.
+    It is strongly recommended to disable these services unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,nis,nisplus,misconfiguration,privilege-escalation,service
+  metadata:
+    verified: true
+    os: linux
+    category: nis
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      running=$(ps -ef | egrep "ypserv|ypbind|ypxfrd|rpc.yppasswdd|rpc.yppupdated" | grep -v grep)
+      if [ -n "$running" ]; then
+        echo "[VULNERABLE] NIS or NIS+ service is running"
+        echo "$running"
+      else
+        echo "[SAFE] NIS and NIS+ services are not running"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-r-command-services-disabled.yaml
+++ b/misconfiguration/linux/linux-r-command-services-disabled.yaml
@@ -1,0 +1,49 @@
+id: linux-r-command-services-disabled
+
+info:
+  name: r-command Services Disabled (rlogin, rsh, rexec)
+  author: songyaeji
+  severity: high
+  description: >
+    If r-command services (rlogin, rsh, rexec) are enabled, unauthorized users may access or extract sensitive information,
+    or disrupt the system through open ports. These legacy services should be disabled unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,misconfiguration,rlogin,rsh,rexec,xinetd
+  metadata:
+    verified: true
+    os: linux
+    category: configuration
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      rlogin_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rlogin 2>/dev/null)
+      rsh_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rsh 2>/dev/null)
+      rexec_check=$(grep -i 'disable[[:space:]]*=[[:space:]]*no' /etc/xinetd.d/rexec 2>/dev/null)
+      if [ -n "$rlogin_check" ]; then
+        echo "[VULNERABLE] rlogin service is enabled"
+      fi
+      if [ -n "$rsh_check" ]; then
+        echo "[VULNERABLE] rsh service is enabled"
+      fi
+      if [ -n "$rexec_check" ]; then
+        echo "[VULNERABLE] rexec service is enabled"
+      fi
+      if [ -z "$rlogin_check" ] && [ -z "$rsh_check" ] && [ -z "$rexec_check" ]; then
+        echo "[SAFE] All r-command services are properly disabled"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"

--- a/misconfiguration/linux/linux-rhosts-hostsequiv-check.yaml
+++ b/misconfiguration/linux/linux-rhosts-hostsequiv-check.yaml
@@ -1,0 +1,49 @@
+id: linux-rhosts-hostsequiv-check
+
+info:
+  name: Detect presence or misconfiguration of .rhosts and hosts.equiv
+  author: songyaeji
+  severity: high
+  description: >
+    Presence or misconfiguration of .rhosts or /etc/hosts.equiv files can allow unauthorized remote command execution (rlogin, rsh).
+    This template detects existence and improper permissions or unsafe "+" usage in these files.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+    - https://linux.die.net/man/5/hosts.equiv
+  tags: linux,local,misconfig,rhosts,compliance
+  metadata:
+    verified: true
+    os: linux
+    max-request: 1
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      # Check if /etc/hosts.equiv exists
+      if [ -f /etc/hosts.equiv ]; then
+        echo "[FOUND] /etc/hosts.equiv exists"
+        ls -l /etc/hosts.equiv
+        echo "[CONTENT]"
+        cat /etc/hosts.equiv
+      fi
+      # Check if any .rhosts files exist under home directories
+      find /home -maxdepth 2 -name ".rhosts" 2>/dev/null | while read rhost; do
+        echo "[FOUND] $rhost"
+        ls -l "$rhost"
+        echo "[CONTENT]"
+        cat "$rhost"
+      done
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "/etc/hosts.equiv"
+          - ".rhosts"


### PR DESCRIPTION
### Template / PR Information

This PR introduces three nuclei templates designed to detect insecure configurations related to **NIS/NIS+ services** and **R-command trust relationships**, in line with the 2024 Cloud Vulnerability Assessment Guide from [KISA (Korea Internet & Security Agency)](https://isms.kisa.or.kr/main/csap/notice/).

1. `linux-nis-nisplus-service-running.yaml`  
   - Checks if NIS or NIS+ services are currently running, which may expose sensitive system information.

2. `linux-r-command-services-disabled.yaml`  
   - Verifies that insecure R-command services (`rlogin`, `rsh`, `rexec`) are disabled.

3. `linux-rhosts-hostsequiv-check.yaml`  
   - Detects the presence of `.rhosts` or `/etc/hosts.equiv` files, which could allow unauthorized trust-based logins.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2299" height="1442" alt="image" src="https://github.com/user-attachments/assets/9e180ad9-71f2-47ef-86c5-1c6f4aa7f55b" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)