### PR TITLE
add CVE-2025-9196

### DIFF
--- a/http/cves/2025/CVE-2025-9196.yaml
+++ b/http/cves/2025/CVE-2025-9196.yaml
@@ -6,6 +6,10 @@ info:
   severity: medium
   description: |
     The Trinity Audio Text to Speech AI audio player to convert content into audio plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 5.21.0 via the ~/admin/inc/phpinfo.php file that gets created on install. This makes it possible for unauthenticated attackers to extract sensitive data including configuration data.
+  impact: |
+    Unauthenticated attackers can extract sensitive configuration data, potentially aiding further attacks.
+  remediation: |
+    Update to the latest version beyond 5.21.0.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/trinity-audio/trinity-audio-5210-unauthenticated-information-exposure
     - https://nvd.nist.gov/vuln/detail/CVE-2025-9196
@@ -23,7 +27,7 @@ info:
     product: trinity-audio
     framework: wordpress
     fofa-query: body="/wp-content/plugins/trinity-audio"
-  tags: cve,cve2025,wp-plugin,wordpress,exposure
+  tags: cve,cve2025,wp-plugin,wordpress,trinity-audio,exposure
 
 http:
   - raw:
@@ -32,9 +36,10 @@ http:
         Host: {{Hostname}}
 
     host-redirects: true
+
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(body, "PHP Version", "PHP Extension")'
+          - 'contains_all(body, "PHP Version", "PHP Extension","trinity-audio")'
           - 'status_code == 200'
         condition: and


### PR DESCRIPTION
Trinity Audio <= 5.21.0 - Unauthenticated Information Exposure

The Trinity Audio – Text to Speech AI audio player to convert content into audio plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 5.21.0 via the ~/admin/inc/phpinfo.php file that gets created on install. This makes it possible for unauthenticated attackers to extract sensitive data including configuration data.

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)