### PR TITLE
Add templates to check Xinetd finger, tftp, and talk service configuration

### DIFF
--- a/misconfiguration/linux/linux-xinetd-finger-disabled.yaml
+++ b/misconfiguration/linux/linux-xinetd-finger-disabled.yaml
@@ -1,0 +1,43 @@
+id: linux-xinetd-finger-disabled
+
+info:
+  name: Linux Finger Service Disabled - xinetd Misconfiguration
+  author: songyaeji
+  severity: high
+  description: >
+    If the Finger service is enabled, it may expose user information to unauthorized users,
+    leading to potential password-based attacks. This template checks whether the Finger
+    service is properly disabled by inspecting the 'disable' directive in /etc/xinetd.d/finger.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,finger,xinetd,misconfiguration,local
+  metadata:
+    os: linux
+    category: configuration
+    verified: true
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.5
+    cwe-id: CWE-200
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if [ -f /etc/xinetd.d/finger ]; then
+        disable_status=$(grep -i 'disable' /etc/xinetd.d/finger | grep -v '^#' | awk -F '=' '{print $2}' | xargs)
+        if [ "$disable_status" = "no" ]; then
+          echo "[VULNERABLE] Finger service is enabled (disable = no)"
+        else
+          echo "[SAFE] Finger service is disabled"
+        fi
+      else
+        echo "[SAFE] /etc/xinetd.d/finger does not exist"
+      fi
+    matchers:
+      - type: word
+        words:
+          - "[VULNERABLE] Finger service is enabled"

--- a/misconfiguration/linux/linux-xinetd-tftp-talk-disabled.yaml
+++ b/misconfiguration/linux/linux-xinetd-tftp-talk-disabled.yaml
@@ -1,0 +1,45 @@
+id: linux-xinetd-tftp-talk-disabled
+
+info:
+  name: Linux tftp, talk, ntalk Services Should Be Disabled
+  author: songyaeji
+  severity: high
+  description: >
+    Unused services like tftp, talk, or ntalk may have known vulnerabilities.
+    If these are enabled, they could be targeted by attackers.
+    This template checks if they are properly disabled in the xinetd configuration.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux,tftp,talk,ntalk,xinetd,service,misconfiguration
+  metadata:
+    os: linux
+    category: system
+    verified: true
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
+    cvss-score: 6.2
+    cwe-id: CWE-732
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      for svc in tftp talk ntalk; do
+        file="/etc/xinetd.d/$svc"
+        if [ -f "$file" ]; then
+          if grep -q "disable[[:space:]]*=[[:space:]]*yes" "$file"; then
+            echo "[SAFE] $svc is disabled."
+          else
+            echo "[VULNERABLE] $svc is not disabled in $file."
+          fi
+        else
+          echo "[SAFE] $svc service config file not found. Assuming not installed."
+        fi
+      done
+    matchers:
+      - type: word
+        words:
+          - "[VULNERABLE] $svc is not disabled in"


### PR DESCRIPTION
…ations

### Template / PR Information

This PR adds two nuclei templates to verify that insecure and unnecessary **Xinetd services** are disabled, based on the 2024 KISA Cloud Vulnerability Assessment Guide.

1. `linux-xinetd-finger-disabled.yaml`  
   - Checks whether the `finger` service is disabled in the Xinetd configuration.  
     The finger service can expose sensitive user information.

2. `linux-xinetd-tftp-talk-disabled.yaml`  
   - Verifies that `tftp` and `talk` services are disabled.  
     These services may allow unauthorized file transfers or communications.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2302" height="959" alt="image" src="https://github.com/user-attachments/assets/cfda476c-07be-4ae1-ae16-164088bb3d80" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)