### PR TITLE
Add Crestron AirMedia default login template

### DIFF
--- a/http/default-logins/crestron/crestron-airmedia-default-login.yaml
+++ b/http/default-logins/crestron/crestron-airmedia-default-login.yaml
@@ -1,0 +1,43 @@
+id: crestron-airmedia-default-login
+
+info:
+  name: Crestron Airmedia 2.0 - Default Login
+  author: Andrew Lentz
+  severity: high
+  description: |
+      Crestron AirMedia 2.0 devices contain default credentials (admin:admin) that allow unauthorized administrative access to device configuration and control.
+  # No reference field - product discontinued
+  metadata:
+    verified: true
+    max-request: 3
+    shodan-query: crestron airmedia
+    product: crestron-device
+    vendor: crestron
+  tags: crestron,default-login,iot,misconfig
+
+http:
+  - id: step-2-authenticate
+    method: POST
+    path:
+      - "{{BaseURL}}/userlogin.html"
+    headers:
+      Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+      X-Requested-With: XMLHttpRequest
+      Origin: "{{BaseURL}}"
+      Referer: "{{BaseURL}}/userlogin.html"
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+    attack: pitchfork
+    body: "login={{username}}&passwd={{password}}"
+    redirects: true
+    max-redirects: 3
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - 'Set-Cookie: (AuthByPasswd)'


### PR DESCRIPTION


### Template / PR Information

Detects default admin:admin credentials on Crestron AirMedia 2.0 devices. This template identifies discontinued Crestron AirMedia 2.0 devices that are still using factory default credentials, allowing unauthorized administrative access to device configuration and control.

- Added new default login template for Crestron AirMedia 2.0 devices
- References: N/A (discontinued product, no current vendor documentation available)


### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

**Testing Environment:**
- Tested against 30+ Crestron AirMedia 2.0 devices in controlled lab environment
- Successfully identified devices with default admin:admin credentials
- Verified full authentication flow including access to device administration panel

**Shodan Query:**
title:"Device Administration" "Crestron"

**Matched Response Data:**
Template detects devices that:
1. Accept POST authentication to /userlogin.html with admin:admin credentials
2. Return authentication cookies (AuthByPasswd) in response headers
3. Allow access to /index_device.html

**Device Information:**
- Target: Crestron AirMedia 2.0 (discontinued model)
- Vulnerability: Default credentials never changed from factory settings
- Impact: Full administrative access to device configuration

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)