### PR TITLE
Added shibboleth-open-redirect template

### DIFF
--- a/http/misconfiguration/shibboleth-open-redirect.yaml
+++ b/http/misconfiguration/shibboleth-open-redirect.yaml
@@ -4,8 +4,10 @@ info:
   name: Shibboleth SSO - Open Redirect
   author: aushack
   severity: medium
-  description: Shibboleth SSO contains an open redirect vulnerability. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
-  remediation: Set the redirectLimit option documented in the references.
+  description: |
+    Shibboleth SSO contains an open redirect vulnerability. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
+  remediation: |
+    Set the redirectLimit option documented in the references.
   reference:
     - https://shibboleth.atlassian.net/wiki/spaces/SP3/pages/2065334342/Sessions
   classification:
@@ -14,6 +16,8 @@ info:
     cwe-id: CWE-601
   metadata:
     max-request: 1
+    verified: true
+    shodan-query: html:"Shibboleth"
   tags: redirect,shibboleth,misconfig
 
 http:


### PR DESCRIPTION
### Template / PR Information

Tests Shibboleth.sso for open redirect misconfiguration (unrestricted in earlier versions, able to be restricted since v3.1 but still enabled by default and should be manually configured)

- References: https://shibboleth.atlassian.net/wiki/spaces/SP3/pages/2065334342/Sessions

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

#### Additional Details (leave it blank if not applicable)

```
[INF] [shibboleth-open-redirect] Dumped HTTP request for https://server/Shibboleth.sso/Logout?return=https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh

GET /Shibboleth.sso/Logout?return=https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh HTTP/1.1
Host: server
User-Agent: Mozilla/5.0 (Windows NT 11.0) AppleWebKit/537.36 (KHTML, like Gecko) Safari/127.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [shibboleth-open-redirect] Dumped HTTP response https://server/Shibboleth.sso/Logout?return=https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh

HTTP/1.1 302 Found
Connection: close
Content-Length: 231
Cache-Control: private,no-store,no-cache,max-age=0
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 15 Oct 2025 07:50:37 GMT
Expires: Wed, 01 Jan 1997 12:00:00 GMT
Location: https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh
Server: Apache

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh">here</a>.</p>
</body></html>
[shibboleth-open-redirect:regex-1] [http] [medium] https://server/Shibboleth.sso/Logout?return=https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh
[shibboleth-open-redirect:status-2] [http] [medium] https://server/Shibboleth.sso/Logout?return=https://345sCHoxBeceacAkIBlpwHPH2Lf.interact.sh

```