### PR TITLE
chore: remove redundant condition in CVE-2024-9047.yaml

### DIFF
--- a/http/cves/2024/CVE-2024-9047.yaml
+++ b/http/cves/2024/CVE-2024-9047.yaml
@@ -2,7 +2,7 @@ id: CVE-2024-9047
 
 info:
   name: WordPress File Upload <= 4.24.11 - Arbitrary File Read
-  author: s4e-io
+  author: s4e-io,S9n3x
   severity: critical
   description: |
     The WordPress File Upload plugin for WordPress is vulnerable to Path Traversal in all versions up to, and including, 4.24.11 via wfu_file_downloader.php. This makes it possible for unauthenticated attackers to read or delete files outside of the originally intended directory. Successful exploitation requires the targeted WordPress installation to be using PHP 7.4 or earlier.
@@ -49,7 +49,6 @@ http:
       - type: dsl
         dsl:
           - "regex('root:.*:0:0:', body)"
-          - 'contains(content_type, "application/octet-stream")'
           - "status_code == 200"
         condition: and
 # digest: 490a004630440220019457389f8c4c2b7c8c49952d2966b28bdfa634537fa3d85a85c1445236a7b902204e9df638f5e51cc65a0ea9c5a677829895c1787b92f5365a06ed2dd4f0f98d66:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
This PR updates the Nuclei template for CVE-2024-9047 (WordPress File Upload <= 4.24.11 - Arbitrary File Read) to improve detection accuracy. The original template included a restrictive Content-Type: application/octet-stream matcher, which caused false negatives in cases where the server returns sensitive file contents (e.g., /etc/passwd) but with a Content-Type: text/html header due to error handling or server configuration. This update removes the Content-Type matcher, ensuring the template correctly identifies the vulnerability when the response body contains /etc/passwd and the status code is 200.
- Updated: CVE-2024-9047

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)