### PR TITLE
feat: make CVE-2018-0171 stable and add additional info

### DIFF
--- a/javascript/cves/2018/CVE-2018-0171.yaml
+++ b/javascript/cves/2018/CVE-2018-0171.yaml
@@ -5,7 +5,7 @@ info:
   author: ritikchaddha,matejsmycka
   severity: critical
   description: |
-    A vulnerability in the Smart Install feature of Cisco IOS Software and Cisco IOS XE Software could allow an unauthenticated, remote attacker to trigger a reload of an affected device, resulting in a denial of service (DoS) condition, or to execute arbitrary code on an affected device. The vulnerability is due to improper validation of packet data. 
+    A vulnerability in the Smart Install feature of Cisco IOS Software and Cisco IOS XE Software could allow an unauthenticated, remote attacker to trigger a reload of an affected device, resulting in a denial of service (DoS) condition, or to execute arbitrary code on an affected device. The vulnerability is due to improper validation of packet data.
   reference:
     - https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2
     - https://nvd.nist.gov/vuln/detail/CVE-2018-0171


### PR DESCRIPTION
### Template / PR Information

We have been using a similar template for the same vulnerability for some time, but I did not want to share the template due to the responsible disclosure time.

Now, I want to share my findings on this vulnerability.

This PR makes the original exploit more stable. The old exploit left the TFTP connections hanging, which means it created false negatives on repeated scans; this fixes that.

I have also added some additional info.

Lastly, I changed the 'hostname' matcher because the router might not have one configured.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)