### PR TITLE
Add detection of ThingsBoard login panel instances.

### DIFF
--- a/http/exposed-panels/thingsboard-panel.yaml
+++ b/http/exposed-panels/thingsboard-panel.yaml
@@ -13,7 +13,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: http.title:"ThingsBoard"
-  tags: panel,thingsboard,detect,
+  tags: panel,thingsboard,detect
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **ThingsBoard** software.

References:

- https://github.com/thingsboard/thingsboard
- https://thingsboard.io/

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="828" height="971" alt="image" src="https://github.com/user-attachments/assets/cf917311-2883-4783-a0a9-4f826fb9902d" />

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
http://5.75.130.34:8080
http://212.47.226.32
http://51.159.155.114
https://92.222.79.212
https://65.109.218.222
http://95.216.198.49
http://52.87.73.92
http://47.253.118.79
http://35.232.165.15
http://64.227.89.91
http://54.212.226.105
http://161.246.160.28
http://103.191.63.31:8080
http://60.205.4.24:8080
http://35.240.150.248:8080
https://129.152.1.226:8443
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=title%3A%22ThingsBoard%22

<img width="1121" height="808" alt="image" src="https://github.com/user-attachments/assets/82311239-ddb4-4409-af28-db7d24914c51" />

### Additional References

None