### PR TITLE
feat(api): detect exposed ReDoc API docs UI

### DIFF
--- a/http/exposures/apis/redoc-api-docs.yaml
+++ b/http/exposures/apis/redoc-api-docs.yaml
@@ -24,19 +24,10 @@ http:
 
     stop-at-first-match: true
 
-    matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - "__REDOC_EXPORT"
-          - "redoc.standalone.js"
-
-      - type: word
-        part: content_type
-        words:
-          - "text/html"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "text/html")'
+          - 'contains_any(body, "__REDOC_EXPORT", "redoc.standalone.js")'
+        condition: and


### PR DESCRIPTION
Detects ReDoc-based API documentation UIs exposed in production.

**Path**  
`http/exposures/api/redoc-api-docs.yaml`

**Why**  
ReDoc is a popular OpenAPI UI. When left publicly exposed, it can reveal API surface (endpoints, auth patterns) and aid reconnaissance.
There is partial coverage under `exposed-panels/fastapi-docs.yaml` for FastAPI, but this template generalizes ReDoc detection across stacks and adds explicit ReDoc markers.

**Validation**
- [x] Validated with `nuclei -validate`
- Read-only GET; low-noise.

**Notes**
- Matches recognizable ReDoc markers (e.g., `redoc.standalone.js`, case-insensitive “ReDoc”).
- Generic paths beyond FastAPI (`/redoc`, `/docs`, `/api/docs`, `/openapi`) to reduce false negatives.
