### PR TITLE
feat: Add LDAPS support

### DIFF
--- a/javascript/enumeration/ldap/ldaps-metadata.yaml
+++ b/javascript/enumeration/ldap/ldaps-metadata.yaml
@@ -1,0 +1,85 @@
+id: ldaps-metadata
+
+info:
+  name: LDAPS Metadata - Enumeration
+  author: pussycat0x, matejsmycka
+  severity: info
+  description: |
+    LDAP metadata refers to the data that describes the structure, schema, and attributes of the LDAP directory
+  reference:
+    - https://docs.projectdiscovery.io/templates/protocols/javascript/modules/ldap.Metadata
+  metadata:
+    max-request: 1
+    shodan-query: ldap
+  tags: js,network,ldap
+
+javascript:
+  - code: |
+      const ldap = require('nuclei/ldap');
+      const cfg = new ldap.Config();
+      cfg.Upgrade = true;
+      const client = new ldap.Client(Host, Port);
+      const metadata = client.CollectMetadata();
+      Export((metadata))
+
+    args:
+      Host: "ldaps://{{Host}}"
+      Port: 636
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "len(BaseDn) != 0"
+          - "len(DnsHostName) != 0"
+          - "len(DefaultNamingContext) != 0"
+          - "len(DomainFunctionality) != 0"
+          - "len(ForestFunctionality) != 0"
+          - "len(DomainControllerFunctionality) != 0"
+          - "success == true"
+
+    extractors:
+      - type: json
+        internal: true
+        name: BaseDn
+        json:
+          - '.BaseDN'
+
+      - type: json
+        internal: true
+        name: DnsHostName
+        json:
+          - '.DnsHostName'
+
+      - type: json
+        internal: true
+        name: DefaultNamingContext
+        json:
+          - '.DefaultNamingContext'
+
+      - type: json
+        internal: true
+        name: DomainFunctionality
+        json:
+          - '.DomainFunctionality'
+
+      - type: json
+        internal: true
+        name: ForestFunctionality
+        json:
+          - '.ForestFunctionality'
+
+      - type: json
+        internal: true
+        name: DomainControllerFunctionality
+        json:
+          - '.DomainControllerFunctionality'
+
+      - type: json
+        json:
+          - '"BaseDN: " + .BaseDN'
+          - '"DnsHostName: " + .DnsHostName'
+          - '"DefaultNamingContext: "+ .DefaultNamingContext'
+          - '"DomainFunctionality: "+ .DomainFunctionality'
+          - '"ForestFunctionality: " + .ForestFunctionality'
+          - '"DomainControllerFunctionality: "+ .DomainControllerFunctionality'
+# digest: 4b0a00483046022100cbfe0c1d3dfae0a65e393d39f5e3f59d0b9f66f477cb66b57872f6a77d50e4f8022100ffb9acd602b1a8397a7151648316ef51216d7e94f3941a708d4b05b97bad575e:922c64590222798bb761d5b6d8e72950

--- a/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
+++ b/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
@@ -1,8 +1,8 @@
 id: ldap-anonymous-login-detect
 
 info:
-  name: LDAP Anonymous Login - Detect
-  author: pussycat0x,s0obi
+  name: LDAPS Anonymous Login - Detect
+  author: pussycat0x,s0obi,matejsmycka
   severity: medium
   description: |
     Detects whether an LDAP server allows anonymous bind (login without credentials).Anonymous access can expose sensitive directory information and should be restricted
@@ -11,7 +11,7 @@ info:
     - https://ldap.com/ldapv3-wire-protocol-reference-bind/#anonymous
     - https://docs.projectdiscovery.io/templates/protocols/javascript/modules/ldap.Client#getadgroups
   metadata:
-    max-request: 1
+    max-request: 2
     shodan-query: ldap
     verified: true
   tags: js,network,ldap,enum
@@ -34,4 +34,21 @@ javascript:
       - type: dsl
         dsl:
           - "success == true"
-# digest: 4a0a00473045022012b60864cebf59ef2b2787b260e160c3149949a2bde6660288c97cce2192d796022100ec5e9e76ca6f37bb627e02a32c4dd04c7802266a0f1f024f9e8a04d203a46389:922c64590222798bb761d5b6d8e72950
+
+  - code: |
+      let ldap = require('nuclei/ldap');
+      let cfg = ldap.Config();
+      cfg.Upgrade = true;
+      let client = ldap.Client(Host, Port, cfg);
+      let result = client.Authenticate('', '');
+      let metadata = client.CollectMetadata();
+      Export(metadata);
+
+    args:
+      Host: "ldaps://{{Host}}"
+      Port: 636
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "success == true"


### PR DESCRIPTION
….yaml

### Template / PR Information

Nuclei did not have support for LDAPS. This is a problem on LDAP instances that have port 389 disabled and communicate only over 636.

Often, LDAP servers do have both ports open; however, it is still better to check for both ports to not miss anything.
<img width="2089" height="960" alt="image" src="https://github.com/user-attachments/assets/61cd2780-3a45-4486-92a8-10de2ad734c9" />



Both templates are tested.
<img width="1853" height="658" alt="Screenshot From 2025-08-19 10-30-39" src="https://github.com/user-attachments/assets/2ce3ebf8-c5b8-4e7b-b494-cbe07c18fe1c" />

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)