### PR TITLE
Add CVE-2025-2611(kev)

### DIFF
--- a/http/cves/2025/CVE-2025-2611.yaml
+++ b/http/cves/2025/CVE-2025-2611.yaml
@@ -22,7 +22,7 @@ info:
     verified: true
     max-request: 2
     shodan-query: html:"ICTBroadcast"
-  tags: cve,cve2025,rce,ictbroadcast,oast,oob
+  tags: cve,cve2025,rce,ictbroadcast,oast,oob,kev,vkev
 
 flow: http(1) && http(2)
 


### PR DESCRIPTION
### Template / PR Information

Add CVE-2025-2611

### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO

### Lab setup

To test the template, spin up a vulnerable ICTBroadcast instance with Docker.

```yaml
services:
  db:
    image: mariadb:10.6
    container_name: ictmysql
    restart: unless-stopped
    environment:
      MYSQL_ROOT_PASSWORD: root     
      MARIADB_ROOT_HOST: '%'       
      MYSQL_DATABASE: ictbroadcast
      MYSQL_USER: ictuser
      MYSQL_PASSWORD: ictpass
    volumes:
      - db_data:/var/lib/mysql
    ports:
      - "3306:3306"

  ictbroadcast:
    image: chocapikk/ictbroadcast-cve-2025-2611:latest
    container_name: ictbroadcast
    depends_on:
      - db
    ports:
      - "80:80"
      - "443:443"
    command: >
      bash -c "
        composer --working-dir=/usr require stefangabos/zebra_pagination &&
        /usr/sbin/httpd -k start &&
        /usr/sbin/php-fpm &&
        tail -f /dev/null
      "

volumes:
  db_data:
```

1. Start the stack:

```bash
docker compose up -d
```

2. Verify that the login page is reachable at **`http://localhost/login.php`**.
   The application should issue a valid session cookie on first visit.


### Additional References:

* https://www.vulncheck.com/blog/ictbroadcast-kev
* https://github.com/rapid7/metasploit-framework/blob/master//modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb