### PR TITLE
Add CVE-2024-46982

### DIFF
--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -5,16 +5,12 @@ info:
   author: hnd3884
   severity: high
   description: |
-    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router.
-    By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`)
-    to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like 
-    `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users.
-    This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later.  
-    We strongly recommend upgrading to a safe version.
+    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router. By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`) to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users. This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later. We strongly recommend upgrading to a safe version.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
     - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
     - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
+    - https://github.com/advisories/GHSA-gp8f-8m3g-qvj9
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
     cvss-score: 7.5

--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -1,0 +1,56 @@
+id: CVE-2024-46982
+
+info:
+  name: Next.js Pages Router <= 14.2.9 - Cache Poisoning of Non-Dynamic SSR Routes
+  author: hnd3884
+  severity: high
+  description: |
+    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router.
+    By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`)
+    to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like 
+    `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users.
+    This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later.  
+    We strongly recommend upgrading to a safe version.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
+    - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
+    - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-46982
+    cwe-id: CWE-639
+    epss-score: 0.015
+    cpe: cpe:2.3:a:vercel:next.js:*:*:*:*:*:node.js:*:*
+  metadata:
+    verified: true
+    vendor: vercel
+    product: next.js
+    publicwww-query: "next.config.js"
+  tags: cve,cve2024,nextjs,cache,poisoning,ssr,non-dynamic
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}?__nextDataReq=1"
+    headers:
+      x-now-route-matches: "1"
+      x-NextJS-cache: "INVALIDATE"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Cache-Control: s-maxage=1, stale-while-revalidate" # vulnerable cache header
+          - "application/json" # ensure it's a JSON response
+      - type: word
+        part: body
+        words:
+          - "pageProps"
+
+    extractors:
+      - type: regex # type of the extractor
+        part: body # part of the response (header,body,all)
+        regex:
+          - '(pageProps":{.+?})' # regex to use for extraction.


### PR DESCRIPTION
 /claim #13204
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2024-46982
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
    - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
    - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
    - https://github.com/advisories/GHSA-gp8f-8m3g-qvj9

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### The template do the following
- send GET request to BaseURL with param **__nextDataReq=1** and 2 headers **x-now-route-matches: 1** and **x-NextJS-cache: INVALIDATE**
- Check response for 
    - **Cache-Control: s-maxage=1, stale-while-revalidate** that indicates forcing SSR cache
    - **pageProps** in json body indicates that the page is potentionally vulnerable to cache poisoning, need fuzz more to findout reflected parameter to exploit

#### vulnerable lab setup
1. Create app with these opion choices
<img width="717" height="120" alt="image" src="https://github.com/user-attachments/assets/c3449de5-83cf-45cc-84d4-6a55f01e53b2" />

```bash
npx create-next-app@13.5.2 vul-lab
cd vul-lab
```
2. create src/pages/poc.tsx file
```typescript
// pages/poc.tsx
import { GetServerSidePropsContext } from "next";

type Props = {
  userAgent: string;
};

export default function Poc({ userAgent }: Props) {
  return <div>{userAgent}</div>; // raw injection
}

export async function getServerSideProps(context: GetServerSidePropsContext) {
  const userAgent = context.req.headers['user-agent']; // attacker-controlled

  return {
    props: {
      userAgent, // goes straight to render
    }
  };
}
```
3. Change dependencies in package.json
```json
{
    "@types/node": "24.3.1",
    "@types/react": "18.2.0",
    "@types/react-dom": "18.2.0",
    "eslint": "8.0.0",
    "eslint-config-next": "13.5.5",
    "next": "13.5.5",
    "react": "18.2.0",
    "react-dom": "18.2.0",
    "typescript": "5.9.2"
  }
}
```
4. Install, build and run
```bash
npm install
npm run build
npm run start
```

#### debug
```bash
nuclei -t /mnt/d/1day/nextjs/CVE-2024-46982.yaml -u "http://172.20.224.1:3000/poc" -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

                projectdiscovery.io

[INF] Current nuclei version: v3.4.7 (outdated)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2024-46982] Dumped HTTP request for http://172.20.224.1:3000/poc?__nextDataReq=1

GET /poc?__nextDataReq=1 HTTP/1.1
Host: 172.20.224.1:3000
User-Agent: Mozilla/5.0 (Ubuntu; Linux i686; rv:121.0) Gecko/20100101 Firefox/121.0
Connection: close
Accept: */*
Accept-Language: en
x-NextJS-cache: INVALIDATE
x-now-route-matches: 1
Accept-Encoding: gzip

[DBG] [CVE-2024-46982] Dumped HTTP response http://172.20.224.1:3000/poc?__nextDataReq=1

HTTP/1.1 200 OK
Connection: close
Content-Length: 116
Cache-Control: s-maxage=1, stale-while-revalidate
Content-Type: application/json
Date: Thu, 11 Sep 2025 09:16:03 GMT
Etag: "eu88dmawav38"
Vary: Accept-Encoding
X-Nextjs-Cache: MISS

{"pageProps":{"userAgent":"Mozilla/5.0 (Ubuntu; Linux i686; rv:121.0) Gecko/20100101 Firefox/121.0"},"__N_SSP":true}
[CVE-2024-46982:word-1] [http] [high] http://172.20.224.1:3000/poc?__nextDataReq=1 ["pageProps":{"userAgent":"Mozilla/5.0 (Ubuntu; Linux i686; rv:121.0) Gecko/20100101 Firefox/121.0"}"]
[CVE-2024-46982:word-2] [http] [high] http://172.20.224.1:3000/poc?__nextDataReq=1 ["pageProps":{"userAgent":"Mozilla/5.0 (Ubuntu; Linux i686; rv:121.0) Gecko/20100101 Firefox/121.0"}"]
[INF] Scan completed in 20.646929ms. 2 matches found.
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)