### PR TITLE
fix: add space for list item in tcpwrapper-access.yaml

### DIFF
--- a/code/linux/audit/tcpwrapper-access.yaml
+++ b/code/linux/audit/tcpwrapper-access.yaml
@@ -14,7 +14,7 @@ self-contained: true
 
 code:
   - engine:
-      -sh
+      - sh
       - bash
     source: |
       echo "[*] Checking /etc/hosts.deny (default deny policy)"


### PR DESCRIPTION
### Template / PR Information

I think `-sh` should be written as `- sh` and would like to propose the change.

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)