### PR TITLE
Add CVE-2025-30154 template

### DIFF
--- a/http/cves/2025/CVE-2025-30154.yaml
+++ b/http/cves/2025/CVE-2025-30154.yaml
@@ -1,0 +1,60 @@
+id: CVE-2025-30154
+
+info:
+  name: reviewdog/action-setup - Code Injection
+  author: intelligent-ears
+  severity: high
+  description: |
+    reviewdog/action-setup contains a malicious code injection caused by compromise of reviewdog/action-setup@v1 on March 11, 2025, between 18:42 and 20:31 UTC, letting attackers dump exposed secrets to Github Actions Workflow Logs.
+  reference:
+    - https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup
+    - CVE-2025-30154
+  classification:
+    cve-id: CVE-2025-30154
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    shodan-query: N/A
+  tags: cve,cve2025,github,code-injection,kev,supply-chain
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/repos/{{github_repo}}/contents/{{file_path}}?ref={{ref}}"
+
+    headers:
+      Accept: "application/vnd.github.v3+json"
+      User-Agent: "Nuclei"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "content"
+          - "encoding"
+
+      - type: word
+        part: body
+        words:
+          - "${{ secrets }}"
+          - "base64 -w0"
+          - "::warning::"
+        condition: or
+
+    extractors:
+      - type: json
+        json:
+          - '.content'
+        part: body
+
+    variables:
+      github_repo: "reviewdog/action-setup"
+      file_path: "install.sh"
+      ref: "v1"


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-30154 - reviewdog/action-setup Code Injection template
- References: 
  - https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup
  - CVE-2025-30154

- Added CVE-2025-30154
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

**Test Environment:** Docker-based mock server with malicious payload
**Validation:** Template successfully detects the base64-encoded malicious pattern in GitHub API responses
**Pattern Detected:** `echo "::warning::$(echo -n \"|${{ github.token }}|${{ secrets }}|\" | base64 -w0)"`

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

/claim #12980