### PR TITLE
Add Checkmk Agent Info Disclosure template

### DIFF
--- a/network/exposures/checkmk-info-disclosure.yaml
+++ b/network/exposures/checkmk-info-disclosure.yaml
@@ -10,7 +10,7 @@ info:
     - https://medium.com/@Th3hound/the-hidden-danger-of-the-exposed-checkmk-agent-mapping-your-infrastructure-for-attackers-151cc2180e73
   metadata:
     verified: true
-    shodan-query: http.favicon.hash:-1341442175
+    shodan-query: product:"check_mk"
   tags: tcp,network,checkmk,unauth
 
 tcp:


### PR DESCRIPTION
### Template / PR Information

This PR adds a new template for detecting exposed **Checkmk Agent** on TCP port 6556.  
The Checkmk Agent, when accessible without authentication, discloses sensitive system information such as OS version, hardware details, running processes, and internal IP addresses.  
This template helps identify misconfigured systems that are leaking this data.

- Added: Checkmk Agent Info Disclosure (6556)
- References:
  - https://medium.com/@Th3hound/the-hidden-danger-of-the-exposed-checkmk-agent-mapping-your-infrastructure-for-attackers-151cc2180e73

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

- Shodan Query: `port:6556 "<<<check_mk>>>"`  
- Sample Matched Response Snippet: <<<check_mk>>>

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)