### PR TITLE
hotfix(osint): correct `redirects` and `max-redirects` placement

### DIFF
--- a/http/osint/user-enumeration/scribd.yaml
+++ b/http/osint/user-enumeration/scribd.yaml
@@ -15,13 +15,13 @@ info:
   tags: osint,osint-social,scribd
 
 self-contained: true
-redirects: true
-max-redirects: 1
 
 http:
   - method: GET
     path:
       - "https://www.scribd.com/{{user}}"
+    redirects: true
+    max-redirects: 1
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
This is what’s making the tests fail in the nuclei CI.

Refs:
* https://github.com/projectdiscovery/nuclei/actions/runs/16913749578/job/47963394023
* https://github.com/projectdiscovery/nuclei/actions/runs/16938517026/job/48010018809