### PR TITLE
CVE-2022-37932: fix flow to remove false positives

### DIFF
--- a/network/cves/2022/CVE-2022-37932.yaml
+++ b/network/cves/2022/CVE-2022-37932.yaml
@@ -24,7 +24,7 @@ info:
 variables:
   password: "{{rand_base(8)}}"
 
-flow: http(1) && http(2) || http(3)
+flow: http(1) && (http(2) || http(3))
 
 http:
   - raw:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2022-37932

I suppose this was a typo in the existing flow as the main page would only need to match with the first path to reset a password (`/login/default_password_cfg.lua`). However, this leads to several false positives with the second path (`/htdocs/login/default_password_cfg.lua`).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
