### PR TITLE
Update netstat detection template

### DIFF
--- a/http/exposed-panels/netdata-panel.yaml
+++ b/http/exposed-panels/netdata-panel.yaml
@@ -53,15 +53,14 @@ http:
       - type: regex
         part: body
         regex:
-            - 'version"\s*:\s*"v([^"]+)"' 
-  
+          - 'version"\s*:\s*"v([^"]+)"'
+
       - type: regex
         part: body
         regex:
-            - 'kernel_version"\s*:\s*"([^"]+)"' 
+          - 'kernel_version"\s*:\s*"([^"]+)"'
 
       - type: regex
         part: body
         regex:
           - '(?i)nodeEnv:\s+"([a-z0-9]+)"'
-# digest: 4a0a004730450220263da5943818fcafea164207552c6035354758c51f0c8e845d9c5aa4cf11fc88022100950e4c5549b5264077982ef9659d96bfea05cd4e3c697b5345cb2cb9251b9202:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/netdata-panel.yaml
+++ b/http/exposed-panels/netdata-panel.yaml
@@ -2,7 +2,7 @@ id: netdata-panel
 
 info:
   name: Netdata Panel - Detect
-  author: TechbrunchFR,righettod
+  author: TechbrunchFR,righettod, matejsmycka
   severity: info
   description: |
     Netdata panel was detected.
@@ -28,7 +28,9 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/api/v1/info"
+      - "{{BaseURL}}:19999/api/v2/info"
+      - "{{BaseURL}}:19999/sign-in"
+      - "{{BaseURL}}/api/v2/info"
       - "{{BaseURL}}/sign-in"
 
     stop-at-first-match: true
@@ -50,13 +52,16 @@ http:
     extractors:
       - type: regex
         part: body
-        group: 1
         regex:
-          - '(?i)version:\s+"([0-9.]+)"'
+            - 'version"\s*:\s*"v([^"]+)"' 
+  
+      - type: regex
+        part: body
+        regex:
+            - 'kernel_version"\s*:\s*"([^"]+)"' 
 
       - type: regex
         part: body
-        group: 1
         regex:
           - '(?i)nodeEnv:\s+"([a-z0-9]+)"'
 # digest: 4a0a004730450220263da5943818fcafea164207552c6035354758c51f0c8e845d9c5aa4cf11fc88022100950e4c5549b5264077982ef9659d96bfea05cd4e3c697b5345cb2cb9251b9202:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/netdata-panel.yaml
+++ b/http/exposed-panels/netdata-panel.yaml
@@ -2,10 +2,10 @@ id: netdata-panel
 
 info:
   name: Netdata Panel - Detect
-  author: TechbrunchFR,righettod, matejsmycka
+  author: TechbrunchFR,righettod,matejsmycka
   severity: info
   description: |
-    Netdata panel was detected.
+    Netdata panel was discovered.
   reference:
     - https://github.com/netdata/netdata
     - https://www.netdata.cloud/
@@ -23,13 +23,12 @@ info:
       - "server: netdata embedded http server"
     fofa-query: title="netdata dashboard"
     google-query: intitle:"netdata dashboard"
-  tags: panel,netdata
+  tags: panel,netdata,login,dashboard
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}:19999/api/v2/info"
-      - "{{BaseURL}}:19999/sign-in"
+      - "{{BaseURL}}/api/v1/info"
       - "{{BaseURL}}/api/v2/info"
       - "{{BaseURL}}/sign-in"
 


### PR DESCRIPTION
### Template / PR Information


- The old template was not checking the default port on which the software runs.  19999 https://learn.netdata.cloud/docs/netdata-agent/configuration/securing-agents/web-server-reference
- update extractors
- Ordered URLs based on the probability of encounter to make it efficient

This software is being used in production a lot and CTF because of its local PrivEsc potential.

### Template Validation

I've validated this template locally.
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)