### PR TITLE
Centos apache detection

### DIFF
--- a/http/technologies/centos-eol.yaml
+++ b/http/technologies/centos-eol.yaml
@@ -11,9 +11,8 @@ info:
     - https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
   metadata:
     max-request: 1
-    shodan-query: "Server: Apache/" "centos"
-    fofa-query: header="Server: Apache/" && "centos"
-    zoomeye-query: app:"Apache httpd" and banner:"CentOS"
+    shodan-query: '"Server: Apache/" "centos"'
+    fofa-query: 'header="Server: Apache/" && "centos"'
   tags: centos,eol,tech
 
 http:


### PR DESCRIPTION
### Template / PR Information

CentOS is EOL and thus has many unfixed vulnerabilities.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

<img width="628" height="435" alt="image" src="https://github.com/user-attachments/assets/bc4a48db-794e-44b0-abf0-6a12795eda4f" />

In #13495 the template included extracted Apache version. This was removed on request from the reviewer. I it not possible to extract CentOS version directly. It be can only guessed, e.g. 2.4.6 is the latest version of Apache released on CentOS 7, but CentOS 8 also included this version in the past, so it might be outdated CentOS 8 too. I included the extractor to make it easier for triagers to deduce the CentOS version on their own. I think the best way forward is to include the template without the extraction logic.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)