### PR TITLE
Added CVE-2025-22457 template

### DIFF
--- a/http/cves/2025/CVE-2025-22457.yaml
+++ b/http/cves/2025/CVE-2025-22457.yaml
@@ -1,0 +1,47 @@
+id: CVE-2025-22457
+
+info:
+  name: Ivanti Connect Secure - Unauthenticated RCE (CVE-2025-22457)
+  author: shahil
+  severity: critical
+  description: |
+    Ivanti Connect Secure, Ivanti Policy Secure, and ZTA gateways are vulnerable 
+    to a stack-based buffer overflow (CVE-2025-22457). Versions **22.7R2.5 and earlier**
+    are affected. This template checks the product version from the web interface 
+    to determine if the instance is likely vulnerable.
+  reference:
+    - https://forums.ivanti.com/s/article/April-Security-Advisory-Ivanti-Connect-Secure-Policy-Secure-ZTA-Gateways-CVE-2025-22457
+    - https://attackerkb.com/topics/0ybGQIkHzR/cve-2025-22457/rapid7-analysis
+    - https://github.com/sfewer-r7/CVE-2025-22457
+  classification:
+    cve-id: CVE-2025-22457
+    cwe-id: CWE-121
+  metadata:
+    vendor: ivanti
+    product: connect-secure
+    shodan-query: http.title:"Ivanti Connect Secure"
+  tags: cve,ivanti,rce,overflow
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dana-na/auth/url_admin/welcome.cgi?type=inter"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - 'name="productversion"\s+value="([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"'
+
+    extractors:
+      - type: regex
+        name: product_version
+        part: body
+        group: 1
+        regex:
+          - 'name="productversion"\s+value="([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"'


### PR DESCRIPTION
### Template / PR Information

- Pull out the version check logic from the exploit (product_version function).

Note the vendor’s fixed version (22.7.2.3981 = Ivanti Connect Secure 22.7R2.6).

- Requests the same endpoint (/dana-na/auth/url_admin/welcome.cgi?type=inter) and extracts the productversion value.

Fix #12969

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)