### PR TITLE
feat(graphql): Add template for GraphQL introspection and interface exposure

### DIFF
--- a/dast/vulnerabilities/GraphQL/introspection.yaml
+++ b/dast/vulnerabilities/GraphQL/introspection.yaml
@@ -10,8 +10,6 @@ info:
   reference:
     - https://graphql.org/learn/introspection/
     - https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/GraphQL%20Injection
-  classification:
-    cwe-id: CWE-200
   tags: graphql,introspection,dast,graphiql,exposure
 
 requests:

--- a/dast/vulnerabilities/GraphQL/introspection.yaml
+++ b/dast/vulnerabilities/GraphQL/introspection.yaml
@@ -1,0 +1,57 @@
+id: graphql-introspection
+info:
+  name: GraphQL Introspection & Interface Exposure
+  author: Jaenact
+  severity: medium
+  description: |
+    Detects if GraphQL introspection query is enabled or if a GraphQL explorer
+    interface (GraphiQL, Playground) is publicly exposed. This allows attackers
+    to easily enumerate the entire API schema.
+  reference:
+    - https://graphql.org/learn/introspection/
+    - https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/GraphQL%20Injection
+  classification:
+    cwe-id: CWE-200
+  tags: graphql,introspection,dast,graphiql,exposure
+
+requests:
+  - method: POST
+    path:
+      - "{{BaseURL}}/graphql"
+      - "{{BaseURL}}/api"
+      - "{{BaseURL}}/graph"
+      - "{{BaseURL}}/graphql.php"
+      - "{{BaseURL}}/graphql/console"
+      - "{{BaseURL}}/graphiql"
+      - "{{BaseURL}}/graphiql.php"
+      - "{{BaseURL}}/v1"
+      - "{{BaseURL}}/v2"
+      - "{{BaseURL}}/api/graphql"
+      - "{{BaseURL}}/graphql/v1"
+      - "{{BaseURL}}/v1/explorer"
+      - "{{BaseURL}}/v1/graphiql"
+
+    headers:
+      Content-Type: "{{contentType}}"
+    
+    body: |
+      {"query":"query IntrospectionQuery { __schema { types { name } } }"}
+
+    stop-at-first-match: true
+
+    payloads:
+      contentType:
+        - "application/json"
+        - "application/graphql"
+    
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "__schema"
+          - "types"
+        part: body
+        condition: and


### PR DESCRIPTION
# What is the purpose of this template?

This PR adds a new, comprehensive template to detect misconfigured GraphQL endpoints.

Many GraphQL servers expose their API schema through two primary vectors: the **introspection query** and **developer explorer interfaces (e.g., GraphiQL)**. This template efficiently checks for both of these common security misconfigurations in a single scan.

* **GraphQL Introspection (The Feature):** It directly verifies if the introspection query feature, which can leak the entire API schema, is enabled.
* **Explorer Interface Exposure (The Tool):** It checks for publicly accessible graphical interfaces like `GraphiQL` and `GraphQL Playground`, which are provided for developer convenience but can be abused by attackers.

By combining these checks into a single template, it provides a more efficient way to identify insecure GraphQL endpoints that allow an attacker to easily map the internal structure of an API and plan further attacks.

---

# Template Validation

I have manually tested this template to verify its effectiveness by building a deliberately vulnerable test environment.

* [x] I have tested the template manually against a vulnerable target.
* [x] The template yielded the expected findings without any false positives.
* [x] I have validated the template syntax and format using the `nuclei -validate` command.
<img width="2230" height="512" alt="image" src="https://github.com/user-attachments/assets/b585597c-b27c-43dc-b807-9b76d1c2bb5a" />


## Vulnerable Target

* **Application:** Damn Vulnerable GraphQL Application (DVGA) ( https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application)
* **Environment:** Deployed locally using Docker (`http://localhost:5013`)
* **Goal:** The objective was to confirm that the template operates correctly under conditions that mimic a real-world environment.

## Detailed Validation Log

<img width="2616" height="1136" alt="image" src="https://github.com/user-attachments/assets/b7abafee-1292-400b-9bdc-7aacaf3da36b" />


### This confirms that the template works as expected. Thank you for your consideration!