### PR TITLE
Added template to detect samesite cookie attribute not set to strict

### DIFF
--- a/http/misconfiguration/missing-cookie-samesite-strict.yaml
+++ b/http/misconfiguration/missing-cookie-samesite-strict.yaml
@@ -5,7 +5,7 @@ info:
   author: lucky0x0d,PulseSecurity.co.nz
   severity: info
   description: |
-    Detects cookies that do not have the attribute 'samesite=strict', which prevents sending any cross-domain cookies, under any circumstances.
+    Identified cookies that lacked the samesite=strict attribute, which prevented enforcement of restrictions on cross-domain cookie transmission.
   reference:
     - https://pulsesecurity.co.nz/articles/samesite-lax-csrf
   classification:
@@ -15,7 +15,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: misconfiguration,samesite
+  tags: misconfig,samesite,cookie
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Created a new template to detect cookies issued that do not have SameSite set to Strict
- References:  https://pulsesecurity.co.nz/articles/samesite-lax-csrf

### Template Validation

I've validated this template locally?
- [x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)