### PR TITLE
Create bugzilla-detect.yaml and bugzilla-config-exposed.yaml

### DIFF
--- a/http/exposures/configs/bugzilla-config-exposed.yaml
+++ b/http/exposures/configs/bugzilla-config-exposed.yaml
@@ -1,0 +1,56 @@
+id: bugzilla-config-exposed
+
+info:
+  name: Bugzilla - Config Exposed
+  author: icarot
+  severity: low
+  description: |
+    Because the config.cgi is publicly exposed, it is possible to enumerate main domain and possible users registered on Bugzilla server.
+  reference:
+    - https://github.com/bugzilla/bugzilla/
+  classification:
+    cpe: cpe:2.3:a:mozilla:bugzilla:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: mozilla
+    product: bugzilla
+    shodan-query: title:"Bugzilla"
+  tags: bugzilla,mozilla,config,exposed,enum
+
+http:
+  - raw:
+      - |
+        GET /config.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'base_url'
+          - 'maintainer'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/x-javascript; charset=UTF-8'
+
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        name: base_url
+        group: 1
+        part: body
+        regex:
+          - ".+base_url.+:.(?<base_url>\\'.+\\')"
+      - type: regex
+        name: maintainer
+        group: 1
+        part: body
+        regex:
+          - ".+maintainer.+:.(?<maintainer>\\'.+\\')"

--- a/http/exposures/configs/bugzilla-config.yaml
+++ b/http/exposures/configs/bugzilla-config.yaml
@@ -18,29 +18,17 @@ info:
   tags: bugzilla,mozilla,config,exposure
 
 http:
-  - raw:
-      - |
-        GET /config.cgi HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
+  - method: GET
+    path:
+      - "{{BaseURL}}/config.cgi"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - 'base_url'
-          - 'maintainer'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "base_url", "maintainer")'
+          - 'contains(content_type, "application/x-javascript")'
         condition: and
-
-      - type: word
-        part: content_type
-        words:
-          - 'application/x-javascript'
-
-      - type: status
-        status:
-          - 200
 
     extractors:
       - type: regex

--- a/http/exposures/configs/bugzilla-config.yaml
+++ b/http/exposures/configs/bugzilla-config.yaml
@@ -1,4 +1,4 @@
-id: bugzilla-config-exposed
+id: bugzilla-config
 
 info:
   name: Bugzilla - Config Exposed
@@ -15,7 +15,7 @@ info:
     vendor: mozilla
     product: bugzilla
     shodan-query: title:"Bugzilla"
-  tags: bugzilla,mozilla,config,exposed,enum
+  tags: bugzilla,mozilla,config,exposure
 
 http:
   - raw:
@@ -36,11 +36,12 @@ http:
       - type: word
         part: content_type
         words:
-          - 'application/x-javascript; charset=UTF-8'
+          - 'application/x-javascript'
 
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         name: base_url
@@ -48,6 +49,7 @@ http:
         part: body
         regex:
           - ".+base_url.+:.(?<base_url>\\'.+\\')"
+
       - type: regex
         name: maintainer
         group: 1

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -31,3 +31,9 @@ http:
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "class=\"header_addl_info\">version ([^<]+)</span>"

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -28,6 +28,7 @@ http:
           - 'title="Bugzilla" href="./search_plugin.cgi">'
           - 'id="help" href="https://bugzilla.readthedocs.org/'
         condition: or
+
       - type: status
         status:
           - 200

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -1,0 +1,33 @@
+id: bugzilla-detect
+
+info:
+  name: Bugzilla - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Bugzilla server, official repository for the Bugzilla bug tracking system.
+  reference:
+    - https://github.com/bugzilla/bugzilla/
+  classification:
+    cpe: cpe:2.3:a:mozilla:bugzilla:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: mozilla
+    product: bugzilla
+    shodan-query: title:"Bugzilla"
+  tags: tech,bugzilla,mozilla,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Bugzilla Main Page</title>'
+          - '"title">Bugzilla'
+          - 'bugzilla'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -24,10 +24,10 @@ http:
     matchers:
       - type: word
         words:
-          - '<title>Bugzilla Main Page</title>'
-          - '"title">Bugzilla'
-          - 'bugzilla'
-        condition: and
+          - "<title>Bugzilla Main Page</title>"
+          - 'title="Bugzilla" href="./search_plugin.cgi">'
+          - 'id="help" href="https://bugzilla.readthedocs.org/'
+        condition: or
       - type: status
         status:
           - 200

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -16,10 +16,12 @@ info:
     product: bugzilla
     shodan-query: title:"Bugzilla"
   tags: tech,bugzilla,mozilla,detect
+
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
+
     matchers-condition: and
     matchers:
       - type: word

--- a/http/technologies/bugzilla-detect.yaml
+++ b/http/technologies/bugzilla-detect.yaml
@@ -11,6 +11,7 @@ info:
   classification:
     cpe: cpe:2.3:a:mozilla:bugzilla:-:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
     vendor: mozilla
     product: bugzilla
@@ -26,9 +27,9 @@ http:
     matchers:
       - type: word
         words:
-          - "<title>Bugzilla Main Page</title>"
-          - 'title="Bugzilla" href="./search_plugin.cgi">'
-          - 'id="help" href="https://bugzilla.readthedocs.org/'
+          - "<title>Bugzilla Main"
+          - 'title="Bugzilla'
+          - 'href="https://bugzilla.readthedocs.org/'
         condition: or
 
       - type: status


### PR DESCRIPTION
These nuclei templates:

* Detects a Bugzilla server, official repository for the Bugzilla bug tracking system.
* Because the config.cgi is publicly exposed, it is possible to enumerate main domain and possible users registered on Bugzilla server.

- References:

https://github.com/bugzilla/bugzilla/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Bugzilla Docker:**

1. Running container:

`$ git clone https://github.com/bugzilla/bugzilla/`
`$ docker compose up -d`

2. Acessing the Bugzilla service:
`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' bugzilla-bugzilla5.web-1`

3. Starting a docker container Kali in the same network as the Bugzilla:
`$ docker run --rm --tty --interactive --network bugzilla_default --dns 8.8.8.8 --dns 8.8.4.4 --name container_kali kalilinux/kali-rolling /bin/bash`

And the access URL will be http://<obteined_inspect_IP_Address>/ or http://<host_IP_Address>/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t bugzilla-detect.yaml -t bugzilla-config-exposed.yaml -u "http://<obteined_inspect_IP_Address>" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="800" height="623" alt="image" src="https://github.com/user-attachments/assets/127c7dcd-1c9a-41d8-9fe1-0f567a287ac9" />

<img width="1256" height="1039" alt="image" src="https://github.com/user-attachments/assets/e9c03261-d0c7-49a7-8a10-88dcb48ad838" />

<img width="1851" height="454" alt="image" src="https://github.com/user-attachments/assets/7ea49d15-44f7-4cc7-8002-8442cbc75368" />
