### PR TITLE
Add Allegro RomPager detection template

### DIFF
--- a/http/exposed-panels/allegro-rompager-detect.yaml
+++ b/http/exposed-panels/allegro-rompager-detect.yaml
@@ -1,0 +1,52 @@
+id: allegro-rompager-detect
+
+info:
+  name: Allegro RomPager - Detect
+  author: matejsmycka
+  severity: info
+  description: |
+    Allegro RomPager was detected.
+    This toolkit is often used in embedded devices such as routers, cameras, and IoT devices.
+    Hardware using RomPager is often historical and possibly with default credentials.
+  reference:
+    - http://rompager.com/
+  metadata:
+    shodan-query:
+      - product:"Allegro RomPager"
+  tags: panel,allegro,rompager
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Server: Allegro-Software-RomPager/"
+
+      - type: status
+        status:
+          - 200
+
+      # The uppercase HTML tags are typical for RomPager pages
+      - type: word
+        part: body
+        condition: or
+        words:
+          - "BGCOLOR"
+          - "SCRIPT"
+          - "HTML"
+          - "BODY"
+          - "FONT"
+          - "INPUT"
+          - "FRAME"
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - "RomPager/([\\d\\.]+)"


### PR DESCRIPTION
### Template / PR Information

Visit the hosts below, and you will get an idea about what this template detects. 
Hosts with this are usually very old and vulnerable, also many are using default credentials.

Hosts:
- http://45.22.249.78
- http://211.73.27.22
- http://46.252.176.117
- http://190.26.130.16
 https://www.shodan.io/search?query=product%3A%22Allegro+RomPager%22+%22200+OK%22+Software

References:
- https://www.exploit-db.com/exploits/39739
- http://rompager.com/


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)