### PR TITLE
Add CVE-2022-22956 (vKEV)

### DIFF
--- a/http/cves/2022/CVE-2022-22956.yaml
+++ b/http/cves/2022/CVE-2022-22956.yaml
@@ -6,23 +6,31 @@ info:
   severity: critical
   description: |
     VMware Workspace ONE Access has two authentication bypass vulnerabilities (CVE-2022-22955 & CVE-2022-22956) in the OAuth2 ACS framework. A malicious actor may bypass the authentication mechanism and execute any operation due to exposed endpoints in the authentication framework.
+  impact: |
+    Attackers can bypass authentication and perform unauthorized operations, potentially leading to full system compromise.
+  remediation: |
+    Apply the latest security patches provided by VMware to address these vulnerabilities.
   reference:
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/vmware_workspace_one_access_vmsa_2022_0011_chain.rb
     - https://srcincite.io/blog/2022/08/11/i-am-whoever-i-say-i-am-infiltrating-vmware-workspace-one-access-using-a-0-click-exploit.html
     - https://nvd.nist.gov/vuln/detail/CVE-2022-22956
+    - http://packetstormsecurity.com/files/171918/Mware-Workspace-ONE-Remote-Code-Execution.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-22956
     cwe-id: CWE-287
-    cpe: cpe:2.3:a:vmware:workspace_one_access:*:*:*:*:*:*:*:*
+    epss-score: 0.56895
+    epss-percentile: 0.97982
+    cpe: cpe:2.3:a:vmware:identity_manager:3.3.3:*:*:*:*:*:*:*
   metadata:
     verified: true
     max-request: 3
     vendor: vmware
-    product: workspace_one_access
-    shodan-query: http.favicon.hash:-1250474341
-  tags: cve,cve2022,vmware,workspace_one_access,auth-bypass,vkev
+    product: identity_manager
+    shodan-query: http.favicon.hash:"-1250474341"
+    fofa-query: icon_hash=-1250474341
+  tags: cve,cve2022,vmware,workspace,auth-bypass,vkev
 
 flow: http(1) && http(2) && http(3)
 


### PR DESCRIPTION
### Template / PR Information

VMware Workspace ONE Access has two authentication bypass vulnerabilities (CVE-2022-22955 & CVE-2022-22956) in the OAuth2 ACS framework. A malicious actor may bypass the authentication mechanism and execute any operation due to exposed endpoints in the authentication framework.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO