### PR TITLE
Added CVE-2025-10035 - (GoAnywhere - Authentication Bypass)

### DIFF
--- a/http/cves/2025/CVE-2025-10035.yaml
+++ b/http/cves/2025/CVE-2025-10035.yaml
@@ -5,14 +5,20 @@ info:
   author: DhiyaneshDk,watchtowr
   severity: critical
   description: |
-    A deserialization vulnerability in the License Servlet of Fortra's GoAnywhere MFT allows an actor with a validly forged license response signature to deserialize an arbitrary actor-controlled object, possibly leading to command injection.
+    Fortra GoAnywhere MFT contains an insecure deserialization vulnerability in the License Servlet caused by deserializing attacker-controlled objects with a valid forged license response signature, letting attackers perform command injection, exploit requires valid forged license signature.
   reference:
     - https://labs.watchtowr.com/is-this-bad-this-feels-bad-goanywhere-cve-2025-10035/
     - https://attackerkb.com/topics/LbA9ANjcdz/cve-2025-10035/rapid7-analysis
+    - https://www.fortra.com/security/advisories/product-security/fi-2025-011
+  impact: |
+    Attackers can execute arbitrary commands remotely, potentially leading to full system compromise.
+  remediation: |
+    Update to the latest version with the deserialization fix.
   metadata:
     verified: true
     max-request: 1
     shodan-query: title:"GoAnywhere"
+    fofa-query: title="GoAnywhere"
   tags: cve,cve2025,goanywhere,auth-bypass
 
 variables:
@@ -25,14 +31,14 @@ http:
       - "{{BaseURL}}/license/Unlicensed.xhtml/{{string}}?javax.faces.ViewState={{string}}&GARequestAction=activate"
 
     stop-at-first-match: true
-
-    matchers-condition: and
     matchers:
-      - type: word
-        part: location
-        words:
-          - "request?bundle="
+      - type: dsl
+        dsl:
+          - contains_all(location, "request?bundle=", "my.goanywhere.com")
+          - status_code == 302
+        condition: and
 
-      - type: status
-        status:
-          - 302
+    extractors:
+      - type: dsl
+        dsl:
+          - location


### PR DESCRIPTION
Added severity level for CVE-2025-10035.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

Reference:
    - https://labs.watchtowr.com/is-this-bad-this-feels-bad-goanywhere-cve-2025-10035/
    - https://attackerkb.com/topics/LbA9ANjcdz/cve-2025-10035/rapid7-analysis
    - https://www.fortra.com/security/advisories/product-security/fi-2025-011


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)