### PR TITLE
feat(gcloud-service-account-keys-rotation): add detection for non-rotating service account keys

### DIFF
--- a/cloud/gcp/iam/gcloud-service-account-keys-rotation.yaml
+++ b/cloud/gcp/iam/gcloud-service-account-keys-rotation.yaml
@@ -1,9 +1,9 @@
 id: gcloud-service-account-keys-rotation
 
 info:
-  name: Service Account Keys without rotation Found
+  name: GCP Service Account Keys - No Rotation Configured
   author: kelu27
-  severity: critical
+  severity: high
   description: |
     Detects Google Cloud Platform (GCP) service account keys that have no rotation enabled.
     Keys with an expiration date of 9999-12-31T23:59:59 are considered non-rotating and pose security risks if compromised.
@@ -15,7 +15,9 @@ info:
     - https://cloud.google.com/iam/docs/understanding-service-accounts
     - https://cloud.google.com/iam/docs/best-practices-for-securing-service-accounts
     - https://cloud.google.com/iam/docs/key-rotation
-  tags: cloud,devops,gcp,gcloud,google-cloud-iam,gcp-cloud-config,security,rotation
+  metadata:
+    max-request: 3
+  tags: cloud,devops,gcp,gcloud,iam,google-cloud-iam,gcp-cloud-config,security,rotation
 
 flow: |
   code(1)


### PR DESCRIPTION
### Template / PR Information

Create template gcloud-service-account-keys-rotation to detect keys that never expire.
This change targets service account keys that have no rotation configured. In GCP the IAM API exposes a field named validBeforeTime. When this field is set to the far future sentinel date that GCP uses to mean no expiration the key is effectively permanent. The template now matches on that condition and reports the key as a finding.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)


### Additional References:
- https://cloud.google.com/iam/docs/key-rotation
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)