### PR TITLE
feat: add template for Microsoft SCCM - Anonymous DP Accesss

### DIFF
--- a/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
+++ b/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
@@ -5,14 +5,12 @@ info:
   author: matejsmycka
   severity: medium
   description: |
-    Microsoft System Center Configuration Manager (SCCM) can be configured to allow anonymous access to its distribution points.
-    This can lead to sensitive data exposure and information gathering by unauthorized users.
-    This misconfiguration is exploitable only via HTTP.
+    Microsoft System Center Configuration Manager (SCCM) can be configured to allow anonymous access to its distribution points.This can lead to sensitive data exposure and information gathering by unauthorized users.This misconfiguration is exploitable only via HTTP.
   reference:
     - https://www.synacktiv.com/en/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial
     - https://github.com/badsectorlabs/sccm-http-looter
     - https://learn.microsoft.com/en-us/intune/configmgr/core/servers/deploy/configure/install-and-configure-distribution-points
-  tags: misconfig,microsoft,sccm,anonymous,distribution-point,http
+  tags: misconfig,microsoft,sccm,anonymous,distribution-point
 
 http:
   - method: GET
@@ -20,11 +18,12 @@ http:
       - "{{BaseURL}}/SMS_DP_SMSPKG$/Datalib"
       - "{{BaseURL}}:80/SMS_DP_SMSPKG$/Datalib"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: regex
         regex:
-          - "/SMS_DP_SMSPKG\\$/Datalib/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          - '/SMS_DP_SMSPKG\$\/Datalib/([0-9a-z-]+)\.INI'
 
       - type: status
         status:

--- a/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
+++ b/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
@@ -6,7 +6,7 @@ info:
   severity: medium
   description: |
     Microsoft System Center Configuration Manager (SCCM) can be configured to allow anonymous access to its distribution points.
-    This can lead to sensitive data exposure and information gathering by unauthorized users. 
+    This can lead to sensitive data exposure and information gathering by unauthorized users.
     This misconfiguration is exploitable only via HTTP.
   reference:
     - https://www.synacktiv.com/en/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial
@@ -19,7 +19,7 @@ http:
     path:
       - "{{BaseURL}}/SMS_DP_SMSPKG$/Datalib"
       - "{{BaseURL}}:80/SMS_DP_SMSPKG$/Datalib"
-  
+
     matchers-condition: and
     matchers:
       - type: regex

--- a/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
+++ b/http/misconfiguration/microsoft/anonymous-distribution-point-sccm.yaml
@@ -1,0 +1,31 @@
+id: anonymous-distribution-point-sccm
+
+info:
+  name: Microsoft SCCM - Anonymous Distribution Point Access
+  author: matejsmycka
+  severity: medium
+  description: |
+    Microsoft System Center Configuration Manager (SCCM) can be configured to allow anonymous access to its distribution points.
+    This can lead to sensitive data exposure and information gathering by unauthorized users. 
+    This misconfiguration is exploitable only via HTTP.
+  reference:
+    - https://www.synacktiv.com/en/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial
+    - https://github.com/badsectorlabs/sccm-http-looter
+    - https://learn.microsoft.com/en-us/intune/configmgr/core/servers/deploy/configure/install-and-configure-distribution-points
+  tags: misconfig,microsoft,sccm,anonymous,distribution-point,http
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/SMS_DP_SMSPKG$/Datalib"
+      - "{{BaseURL}}:80/SMS_DP_SMSPKG$/Datalib"
+  
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "/SMS_DP_SMSPKG\\$/Datalib/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

The usual-looking instances we found were regular empty IIS servers.
<img width="1061" height="695" alt="image" src="https://github.com/user-attachments/assets/772f0ca8-39ac-42f6-bc23-b0d865bf6a07" />
https://github.com/synacktiv/SCCMSecrets could exfiltrate a lot of data from these endpoints.

There is a legit use case for anon SCCM (if you need speed), however, if you can list SCCM packages as non-domain PC, something is very wrong.

reference:
    - https://www.synacktiv.com/en/publications/sccmsecretspy-exploiting-sccm-policies-distribution-for-credentials-harvesting-initial
    - https://github.com/badsectorlabs/sccm-http-looter
    - https://learn.microsoft.com/en-us/intune/configmgr/core/servers/deploy/configure/install-and-configure-distribution-points

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)