### PR TITLE
add: template for CVE-2025-49596

### DIFF
--- a/http/cves/2025/CVE-2025-49596.yaml
+++ b/http/cves/2025/CVE-2025-49596.yaml
@@ -20,6 +20,7 @@ info:
     verified: true
     fofa-query: title="MCP Inspector"
   tags: cve,cve2025,mcp,anthropic,unauth
+
 flow: http(1) && http(2) && http(3)
 
 http:
@@ -85,3 +86,4 @@ http:
         group: 1
         regex:
           - '\/message\?sessionId=([a-z0-9-]+)' # Returns: Session ID as proof of execution
+


### PR DESCRIPTION
This PR adds a non-destructive Nuclei template to detect vulnerable endpoints in Anthropic's MCP Inspector related to **CVE-2025-49596**.

CVE-2025-49596 describes a critical **Remote Code Execution (RCE)** vulnerability in the MCP Inspector component.  
The issue arises from the way the `/sse` endpoint handles user-supplied arguments (`transportType`, `command`, and `args[]`).  
An attacker can abuse this endpoint to execute arbitrary commands on the underlying system without authentication, leading to full compromise.

The vulnerable service is typically exposed by developer or local tooling, but if reachable by a remote attacker, it can allow them to:
- Execute arbitrary system commands in the context of the MCP Inspector process
- Steal sensitive data such as API keys or configuration
- Pivot further into internal networks

This template focuses on detecting the vulnerable exposure by:
1. Sending an initial SSE request with a benign `echo` command and extracting the returned `sessionId`
2. Following up with a `/message` request to confirm that the echoed string(sessionId) is returned in the response

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-49596  
- https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596  
- https://github.com/modelcontextprotocol/inspector/security/advisories/GHSA-7f8r-222p-6f5g  

### Template Validation
I've validated this template locally?
- [x] YES
- [ ] NO


### Additional Details
- Sends a lightweight GET request to `/sse` and `/message` endpoints  
- Requires `HTTP 200 OK` and a valid `sessionId` to proceed (avoids generic error/auth pages)  
- Confirms that the follow-up /message response contains the echoed string "hello-from-browser"
- Excludes pages that lack proper SSE response structure to reduce false positives  
- Adds extractors for:
  - `sessionId` (from SSE response)
  - Basic endpoint hints (e.g., `/sse`, `/message`)  
- The check is non-destructive: it does not create, modify, or persist any server-side state

<img width="1360" height="352" alt="image" src="https://github.com/user-attachments/assets/9c45596b-fcfc-4431-af08-98e71449e0eb" />


### Additional References
- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
