### PR TITLE
Add eSCL unauthorized endpoint access template

### DIFF
--- a/http/misconfiguration/escl-endpoint-exposure.yaml
+++ b/http/misconfiguration/escl-endpoint-exposure.yaml
@@ -1,17 +1,18 @@
 id: escl-endpoint-exposure
 
 info:
-  name: eSCL unauthorized endpoint access
+  name: eSCL Unauthorized Access
   author: matejsmycka
   severity: medium
   description: |
-    Unauthorized access to MFP (Multi-function printer) using eSCL protocol allows attackers to scan documents left physically in the printer and send them to an arbitrary location.
-    Furthermore, exposure of this endpoint allows attackers to gather information about the printer, serial number, model, and possibly pull documents scanned by legitimate users.
+    Unauthorized access to MFP (Multi-function printer) using eSCL protocol allows attackers to scan documents left physically in the printer and send them to an arbitrary location. Furthermore, exposure of this endpoint allows attackers to gather information about the printer, serial number, model, and possibly pull documents scanned by legitimate users.
   reference:
     - https://wiki.debian.org/eSCL
     - https://support.princh.com/en/the-onboarding-process-1
     - https://mopria.org/spec-download
     - https://github.com/xJonathanLEI/escl-rs
+  metadata:
+    max-request: 1
   tags: network,iot,printer,misconfig,http,escl
 
 http:
@@ -22,21 +23,21 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        condition: and
         words:
           - "xmlns:pwg="
           - "<scan:ScannerCapabilities"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/xml"
+          - "text/xml"
+        condition: or
 
       - type: status
         status:
           - 200
-
-      - type: word
-        part: header
-        condition: or
-        words:
-          - "application/xml"
-          - "text/xml"
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Template / PR Information
Usual port depends on vendor:

<img width="711" height="490" alt="image" src="https://github.com/user-attachments/assets/77a5f253-e88e-4dc8-a173-0cc8c05d7ec9" />


Connected to  https://nvd.nist.gov/vuln/detail/cve-2025-8452 on brother printers.

Tested:

<img width="1248" height="828" alt="Screenshot From 2025-09-11 15-20-04" src="https://github.com/user-attachments/assets/18c06cd5-9e1d-4299-b8b4-89c007aaf4f0" />


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)