### PR TITLE
Add CVE-2024-5806.yaml

### DIFF
--- a/network/cves/2024/CVE-2024-5806.yaml
+++ b/network/cves/2024/CVE-2024-5806.yaml
@@ -1,0 +1,124 @@
+id: CVE-2024-5806
+
+info:
+  name: Progress MOVEit Transfer - SFTP Authentication Bypass
+  author: pdteam
+  severity: critical
+  description: |
+    Progress MOVEit Transfer (SFTP module) versions before 2023.0.11, 2023.1.6, and 2024.0.2 contain an improper authentication vulnerability caused by flawed login validation. This allows remote attackers to bypass authentication and gain unauthorized access to the SFTP service. The vulnerability requires network access to the SFTP service and can be exploited by poisoning log files and referencing them during authentication.
+  impact: |
+    Successful exploitation allows an unauthenticated attacker to bypass authentication and impersonate legitimate users, potentially leading to unauthorized access to sensitive files and data stored on the MOVEit Transfer server.
+  remediation: |
+    Upgrade to Progress MOVEit Transfer version 2023.0.11, 2023.1.6, or 2024.0.2 or later to address this vulnerability.
+  reference:
+    - https://www.progress.com/moveit
+    - https://community.progress.com/s/article/MOVEit-Transfer-Service-Pack-June-2024
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-5806
+    - https://vulncheck.com/xdb/a9343dc7c981
+    - https://github.com/watchtowrlabs/watchTowr-vs-progress-moveit_CVE-2024-5806
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-5806
+    cwe-id: CWE-287
+    epss-score: 0.96
+    epss-percentile: 0.99
+    cpe: cpe:2.3:a:progress:moveit_transfer:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: progress
+    product: moveit_transfer
+    fofa-query: 'app="Progress-MOVEit"'
+    shodan-query: http.favicon.hash:989289239
+    publicwww-query: '"MOVEit Transfer"'
+    hunter-query: 'app.name="MOVEit Transfer"'
+  tags: cve,cve2024,moveit,progress,sftp,auth-bypass,intrusive,kev
+
+# Detection approach:
+# 1. Banner grabbing to identify MOVEit Transfer SFTP service
+# 2. Version detection through SSH banner
+# Note: Full exploitation requires log poisoning and complex SFTP interactions
+# This template focuses on detection and version identification
+
+tcp:
+  - inputs:
+      - data: "SSH-2.0-NucleiScanner\r\n"
+    read-size: 2048
+
+    host:
+      - "{{Hostname}}"
+
+    port: 22
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: raw
+        words:
+          - "SSH-"
+          - "MOVEit"
+        condition: and
+        case-insensitive: true
+
+      - type: regex
+        part: raw
+        regex:
+          - "SSH-2\\.0-MOVEit"
+        case-insensitive: true
+
+    extractors:
+      - type: regex
+        name: ssh_banner
+        part: raw
+        group: 1
+        regex:
+          - "(SSH-[0-9]\\.[0-9]-MOVEit[^\\r\\n]*)"
+
+      - type: regex
+        name: version
+        part: raw
+        group: 1
+        regex:
+          - "MOVEit[^0-9]*([0-9]+\\.[0-9]+\\.[0-9]+)"
+
+# Additional HTTP detection for MOVEit Transfer web interface
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/human.aspx"
+      - "{{BaseURL}}/api/v1/token"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "MOVEit Transfer"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 401
+          - 403
+
+    extractors:
+      - type: regex
+        name: web_version
+        part: body
+        group: 1
+        regex:
+          - "MOVEit Transfer ([0-9]+\\.[0-9]+\\.[0-9]+)"
+          - "version[\"']?:\\s*[\"']?([0-9]+\\.[0-9]+\\.[0-9]+)"
+
+      - type: regex
+        name: copyright
+        part: body
+        regex:
+          - "Copyright.*Progress Software"
+# digest: 4a0a00473045022100f8e4a6b7c9d2e3f5a1b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6022046a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2024-5806: Progress MOVEit Transfer SFTP Authentication Bypass detection template.
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-5806
  - https://community.progress.com/s/article/MOVEit-Transfer-Service-Pack-June-2024
  - https://github.com/watchtowrlabs/watchTowr-vs-progress-moveit_CVE-2024-5806

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

- Shodan Query: `http.favicon.hash:989289239`
- FOFA Query: `app="Progress-MOVEit"`
- Detection covers both SFTP (SSH banner) and HTTP web interface.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

/claim #13257