### PR TITLE
fix case-sensitive issue

### DIFF
--- a/network/detection/ftp-detect.yaml
+++ b/network/detection/ftp-detect.yaml
@@ -30,9 +30,10 @@ tcp:
     matchers:
       - type: regex
         regex:
-          - "^220.*Ftp.*"
+          - "(?i)^220.*Ftp.*"
 
       - type: word
+        case-insensitive: true
         words:
           - "Ftp"
 # digest: 4b0a00483046022100e0020657355e1301b0e0ec9f5efc02c3b24e789a6eb06a0b794150e03c666bae022100ca0cce61ea009086b48cd39dd81bfa47a209ffb2e23671576995920d9bcf77bc:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information
- Fixed ftp-detect

### Template Validation

I've validated this template locally?
- [x] YES


#### Additional Details (leave it blank if not applicable)

On most FTP servers, “FTP” is capitalized in the header. To ensure that detection is independent of the manufacturer's spelling, both matchers have been changed to be case-insensitive. This improves detection.