### PR TITLE
add k8s-apiserver-service-account-lookup

### DIFF
--- a/cloud/kubernetes/security-compliance/k8s-apiserver-service-account-lookup.yaml
+++ b/cloud/kubernetes/security-compliance/k8s-apiserver-service-account-lookup.yaml
@@ -16,31 +16,24 @@ info:
     - Cloud Vulnerability Assessment Guide(2024) by KISA
   tags: cloud,devops,kubernetes,devsecops,api-server,k8s,k8s-cluster-security
 
-variables:
-  argument: "--service-account-lookup=true"
-
 self-contained: true
 code:
   - engine:
       - sh
       - bash
     source: |
-      # fetch kube-apiserver container command lines (try common selectors)
       kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath="{.items[*].spec.containers[*].command}" 2>/dev/null || \
       kubectl get pods -n kube-system -l k8s-app=kube-apiserver -o jsonpath="{.items[*].spec.containers[*].command}" 2>/dev/null || \
       kubectl get pods -n kube-system -o jsonpath="{.items[?(@.metadata.name.indexOf('kube-apiserver')>=0)].spec.containers[*].command}" 2>/dev/null || \
       echo ""
-
-    matchers-condition: and
     matchers:
       - type: word
         words:
           - 'kube-apiserver'
-      - type: word
-        words:
-          - "{{argument}}"
-
+          - '--service-account-lookup=true'
+        condition: and
     extractors:
       - type: dsl
         dsl:
-          - '"kube-apiserver is configured with " + argument + ". Verify whether this is required and secure."'
+          - '"kube-apiserver is configured with --service-account-lookup=true. Verify whether this is required and secure."'
+# digest: 4b0a00483046022100b94ab656526e3c7d75656920143bef3d23daeefa8803badab74dbbbafab27570022100eca10fd2c3edd114341322e4dcf83678a5673b61cb1e3d89efb65a01262a1225:bd4199f08311fe94da3c6b619521b96e


### PR DESCRIPTION
### Template / PR Information
When --service-account-lookup=true is set, the API server will perform service account lookup behavior which can have security implications depending on cluster configuration. Review whether this behavior is required.

- References:
- https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
- Cloud Vulnerability Assessment Guide(2024) by KISA

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)