### PR TITLE
Add non-destructive detection template for CVE-2025-52970

### DIFF
--- a/http/cves/2024/CVE-2024-8353.yaml
+++ b/http/cves/2024/CVE-2024-8353.yaml
@@ -1,0 +1,73 @@
+id: CVE-2024-8353
+info:
+  name: Fortinet FortiWeb - CVE-2025-52970 - Auth bypass (non-destructive probes)
+  author: gsharma101
+  severity: high
+  description: >
+    Non-destructive probes for Fortinet FortiWeb auth bypass (CVE-2025-52970).
+    Public PoCs abuse the Authorization header (e.g. Authorization: Bearer ';<injection>') against
+    /api/fabric/device/status to trigger SQLi and further exploitation. This template performs
+    safe read-only probes using harmless placeholders and flags unexpected responses (HTTP 200/500
+    or JSON fields like "token" / "role" / "super_admin"). Do NOT run destructive payloads.
+  reference:
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://github.com/Hex00-0x4/FortiWeb-CVE-2025-52970-Authentication-Bypass
+  tags: fortinet,fortiweb,cve-2025-52970,auth-bypass
+
+requests:
+  - id: probe-bearer-test
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer ';test"
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+      - type: status
+        status:
+          - 200
+          - 500
+
+  - id: probe-bearer-comment
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer ';--"
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+      - type: status
+        status:
+          - 200
+          - 500
+
+  - id: probe-bearer-escaped
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer '\\';--"
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+      - type: status
+        status:
+          - 200
+          - 500


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-52970 — Fortinet FortiWeb Authentication Bypass (related to CVE-2025-52970 PoC).
- This template implements **non-destructive, read-only probes** modeled after the public PoC.
- Targeted endpoint: `/api/fabric/device/status` with crafted `Authorization: Bearer` headers.
- References:
  - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
  - https://github.com/Hex00-0x4/FortiWeb-CVE-2025-52970-Authentication-Bypass

### Template Validation

I've validated this template locally?
- [x] YES

#### Additional Details

**Lab Environment:**
- FortiWeb-VM 7.6.3 build1043 (VirtualBox, default setup)
- Accessed dashboard at `https://192.168.1.99/root/system/dashboard/1`

**Testing Steps:**
- Ran nuclei:
  ```bash
  nuclei -t http/cves/2024/CVE-2024-8353.yaml -u https://192.168.1.99 -debug > CVE-2024-8353_debug.txt 2>&1

* Probes included in the template:

  * `Authorization: Bearer ';test`
  * `Authorization: Bearer ';--`
  * `Authorization: Bearer '\\';--`

**Observed Results:**

* All probes returned `401 Unauthorized` with HTML login page.
* No `token`/`role`/`super_admin` strings observed.
* Behavior indicates this build is patched or requires destructive SQLi chaining.

**Debug Evidence (excerpt from CVE-2024-8353\_debug.txt):**

```
GET /api/fabric/device/status HTTP/1.1
Host: 192.168.1.99
User-Agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Safari/105.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Authorization: Bearer ';test
Accept-Encoding: gzip

< HTTP/1.1 401 Unauthorized
< Connection: close
< Content-Security-Policy: Script-Src 'self', frame-ancestors 'self'; Object-Src 'self'; base-uri 'self';
< Date: Mon, 08 Sep 2025 20:00:52 GMT
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Xss-Protection: 1; mode=block
< Content-Length: 0

```

**Notes:**

* Template is **non-destructive** — it does not execute SQL injection or file-write steps from the PoC.
* Safe for scanning and validation.
* Full debug output attached: [CVE-2024-8353_debug.txt](https://github.com/user-attachments/files/22219004/CVE-2024-8353_debug.txt)

#13123 
