### PR TITLE
Removing "cloudapp.net" as it is no longer exploitable.

### DIFF
--- a/dns/azure-takeover-detection.yaml
+++ b/dns/azure-takeover-detection.yaml
@@ -40,7 +40,6 @@ dns:
           - 'contains(cname, "azurewebsites.windows.net")'
           - 'contains(cname, "blob.core.windows.net")'
           - 'contains(cname, "cloudapp.azure.com")'
-          - 'contains(cname, "cloudapp.net")'
           - 'contains(cname, "database.windows.net")'
           - 'contains(cname, "redis.cache.windows.net")'
           - 'contains(cname, "search.windows.net")'


### PR DESCRIPTION
"cloudapp.net" is no longer exploitable.

Microsoft replaced "cloud service (classic)" with "cloud service (extended support)" which has another DNS zone `cloudapp.azure.com`.

Microsoft no longer allows register new cloud services under `cloudapp.net`


Reference: 
`https://learn.microsoft.com/en-us/answers/questions/867628/using-a-cloudapp-net-domain-with-cloud-services-(e`