### PR TITLE
ADD CVE-2022-40769(vKEV)

### DIFF
--- a/http/cves/2022/CVE-2022-40769.yaml
+++ b/http/cves/2022/CVE-2022-40769.yaml
@@ -1,0 +1,34 @@
+id: CVE-2022-40769
+
+info:
+  name: Profanity weak cryptography
+  author: intelligent-ears
+  severity: high
+  description: Detects exposure of Profanity vanity address generator scripts that may be vulnerable to private key recovery.
+  reference:
+    - https://github.com/johguse/profanity
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40769
+  tags: cve,cve2022,profanity,exposure
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/scripts/generate.sh"
+      - "{{BaseURL}}/Dockerfile"
+      - "{{BaseURL}}/README.md"
+      - "{{BaseURL}}/profanity.conf"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "profanity --leading"
+          - "johguse/profanity"
+          - "vanity_address"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - "contains(body, 'profanity --leading')"
+          - "contains(body, 'johguse/profanity')"


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2022-40769
- References:
  - https://github.com/johguse/profanity/releases
  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40769

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
```bash
┌──(kali㉿kali)-[~/…/nuclei-templates/http/cves/2022]
└─$ nuclei -u http://localhost:8000 -t CVE-2022-40769.yaml -debug   


                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

		projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2022-40769] Dumped HTTP request for http://localhost:8000/scripts/generate.sh

GET /scripts/generate.sh HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2022-40769] Dumped HTTP response http://localhost:8000/scripts/generate.sh

HTTP/1.0 200 OK
Connection: close
Content-Length: 52
Content-Type: text/x-sh
Date: Thu, 25 Sep 2025 21:50:07 GMT
Last-Modified: Thu, 25 Sep 2025 21:36:01 GMT
Server: SimpleHTTP/0.6 Python/3.8.10

#!/bin/bash
/opt/profanity/profanity --leading cafe
[CVE-2022-40769:word-1] [http] [high] http://localhost:8000/scripts/generate.sh
[CVE-2022-40769:dsl-2] [http] [high] http://localhost:8000/scripts/generate.sh
[INF] [CVE-2022-40769] Dumped HTTP request for http://localhost:8000/Dockerfile

GET /Dockerfile HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (SS; Linux i686; rv:128.0) Gecko/20100101 Firefox/128.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2022-40769] Dumped HTTP response http://localhost:8000/Dockerfile

HTTP/1.0 404 File not found
Content-Length: 469
Connection: close
Content-Type: text/html;charset=utf-8
Date: Thu, 25 Sep 2025 21:50:07 GMT
Server: SimpleHTTP/0.6 Python/3.8.10

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
        <title>Error response</title>
    </head>
    <body>
        <h1>Error response</h1>
        <p>Error code: 404</p>
        <p>Message: File not found.</p>
        <p>Error code explanation: HTTPStatus.NOT_FOUND - Nothing matches the given URI.</p>
    </body>
</html>
[INF] [CVE-2022-40769] Dumped HTTP request for http://localhost:8000/README.md

GET /README.md HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.7 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2022-40769] Dumped HTTP response http://localhost:8000/README.md

HTTP/1.0 404 File not found
Content-Length: 469
Connection: close
Content-Type: text/html;charset=utf-8
Date: Thu, 25 Sep 2025 21:50:07 GMT
Server: SimpleHTTP/0.6 Python/3.8.10

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
        <title>Error response</title>
    </head>
    <body>
        <h1>Error response</h1>
        <p>Error code: 404</p>
        <p>Message: File not found.</p>
        <p>Error code explanation: HTTPStatus.NOT_FOUND - Nothing matches the given URI.</p>
    </body>
</html>
[INF] [CVE-2022-40769] Dumped HTTP request for http://localhost:8000/profanity.conf

GET /profanity.conf HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Ubuntu; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2022-40769] Dumped HTTP response http://localhost:8000/profanity.conf

HTTP/1.0 404 File not found
Content-Length: 469
Connection: close
Content-Type: text/html;charset=utf-8
Date: Thu, 25 Sep 2025 21:50:07 GMT
Server: SimpleHTTP/0.6 Python/3.8.10

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
        <title>Error response</title>
    </head>
    <body>
        <h1>Error response</h1>
        <p>Error code: 404</p>
        <p>Message: File not found.</p>
        <p>Error code explanation: HTTPStatus.NOT_FOUND - Nothing matches the given URI.</p>
    </body>
</html>
[INF] Scan completed in 21.373506ms. 2 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)