### PR TITLE
Removed name bit in the extractor section for grafana-detect template

### DIFF
--- a/http/exposed-panels/grafana-detect.yaml
+++ b/http/exposed-panels/grafana-detect.yaml
@@ -39,7 +39,6 @@ http:
 
     extractors:
       - type: regex
-        name: version
         part: body
         group: 1
         regex:


### PR DESCRIPTION


### Template / PR Information

Made the template to only report [grafana-detect] without including the 'version' bit in the name. The version still gets reported if available.
This makes it neater and consistent.

Old output:
`[grafana-detect:version] [http] [info] https://[redacted].com/login ["11.6.2"]`
<img width="1515" height="412" alt="image" src="https://github.com/user-attachments/assets/2b49b4e4-7ade-4074-b136-d9ad7fedff4d" />

New output:
`[grafana-detect] [http] [info] https://[redacted].com/login ["11.6.2"]`

<img width="1021" height="395" alt="image" src="https://github.com/user-attachments/assets/8388660e-f1b9-4065-9a33-aef19012d86e" />


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)