### PR TITLE
magicinto  panel and conf exposure

### DIFF
--- a/http/exposed-panels/magicinfo-panel.yaml
+++ b/http/exposed-panels/magicinfo-panel.yaml
@@ -1,0 +1,29 @@
+id: magicinfo-panel
+
+info:
+  name: Samsung MagicINFO Panel - Detect
+  author: s4e-io
+  severity: info
+  description: |
+    Samsung MagicINFO panel was discovered.
+  reference:
+    - https://www.samsung.com/de/business/display-solutions/magicinfo/
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: samsung
+    product: magicinfo
+  tags: panel,login,magicinfo,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/MagicInfo/login"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "<title>MagicInfo Server", "/MagicInfo/logo.ico")'
+        condition: and

--- a/http/exposures/configs/magicinfo-config-exposure.yaml
+++ b/http/exposures/configs/magicinfo-config-exposure.yaml
@@ -1,0 +1,37 @@
+id: magicinfo-config-exposure
+
+info:
+  name: Samsung MagicINFO Configuration File Exposure
+  author: s4e-io
+  severity: medium
+  description: |
+    Detects exposure of Samsung MagicINFO configuration file (/MagicInfo/config.js),
+    and extracts magicInfoFrontEndVersion.
+  reference:
+    - https://www.samsung.com/de/business/display-solutions/magicinfo/
+  metadata:
+    vendor: samsung
+    product: magicinfo_9_server
+    shodan-query: server:"magicinfo premium server"
+  tags: config,exposure,magicinfo
+
+http:
+  - raw:
+      - |
+        GET /MagicInfo/config.js HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "globalConfig", "MagicINFO", "samsung")'
+          - "status_code == 200"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: magicinfo_version
+        group: 1
+        part: body
+        regex:
+          - '"magicInfoFrontEndVersion":\s*"([^"]+)"'


### PR DESCRIPTION
While writing the CVE template, I noticed that panel scanning and config exposure scanning weren’t included template repo, so I thought I’d add them. :)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)