### PR TITLE
Barracuda Message Archiver exposed panel

### DIFF
--- a/http/exposed-panels/barracuda-message-archiver-panel.yaml
+++ b/http/exposed-panels/barracuda-message-archiver-panel.yaml
@@ -1,0 +1,35 @@
+id: barracuda-message-archiver-panel
+
+info:
+  name: Barracuda Message Archiver - Exposed Panel
+  author: inokii
+  severity: info
+  description: |
+    Barracuda Networks Barracuda Message Archiver (BMA) panel was detected.
+  reference:
+    - https://www.barracuda.com/products/email-protection/message-archiver
+  metadata:
+    max-request: 1
+    vendor: Barracuda Networks
+    product: Barracuda Message Archiver
+    shodan-query: http.favicon.hash:1436966696 http.html:"/css/archiver.css"
+  tags: barracuda,panel,tech
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-mod/index.cgi"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '<link href="/css/archiver.css'
+          - '<div id="barracuda_info" style="float:right">'
+        condition: and
+

--- a/http/exposed-panels/barracuda-message-panel.yaml
+++ b/http/exposed-panels/barracuda-message-panel.yaml
@@ -1,7 +1,7 @@
-id: barracuda-message-archiver-panel
+id: barracuda-message-panel
 
 info:
-  name: Barracuda Message Archiver - Exposed Panel
+  name: Barracuda Message Archiver - Panel Detect
   author: inokii
   severity: info
   description: |
@@ -10,10 +10,8 @@ info:
     - https://www.barracuda.com/products/email-protection/message-archiver
   metadata:
     max-request: 1
-    vendor: Barracuda Networks
-    product: Barracuda Message Archiver
     shodan-query: http.favicon.hash:1436966696 http.html:"/css/archiver.css"
-  tags: barracuda,panel,tech
+  tags: barracuda,panel,login
 
 http:
   - method: GET
@@ -22,10 +20,6 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
@@ -33,3 +27,6 @@ http:
           - '<div id="barracuda_info" style="float:right">'
         condition: and
 
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information
- Adds Barracuda Networks Barracuda Message Archiver (BMA) exposed panel detection.

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### http/exposed-panels/barracuda-message-archiver-panel.yaml
```
nuclei -u http://example.net -t http/exposed-panels/barracuda-message-archiver-panel.yaml
...
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[barracuda-message-archiver-panel] [http] [info] http://example.net/cgi-mod/index.cgi
[INF] Scan completed in 8.025456879s. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

- Shodan query: `http.favicon.hash:1436966696 http.html:"/css/archiver.css"`