### PR TITLE
ADD CVE-2024-9634 - GiveWP Plugin ≤ 3.16.3 - Unauthenticated PHP Object Injection (RCE)

### DIFF
--- a/http/cves/2024/CVE-2024-9634.yaml
+++ b/http/cves/2024/CVE-2024-9634.yaml
@@ -1,0 +1,38 @@
+id: CVE-2024-9634
+
+info:
+  name: GiveWP Plugin ≤ 3.16.3 - Unauthenticated PHP Object Injection (RCE)
+  author: kankburhan
+  severity: critical
+  description: Detects CVE-2024-9634, a PHP Object Injection leading to RCE in GiveWP plugin (WordPress) versions ≤ 3.16.3.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-9634
+    - https://patchstack.com/database/wordpress/plugin/give/vulnerability/wordpress-givewp-plugin-3-16-3-unauthenticated-php-object-injection-to-remote-code-execution-vulnerability
+    - https://www.wordfence.com/blog/2024/06/critical-vulnerability-patched-in-givewp-plugin/-
+    - https://github.com/kankburhan/pocs/tree/main/CVE-2024-9634
+  tags: cve,cve2024,wordpress,givewp,rce,poi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/give/readme.txt"
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "Stable tag: (3\\.16\\.[0-3]|3\\.1[0-5]\\.\\d+|3\\.[0-9]\\.\\d+|2\\.\\d+\\.\\d+|1\\.\\d+\\.\\d+)"
+        condition: or
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "action=give_process_donation&give_company_name=O:8:\"Example\":1:{s:5:\"dummy\";s:7:\"test123\";}"
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "unserialize\\(\\): Error at offset"
+          - "PHP Fatal error"
+        condition: or


### PR DESCRIPTION
### Template / PR Information

Added CVE-2024-9634: Detecteion for GiveWP Plugin ≤ 3.16.3 - Unauthenticated PHP Object Injection (RCE).

- References:
   - https://nvd.nist.gov/vuln/detail/CVE-2024-9634
   - https://patchstack.com/database/wordpress/plugin/give/vulnerability/wordpress-givewp-plugin-3-16-3-unauthenticated-php-object-injection-to-remote-code-execution-vulnerability
   - https://github.com/kankburhan/pocs/tree/main/CVE-2024-9634

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


### Notes for Reviewers:
- The template includes both passive (version check) and active (exploit PoC) detection.
- Regex escapes are double-formatted (\\. instead of \.) to comply with YAML syntax.
- Tested against a local WordPress instance with GiveWP 3.16.3 (vulnerable) and 3.16.4 (patched).

<img width="1300" height="578" alt="image" src="https://github.com/user-attachments/assets/18df0bb9-80a3-43b0-b1cf-a5e8cfb8dbd7" />

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)