### PR TITLE
add: FortiWeb CVE-2025-52970 auth bypass detection template

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,71 @@
+id: fortinet-fortiweb-cve-2025-52970-auth-bypass
+
+info:
+  name: Fortinet FortiWeb Auth Bypass (CVE-2025-52970) – admin status JSON exposed
+  author: yourhandle
+  severity: high
+  description: |
+    Detects unauthenticated access to the admin-only status API on FortiWeb
+    indicative of CVE-2025-52970 ("FortMajeure"). The first request tests for
+    exposure without credentials. The second request adds a minimal cookie with
+    an invalid Era value (Era=9) that exercises the broken parameter handling
+    described by the researcher. Both requests are strictly read-only.
+  reference:
+    - https://github.com/projectdiscovery/nuclei-templates/issues/13123
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://fortiguard.fortinet.com/psirt/FG-IR-25-448
+  metadata:
+    cve: CVE-2025-52970
+    product: Fortinet FortiWeb
+    shodan-query: 'ssl:"cn=fortiweb" port:8443'
+    verified: false
+  tags: cve,fortinet,fortiweb,auth-bypass,exposure
+
+http:
+  # Probe 1: direct, unauthenticated call to the admin-only status endpoint
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2.0/system/status.systemstatus"
+    headers:
+      Accept: application/json
+    max-redirects: 1
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          # Keys observed in the researcher's PoC response body
+          - '"firmwareVersion":'
+          - '"haStatus":'
+          - '"readonly":'
+    extractors:
+      - type: json
+        name: firmware
+        json:
+          - ".results.firmwareVersion"
+    stop-at-first-match: true
+
+  # Probe 2: repeat with a minimal cookie that sets an out-of-range Era=9.
+  # NOTE: This is benign: it does not attempt brute force, encryption, or any write.
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2.0/system/status.systemstatus"
+    headers:
+      Accept: application/json
+      # Invalid / out-of-range Era value per write-up; dummy placeholders for other parts.
+      Cookie: APSCOOKIE_FWEB_{{rand_int}}=Era=9&Payload={{base64("x")}}&AuthHash={{base64("x")}}
+    max-redirects: 1
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"firmwareVersion":'
+          - '"haStatus":'
+          - '"readonly":'


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-52970 Fortinet FortiWeb Auth Bypass detection template
- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/13123
  - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
  - https://fortiguard.fortinet.com/psirt/FG-IR-25-448

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

- Shodan Query: `ssl:"cn=fortiweb" port:8443`
- Detection logic:
  - Unauthenticated request to `/api/v2.0/system/status.systemstatus`
  - Match on unique admin-only JSON keys (`firmwareVersion`, `haStatus`, `readonly`)
  - Optional second probe with crafted `Era=9` cookie to exercise bypass condition
- Non-destructive, read-only verification (no exploitation, no state changes)

#### Validation Artifacts (Redacted)

Attach request/response snippets or screenshots here from running with:

```bash
nuclei -t http/cves/2025/CVE-2025-52970.yaml   -u https://TARGET:8443   -debug -irr -duc
```

Example (with sensitive data like `serialNumber` masked):

```
[INF] [CVE-2025-52970] fortinet-fortiweb-cve-2025-52970-auth-bypass
  [request]
  GET /api/v2.0/system/status.systemstatus HTTP/1.1
  Host: TARGET:8443

  [response]
  HTTP/1.1 200 OK
  Content-Type: application/json
  {
    "firmwareVersion": "7.4.6",
    "haStatus": "active",
    "readonly": false,
    "serialNumber": "XXXXXXX"
  }
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
