### PR TITLE
Create redirect-pizza-takeover.yaml

### DIFF
--- a/http/takeovers/redirect-pizza-takeover.yaml
+++ b/http/takeovers/redirect-pizza-takeover.yaml
@@ -6,14 +6,12 @@ info:
   description: |
     Redirect.pizza subdomain takeover was detected.
   reference:
-    - https://redirect.pizza
-    - https://github.com/EdOverflow/can-i-take-over-xyz
     - https://redirect.pizza/docs
   metadata:
     max-request: 1
     shodan-query: html:"redirect.pizza"
     fofa-query: body="redirect.pizza"
-  tags: takeover,redirect.pizza,subdomain,bugbounty
+  tags: takeover,redirect-pizza
 
 http:
   - method: GET
@@ -25,18 +23,9 @@ http:
       - type: dsl
         dsl:
           - Host != ip
-
-      - type: word
-        part: body
-        words:
-          - "redirect.pizza"
-          - "Unable to redirect"
-        condition: or
-
-      - type: word
-        part: content_type
-        words:
-          - "text/html"
+          - contains_all(body, "Unable to redirect","redirect.pizza")
+          - contains(content_type, "text/html")
+        condition: and
 
     extractors:
       - type: dsl


### PR DESCRIPTION
### Template / PR Information

Redirect.Pizza is a third-party redirection service where customers add domains/subdomains in their dashboard and configure where those hostnames should redirect.

<img width="1223" height="780" alt="redirect-pizza" src="https://github.com/user-attachments/assets/a5325559-620c-4d6d-9989-39e8414c976b" />


- References: 

### Template Validation
<img width="1223" height="780" alt="redirect-pizza" src="https://github.com/user-attachments/assets/c94383d9-9c28-4e2f-8c80-45e6d56fd325" />


I've validated this template locally?
-  YES


#### Additional Details (leave it blank if not applicable)

https://app.netlas.io/responses/?page=1&q=redirect.pizza

### Additional References:
Exploit / Proof of Concept:
   - Go to https://redirect.pizza
   - Sign up for a free account.
   - Add the target subdomain (sub.example.com) to your dashboard.
   - Redirect it to your controlled site (for POC, e.g., https://evil.com).
   - When you visit sub.example.com, it should now redirect to your site → Takeover confirmed

https://github.com/user-attachments/assets/7d54edcf-4b37-4e90-a20a-cdd971a6eabe

