### PR TITLE
CVE-2022-22274: SonicOS Buffer Overflow - Safe Detection Template

### DIFF
--- a/http/cves/2022/CVE-2022-22274.yaml
+++ b/http/cves/2022/CVE-2022-22274.yaml
@@ -1,0 +1,48 @@
+id: CVE-2022-22274
+
+info:
+  name: SonicWall SonicOS - Stack Buffer Overflow (Safe Detection)
+  author: imbios
+  severity: critical
+  description: |
+    SonicOS contains a stack-based buffer overflow reachable via crafted HTTP requests with URI paths longer than 1024 characters. A remote unauthenticated attacker can cause denial of service or potentially execute code. This template performs safe detection by sending long-path requests and observing redirect/empty behaviors reported by public PoCs.
+  reference:
+    - https://github.com/BishopFox/CVE-2022-22274_CVE-2023-0656
+    - https://vulncheck.com/xdb/e06bad581fa1
+    - https://github.com/forthisvideo/CVE-2022-22274_poc
+  metadata:
+    vendor: sonicwall
+    product: sonicos
+    cvss-score: 9.8
+    cwe-id: CWE-121
+    shodan-query: NA
+    verified: false
+    max-request: 4
+  classification:
+    cve-id: CVE-2022-22274
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/resources/{{repeat('A', 1100)}}"
+      - "{{BaseURL}}//{{repeat('A', 1100)}}"
+      - "{{BaseURL}}/atp/{{repeat('A', 1100)}}"
+
+    # BishopFox PoC indicates vulnerable devices often respond with HTTP 302 on long path.
+    redirects: false
+    max-redirects: 0
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(tolower(header_1), 'server: sonicwall')"
+      - type: dsl
+        condition: or
+        dsl:
+          - "status_code_2 == 302 || status_code_2 == 301"
+          - "status_code_3 == 302 || status_code_3 == 301"
+          - "status_code_4 == 302 || status_code_4 == 301"


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2022-22274 - SonicOS - Buffer Overflow (Safe Detection)
- References:
  - https://vulncheck.com/xdb/aaa87dc4f469
  - https://gitee.com/river3587/CVE-2022-22274_CVE-2023-0656
  - https://github.com/BishopFox/CVE-2022-22274_CVE-2023-0656
  - https://vulncheck.com/xdb/e06bad581fa1
  - https://github.com/forthisvideo/CVE-2022-22274_poc
  - https://github.com/4lucardSec/Sonic_CVE-2022-22274_poc

### Template Validation

I have validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

- Safe long-path checks at endpoints: /resources/, //, /atp/ with 1100 As (>1024) as per public PoC behavior.
- Does not follow redirects; matches only if Server: SonicWALL observed on / and a 301/302 on any long path.
- No exploit or crash; safe detection only; only the web management interface is in-scope.

### Additional References:

- https://nuclei.projectdiscovery.io/templating-guide/
- https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers
- https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md
- https://discord.gg/projectdiscovery

fix #12699