### PR TITLE
ADD CVE-2010-20103 (vKEV)

### DIFF
--- a/http/cves/2010/CVE-2010-20103.yaml
+++ b/http/cves/2010/CVE-2010-20103.yaml
@@ -8,8 +8,14 @@ info:
     A backdoor was inserted into ProFTPD 1.3.3c between Nov 28 - Dec 2, 2010.
     Sending HELP ACIDBITCHEZ triggers a shell with root privileges.
   reference:
+    - http://www.proftpd.org/
+    - https://advisories.checkpoint.com/defense/advisories/public/2011/cpai-2010-151.html/
+    - https://github.com/proftpd/proftpd
+    - https://raw.githubusercontent.com/rapid7/metasploit-framework/master/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+    - https://web.archive.org/web/20111107212129/http://rsync.proftpd.org/
+    - https://www.exploit-db.com/exploits/15662
     - https://www.exploit-db.com/exploits/16921
-    - https://nvd.nist.gov/vuln/detail/CVE-2010-20103
+    - https://www.vulncheck.com/advisories/proftpd-backdoor-command-execution
   classification:
     cve-id: CVE-2010-20103
     cwe-id: CWE-912
@@ -18,18 +24,18 @@ info:
 network:
   - host:
       - "{{Hostname}}:21"
-    
+
     inputs:
       - data: "HELP ACIDBITCHEZ\r\n"
-    
+
     read-size: 1024
-    
+
     matchers-condition: and
     matchers:
       - type: word
         words:
           - "220 ProFTPD 1.3.3c"
-      
+
       - type: word
         words:
           - "502 Unknown command"


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2010-20103
- References:
  - http://www.proftpd.org/
  - https://advisories.checkpoint.com/defense/advisories/public/2011/cpai-2010-151.html/
  - https://github.com/proftpd/proftpd
  - https://raw.githubusercontent.com/rapid7/metasploit-framework/master/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
  - https://web.archive.org/web/20111107212129/http://rsync.proftpd.org/
  - https://www.exploit-db.com/exploits/15662
  - https://www.exploit-db.com/exploits/16921
  - https://www.vulncheck.com/advisories/proftpd-backdoor-command-execution

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
```bash
┌──(kali㉿kali)-[~/…/nuclei-templates/http/cves/2010]
└─$ nuclei -t CVE-2010-20103.yaml -u {IP} -debug -v   


                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.6

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.4.6 (outdated)
[INF] Current nuclei-templates version: v10.3.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 124
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2010-20103] Dumped Network request for {IP}:21
00000000  48 45 4c 50 20 41 43 49  44 42 49 54 43 48 45 5a  |HELP ACIDBITCHEZ|
00000010  0d 0a                                             |..| address={IP}:21
[VER] Sent TCP request to {IP}:21
[CVE-2010-20103:word-1] [tcp] [critical] {IP}:21 ["220 ProFTPD 1.3.3c"]
[CVE-2010-20103:word-2] [tcp] [critical] {IP}:21 ["220 ProFTPD 1.3.3c"]
[DBG] [CVE-2010-20103] Dumped Network response for {IP}:21

00000000  32 32 30 20 50 72 6f 46  54 50 44 20 31 2e 33 2e  |220 ProFTPD 1.3.|
00000010  33 63 20 53 65 72 76 65  72 20 28 66 74 70 2e 74  |3c Server (ftp.t|
00000020  72 61 77 69 63 6b 63 6f  6e 73 74 72 75 63 74 69  |rawickconstructi|
00000030  6f 6e 2e 63 6f 6d 29 20  5b 3a 3a 66 66 66 66 3a  |on.com) [::ffff:|
00000040  36 34 2e 39 32 2e 31 30  38 2e 31 30 39 5d 0d 0a  |{IP}]..|
[INF] Scan completed in 579.548963ms. 2 matches found.
```

#### Additional Details (leave it blank if not applicable)

- Shodan Query: port:21 ProFTPD 1.3.3c
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)