### PR TITLE
Create unauthenticated-ckfinder.yaml

### DIFF
--- a/http/misconfiguration/unauth-ckfinder.yaml
+++ b/http/misconfiguration/unauth-ckfinder.yaml
@@ -1,15 +1,19 @@
-id: unauthenticated-ckfinder
+id: unauth-ckfinder
 
 info:
-  name: CKFinder Exposed Interface
+  name: CKFinder - Unauthenticated Exposure
   author: Amjad Ali
   severity: high
   description: |
-    CKFinder is a powerful file manager for web browsers. If exposed without authentication, it allows unauthorized users to browse, upload, or manage files on the server, leading to Broken Access Control.
+    The CKFinder file manager was found to be exposed without authentication, allowing unauthenticated users to directly access its web interface. Due to this misconfiguration, attackers were able to browse server directories, upload arbitrary files, and manage existing files.
   reference:
     - https://cksource.com/ckfinder
     - https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-  tags: ckfinder,exposure,broken-access-control
+  metadata:
+    verified: true
+    max-request: 1
+    google-query: inurl:ckfinder/ckfinder.html ext:html
+  tags: ckfinder,misconfig,unauth
 
 http:
   - method: GET


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- It's a Unauthentocated Panel Exposed Issue
- References: https://cksource.com/ckfinder & https://owasp.org/Top10/A01_2021-Broken_Access_Control

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
<img width="1683" height="483" alt="image" src="https://github.com/user-attachments/assets/28082f33-1510-4c2e-b797-d88be99a4a11" />
<img width="1918" height="966" alt="image" src="https://github.com/user-attachments/assets/85cf9b5d-2d80-46cd-97f5-161c2b38fa3b" />

#### With the "_inurl:ckfinder/ckfinder.html ext:html_" Google Dork you can obtain the websites to test this template

#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)