### PR TITLE
Edited wazuh-panel.yaml

### DIFF
--- a/http/exposed-panels/wazuh-panel.yaml
+++ b/http/exposed-panels/wazuh-panel.yaml
@@ -2,7 +2,7 @@ id: wazuh-panel
 
 info:
   name: Wazuh Login Panel
-  author: cyllective,daffainfo
+  author: cyllective,daffainfo,idealphase
   severity: info
   description: Wazuh - The Open Source Security Platform
   reference:
@@ -45,5 +45,4 @@ http:
         part: body
         group: 1
         regex:
-          - '&quot;version&quot;:&quot;([0-9.]+)&quot;'
-# digest: 4a0a0047304502203748cab61f0d7eb8ad40f924f5f55438b859f813016bcfa1644a2f679a1e0b3f022100d89918a2b80e4b369421c98b34e34b0f6da2c9893b9a53922191d4590c515bd8:922c64590222798bb761d5b6d8e72950
+          - '&quot;wazuhVersion&quot;:&quot;([0-9.]+)&quot;'

--- a/http/exposed-panels/wazuh-panel.yaml
+++ b/http/exposed-panels/wazuh-panel.yaml
@@ -45,4 +45,4 @@ http:
         part: body
         group: 1
         regex:
-          - '&quot;wazuhVersion&quot;:&quot;([0-9.]+)&quot;'
+          - '&quot;(?:version|wazuhVersion)&quot;:&quot;([0-9.]+)&quot;'


### PR DESCRIPTION
Edit extractor part from https://github.com/projectdiscovery/nuclei-templates/blob/6787b185044c815ec14a3904071c271c3b02ac56/http/exposed-panels/wazuh-panel.yaml#L48 to get correct current Wazuh verison.

### Template / PR Information
Updated the legacy extractors to correctly parse the Wazuh version, which was previously being misreported. The changes and their output are demonstrated in the figures below.

- References:
https://documentation.wazuh.com/current/release-notes/index.html

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
1. old extractors get incorrect version 2.1.6.0
![2025-09-09_21-11](https://github.com/user-attachments/assets/2b80a4e8-4e55-43de-8520-ff1a01dce4f1)
2. current Wazuh version is 4.11.0
![2025-09-09_20-24_2](https://github.com/user-attachments/assets/bd9e22a7-873f-47b2-8c72-6b6273965a08)
3. extract Wazuh version from wazuhVersion
![2025-09-09_20-24_1](https://github.com/user-attachments/assets/85cf4ad3-8383-47ee-9d6a-b3c32f5fe134)
4. validate new nuclei template with Wazuh targets
![2025-09-09_20-50](https://github.com/user-attachments/assets/a175ac75-06fb-433e-a0fa-397ebd808a60)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)