### PR TITLE
Add CVE-2020-3952 - VMware vCenter Server LDAP Broken Access Control (KEV) (Passive)

### DIFF
--- a/http/cves/2020/CVE-2020-3952.yaml
+++ b/http/cves/2020/CVE-2020-3952.yaml
@@ -27,8 +27,6 @@ info:
     max-request: 1
     vendor: vmware
     product: vcenter_server
-    shodan-query: http.title:"vmware vcenter"
-    fofa-query: title="vmware vcenter"
   tags: cve,cve2020,vmware,vcenter,ldap,auth-bypass,passive,kev
 
 http:
@@ -71,7 +69,7 @@ http:
 
       - type: dsl
         dsl:
-          - compare_versions(version, '< 6.7')
+          - compare_versions(version, '< 6.7.0')
 
     extractors:
       - type: regex
@@ -79,5 +77,4 @@ http:
         name: version
         group: 1
         regex:
-          - "<version>(.*?)</version>"
-        internal: true
+          - "<version>([^<]+)</version>"


### PR DESCRIPTION
Added CVE-2020-3952 vulnerability details and detection code.

### Template / PR Information
VMware vCenter Server LDAP Broken Access Control 
- Reference:
    - https://nvd.nist.gov/vuln/detail/CVE-2020-3952
    - https://www.vmware.com/security/advisories/VMSA-2020-0006.html
    - https://github.com/guardicore/vmware_vcenter_cve_2020_3952
    - 
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)