### PR TITLE
add CVE-2024-11972 template for Hunk Companion < 1.9.0

### DIFF
--- a/http/cves/2024/CVE-2024-11972.yaml
+++ b/http/cves/2024/CVE-2024-11972.yaml
@@ -1,0 +1,62 @@
+id: CVE-2024-11972
+info:
+  name: WordPress Hunk Companion < 1.9.0 - Unauthenticated Plugin Install via REST
+  author: gsharma101
+  severity: critical
+  description: |
+    The Hunk Companion plugin before 1.9.0 exposes /wp-json/hc/v1/themehunk-import
+    with an ineffective permission_callback, allowing unauthenticated requests to
+    trigger plugin installation/activation from WordPress.org.
+    This check is non-invasive: it uses a fake plugin slug and matches for
+    “install flow” behavior without actually changing state.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-11972
+    - https://wpscan.com/blog/unauthorized-plugin-installation-activation-in-hunk-companion/
+    - https://www.exploit-db.com/exploits/52259
+  tags: cve,wordpress,wp,rest,auth-bypass,hunk-companion
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/hc/v1/themehunk-import"
+
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+
+    body: |
+      {
+        "params": {
+          "plugin": { "zzz-not-a-plugin-999": "Plugin Label" },
+          "allPlugins": [{ "zzz-not-a-plugin-999": "zzz-not-a-plugin-999/zzz-not-a-plugin-999.php" }],
+          "themeSlug": "theme",
+          "proThemePlugin": "plugin",
+          "templateType": "free",
+          "tmplFreePro": "theme",
+          "wpUrl": "{{BaseURL}}"
+        }
+      }
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 400
+          - 500
+
+      - type: word
+        words:
+          - "rest_forbidden"
+          - "Unauthorized"
+          - "You must be logged in"
+          - "nonce"
+        negative: true
+
+      - type: word
+        condition: or
+        words:
+          - "download"
+          - "install"
+          - "plugin"
+          - "activate"

--- a/http/cves/2024/CVE-2024-11972.yaml
+++ b/http/cves/2024/CVE-2024-11972.yaml
@@ -19,6 +19,7 @@ http:
   - method: POST
     path:
       - "{{BaseURL}}/wp-json/hc/v1/themehunk-import"
+      - "{{BaseURL}}/?rest_route=/hc/v1/themehunk-import"
 
     headers:
       Accept: application/json


### PR DESCRIPTION
**Summary**
Adds a Nuclei template for CVE-2024-11972 — WordPress Hunk Companion < 1.9.0 unauthenticated plugin install via REST.

/claim #13009

**Detection (safe)**
POST /wp-json/hc/v1/themehunk-import with a bogus plugin slug; vulnerable versions show install-flow responses without auth. Patched show 401/rest_forbidden/nonce.

**Safety**
No state change; uses a non-existent plugin slug.

**Attached full debug artifacts: version, verbose run, JSONL, and raw POST.**
[debug_version.txt](https://github.com/user-attachments/files/22030308/debug_version.txt)
[debug_run.txt](https://github.com/user-attachments/files/22030311/debug_run.txt)
[debug_run.json](https://github.com/user-attachments/files/22030959/debug_run.json)
[debug_curl.txt](https://github.com/user-attachments/files/22030321/debug_curl.txt)

**Debug Data**
- nuclei -version attached
- Full verbose run attached (-vv -debug -json)
- Optional cURL transcript attached (redacted)

**References**
- https://nvd.nist.gov/vuln/detail/CVE-2024-11972
- https://wpscan.com/blog/unauthorized-plugin-installation-activation-in-hunk-companion/
- https://www.exploit-db.com/exploits/52259
