### PR TITLE
feat: add SNMPv1 public misconfig detection template

### DIFF
--- a/javascript/udp/misconfiguration/snmpv1-public-discovery.yaml
+++ b/javascript/udp/misconfiguration/snmpv1-public-discovery.yaml
@@ -1,0 +1,53 @@
+id: snmpv1-public-discovery
+
+info:
+  name: SNMPv1 Public Discovery
+  author: matejsmycka
+  severity: medium
+  description: |
+    The remote host is running an SNMPv1 server with a default community string. 
+    SNMPv1 is an insecure protocol that can be exploited to gather sensitive information.
+    Use other tools like snmpwalk to gather more information.
+  reference:
+    - https://hackers-arise.com/exploiting-snmpv1-for-reconnaissance/
+    - https://hacktricks.boitatech.com.br/pentesting/pentesting-snmp
+    - https://www.tenable.com/plugins/nnm/1344
+    - https://linux.die.net/man/1/snmpwalk
+  tags: js,udp,network
+
+javascript:
+  - pre-condition: |
+      isUDPPortOpen(Host, Port);
+    code: |
+      const c = require("nuclei/net");
+      const conn = c.Open('udp', `${Host}:${Port}`, `${Timeout}`);
+      let community_string =  bytes.NewBuffer();
+      community_string.WriteString(Community);
+      let payload = "30290201010406";
+      payload += community_string.Hex(); 
+      payload += "a01c02040eb376f4020100020100" 
+      payload += "300e300c06082b060102010105000500" // VarBind list for sysName.0
+      conn.SendHex(payload);
+      let resp = conn.RecvFull(64);
+      resp; 
+    args:
+      Host: "{{Host}}"
+      Port: 161
+      Timeout: 2
+      Community: "{{community_string}}"
+
+    attack: clusterbomb
+    payloads:
+      community_string:
+        - public
+
+    matchers:
+      - type: binary
+        binary:
+          - "0201010406"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+            - "public.*\x00\x04.(.*)"


### PR DESCRIPTION
### Template / PR Information

This template targets older devices with the default "public" community string in SNMP.
SNMP often exposes open ports, interfaces, uptime, or system information.

<img width="1114" height="254" alt="Screenshot From 2025-08-20 11-33-55" src="https://github.com/user-attachments/assets/4e7ee863-74d6-494f-9f98-52a1edc6b0e6" />

### References
- https://github.com/TheSnowWight/hackdocs/blob/master/pentesting/pentesting-snmp/README.md
- https://www.rapid7.com/blog/post/2016/05/05/snmp-data-harvesting-during-penetration-testing/
- https://www.offsec.com/metasploit-unleashed/scanner-snmp-auxiliary-modules/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)