### PR TITLE
Added heroku-oauth2-token.yaml Template

### DIFF
--- a/http/exposures/tokens/heroku/heroku-oauth2-token.yaml
+++ b/http/exposures/tokens/heroku/heroku-oauth2-token.yaml
@@ -1,17 +1,15 @@
 id: heroku-oauth2-token
 
 info:
-  name: Heroku OAuth2 Token Detection
+  name: Heroku OAuth2 Token
   author: Chemo850
-  severity: high
-  description: |
-    Detects exposed Heroku OAuth2 tokens in the response body of HTTP requests. These tokens typically start with 'HRKU-' and are 60 characters in length. Exposure of these tokens can lead to unauthorized access to Heroku applications.
+  severity: info
   reference:
     - https://devcenter.heroku.com/articles/oauth#prefixed-oauth-tokens
   metadata:
     verified: true
     max-request: 1
-  tags: heroku,exposure,tokens
+  tags: heroku,token,exposure
 
 http:
   - method: GET
@@ -22,15 +20,4 @@ http:
       - type: regex
         part: body
         regex:
-          - HRKU-[0-9a-zA-Z_\-]{60}
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "HRKU-"
-      - type: regex
-        part: body
-        regex:
-          - HRKU-[0-9a-zA-Z_\-]{60}
+          - 'HRKU-[0-9a-zA-Z_\-]{60}'


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- The Heroku Token pattern has been updated to now include a prefix for any new tokens. The existing rule (heroku-api-key.yaml) should now be considered to be the legacy rule, since newly minted tokens will no longer follow the original UUID pattern.
- References: https://devcenter.heroku.com/articles/oauth#prefixed-oauth-tokens

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

I have validated this rule by scanning the Heroku pre-fixed token article regarding the change and I have attached the scan results.

<img width="940" height="162" alt="herokunuclei" src="https://github.com/user-attachments/assets/a266479e-9bdc-40ea-bfec-96435b415539" />


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)