### PR TITLE
Create n8n-config.yaml

### DIFF
--- a/http/exposures/configs/n8n-config.yaml
+++ b/http/exposures/configs/n8n-config.yaml
@@ -5,7 +5,7 @@ info:
   author: icarot
   severity: medium
   description: |
-    Detects if path /rest/settings of N8n web application is exposed, getting internal information. N8n is a Fair-code workflow automation platform with native AI capabilities.
+    The `/rest/settings` endpoint in N8n was publicly exposed, which could have disclosed internal configuration details and sensitive application information.
   reference:
     - https://github.com/n8n-io/n8n
   classification:

--- a/http/exposures/configs/n8n-config.yaml
+++ b/http/exposures/configs/n8n-config.yaml
@@ -39,42 +39,8 @@ http:
       - type: word
         part: content_type
         words:
-          - 'application/json; charset=utf-8'
+          - 'application/json'
 
       - type: status
         status:
           - 200
-
-    extractors:
-      - type: json
-        name: urlBaseEditor
-        json:
-          - '.data.urlBaseEditor'
-      - type: json
-        name: isDocker
-        json:
-          - '.data.isDocker'
-      - type: json
-        name: databaseType
-        json:
-          - '.data.databaseType'
-      - type: json
-        name: nodeJsVersion
-        json:
-          - '.data.nodeJsVersion'
-      - type: json
-        name: versionCli
-        json:
-          - '.data.versionCli'
-      - type: json
-        name: instanceId
-        json:
-          - '.data.instanceId'
-      - type: json
-        name: planName
-        json:
-          - '.data.license.planName'
-      - type: json
-        name: allowedModules
-        json:
-          - '.data.allowedModules'

--- a/http/exposures/configs/n8n-config.yaml
+++ b/http/exposures/configs/n8n-config.yaml
@@ -1,0 +1,80 @@
+id: n8n-config
+
+info:
+  name: N8n - Config
+  author: icarot
+  severity: medium
+  description: |
+    Detects if path /rest/settings of N8n web application is exposed, getting internal information. N8n is a Fair-code workflow automation platform with native AI capabilities.
+  reference:
+    - https://github.com/n8n-io/n8n
+  classification:
+    cpe: cpe:2.3:a:n8n:n8n:*:*:*:*:*:node.js:*:*
+  metadata:
+    max-request: 1
+    vendor: n8n
+    product: n8n
+    shodan-query: http.html:"N8n"
+  tags: n8n,config,exposed
+
+http:
+  - raw:
+      - |
+        GET /rest/settings HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'isDocker'
+          - 'databaseType'
+          - 'nodeJsVersion'
+          - 'versionCli'
+          - 'instanceId'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json; charset=utf-8'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        name: urlBaseEditor
+        json:
+          - '.data.urlBaseEditor'
+      - type: json
+        name: isDocker
+        json:
+          - '.data.isDocker'
+      - type: json
+        name: databaseType
+        json:
+          - '.data.databaseType'
+      - type: json
+        name: nodeJsVersion
+        json:
+          - '.data.nodeJsVersion'
+      - type: json
+        name: versionCli
+        json:
+          - '.data.versionCli'
+      - type: json
+        name: instanceId
+        json:
+          - '.data.instanceId'
+      - type: json
+        name: planName
+        json:
+          - '.data.license.planName'
+      - type: json
+        name: allowedModules
+        json:
+          - '.data.allowedModules'


### PR DESCRIPTION
This nuclei template:

* Detects if path /rest/settings of N8n web application is exposed, getting internal information. N8n is a Fair-code workflow automation platform with native AI capabilities.

- References:

https://github.com/n8n-io/n8n/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**N8n Docker:**

1. Running container:

`$ docker volume create n8n_data`

`$ docker run -it --rm --name n8n_container -p 5678:5678 -v n8n_data:/home/node/.n8n docker.n8n.io/n8nio/n8n`

2. Acessing the N8n service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' n8n_container`

And the access URL will be http://<obteined_inspect_IP_Address>:5678

**Nuclei execution:**

`$ ~/go/bin/nuclei -t n8n-config.yaml -u "http://<obteined_inspect_IP_Address>:5678/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1071" height="1073" alt="image" src="https://github.com/user-attachments/assets/c1f007a3-ed2d-4ead-9400-b26b1e0b9d36" />

<img width="1706" height="501" alt="image" src="https://github.com/user-attachments/assets/c18586e5-d2f5-4e8a-b961-79ec2dbbaafe" />
