### PR TITLE
Fix typo in BIGipServer matcher

### DIFF
--- a/http/technologies/bigip-detect.yaml
+++ b/http/technologies/bigip-detect.yaml
@@ -23,7 +23,7 @@ http:
       - type: word
         part: header
         words:
-          - 'BIGipServer~'
+          - 'BIGipServer'
 
       - type: word
         part: header


### PR DESCRIPTION

### Template / PR Information

Some BigIP Cookie persistent injects do not have the ~. This is missing a vast amount of services. Due to the ongoing F5 incident, this could be affecting analysts and teams discovery processes.


### Template Validation

I've validated this template locally?
- [X] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)
<img width="1237" height="77" alt="image" src="https://github.com/user-attachments/assets/66787a0b-1633-48ba-b70c-e4e0b03679a3" />

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)