### PR TITLE
CVE-2020-0610 – RD Gateway BlueGate UDP/DTLS detection (variables added)

### DIFF
--- a/network/cves/2020/CVE-2020-0610.yaml
+++ b/network/cves/2020/CVE-2020-0610.yaml
@@ -1,0 +1,98 @@
+id: CVE-2020-0610
+
+info:
+  name: Microsoft Windows RD Gateway UDP (DTLS) - Remote Code Execution (BlueGate)
+  author: imbios
+  severity: critical
+  description: |
+    Detects CVE-2020-0610 in Microsoft Windows Remote Desktop Gateway (RD Gateway) by performing a DTLS handshake on UDP 3391 and sending
+    a crafted RDG UDP fragment packet derived from the BlueGate PoC. A vulnerable gateway will not return the specific error trailer
+    0x8000ffff observed on patched systems.
+  reference:
+    - https://www.kryptoslogic.com/blog/2020/01/rdp-to-rce-when-fragmentation-goes-wrong/
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-0610
+    - https://gitlab.com/ind3p3nd3nt/BlueGate
+    - https://vulncheck.com/xdb/3a3f10478ff3
+  classification:
+    cve-id: CVE-2020-0610
+    cwe-id: CWE-787
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cpe: cpe:2.3:o:microsoft:windows_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    shodan-query: 'port:3391 product:"Remote Desktop Gateway"'
+    vendor: Microsoft
+    product: Windows RD Gateway
+    max-request: 1
+    kev: true
+  tags: cve,cve2020,windows,rdg,rdp,dtls,udp,network,kev
+
+self-contained: true
+
+code:
+  - engine:
+      - bash
+    source: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      HOST="{{Hostname}}"
+      PORT="3391"
+      # BlueGate check packet: pkt_ID=5, pkt_Len=7, fragment_id=0, no_of_fragments=65, fragment_length=1, fragment=00
+      PACKET_HEX="0500070000004100010000"
+
+      OUT_HEX=""
+      ERR_LOG=""
+
+      if command -v openssl >/dev/null 2>&1; then
+        TMP_OUT="$(mktemp)" || true
+        TMP_ERR="$(mktemp)" || true
+        # Start DTLS client and interact via coproc
+        coproc SSLP { timeout 6 openssl s_client -dtls1_2 -connect "${HOST}:${PORT}" -quiet 2>"$TMP_ERR"; }
+        # allow handshake time
+        sleep 1
+        # send crafted packet
+        if [ -n "${SSLP[1]-}" ]; then
+          printf "%s" "$PACKET_HEX" | xxd -r -p >&"${SSLP[1]}" || true
+        fi
+        # read up to 32 bytes from server (should contain error trailer on patched targets)
+        if [ -n "${SSLP[0]-}" ]; then
+          dd bs=1 count=32 <&"${SSLP[0]}" > "$TMP_OUT" 2>/dev/null || true
+        fi
+        OUT_HEX="$(xxd -p -c 32 "$TMP_OUT" 2>/dev/null || true)"
+        ERR_LOG="$(tail -n 20 "$TMP_ERR" 2>/dev/null || true)"
+        rm -f "$TMP_OUT" "$TMP_ERR" || true
+      else
+        echo "ERROR: openssl not found" >&2
+      fi
+
+      echo "DEBUG_HEX:${OUT_HEX}"
+      if [ -n "$ERR_LOG" ]; then
+        echo "DEBUG_ERR:${ERR_LOG}"
+      fi
+
+      # Interpret result: if trailing 4 bytes == 0x8000ffff (little-endian ffff0080), treat as NOT vulnerable; otherwise VULNERABLE
+      HEX_LINE="$(printf "%s" "$OUT_HEX" | tr -d '\n' | tr 'A-F' 'a-f')"
+      if [ -z "$HEX_LINE" ]; then
+        echo "NUCLEI_RESULT:VULNERABLE"
+      elif echo "$HEX_LINE" | grep -qi 'ffff0080$'; then
+        echo "NUCLEI_RESULT:NOT_VULNERABLE"
+      else
+        echo "NUCLEI_RESULT:VULNERABLE"
+      fi
+
+    matchers:
+      - type: word
+        words:
+          - "NUCLEI_RESULT:VULNERABLE"
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "DEBUG_HEX:([0-9a-fA-F]+)"
+      - type: regex
+        part: body
+        regex:
+          - "DEBUG_ERR:(.*)"

--- a/network/cves/2020/CVE-2020-0610.yaml
+++ b/network/cves/2020/CVE-2020-0610.yaml
@@ -30,6 +30,11 @@ info:
 
 self-contained: true
 
+variables:
+  rdg_host: "{{Hostname}}"
+  rdg_port: "3391"
+  dtls_timeout: "6"
+
 code:
   - engine:
       - bash
@@ -37,8 +42,8 @@ code:
       #!/usr/bin/env bash
       set -euo pipefail
 
-      HOST="{{Hostname}}"
-      PORT="3391"
+      HOST="{{rdg_host}}"
+      PORT="{{rdg_port}}"
       # BlueGate check packet: pkt_ID=5, pkt_Len=7, fragment_id=0, no_of_fragments=65, fragment_length=1, fragment=00
       PACKET_HEX="0500070000004100010000"
 
@@ -49,7 +54,7 @@ code:
         TMP_OUT="$(mktemp)" || true
         TMP_ERR="$(mktemp)" || true
         # Start DTLS client and interact via coproc
-        coproc SSLP { timeout 6 openssl s_client -dtls1_2 -connect "${HOST}:${PORT}" -quiet 2>"$TMP_ERR"; }
+        coproc SSLP { timeout {{dtls_timeout}} openssl s_client -dtls1_2 -connect "${HOST}:${PORT}" -quiet 2>"$TMP_ERR"; }
         # allow handshake time
         sleep 1
         # send crafted packet


### PR DESCRIPTION
### Template / PR Information

- Added/Updated: CVE-2020-0610 – Microsoft Windows RD Gateway (UDP/DTLS) – Remote Code Execution (BlueGate) detection
- Path: 
- References:
  - Kryptos Logic: https://www.kryptoslogic.com/blog/2020/01/rdp-to-rce-when-fragmentation-goes-wrong/
  - BlueGate PoC: https://gitlab.com/ind3p3nd3nt/BlueGate
  - VulnCheck: https://vulncheck.com/xdb/3a3f10478ff3
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2020-0610

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

- nuclei version: v3.4.10
- validation: nuclei -vv -validate -t network/cves/2020/CVE-2020-0610.yaml
- run example: nuclei -t network/cves/2020/CVE-2020-0610.yaml -u <host> -var rdg_port=3391 -var dtls_timeout=6 -debug

#### Additional Details (leave it blank if not applicable)

- Improved inputs:
  - variables: rdg_host (default {{Hostname}}), rdg_port (default 3391), dtls_timeout (default 6)
  - code uses imbios-baltimore: built from variables
- Shodan Query: port:3391 product:Remote
