### PR TITLE
fix: exclude float number with fractional part equals to cc number

### DIFF
--- a/http/miscellaneous/credit-card-number-detect.yaml
+++ b/http/miscellaneous/credit-card-number-detect.yaml
@@ -53,6 +53,7 @@ http:
         regex:
           - "\\b4[0-9]{12}(?:[0-9]{3})?-[a-fA-F0-9]" # Exclude hex patterns after card-like numbers
           - "\\b[0-9]{13,19}\\.[a-zA-Z]{2,4}\\b" # Exclude file extensions
+          - "\\b\\.[0-9]{13,19}\\b" # Exclude float numbers that have fractional part equals cc number
           - "href=[\"'][^\"']*[0-9]{13,19}[a-fA-F0-9]" # Exclude URLs with long hex strings
           - "src=[\"'][^\"']*[0-9]{13,19}[a-fA-F0-9]" # Exclude asset URLs
         condition: or


### PR DESCRIPTION
### Template / PR Information

Template generate False Positives for float number with fractional part equals to cc number eg `y1="0.4975124378109453"`

### Template Validation

I've validated this template locally?
- [x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
