### PR TITLE
Make Canon iR-ADV panel  generic detection

### DIFF
--- a/http/exposed-panels/canon/canon-iR-ADV.yaml
+++ b/http/exposed-panels/canon/canon-iR-ADV.yaml
@@ -1,14 +1,14 @@
-id: canon-iradv-c3325
+id: canon-ir-adv
 
 info:
-  name: Canon iR-ADV C3325 Panel - Detect
-  author: ritikchaddha
+  name: Canon iR-ADV Panel - Detect
+  author: ritikchaddha, matejsmycka
   severity: info
   metadata:
     verified: true
     max-request: 2
-    shodan-query: title:"c3325"
-  tags: canon,c3325,panel,login,detect
+    shodan-query: title:"Canon iR-ADV"
+  tags: canon,panel,login,detect
 
 http:
   - method: GET
@@ -24,10 +24,17 @@ http:
         part: response
         words:
           - 'iR-ADV'
-          - 'C3325'
+          - 'Authentication'
+          - 'CANON'
         condition: and
 
       - type: status
         status:
           - 200
-# digest: 490a004630440220475fd2b9779c83ba380a92f399b3cde5e67c57394b2c0e42fe245c4c5376d5fd02203db0c51c2ae13f2ef99a244ab63a81082d3217f6accf178e083c8a39ed45be60:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: title
+        regex:
+          - '(iR-ADV C[0-9]+)'
+        group: 1

--- a/http/exposed-panels/canon/canon-ir-adv.yaml
+++ b/http/exposed-panels/canon/canon-ir-adv.yaml
@@ -2,7 +2,7 @@ id: canon-ir-adv
 
 info:
   name: Canon iR-ADV Panel - Detect
-  author: ritikchaddha, matejsmycka
+  author: ritikchaddha,matejsmycka
   severity: info
   metadata:
     verified: true


### PR DESCRIPTION
### Template / PR Information

Instead of one specific product, I modified the template to detect all iR-ADV C<NUMBER> products.
I was tested on multiple versions.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)