### PR TITLE
Add detection of WOODPECKER CI/CD instances. 

### DIFF
--- a/http/technologies/woodpecker-detect.yaml
+++ b/http/technologies/woodpecker-detect.yaml
@@ -1,0 +1,37 @@
+id: woodpecker-detect
+
+info:
+  name: Woodpecker - Detect
+  author: righettod
+  severity: info
+  description: |
+    Woodpecker is a simple, yet powerful CI/CD engine with great extensibility.
+  reference:
+    - https://github.com/woodpecker-ci/woodpecker
+    - https://woodpecker-ci.org/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: woodpecker
+    product: woodpecker
+    shodan-query: http.title:"woodpecker"
+  tags: tech,woodpecker,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web-config.js"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "window.woodpecker_")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)window.WOODPECKER_VERSION\s*=\s*"([0-9.]+)"'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the **WOODPECKER** software.

References:

- https://github.com/woodpecker-ci/woodpecker
- https://woodpecker-ci.org/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="814" height="594" alt="image" src="https://github.com/user-attachments/assets/3aea5683-dd7d-431d-9688-a314c87481e5" />

Hosts used for the test found via Shodan and/or https://crt.sh :

```
https://91.134.159.67
https://130.133.110.68
https://45.150.187.226
https://150.136.225.61
http://34.27.152.163:8080
http://35.244.11.170
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22woodpecker%22

<img width="1368" height="820" alt="image" src="https://github.com/user-attachments/assets/78df434e-ff29-4f2a-bfba-87cc356182a4" />

### Additional References

None