### PR TITLE
feat(api): add AsyncAPI spec inventory (JSON/YAML)

### DIFF
--- a/http/exposures/api/asyncapi-inventory.yaml
+++ b/http/exposures/api/asyncapi-inventory.yaml
@@ -1,0 +1,23 @@
+id: asyncapi-inventory
+info:
+  name: AsyncAPI Spec Inventory (JSON/YAML)
+  author: Hamza Sahin
+  severity: info
+  description: Locates exposed AsyncAPI specifications which may reveal event-driven API surface.
+  tags: api,asyncapi,inventory,exposure,web
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/asyncapi.json"
+      - "{{BaseURL}}/asyncapi.yaml"
+      - "{{BaseURL}}/asyncapi.yml"
+      - "{{BaseURL}}/api/asyncapi.json"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words: ["application/json","application/yaml","text/yaml"]
+      - type: regex
+        part: body
+        regex:
+          - "(?i)asyncapi\"?\\s*:\\s*\"?2\\."

--- a/http/exposures/api/redoc-api-docs.yaml
+++ b/http/exposures/api/redoc-api-docs.yaml
@@ -1,0 +1,25 @@
+id: redoc-api-docs
+info:
+  name: ReDoc API Docs UI Exposed
+  author: Hamza Sahin
+  severity: low
+  description: Detects ReDoc API documentation UI exposed publicly which may reveal API surface.
+  tags: api,openapi,redoc,exposure,web
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/redoc"
+      - "{{BaseURL}}/docs"
+      - "{{BaseURL}}/api/docs"
+      - "{{BaseURL}}/openapi"
+    matchers-condition: or
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "(?i)ReDoc(\\s|&nbsp;)?(Standalone|Live|\\b)"
+          - "(?i)redoc\\.(standalone\\.)?js"
+      - type: word
+        part: header
+        words:
+          - "text/html"

--- a/http/misconfiguration/graphql/graphql-apollo-sandbox.yaml
+++ b/http/misconfiguration/graphql/graphql-apollo-sandbox.yaml
@@ -1,0 +1,33 @@
+id: graphql-apollo-sandbox
+info:
+  name: Apollo Sandbox UI Exposed
+  author: Hamza Sahin
+  severity: low
+  description: Detects Apollo Sandbox developer UI exposed in production which may aid schema discovery/testing.
+  tags: graphql,apollo,misconfig,exposure,web
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sandbox"
+      - "{{BaseURL}}/graphql/sandbox"
+      - "{{BaseURL}}/api/graphql/sandbox"
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Apollo Sandbox"
+          - "apollo.dev"
+      - type: regex
+        part: body
+        regex:
+          - "(?i)apollo\\s*sandbox"
+      - type: word
+        part: header
+        words:
+          - "text/html"
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - "server"


### PR DESCRIPTION
Locates exposed AsyncAPI specifications (JSON/YAML) that may reveal event-driven API surface.

**Path**  
`http/exposures/api/asyncapi-inventory.yaml`

**Why**  
AsyncAPI specs often include channels, servers, and security schemes. If publicly reachable, they can reveal messaging endpoints and integration details.

**Validation**
- [x] Validated with `nuclei -validate`
- Read-only GET; low-noise.

**Notes**
- Matches presence of `"asyncapi": "2.x"` (JSON) or `asyncapi: "2.x"` (YAML) plus JSON/YAML content types.
- Conservative paths (`/asyncapi.json`, `/asyncapi.yaml`, `/api/asyncapi.json`) to reduce noise.
