### PR TITLE
Create template for enabled SSH password auth on root account

### DIFF
--- a/javascript/detection/ssh-root-password-enabled.yaml
+++ b/javascript/detection/ssh-root-password-enabled.yaml
@@ -1,0 +1,36 @@
+id: ssh-root-password-enabled
+
+info:
+  name: SSH Root Password Enabled - Detection
+  author: staticnoise
+  severity: info
+  description: Enabled password authentication on root account increases risk of credential stuffing and may expose the server to bruteforce attacks.
+  reference:
+    - https://man.openbsd.org/sshd_config
+  metadata:
+    max-request: 1
+  tags: js,detect,ssh,enum,network
+
+javascript:
+  - pre-condition: |
+      isPortOpen(Host,Port);
+
+    code: |
+      var m = require("nuclei/ssh");
+      var c = m.SSHClient();
+      try {
+        c.Connect(Host, Port, "root", "asdf");
+      } catch (error) {
+        Export(error);
+      }
+
+    args:
+      Host: "{{Host}}"
+      Port: "22"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'success == true'
+          - 'contains(response, "password") || contains(response, "keyboard-interactive")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Nuclei already includes `ssh-auth-methods.yaml` which lists all enabled authentication types on a  host. This template checks password authentication enabled on root account only. It is common to have password authentication enabled for common users and prohibited for `root`. Password authentication on root raises risk and attack surface.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

The error message returns information on attempted authentication types.  If password or keyboard-interactive authentication is enabled, it is tried and listed in the error message:

```
map[value:ssh: handshake failed: ssh: unable to authenticate, attempted methods [none keyboard-interactive], no supported methods remain]
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)