### PR TITLE
Add CVE-2025-53118 - (Securden Unified PAM - Authentication Bypass)

### DIFF
--- a/http/cves/2025/CVE-2025-53118.yaml
+++ b/http/cves/2025/CVE-2025-53118.yaml
@@ -1,0 +1,57 @@
+id: CVE-2025-53118
+
+info:
+  name: Securden Unified PAM - Authentication Bypass
+  author: DhiyaneshDk,pussycat0x,iamnoooob,pdresearch
+  severity: critical
+  description: |
+    An authentication bypass vulnerability exists which allows an unauthenticated attacker to control administrator backup functions, leading to compromise of passwords, secrets, and application session tokens stored by the Unified PAM.
+  reference:
+    - https://www.rapid7.com/blog/post/securden-unified-pam-multiple-critical-vulnerabilities-fixed/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-53118
+  metadata:
+    verified: true
+    max-request: 3
+    fofa-query: (icon_hash="1798893256" || icon_hash="-766529773")
+  tags: cve,cve2025,securden,pam,auth-bypass
+
+flow: http(1) & http(2) & http(3)
+
+http:
+  - raw:
+      - |
+        GET /thirdparty-access HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 302
+        internal: true
+
+  - raw:
+      - |
+        GET /get_csrf_token HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, 'token')
+          - contains(content_type, 'application/json')
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /get_date_picker_format HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, 'current_date')
+          - contains(content_type, 'application/json')
+        condition: and


### PR DESCRIPTION
Added CVE-2025-53118 entry detailing an authentication bypass vulnerability in Securden Unified PAM.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)