### PR TITLE
Add CVE-2023-37582 (vKEV)

### DIFF
--- a/network/cves/2023/CVE-2023-37582.yaml
+++ b/network/cves/2023/CVE-2023-37582.yaml
@@ -29,7 +29,7 @@ info:
     vendor: apache
     product: rocketmq
     shodan-query: rocketmq port:"9876"
-  tags: cve,cve2023,apache,rocketmq,network,vkev
+  tags: cve,cve2023,apache,rocketmq,network,intrusive,vkev
 
 tcp:
   - inputs:


### PR DESCRIPTION
### Template / PR Information

The RocketMQ NameServer component still has a remote command execution vulnerability as the CVE-2023-33246 issue was not completely fixed in version 5.1.1. When NameServer address are leaked on the extranet and lack permission verification, an attacker can exploit this vulnerability by using the update configuration function on the NameServer component to execute commands as the system users that RocketMQ is running as. It is recommended for users to upgrade their NameServer version to 5.1.2 or above for RocketMQ 5.x or 4.9.7 or above for RocketMQ 4.x to prevent these attacks.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
