### PR TITLE
Create apache-streampark-detect.yaml and apache-streampark-default-login.yaml

### DIFF
--- a/http/default-logins/apache/apache-streampark-default-login.yaml
+++ b/http/default-logins/apache/apache-streampark-default-login.yaml
@@ -1,0 +1,58 @@
+id: apache-streampark-default-login
+
+info:
+  name: Apache Streampark - Default Login
+  author: icarot
+  severity: high
+  description: |
+    Apache Streampark server enables default admin credentials. An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/apache/streampark
+  classification:
+    cpe: cpe:2.3:a:apache:streampark:*:*:*:*:*:*:*
+  metadata:
+    max-request: 4
+    vendor: apache
+    product: streampark
+    shodan-query: title:"Apache StreamPark"
+  tags: apache,streampark,default-login
+
+variables:
+  password: streampark
+
+http:
+  - raw:
+      - |
+        POST /passport/signin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+
+        password={{password}}&username={{username}}&loginType=PASSWORD
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+        - test1
+        - test2
+        - test3
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"userId":'
+          - '"username":'
+          - '"token":'
+          - '"expire":'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200

--- a/http/default-logins/apache/apache-streampark-default-login.yaml
+++ b/http/default-logins/apache/apache-streampark-default-login.yaml
@@ -17,9 +17,6 @@ info:
     shodan-query: title:"Apache StreamPark"
   tags: apache,streampark,default-login
 
-variables:
-  password: streampark
-
 http:
   - raw:
       - |
@@ -36,23 +33,13 @@ http:
         - test1
         - test2
         - test3
+      password:
+        - streampark
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"userId":'
-          - '"username":'
-          - '"token":'
-          - '"expire":'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "userId\":", "username\":", "token\":", "expire\":")'
         condition: and
-
-      - type: word
-        part: content_type
-        words:
-          - 'application/json'
-
-      - type: status
-        status:
-          - 200

--- a/http/technologies/apache/apache-streampark-detect.yaml
+++ b/http/technologies/apache/apache-streampark-detect.yaml
@@ -1,0 +1,33 @@
+id: apache-streampark-detect
+
+info:
+  name: Apache Streampark - Detect
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Streampark server, a easy-to-use streaming application development framework and operation platform.
+  reference:
+    - https://github.com/apache/streampark
+  classification:
+    cpe: cpe:2.3:a:apache:streampark:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: streampark
+    shodan-query: title:"Apache StreamPark"
+  tags: tech,apache,streampark,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '<title>Apache StreamPark</title>'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache Streampark server, a easy-to-use streaming application development framework and operation platform.
* Apache Streampark server enables default admin credentials. An attacker can execute unauthorized operations.

- References:

https://github.com/apache/streampark

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Streampark Docker:**

1. Running container:

`$ docker run -d --rm --name apache_streampark_container -p 10000:10000 apache/streampark:latest`

2. Acessing the Apache Streampark service::

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache_streampark_container`

And the access URL will be http://<obteined_inspect_IP_Address>:10000/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-streampark-detect.yaml -t apache-streampark-default-login.yaml -u "http://172.17.0.2:10000/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1099" height="627" alt="image" src="https://github.com/user-attachments/assets/886a0b21-1701-4cf0-bdbc-9dfc399bd414" />

<img width="809" height="895" alt="image" src="https://github.com/user-attachments/assets/76dbcd4c-15af-4612-bc02-a9d18477c608" />

<img width="1838" height="428" alt="image" src="https://github.com/user-attachments/assets/ee63fb9b-e685-4321-8d18-c398f8c5bedd" />
