### PR TITLE
Add template for Creston device default login

### DIFF
--- a/http/default-logins/crestron-default-login.yaml
+++ b/http/default-logins/crestron-default-login.yaml
@@ -1,0 +1,65 @@
+id: crestron-default-login
+info:
+  name: Crestron Devices Default Login
+  author: mister-joe
+  severity: medium
+  description: |
+    Test for default credentials on various Crestron devices and versions.
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: Crestron
+  tags: crestron,default-login
+
+http:
+  - raw:
+      - |
+        POST /userlogin.html HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        login={{username}}&passwd={{password}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 302
+      - type: regex
+        part: header
+        regex:
+          - "Set-Cookie:\\s?AuthByPasswd=.*"
+
+  - raw:
+      - |
+        POST /main.html HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"Cmd":"Authenticate","User":"{{username}}","Pass":"{{password}}"}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - "Set-Cookie:\\s?User=.*;"
+      - type: regex
+        part: body
+        regex:
+          - '{"Authenticated":true}'


### PR DESCRIPTION
### Template / PR Information

This template identifies various Crestron devices with default credentials. Crestron makes various devices from touch screens for conference rooms to video encoder/decoders.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Sample Output

<img width="849" height="514" alt="image" src="https://github.com/user-attachments/assets/bbcf7825-a9ea-414d-9024-b6af2fd6c874" />

### Additional References:

- [Crestron Web Interface Configuration Guide](https://www.crestron.com/getmedia/2abeee88-c70c-441f-82dc-4f9e4c61fdfd/mg_wicg_dm-nvx-350_351) (this refers to the DM-NVX-350 model but the default credentials apply to many models)