### PR TITLE
Add exposed-phpinfo.yaml template

### DIFF
--- a/exposed-phpinfo.yaml
+++ b/exposed-phpinfo.yaml
@@ -1,0 +1,34 @@
+id: exposed-phpinfo
+info:
+  name: Exposed phpinfo() File
+  author: nikhilpatidar01
+  severity: high
+  description: |
+    The phpinfo.php file is publicly accessible, revealing sensitive information about the server's configuration,
+    including PHP version, loaded extensions, and environment variables. This information can be leveraged by
+    attackers to plan further attacks.
+  tags: exposure,config,php,phpinfo
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/phpinfo.php"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "PHP Version"
+          - "php.ini"
+          - "Zend Scripting Language Engine"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "text/html"


### PR DESCRIPTION
### Template / PR Information

This pull request adds the exposed-phpinfo.yaml template, which detects publicly accessible phpinfo.php files that leak critical server configuration, PHP version, loaded extensions, and environment variables.

- Severity: High
- Author: nikhilpatidar01

**Validation:**  
Locally tested with Nuclei v3.4.10 and latest template version, correct output confirmed:

```php
$  nuclei -u https://af.org.pk/ -t /root/exposed-phpinfo.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

		projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.3.0 (latest)
[INF] New templates added in latest release: 124
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[exposed-phpinfo] [http] [high] https://af.org.pk/phpinfo.php
[INF] Scan completed in 2.314093118s. 1 matches found.
```