### PR TITLE
fix(gcloud-service-account-user-keys): update matcher for user-managed keys

### DIFF
--- a/cloud/gcp/iam/gcloud-service-account-user-keys.yaml
+++ b/cloud/gcp/iam/gcloud-service-account-user-keys.yaml
@@ -39,7 +39,7 @@ code:
         name: projectIds
         internal: true
         json:
-          - '.[].projectId'
+          - ".[].projectId"
 
   - engine:
       - sh
@@ -52,7 +52,7 @@ code:
         name: emails
         internal: true
         json:
-          - '.[].email'
+          - ".[].email"
 
   - engine:
       - sh
@@ -63,10 +63,9 @@ code:
     matchers:
       - type: word
         words:
-          - 'KEY_ID'
+          - "USER_MANAGED"
 
     extractors:
       - type: dsl
         dsl:
           - '"User-Managed Keys Found in Service Account " + email + " in project " + projectId'
-# digest: 4a0a0047304502206d029c26c00ff70caf71ace521c4a91a88b47c2a3befd052c8f6b8aafc3df559022100b847c83b437bece07c45ae96c3b0636f4b64365aa023ecc548b446f9e3e6d5af:922c64590222798bb761d5b6d8e72950

--- a/cloud/gcp/iam/gcloud-service-account-user-keys.yaml
+++ b/cloud/gcp/iam/gcloud-service-account-user-keys.yaml
@@ -64,6 +64,8 @@ code:
       - type: word
         words:
           - "USER_MANAGED"
+          - "KEY_ID"
+        condition: or
 
     extractors:
       - type: dsl


### PR DESCRIPTION
### Template / PR Information

Updated template gcloud-service-account-user-keys to improve accuracy

The previous version didn’t match anything because "KEY_ID" is not part of the command output

The matcher was looking for "KEY_ID", which never appeared in the gcloud JSON output, so no matches were reported and user-managed keys could be missed.

Updated matcher now looks for "USER_MANAGED", which is reliably present in the JSON when user-managed keys exist, ensuring accurate detection.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:
- https://cloud.google.com/vpc/docs/vpc#default-network
- https://github.com/projectdiscovery/nuclei-templates/blob/main/cloud/gcp/vpc/gcloud-default-vpc-in-use.yaml
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)