### PR TITLE
CVE-2025-42599 – Active! mail pre-auth fingerprint (discovery)

### DIFF
--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -5,9 +5,8 @@ info:
   author: Excellencedev
   severity: critical
   description: |
-    Identifies Active! mail installations associated with CVE-2025-42599 by analyzing the public login
-    interface at /am_bin/amlogin using product-specific indicators (title, assets, form action, fields).
-    Performs only safe HTTP requests and extracts BUILDID for triage.
+    Detects Active! mail installations via the public login interface (/am_bin/amlogin) using product-specific
+    indicators such as page title, asset path, form action, and required fields.
 
   remediation: |
     Upgrade Active! mail to BuildInfo 6.60.06008562 or later, as advised by the vendor, to remediate

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -1,0 +1,90 @@
+id: CVE-2025-42599
+
+info:
+  name: Active! mail - Product Fingerprint (Pre-Auth, Staging for CVE-2025-42599)
+  author: Excellencedev
+  severity: critical
+  description: |
+    This template safely fingerprints Active! mail by requesting the public login endpoint and matching
+    on product-specific assets and form structure. It does NOT validate or exploit CVE-2025-42599.
+    Use only for discovery while awaiting public disclosure of the exact exploit request (endpoint,
+    method, headers, payload) required to confirm the vulnerability.
+
+  remediation: |
+    Upgrade Active! mail to BuildInfo 6.60.06008562 or later, as advised by the vendor, to remediate
+    CVE-2025-42599. If immediate upgrade is not possible, restrict exposure to the login interface and
+    apply compensating controls (WAF, IP allowlisting) until patched.
+
+    Verified endpoints and parameters collected from public instances include:
+    - GET /am_bin/amlogin (login page)
+    - POST /am_bin/amlogin/login_auth (auth action)
+    - Typical fields: am_authid, am_authpasswd, language, save_authinfo
+    - Hidden fields: login_page_lang, charset, http_user_agent
+
+    Notes:
+    - This is a product fingerprint only and should not be used to claim vulnerability existence.
+    - Once the exact PoC request is available, a separate exploit-based validation will replace this.
+  reference:
+    - https://jvn.jp/en/jp/JVN22348866/
+    - https://www.qualitia.com/jp/news/2025/04/18_1030.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-42599
+  classification:
+    cwe-id: CWE-121
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    product: "Active! mail"
+    vendor: qualitia
+    shodan-query: 'http.title:"Active! mail"'
+    fofa-query: 'title="Active! mail"'
+    max-request: 1
+    verified: false
+  tags: cve,cve2025,active-mail,fingerprint,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/am_bin/amlogin"
+
+    redirects: true
+    stop-at-first-match: true
+
+    headers:
+      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+      Accept-Language: en-US,en;q=0.9
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "<title>\\s*Active! mail.*</title>"
+      - type: word
+        part: content_type
+        words:
+          - "text/html"
+      - type: regex
+        part: body
+        regex:
+          - "am_viz/common/js/activemail\\.js"
+      - type: regex
+        part: body
+        regex:
+          - 'action="(?:https?://[^\"]+)?/am_bin/amlogin/login_auth"'
+      - type: word
+        part: body
+        words:
+          - 'name="am_authid"'
+          - 'name="am_authpasswd"'
+        condition: and
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        name: am_buildid
+        group: 1
+        regex:
+          - 'BUILDID:\\"([0-9\\.]+)\\"'

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -1,14 +1,14 @@
 id: CVE-2025-42599
 
 info:
-  name: Active! mail - Product Fingerprint (Pre-Auth, Staging for CVE-2025-42599)
+  name: Active! mail - Stack-based Buffer Overflow (CVE-2025-42599) [Fingerprint]
   author: Excellencedev
   severity: critical
   description: |
-    This template safely fingerprints Active! mail by requesting the public login endpoint and matching
-    on product-specific assets and form structure. It does NOT validate or exploit CVE-2025-42599.
-    Use only for discovery while awaiting public disclosure of the exact exploit request (endpoint,
-    method, headers, payload) required to confirm the vulnerability.
+    CVE-2025-42599 (KEV) — Active! mail 6 BuildInfo: 6.60.05008561 and earlier contains a stack-based
+    buffer overflow that can be triggered by a specially crafted request, allowing remote unauthenticated
+    code execution or DoS (JVN/JPCERT, NVD). This template is discovery-only and safely fingerprints the
+    public login interface without attempting exploitation.
 
   remediation: |
     Upgrade Active! mail to BuildInfo 6.60.06008562 or later, as advised by the vendor, to remediate
@@ -30,7 +30,10 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-42599
     - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-42599
     - https://www.jpcert.or.jp/at/2025/at250010.html
+    - https://www.cve.org/CVERecord?id=CVE-2025-42599
+    - https://github.com/cisagov/vulnrichment/blob/develop/2025/42xxx/CVE-2025-42599.json
   classification:
+    cve-id: CVE-2025-42599
     cwe-id: CWE-121
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -42,7 +45,7 @@ info:
     max-request: 1
     verified: false
     template-type: discovery
-  tags: cve,cve2025,active-mail,fingerprint,discovery
+  tags: cve,cve2025,active-mail,fingerprint,discovery,rce,buffer-overflow,kev
 
 http:
   - method: GET

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -7,7 +7,6 @@ info:
   description: |
     Detects Active! mail installations via the public login interface (/am_bin/amlogin) using product-specific
     indicators such as page title, asset path, form action, and required fields.
-
   remediation: |
     Upgrade Active! mail to BuildInfo 6.60.06008562 or later per the vendor advisory for CVE-2025-42599.
     If immediate upgrade is not possible, restrict exposure to the login interface and apply compensating

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -5,10 +5,9 @@ info:
   author: Excellencedev
   severity: critical
   description: |
-    CVE-2025-42599 (KEV) — Active! mail 6 BuildInfo: 6.60.05008561 and earlier contains a stack-based
-    buffer overflow that can be triggered by a specially crafted request, allowing remote unauthenticated
-    code execution or DoS (JVN/JPCERT, NVD). This template is discovery-only and safely fingerprints the
-    public login interface without attempting exploitation.
+    Identifies Active! mail installations associated with CVE-2025-42599 by analyzing the public login
+    interface at /am_bin/amlogin using product-specific indicators (title, assets, form action, fields).
+    Performs only safe HTTP requests and extracts BUILDID for triage.
 
   remediation: |
     Upgrade Active! mail to BuildInfo 6.60.06008562 or later, as advised by the vendor, to remediate

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-42599
 
 info:
-  name: Active! mail - Stack-based Buffer Overflow (CVE-2025-42599) [Fingerprint]
+  name: Active! mail - Product Fingerprint (Pre-Auth) (CVE-2025-42599)
   author: Excellencedev
   severity: critical
   description: |
@@ -9,19 +9,9 @@ info:
     indicators such as page title, asset path, form action, and required fields.
 
   remediation: |
-    Upgrade Active! mail to BuildInfo 6.60.06008562 or later, as advised by the vendor, to remediate
-    CVE-2025-42599. If immediate upgrade is not possible, restrict exposure to the login interface and
-    apply compensating controls (WAF, IP allowlisting) until patched.
-
-    Verified endpoints and parameters collected from public instances include:
-    - GET /am_bin/amlogin (login page)
-    - POST /am_bin/amlogin/login_auth (auth action)
-    - Typical fields: am_authid, am_authpasswd, language, save_authinfo
-    - Hidden fields: login_page_lang, charset, http_user_agent
-
-    Notes:
-    - This is a product fingerprint only and should not be used to claim vulnerability existence.
-    - Once the exact PoC request is available, a separate exploit-based validation will replace this.
+    Upgrade Active! mail to BuildInfo 6.60.06008562 or later per the vendor advisory for CVE-2025-42599.
+    If immediate upgrade is not possible, restrict exposure to the login interface and apply compensating
+    controls (WAF, IP allowlisting) until patched.
   reference:
     - https://jvn.jp/en/jp/JVN22348866/
     - https://www.qualitia.com/jp/news/2025/04/18_1030.html

--- a/http/cves/2025/CVE-2025-42599.yaml
+++ b/http/cves/2025/CVE-2025-42599.yaml
@@ -28,6 +28,8 @@ info:
     - https://jvn.jp/en/jp/JVN22348866/
     - https://www.qualitia.com/jp/news/2025/04/18_1030.html
     - https://nvd.nist.gov/vuln/detail/CVE-2025-42599
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-42599
+    - https://www.jpcert.or.jp/at/2025/at250010.html
   classification:
     cwe-id: CWE-121
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
@@ -39,6 +41,7 @@ info:
     fofa-query: 'title="Active! mail"'
     max-request: 1
     verified: false
+    template-type: discovery
   tags: cve,cve2025,active-mail,fingerprint,discovery
 
 http:


### PR DESCRIPTION
/claim #12963

Adds a non–version-based, pre-auth fingerprint template for Active! mail related to CVE-2025-42599. It safely identifies the product via the /am_bin/amlogin page with robust matchers (title regex, asset, form action, fields) and extracts BUILDID for triage. This does not perform exploitation; an exploit-validating template will be added once a public PoC request is available.


Template / PR Information
Added CVE-2025-42599 fingerprint template (discovery-only) at 
http/cves/2025/CVE-2025-42599.yaml

Robust non–version-based matchers:
Asset: am_viz/common/js/activemail.js
Form action (absolute/relative, http/https): action="(?:https?://[^"]+)?/am_bin/amlogin/login_auth"
Fields: name="am_authid", name="am_authpasswd"
Status 200 and Content-Type text/html
Extractor: BUILDID:"([0-9\.]+)" (as am_buildid) for triage.


References:
JVN: https://jvn.jp/en/jp/JVN22348866/
Vendor: https://www.qualitia.com/jp/news/2025/04/18_1030.html
NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-42599
CISA KEV: https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-42599

Template Validation
I've validated this template locally?
 NO
