### PR TITLE
Create CVE-2025-5701.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-5701.yaml
+++ b/http/cves/2025/CVE-2025-5701.yaml
@@ -43,6 +43,7 @@ http:
         group: 1
         regex:
           - '(?i)Stable.tag:\s?([\w.]+)'
+        internal: true
 
   - raw:
       - |
@@ -62,3 +63,8 @@ http:
       - type: status
         status:
           - 200
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"version: " + detected_version'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2025-5701 
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2025-5701
    - https://github.com/Nxploited/CVE-2025-5701
    - https://downloads.wordpress.org/plugin/hypercomments.1.2.2.zip

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

<img width="1126" height="370" alt="image" src="https://github.com/user-attachments/assets/99a4d898-9981-4280-94c5-10f348353b3c" />

This PR adds a strict, false-positive–resistant Nuclei template for CVE-2025-5701 (WordPress HyperComments ≤ 1.2.2 — Unauthenticated Arbitrary Options Update / Privilege Escalation).

The template sends the PoC payload to both endpoints observed in PoCs/environments:
- /?hc_action=update_options
- /wp-admin/index.php?hc_action=update_options


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)