### PR TITLE
Add CVE-2025-32463.yaml

### DIFF
--- a/code/cves/2025/CVE-2025-32463.yaml
+++ b/code/cves/2025/CVE-2025-32463.yaml
@@ -5,9 +5,9 @@ info:
   author: SeungAh-Hong
   severity: critical
   description: |
-    Sudo before 1.9.17p1 allows local users to obtain root access because /etc/nsswitch.conf from a user-controlled directory is used with the --chroot (-R) option.
+    Sudo before 1.9.17p1 allows local users to obtain root access by using /etc/nsswitch.conf from a user-controlled directory with the --chroot (-R) option.
   impact: |
-    A local attacker can escalate privileges to root by placing a crafted nsswitch.conf and malicious NSS library inside a writable chroot directory, leading to arbitrary code execution with root privileges.
+    A local attacker can escalate privileges to root by placing a crafted nsswitch.conf file and a malicious NSS library in a writable chroot directory, enabling arbitrary code execution with root privileges.
   remediation: |
     Upgrade sudo to version 1.9.17p1 or later.
   reference:
@@ -35,6 +35,7 @@ code:
       - bash
     source: |
       whoami
+
     matchers:
       - type: word
         part: response


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2025-32463.yaml
- References: https://github.com/pr0v3rbs/CVE-2025-32463_chwoot?tab=readme-ov-file

### Template Validation

I've validated this template locally?
- [V] YES
```
pwn@6935eb5bbb0c:~$ nuclei -esc -code -t ./CVE-2025-32463.yaml -debug -v -svd

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from seungahhong
[VER] [CVE-2025-32463] Executed code on local machine 
[DBG] Code Protocol request variables: map[string]interface {}:2 {
  "Hostname": "",
  "Input": "",
}
[DBG] [CVE-2025-32463] Dumped Executed Source Code for input/stdin: ''
---------------
Source Code:
---------------
OUT="$(sudo -n -R woot woot 2>&1 || true)"
printf "%s\n" "$OUT"


---------------
Command Executed:
---------------
/usr/bin/sh /tmp/nuclei-tmp-1613536806/4156783178

---------------
Command Output:
---------------
sudo: woot: No such file or directory

[WRN] Command Output here is stdout+sterr, in response variables they are seperate (use -v -svd flags for more details)
[DBG] Code Protocol response variables: map[string]interface {}:9 {
  "interactsh-server": "",
  "response": "sudo: woot: No such file or directory",
  "template-path": "/home/pwn/CVE-2025-32463.yaml",
  "type": "code",
  "Hostname": "",
  "input": "",
  "template-id": "CVE-2025-32463",
  "template-info": "{CVE-2025-32463 �~@~S vulnerable sudo detection (SSH remote, hardened) seungah-hong cve, cve-2025-32463, sudo, code, bash Sudo before 1.9.17p1 allows local users to obtain root access because /etc/nsswitch.conf from a user-controlled directory is used w [...]",
  "Input": "",
}
[DBG] [CVE-2025-32463] Dumped Code Execution for 

sudo: woot: No such file or directory

[CVE-2025-32463:dsl-1] [code] [high] 
[INF] Scan completed in 22.178541ms. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)