### PR TITLE
Create openmetadata-admin-userenum.yaml

### DIFF
--- a/http/exposures/configs/openmetadata-admin-userenum.yaml
+++ b/http/exposures/configs/openmetadata-admin-userenum.yaml
@@ -3,7 +3,7 @@ id: openmetadata-admin-userenum
 info:
   name: OpenMetadata - Admin User Enumeration
   author: icarot
-  severity: info
+  severity: medium
   description: |
     Enumerates the admin users registered on OpenMetadata server.
   reference:

--- a/http/exposures/configs/openmetadata-admin-userenum.yaml
+++ b/http/exposures/configs/openmetadata-admin-userenum.yaml
@@ -1,0 +1,57 @@
+id: openmetadata-admin-userenum
+
+info:
+  name: OpenMetadata - Admin User Enumeration
+  author: icarot
+  severity: info
+  description: |
+    Enumerates the admin users registered on OpenMetadata server.
+  reference:
+    - https://github.com/open-metadata/OpenMetadata
+  classification:
+    cpe: cpe:2.3:a:open-metadata:openmetadata:1.7.0:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: open-metadata
+    product: openmetadata
+    fofa-query: title="OpenMetadata"
+    shodan-query: title:"OpenMetadata"
+  tags: openmetadata,open-metadata,userenum
+
+http:
+  - raw:
+      - |
+        GET /api/v1/system/config/authorizer HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"adminPrincipals":'
+          - '"principalDomain"'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: adminUser
+        json:
+          - '.adminPrincipals'
+      - type: json
+        name: principalDomain
+        json:
+          - '.principalDomain'
+      - type: json
+        name: allowedDomains
+        json:
+          - '.allowedDomains'

--- a/http/exposures/configs/openmetadata-admin-userenum.yaml
+++ b/http/exposures/configs/openmetadata-admin-userenum.yaml
@@ -8,14 +8,13 @@ info:
     Enumerates the admin users registered on OpenMetadata server.
   reference:
     - https://github.com/open-metadata/OpenMetadata
-  classification:
-    cpe: cpe:2.3:a:open-metadata:openmetadata:1.7.0:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
-    vendor: open-metadata
-    product: openmetadata
     fofa-query: title="OpenMetadata"
     shodan-query: title:"OpenMetadata"
+    vendor: open-metadata
+    product: openmetadata
   tags: openmetadata,open-metadata,userenum
 
 http:
@@ -42,16 +41,10 @@ http:
       - type: status
         status:
           - 200
+
     extractors:
-      - type: json
-        name: adminUser
-        json:
-          - '.adminPrincipals'
-      - type: json
-        name: principalDomain
-        json:
-          - '.principalDomain'
-      - type: json
-        name: allowedDomains
-        json:
-          - '.allowedDomains'
+    - type: json
+      json:
+        - '"adminUser: "+ .adminPrincipals'
+        - '"principalDomain: "+ .principalDomain'
+        - '"allowedDomains: "+ .allowedDomains'

--- a/http/exposures/configs/openmetadata-admin-userenum.yaml
+++ b/http/exposures/configs/openmetadata-admin-userenum.yaml
@@ -43,8 +43,8 @@ http:
           - 200
 
     extractors:
-    - type: json
-      json:
-        - '"adminUser: "+ .adminPrincipals'
-        - '"principalDomain: "+ .principalDomain'
-        - '"allowedDomains: "+ .allowedDomains'
+      - type: json
+        json:
+          - '"adminUser: "+ .adminPrincipals'
+          - '"principalDomain: "+ .principalDomain'
+          - '"allowedDomains: "+ .allowedDomains'

--- a/http/exposures/configs/openmetadata-admin-userenum.yaml
+++ b/http/exposures/configs/openmetadata-admin-userenum.yaml
@@ -45,6 +45,6 @@ http:
     extractors:
       - type: json
         json:
-          - '"adminUser: "+ .adminPrincipals'
-          - '"principalDomain: "+ .principalDomain'
-          - '"allowedDomains: "+ .allowedDomains'
+          - '"adminUser: " + ( .adminPrincipals[] | tostring )'
+          - '"principalDomain: " + .principalDomain'
+          - '"allowedDomains: " + ( .allowedEmailRegistrationDomains[] | tostring )'


### PR DESCRIPTION
These nuclei templates:

* Enumerates the admin users registered on OpenMetadata server.

- References:

https://github.com/open-metadata/OpenMetadata

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**OpenMetadata Docker:**

1. Running container:

`$ curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.7.0-release/docker-compose.yml`

OR

`$ curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.8.0-release/docker-compose.yml`

`$ docker compose -f docker-compose.yml up --detach`

2. Acessing the OpenMetadata service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' x'`

And the access URL will be http://<obteined_inspect_IP_Address>:8585/

3. Starting a docker container Kali in the same network as the OpenMetadata:

`$ docker run --rm --tty --interactive --network openmetadata_app_net --dns 8.8.8.8 --dns 8.8.4.4 --name container_kali kalilinux/kali-rolling /bin/bash`

**Nuclei execution:**

`$ ~/go/bin/nuclei -t openmetadata-admin-userenum.yaml -u "http://<obteined_inspect_IP_Address>:8585" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="493" height="878" alt="image" src="https://github.com/user-attachments/assets/5d9d88cb-ad1c-49c1-8542-e86523a85362" />

<img width="1845" height="389" alt="image" src="https://github.com/user-attachments/assets/642cd7f7-0f69-417b-82bb-e7300e9293b5" />
