### PR TITLE
feat(graphql): detect exposed Apollo Sandbox UI

### DIFF
--- a/http/misconfiguration/graphql/graphql-apollo-sandbox.yaml
+++ b/http/misconfiguration/graphql/graphql-apollo-sandbox.yaml
@@ -1,0 +1,33 @@
+id: graphql-apollo-sandbox
+info:
+  name: Apollo Sandbox UI Exposed
+  author: Hamza Sahin
+  severity: low
+  description: Detects Apollo Sandbox developer UI exposed in production which may aid schema discovery/testing.
+  tags: graphql,apollo,misconfig,exposure,web
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sandbox"
+      - "{{BaseURL}}/graphql/sandbox"
+      - "{{BaseURL}}/api/graphql/sandbox"
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Apollo Sandbox"
+          - "apollo.dev"
+      - type: regex
+        part: body
+        regex:
+          - "(?i)apollo\\s*sandbox"
+      - type: word
+        part: header
+        words:
+          - "text/html"
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - "server"


### PR DESCRIPTION
Detects Apollo Sandbox developer UI left exposed in production.

**Path**  
`http/misconfiguration/graphql/graphql-apollo-sandbox.yaml`

**Why**  
Apollo Sandbox is a developer UI for GraphQL. If left enabled in production, it can aid schema discovery and query crafting.

**Validation**
- [x] Validated with `nuclei -validate`
- Read-only GET; low-noise.

**Notes**
- Matches UI text/markers (e.g., "Apollo Sandbox", "apollo.dev").
- Tolerates common server responses (HTML), no intrusive actions.
