### PR TITLE
Add CVE-2024-46982 -Next.js Cache Poisoning (Pages Router)

### DIFF
--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -5,12 +5,18 @@ info:
   author: melmathari
   severity: high
   description: |
-    Next.js versions between 13.5.1 and 14.2.9 (pages router) are vulnerable to cache poisoning.
-    Crafted requests to non-dynamic server-side rendered routes may poison the cache with attacker-supplied headers,
-    allowing attackers to serve malicious content to other users.
+    Next.js is a React framework for building full-stack web applications. By sending a crafted HTTP request, it is possible to poison the cache of a non-dynamic server-side rendered route in the pages router (this does not affect the app router). When this crafted request is sent it could coerce Next.js to cache a route that is meant to not be cached and send a `Cache-Control: s-maxage=1, stale-while-revalidate` header which some upstream CDNs may cache as well. To be potentially affected all of the following must apply: 1. Next.js between 13.5.1 and 14.2.9, 2. Using pages router, & 3. Using non-dynamic server-side rendered routes e.g. `pages/dashboard.tsx` not `pages/blog/[slug].tsx`.
+  remediation: This vulnerability was resolved in Next.js v13.5.7, v14.2.10, and later. We recommend upgrading regardless of whether you can reproduce the issue or not.
   reference:
     - https://github.com/vercel/next.js/security/advisories/GHSA-gp8f-8m3g-qvj9
     - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
+    - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
+    - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-46982
+    cwe-id: CWE-639
   metadata:
     verified: true
     max-request: 1
@@ -18,7 +24,7 @@ info:
     product: next.js
     shodan-query: http.html:"Next.js"
     fofa-query: 'body="Next.js" || header="x-powered-by: Next.js"'
-  tags: cve,cve2024,nextjs,cache,poisoning,xss
+  tags: cve,cve2024,nextjs,cache,poisoning
 
 http:
   - method: GET


### PR DESCRIPTION
/claim #13204 

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->

- Added CVE-2024-46982 - Next.js Cache Poisoning (Pages Router)
- References:
  - https://github.com/vercel/next.js/security/advisories/GHSA-gp8f-8m3g-qvj9
  - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
  - https://github.com/Lercas/CVE-2024-46982
  - https://github.com/CodePontiff/next_js_poisoning

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```bash
nuclei -t http/cves/2024/CVE-2024-46982.yaml -u [hidden]/ -debug -v
```

#### Additional Details (leave it blank if not applicable)

- Debug logs sent to templates@projectdiscovery.io
- Verified against a vulnerable Next.js (13.5.3) instance 
- Control tested against a safe Next.js (14.3.0+) instance

Shodan / Fofa queries for hunting:
- `http.html:"Next.js"`
- `header:"x-powered-by: Next.js"`

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
