### PR TITLE
Add template to check unnecessary RPC services

### DIFF
--- a/misconfiguration/linux/linux-unnecessary-rpc-enabled.yaml
+++ b/misconfiguration/linux/linux-unnecessary-rpc-enabled.yaml
@@ -1,0 +1,42 @@
+id: linux-unnecessary-rpc-enabled
+
+info:
+  name: Unnecessary RPC Service (rstatd) Enabled
+  author: songyaeji
+  severity: high
+  description: >
+    If unnecessary RPC services like rstatd are enabled, attackers may exploit buffer overflow, DoS, or remote execution vulnerabilities to gain root privileges and compromise the system.
+    These services should be disabled unless explicitly required.
+  reference:
+    - https://isms.kisa.or.kr
+    - Cloud Vulnerability Assessment Guide(2024) by KISA
+  tags: linux, misconfiguration, rpc, xinetd, rstatd, privilege-escalation
+  metadata:
+    verified: true
+    os: linux
+    category: rpc
+  classification:
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.8
+    cwe-id: CWE-284
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      if [ -f /etc/xinetd.d/rstatd ]; then
+        if grep -qE 'disable\s*=\s*no' /etc/xinetd.d/rstatd; then
+          echo "[VULNERABLE] rstatd RPC service is enabled in xinetd"
+        else
+          echo "[SAFE] rstatd RPC service is disabled"
+        fi
+      else
+        echo "[SAFE] rstatd service not found"
+      fi
+    matchers:
+      - type: word
+        part: code_1_response
+        words:
+          - "[VULNERABLE]"


### PR DESCRIPTION
### Template / PR Information

This PR adds a nuclei template to verify that unnecessary RPC (Remote Procedure Call) services are disabled, following security best practices from the KISA Cloud Vulnerability Assessment Guide (2024).

1. `linux-unnecessary-rpc-enabled.yaml`  
   - Checks if RPC services that are not required for system operation are still enabled.  
     Unnecessary RPC services may introduce security vulnerabilities such as unauthorized access or information disclosure.

- References: [KISA Cloud Vulnerability Assessment Guide (2024)](https://isms.kisa.or.kr/main/csap/notice/)

### Template Validation

<img width="2295" height="477" alt="image" src="https://github.com/user-attachments/assets/ef15b2a9-ffa7-4d52-ae61-b34cc2d65d7d" />

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)