### PR TITLE
add CVE-2020-4429

### DIFF
--- a/javascript/cves/2020/CVE-2020-4429.yaml
+++ b/javascript/cves/2020/CVE-2020-4429.yaml
@@ -1,16 +1,19 @@
 id: CVE-2020-4429
 
 info:
-  name: IBM Data Risk Manager - Default Password
+  name: IBM Data Risk Manager - Hardcoded Credentials
   author: Kazgangap
   severity: critical
   description: |
     IBM Data Risk Manager 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, and 2.0.6 contains a default password for an IDRM administrative account. A remote attacker could exploit this vulnerability to login and execute arbitrary code on the system with root privileges. IBM X-Force ID- 180534.
+  impact: |
+    Remote attackers can gain root access and execute arbitrary code, potentially leading to complete system compromise.
+  remediation: |
+    Change default passwords and update to the latest version if available.
   reference:
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/180534
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/ssh/ibm_drm_a3user.rb
     - https://www.ibm.com/support/pages/security-bulletin-vulnerabilities-exist-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430
-    - https://www.tenable.com/plugins/nessus/181927
-    - https://exchange.xforce.ibmcloud.com/vulnerabilities/180534
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -24,21 +27,20 @@ info:
     max-request: 1
     vendor: ibm
     product: data_risk_manager
-    shodan-query: http.title:"ibm data risk manager"
   tags: cve,cve2020,ibm,default-login,vkev
-  
+
 javascript:
   - pre-condition: |
       var m = require("nuclei/ssh");
       var c = m.SSHClient();
       var response = c.ConnectSSHInfoMode(Host, Port);
       response["UserAuth"].includes("password")
-    
+
     code: |
       var m = require("nuclei/ssh");
       var c = m.SSHClient();
       c.Connect(Host,Port,Username,Password);
-    
+
     args:
       Host: "{{Host}}"
       Port: "22"


### PR DESCRIPTION
First, hi. I inspired by this Metasploit module: https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/ssh/ibm_drm_a3user.rb

I modified the classic nuclei SSH brute-force template a little and added the values 'a3user' and 'idrm'. Unfortunately I don't have a public example; the situation is similar to this template: https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2020/CVE-2020-4427.yaml

I'm adding the template to the project with verified: false — you're free to merge it.

I've validated this template locally?
- [ ] YES
- [x] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)