### PR TITLE
feat: add Fortinet FortiWeb auth bypass template (CVE-2025-52970)

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,71 @@
+id: fortinet-fortiweb-cve-2025-52970-auth-bypass
+
+info:
+  name: Fortinet FortiWeb Auth Bypass (CVE-2025-52970) – admin status JSON exposed
+  author: yourhandle
+  severity: high
+  description: |
+    Detects unauthenticated access to the admin-only status API on FortiWeb
+    indicative of CVE-2025-52970 ("FortMajeure"). The first request tests for
+    exposure without credentials. The second request adds a minimal cookie with
+    an invalid Era value (Era=9) that exercises the broken parameter handling
+    described by the researcher. Both requests are strictly read-only.
+  reference:
+    - https://github.com/projectdiscovery/nuclei-templates/issues/13123
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://fortiguard.fortinet.com/psirt/FG-IR-25-448
+  metadata:
+    cve: CVE-2025-52970
+    product: Fortinet FortiWeb
+    shodan-query: 'ssl:"cn=fortiweb" port:8443'
+    verified: false
+  tags: cve,fortinet,fortiweb,auth-bypass,exposure
+
+http:
+  # Probe 1: direct, unauthenticated call to the admin-only status endpoint
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2.0/system/status.systemstatus"
+    headers:
+      Accept: application/json
+    max-redirects: 1
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          # Keys observed in the researcher's PoC response body
+          - '"firmwareVersion":'
+          - '"haStatus":'
+          - '"readonly":'
+    extractors:
+      - type: json
+        name: firmware
+        json:
+          - ".results.firmwareVersion"
+    stop-at-first-match: true
+
+  # Probe 2: repeat with a minimal cookie that sets an out-of-range Era=9.
+  # NOTE: This is benign: it does not attempt brute force, encryption, or any write.
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2.0/system/status.systemstatus"
+    headers:
+      Accept: application/json
+      # Invalid / out-of-range Era value per write-up; dummy placeholders for other parts.
+      Cookie: APSCOOKIE_FWEB_{{rand_int}}=Era=9&Payload={{base64("x")}}&AuthHash={{base64("x")}}
+    max-redirects: 1
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"firmwareVersion":'
+          - '"haStatus":'
+          - '"readonly":'

--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -56,7 +56,7 @@ http:
     headers:
       Accept: application/json
       # Invalid / out-of-range Era value per write-up; dummy placeholders for other parts.
-      Cookie: APSCOOKIE_FWEB_{{rand_int}}=Era=9&Payload={{base64("x")}}&AuthHash={{base64("x")}}
+      Cookie: APSCOOKIE_FWEB_{{rand_int(6)}}=Era=9&Payload={{base64("x")}}&AuthHash={{base64("x")}}
     max-redirects: 1
     matchers-condition: and
     matchers:


### PR DESCRIPTION
# Revised PR Body

Hi team — I attempted to validate CVE-2025-52970 against a lab FortiWeb VM but could not reproduce the unauthenticated access.

**Lab details**
- FortiWeb VM: 7.2.10 GA build0409
- Access: `https://10.27.43.200` (mgmt UI reachable)
- Targeted endpoint: `/api/v2.0/system/status.systemstatus`
- Result: consistently `401 Unauthorized`
- Example response (redacted):
```bash
root@DESKTOP-6QN3GRE:~/nuclei/nuclei-templates# nuclei -t http/cves/2025/CVE-2025-52970.yaml -u https://10.27.43.200:443 -debug -irr

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [fortinet-fortiweb-cve-2025-52970-auth-bypass] Dumped HTTP request for https://10.27.43.200:443/api/v2.0/system/status.systemstatus

GET /api/v2.0/system/status.systemstatus HTTP/1.1
Host: 10.27.43.200
User-Agent: Mozilla/5.0 (CentOS; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
Connection: close
Accept: application/json
Accept-Language: en
Accept-Encoding: gzip

[DBG] [fortinet-fortiweb-cve-2025-52970-auth-bypass] Dumped HTTP response https://10.27.43.200:443/api/v2.0/system/status.systemstatus

HTTP/1.1 401 Unauthorized
Connection: close
Content-Security-Policy: Script-Src 'self', frame-ancestors 'self'; Object-Src 'self'; base-uri 'self';
Date: Wed, 10 Sep 2025 07:45:48 GMT
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
Content-Length: 0

[INF] [fortinet-fortiweb-cve-2025-52970-auth-bypass] Dumped HTTP request for https://10.27.43.200:443/api/v2.0/system/status.systemstatus

GET /api/v2.0/system/status.systemstatus HTTP/1.1
Host: 10.27.43.200
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.7 Safari/605.1.15
Connection: close
Accept: application/json
Accept-Language: en
Cookie: APSCOOKIE_FWEB_1232561916=Era=9&Payload=eA==&AuthHash=eA==
Accept-Encoding: gzip

[DBG] [fortinet-fortiweb-cve-2025-52970-auth-bypass] Dumped HTTP response https://10.27.43.200:443/api/v2.0/system/status.systemstatus

HTTP/1.1 401 Unauthorized
Connection: close
Content-Security-Policy: Script-Src 'self', frame-ancestors 'self'; Object-Src 'self'; base-uri 'self';
Date: Wed, 10 Sep 2025 07:45:48 GMT
Set-Cookie: APSCOOKIE_FWEB_1232561916=0&0; path=/; expires=Tue, 23-Sep-1975 07:45:48 GMT; HttpOnly; SameSite=Strict
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
Content-Length: 0

[INF] Scan completed in 133.244086ms. No results found.
```

**What I tried**
- Plain unauthenticated request
- Variant with a minimal cookie (`Era=9`) as per public writeups
- Different ports / schemes (HTTP→HTTPS redirect; HTTPS on 443)


### Template / PR Information

- Added CVE-2025-52970 Fortinet FortiWeb Auth Bypass detection template
- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/13123

### Template Validation

I've validated this template locally?
- [ ] YES
- [x] NO — unable to reproduce bypass with current lab image

#### Additional Details

- Lab image: FortiWeb VM 7.2.10 GA (build0409)
- Endpoint probed: `/api/v2.0/system/status.systemstatus`
- Observed result: `401 Unauthorized` for both plain and cookie-variant probes
- Example (redacted):
  ```
  HTTP/1.1 401 Unauthorized
  Set-Cookie: APSCOOKIE_FWEB_733867907=0&0; path=/; expires=Tue, 23-Sep-1975 ...
  Content-Length: 0
  ```

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de12e338-eb24-4897-ac8e-c50fe409cf8c" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ebd3c187-e27b-4509-a160-cdff91251382" />


Video walthrough/quick live demo:
https://youtu.be/gsMrFjkTbQQ

/claim #13123
