### PR TITLE
CVE-2025-59474 Jenkins 

### DIFF
--- a/http/cves/2025/CVE-2025-59474.yaml
+++ b/http/cves/2025/CVE-2025-59474.yaml
@@ -34,6 +34,7 @@ http:
           - 'Build Executor Status'
           - 'Estado del ejecutor'
           - 'id="executors"'
+        condition: or
 
       - type: regex
         part: body
@@ -47,3 +48,8 @@ http:
         group: 1
         regex:
           - 'href="[^"]*/computer/([^"/]+)/?"'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - 'urldecode(agents)'


### PR DESCRIPTION
### Template / PR Information

This template detects Jenkins sidepanel exposure on /securityRealm/signup
(SECURITY-3594 / CVE-2025-59474), where unauthenticated users can view the
Build Executor Status widget (agent names, build queue).

Affected versions: Jenkins <= 2.527 and LTS <= 2.516.2
Fixed in: 2.528 / LTS 2.516.3

- Paths checked: /securityRealm/signup and /jenkins/securityRealm/signup
- Matchers: "Build Executor Status", id="executors", or links to /computer/<agent>
- Extractors: agent names from /computer/<agent> links

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)