### PR TITLE
implement support for CVE-2023-27532

### DIFF
--- a/network/cves/2023/CVE-2023-27532.yaml
+++ b/network/cves/2023/CVE-2023-27532.yaml
@@ -1,0 +1,150 @@
+id: CVE-2023-27532
+
+info:
+  name: Veeam Backup & Replication - Credential Disclosure
+  author: watzon
+  severity: high
+  description: |
+    Veeam Backup & Replication allows encrypted credentials stored in the configuration database to be obtained by attackers who can access backup infrastructure hosts through an unsecured API endpoint on TCP port 9401. This vulnerability has been actively exploited in ransomware campaigns including Akira and Qilin.
+  impact: |
+    Successful exploitation allows attackers to obtain encrypted credentials from the configuration database, potentially leading to unauthorized access to backup systems and connected infrastructure. This can serve as an initial access vector for ransomware operations.
+  remediation: |
+    Upgrade to patched versions:
+    - V12: Update to 12.0.0.1420 P20230223 or later
+    - V11a: Update to 11.0.1.1261 P20230227 or later
+    - As temporary mitigation, block TCP port 9401 at network perimeter
+  reference:
+    - https://www.veeam.com/kb4424
+    - https://github.com/horizon3ai/CVE-2023-27532
+    - https://github.com/sfewer-r7/CVE-2023-27532
+    - https://github.com/puckiestyle/CVE-2023-27532-RCE-Only
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-27532
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2023-27532
+    cwe-id: CWE-306
+    epss-score: 0.87024
+    epss-percentile: 0.99406
+    cpe: cpe:2.3:a:veeam:backup_and_replication:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: veeam
+    product: backup_and_replication
+    shodan-query:
+      - '"Veeam Backup" http.title:"Veeam Backup Enterprise Manager"'
+      - 'port:9401 "Veeam"'
+      - 'port:9392 "Veeam"'
+    fofa-query:
+      - 'title="Veeam Backup Enterprise Manager"'
+      - 'port="9401" "Veeam"'
+      - 'protocol="tcp" port="9392"'
+    google-query: intitle:"Veeam Backup Enterprise Manager"
+  tags: cve,cve2023,veeam,backup,credential-disclosure,kev,vkev,ransomware,akira,qilin
+
+tcp:
+  # Test the vulnerable TCP 9401 service (unsecured API endpoint)
+  - host:
+      - "{{Hostname}}"
+    port: 9401
+
+    inputs:
+      - data: "GET / HTTP/1.1\r\nHost: {{Hostname}}:9401\r\nUser-Agent: Nuclei\r\nConnection: close\r\n\r\n"
+        read: 1024
+      - data: "\x00\x00\x00\x2a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        read: 1024
+        type: hex
+    read-size: 1024
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Veeam"
+          - "Backup"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "(?i)(configuration|database|credential|server|service)"
+
+    extractors:
+      - type: regex
+        name: service_info
+        regex:
+          - '(?i)Veeam[^\n\r]*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}\.[0-9]{1,4})'
+          - '(?i)version[''"\\s]*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}\.[0-9]{1,4})'
+          - '(?i)(Veeam[^\n\r]*(?:Backup|Enterprise|Manager)[^\n\r]*)'
+
+  # Test standard Veeam Backup Enterprise Manager on port 9392 for version fingerprinting
+  - host:
+      - "{{Hostname}}"
+    port: 9392
+
+    inputs:
+      - data: "GET / HTTP/1.1\r\nHost: {{Hostname}}:9392\r\nUser-Agent: Nuclei\r\nConnection: close\r\n\r\n"
+        read: 1024
+    read-size: 1024
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Veeam"
+          - "Backup"
+        condition: and
+
+      - type: regex
+        part: body
+        # Detect vulnerable versions
+        regex:
+          - "11\\.0\\.1\\.1261"
+          - "12\\.0\\.0\\.1420"
+
+    extractors:
+      - type: regex
+        name: veeam_version
+        group: 1
+        regex:
+          - '(?i)Veeam[^\n\r]*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}\.[0-9]{1,4})'
+          - '(?i)version[''"\\s]*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}\.[0-9]{1,4})'
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "(11\\.0\\.1\\.1261|12\\.0\\.0\\.1420)"
+
+# HTTP-based detection as fallback for web interfaces
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/login.aspx"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Veeam Backup Enterprise Manager"
+          - "Veeam Backup & Replication"
+        condition: or
+
+      - type: regex
+        part: body
+        # Look for vulnerable versions in web interface
+        regex:
+          - "11\\.0\\.1\\.1261"
+          - "12\\.0\\.0\\.1420"
+
+    extractors:
+      - type: regex
+        name: web_version
+        group: 1
+        regex:
+          - '(?i)version[''"\\s]*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}\.[0-9]{1,4})'
+          - 'login.bundle.js\\?v=([0-9\\.]+)'


### PR DESCRIPTION
### Template / PR Information

Added support for CVE-2023-27532. I validated the template locally, but wasn't able to test against a vulnerable host as I was unable to find one or spin one up in my dev environment. That being said, this _should_ work.

/claim #13435

References:
https://nvd.nist.gov/vuln/detail/CVE-2023-27532
https://www.veeam.com/kb4424

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)