### PR TITLE
Create nocobase-config.yaml and fixing nocobase-default-login.yaml

### DIFF
--- a/http/default-logins/nocobase/nocobase-default-login.yaml
+++ b/http/default-logins/nocobase/nocobase-default-login.yaml
@@ -2,7 +2,7 @@ id: nocobase-default-login
 
 info:
   name: NocoBase - Default Login
-  author: Fur1na
+  author: Fur1na, icarot
   severity: high
   description: |
     NocoBase default login was discovered.
@@ -12,7 +12,7 @@ info:
     - https://docs.nocobase.com/welcome/getting-started/installation/docker-compose
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     zoomeye-query: app="NocoBase"
   tags: default-login,nocobase
 
@@ -47,4 +47,27 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a004730450220793daeed0403293a3557a247d244758bda0435d3961a53590ae51d6ddcfe8b4a022100d325278d8c91ca6e03d97fd26c0f94014020dcc2025da401cd6110f108f1175d:922c64590222798bb761d5b6d8e72950
+  - raw:
+      - |
+        POST /api/v1/auth/user/signin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"email":"{{username}}","password": "{{password}}"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '{"token":'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json; charset=utf-8'
+
+      - type: status
+        status:
+          - 200

--- a/http/exposures/configs/nocobase-config.yaml
+++ b/http/exposures/configs/nocobase-config.yaml
@@ -1,0 +1,53 @@
+id: nocobase-config
+
+info:
+  name: Nocobase - Config
+  author: icarot
+  severity: medium
+  description: |
+    Detects if path /api/v1/db/meta/nocodb/info of Nocobase web application is exposed, getting internal information. NocoBase is an extensibility-first, open-source no-code/low-code platform for building business applications and enterprise solutions.
+  reference:
+    - https://github.com/nocobase/nocobase/
+    - https://www.nocobase.com/
+  metadata:
+    max-request: 1
+    vendor: nocobase
+    product: nocobase
+  tags: nocobase,config,exposed
+
+http:
+  - raw:
+      - |
+        GET /api/v1/db/meta/nocodb/info HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"authType":'
+          - '"env":'
+          - '"version":'
+          - '"ncSiteUrl":'
+          - '"mainSubDomain":'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json; charset=utf-8'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        json:
+          - '"authType: " + .authType'
+          - '"env: " + .env'
+          - '"version: " + .version'
+          - '"ncSiteUrl: " + .ncSiteUrl'
+          - '"mainSubDomain: " + .mainSubDomain'


### PR DESCRIPTION
These nuclei templates:

* Detects if path /api/v1/db/meta/nocodb/info of Nocobase web application is exposed, getting internal information. NocoBase is an extensibility-first, open-source no-code/low-code platform for building business applications and enterprise solutions.
* Fixing the template to be able to see if a "NocoBase default login was discovered." in the latest versions.

- References:

https://github.com/nocobase/nocobase/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**NocoBase Docker:**

1. Running container:

`$ docker run --rm -d --name nocobase_container -v "$(pwd)"/nocodb:/usr/app/data/ -p 8080:8080 nocodb/nocodb:latest`

2. Acessing the NocoBase service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nocobase_container`

And the access URL will be "http://<obteined_inspect_IP_Address>:8080".

**Nuclei execution:**

`$ ~/go/bin/nuclei -t nocobase-config.yaml -t nocobase-default-login.yaml -u "http://<obteined_inspect_IP_Address>:8080/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1851" height="1005" alt="image" src="https://github.com/user-attachments/assets/545796df-8c4a-4cb1-84a0-61925b6396ae" />

<img width="532" height="972" alt="image" src="https://github.com/user-attachments/assets/7663a971-1bda-495d-9bbd-c4b887e38241" />

<img width="1851" height="380" alt="image" src="https://github.com/user-attachments/assets/3006bcf7-cf40-4938-9cc0-012bef5f9bb0" />
