### PR TITLE
Added HPE ILO Login Check Template

### DIFF
--- a/http/credential-stuffing/self-hosted/hpe-ilo-login-check.yaml
+++ b/http/credential-stuffing/self-hosted/hpe-ilo-login-check.yaml
@@ -1,25 +1,26 @@
 id: hpe-ilo-login-check
- 
+
 info:
   name: HPE ILO Login Check
   author: tpierru
   severity: critical
-  description: Checks for a valid login on Integrated Lights-Out.
+  description: |
+    Checks for a valid login on Integrated Lights-Out.
   reference:
     - https://owasp.org/www-community/attacks/Credential_stuffing
   classification:
     cpe: cpe:2.3:a:hp:proliant_integrated_lights_out:-:*:*:*:*:*:*:*
   metadata:
     max-request: 1
+    vendor: hp
+    product: proliant_integrated_lights_out
     shodan-query: title:"ILO"
     fofa-query: title="ILO"
-    product: Integrated Lights-Out
-    vendor: HPE
   tags: self-hosted,creds-stuffing,login-check,ilo
 variables:
   username: "{{username}}"
   password: "{{password}}"
- 
+
 http:
   - raw:
       - |
@@ -27,15 +28,15 @@ http:
         Host: {{Hostname}}
         Accept: application/json, text/plain, */*
         Content-type: application/json
- 
+
         {"UserName":"{{username}}","Password":"{{password}}"}
- 
+
     extractors:
       - type: dsl
         dsl:
           - username
           - password
- 
+
     matchers-condition: and
     matchers:
       - type: status


### PR DESCRIPTION
### Template / PR Information

This template checks credentials against HPE Integrated Lights-Out login page and detects successful ones based on the username and password variables.


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
Debug info :
```
nuclei -u https://REDACTED/ -var username=Administrator -var 'password=REDACTED' -t hpe-ilo-login-check.yaml -debug
 
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
/ / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10
 
                projectdiscovery.io
 
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.3.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 124
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [hpe-ilo-login-check] Dumped HTTP request for https://REDACTED/redfish/v1/Sessions/
 
POST /redfish/v1/Sessions/ HTTP/1.1
Host: REDACTED
User-Agent: Mozilla/5.0 (Ubuntu; Linux i686; rv:129.0) Gecko/20100101 Firefox/129.0
Connection: close
Content-Length: 52
Accept: application/json, text/plain, */*
Content-type: application/json
Accept-Encoding: gzip
 
{"UserName":"Administrator","Password":"REDACTED"}
[DBG] [hpe-ilo-login-check] Dumped HTTP response https://REDACTED/redfish/v1/Sessions/
 
HTTP/1.1 201 Created
Connection: close
Transfer-Encoding: chunked
Cache-Control: no-cache
Content-Type: application/json; charset=utf-8
Date: Fri, 10 Oct 2025 11:50:08 GMT
Etag: W/"F9244E94"
Link: </redfish/v1/SessionService/Sessions/administrator00000000REDACTED/>; rel=self
Location: https://REDACTED/redfish/v1/SessionService/Sessions/administrator00000000REDACTED/
Odata-Version: 4.0
X-Auth-Token: REDACTED
X-Content-Type-Options: nosniff
X-Frame-Options: sameorigin
X-Xss-Protection: 1; mode=block
 
{"@odata.context":"/redfish/v1/$metadata#Session.Session","@odata.etag":"W/\"F9244E94\"","@odata.id":"/redfish/v1/SessionService/Sessions/administrator00000000REDACTED/","@odata.type":"#Session.v1_0_0.Session","Id":"administrator00000000REDACTED","Description":"Manager User Session","Name":"User Session","Oem":{"Hpe":{"@odata.context":"/redfish/v1/$metadata#HpeiLOSession.HpeiLOSession","@odata.type":"#HpeiLOSession.v2_1_0.HpeiLOSession","AccessTime":"2025-10-10T11:50:08Z","LoginTime":"2025-10-10T11:50:08Z","MySession":false,"UserExpires":"2025-10-10T12:20:08Z","UserIP":"REDACTED","UserTag":"REST","UserType":"Local"}},"UserName":"Administrator"}
[hpe-ilo-login-check:status-1] [http] [critical] https://REDACTED/redfish/v1/Sessions/ ["Administrator","REDACTED"]
[hpe-ilo-login-check:word-2] [http] [critical] https://REDACTED/redfish/v1/Sessions/ ["Administrator","REDACTED"]
[hpe-ilo-login-check:word-3] [http] [critical] https://REDACTED/redfish/v1/Sessions/ ["Administrator","REDACTED"]
[INF] Scan completed in 359.350289ms. 3 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)