### PR TITLE
docs: Fix broken links in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This documentation contains a set of guidelines to help you during the contribut
 
 - Take a look at the [Existing Templates](https://github.com/projectdiscovery/nuclei-templates) or search for endpoints before creating new one.
 - Take a look at Existing Templates in [GitHub Issues](https://github.com/projectdiscovery/nuclei-templates/issues) and [Pull Request](https://github.com/projectdiscovery/nuclei-templates/pulls) section to avoid duplicate work.
-- Take a look at [Templates](https://nuclei.projectdiscovery.io/templating-guide/) and [Matchers](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers) Guideline for creating new template.
+- Take a look at [Templates](TEMPLATE-CREATION-GUIDE.md) and [Matchers](https://github.com/projectdiscovery/nuclei-templates/wiki/How-to-Write-Unique-Matchers-in-Nuclei-Templates) Guideline for creating new template.
 
 Along with the P.O.C following are the required fields in the info section for submitting new template.
 


### PR DESCRIPTION
This PR fixes broken links in the contribution guide (CONTRIBUTING.md). The updates ensure that contributors can access the correct and up-to-date documentation for creating templates and matchers.

## Changes:
1. Updated Template Guideline Link:
   - Before: https://nuclei.projectdiscovery.io/templating-guide/
   - After: TEMPLATE-CREATION-GUIDE.md
   - Reason: The link now correctly points to the local guide file within the repository, ensuring consistency.
2. Corrected Matchers Guideline Link:
   - Before: A broken or incorrect URL.
   - After: https://github.com/projectdiscovery/nuclei-templates/wiki/How-to-Write-Unique-Matchers-in-Nuclei-Templates
   - Reason: Fixed a URL error that prevented access to the matcher creation guide.