### PR TITLE
feat: add CVE-2025-27915 template for Zimbra stored XSS vulnerability

### DIFF
--- a/http/cves/2025/CVE-2025-27915.yaml
+++ b/http/cves/2025/CVE-2025-27915.yaml
@@ -1,19 +1,15 @@
-id: zimbra-cve-2025-27915
+id: CVE-2025-27915
 
 info:
-  name: Zimbra CVE-2025-27915 - Stored XSS via ICS Files Detection
+  name: Zimbra - Cross-Site Scripting via ICS Files
   author: Snbig,EhsanCreator,eliotworkspac-max
-
   severity: medium
   description: |
-    Detects Zimbra Collaboration Suite versions vulnerable to CVE-2025-27915, a stored XSS vulnerability 
-    in the Classic Web Client due to insufficient sanitization of HTML content in ICS files. When a user 
-    views an email with a malicious ICS entry, embedded JavaScript executes via an ontoggle event inside 
-    a details tag, allowing attackers to perform unauthorized actions like email redirection and data exfiltration.
+    Detects Zimbra Collaboration Suite versions vulnerable to CVE-2025-27915, a stored XSS vulnerability in the Classic Web Client due to insufficient sanitization of HTML content in ICS files. When a user views an email with a malicious ICS entry, embedded JavaScript executes via an ontoggle event inside a details tag, allowing attackers to perform unauthorized actions like email redirection and data exfiltration.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-27915
     - https://wiki.zimbra.com/wiki/Security_Center
     - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-27915
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
@@ -28,7 +24,7 @@ info:
     product: collaboration
     fofa-query: title="Zimbra Collaboration Suite"
     shodan-query: http.title:"Zimbra Collaboration Suite"
-  tags: cve,cve2025,zimbra,xss,ics,stored-xss,kev
+  tags: cve,cve2025,zimbra,xss,ics,kev
 
 http:
   - method: GET
@@ -47,18 +43,11 @@ http:
         words:
           - "application/x-javascript"
 
-      - type: regex
-        part: body
-        name: vulnerable-version
-        regex:
-          # Vulnerable 9.0.0 versions (all patches from initial to p43)
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"9\.0\.0'
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"9\.0\.0'
-          # Vulnerable 10.0.x versions (10.0.0 to < 10.0.13) 
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"10\.0\.[0-9]'
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"10\.0\.1[0-2]'
-          # Vulnerable 10.1.x versions (10.1.0 to < 10.1.5)
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"10\.1\.[0-4]'
+      - type: dsl
+        dsl:
+          - compare_versions(version, '9.0.0')
+          - compare_versions(version, '>= 10.0.0', '< 10.0.13')
+          - compare_versions(version, '>= 10.1.0', '< 10.1.5')
         condition: or
 
     extractors:
@@ -67,4 +56,4 @@ http:
         name: version
         group: 1
         regex:
-          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"([^"]+)"'
+          - CLIENT_VERSION\",\s+{type:ZmSetting\.T_CONFIG, defaultValue:"([0-9.]+)_([A-Z_0-9]+)"\}


### PR DESCRIPTION
- Added template for CVE-2025-27915 affecting Zimbra Collaboration Suite
- Detects stored XSS vulnerability in Classic Web Client via ICS files
- Covers vulnerable versions: 9.0.0 (all patches), 10.0.x < 10.0.13, 10.1.x < 10.1.5
- Template validates using CLIENT_VERSION regex from ZmSettings.js endpoint
- Includes comprehensive metadata with CVSS score, EPSS data, and references
- Successfully tested against sample Zimbra instances from scan results

Resolves: Detection gap for actively exploited zero-day CVE-2025-27915
References: https://nvd.nist.gov/vuln/detail/CVE-2025-27915