### PR TITLE
Add: CVE-2025-52970 – FortiWeb Authentication Bypass (exploit-based)

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -38,6 +38,7 @@ http:
 
     matchers-condition: and
     matchers:
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
### Template / PR Information
 /claim #12953


- Added CVE-2025-52970 – FortiWeb Authentication Bypass (exploit-based)- References:

### Template Validation

I've validated this template locally? NO

References:
Researcher blog: https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-52970
CUHK advisory: https://www.itsc.cuhk.edu.hk/user-trainings/information-security-best-practices/fortiweb-authentication-bypass-vulnerability-cve-2025-52970/
