### PR TITLE
Add detection of ZAMMAD HELPDESK login panel instances.

### DIFF
--- a/http/exposed-panels/zammad-panel.yaml
+++ b/http/exposed-panels/zammad-panel.yaml
@@ -1,0 +1,28 @@
+id: zammad-helpdesk-panel
+
+info:
+  name: Zammad Helpdesk Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    Zammad Helpdesk panel was discovered.
+  reference:
+    - https://github.com/zammad/zammad
+    - https://zammad.org/
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.title:"Zammad Helpdesk"
+  tags: panel,zammad,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>zammad helpdesk</title>", "zammad_form_script")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **ZAMMAD HELPDESK** software.

References:

- https://github.com/zammad/zammad
- https://zammad.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="819" height="701" alt="image" src="https://github.com/user-attachments/assets/7e0eaf81-ebfc-4d6b-a656-73dbf1dc3dd1" />

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://78.47.226.105:8080
https://212.202.167.125
http://46.101.243.46:8080
https://134.96.227.46
http://5.189.153.84:8080
https://109.90.35.24
http://62.171.140.249:8080
http://148.113.6.21:8080
http://146.19.230.62:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Zammad+Helpdesk%22

<img width="1442" height="857" alt="image" src="https://github.com/user-attachments/assets/fa8d7ea3-9704-4010-8d93-70bd44715cd0" />

### Additional References

None