### PR TITLE
feat: add template to check openrouter key in files

### DIFF
--- a/file/keys/openrouter-key.yaml
+++ b/file/keys/openrouter-key.yaml
@@ -1,0 +1,26 @@
+id: openrouter-key
+
+info:
+  name: OpenRouter API Key
+  author: mmqnym
+  severity: info
+  description: OpenRouter API Key was detected.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0
+    cwe-id: CWE-200
+  reference:
+    - https://openrouter.ai/docs/api-reference/overview
+    - https://openrouter.ai/docs/api-reference/authentication
+  metadata:
+    verified: true
+  tags: file,keys,openrouter,token
+file:
+  - extensions:
+      - all
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - \b(sk-or-v1-[a-fA-F0-9]{64})\b


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- OpenRouter is currently the most popular LLM unified interface, and many projects use it. In my opinion, it's very worthwhile to add this template to remind developers to be cautious about key leakage.
- References:
  - https://openrouter.ai/docs/api-reference/overview
  - https://openrouter.ai/docs/api-reference/authentication

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```sh
./nuclei -t openrouter-key.yaml -file -target project/ -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

		projectdiscovery.io

[url] got empty hostname for project/ skipping ip selection
[INF] Current nuclei version: v3.4.7 (latest)
[INF] Current nuclei-templates version: v10.2.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 55
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[DBG] [openrouter-key] Dumped match/extract file snippet for project/test.py at line 1

OKEY = "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"
[openrouter-key] [file] [info] project/test.py ["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"]
[INF] Scan completed in 3.570334ms. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)