### PR TITLE
Fix CVE-2025-49825 version matching

### DIFF
--- a/http/cves/2025/CVE-2025-49825.yaml
+++ b/http/cves/2025/CVE-2025-49825.yaml
@@ -45,6 +45,7 @@ http:
         json:
           - '"Teleport Version: "+ .server_version'
 
+    matchers-condition: and
     matchers:
       - type: dsl
         name: version_check
@@ -56,4 +57,7 @@ http:
           - compare_versions(version, '< 13.4.27', '>= 13.0.0')
           - compare_versions(version, '< 12.4.35')
         condition: or
-# digest: 4a0a004730450220450ab19d03bc692fb337fe522091c17d13475e389cebc9f4591c62a641702159022100f3ec7936452f74caa23155616108c3d3cb0149fbef89e2cda1f3553ce32ec102:922c64590222798bb761d5b6d8e72950
+
+      - type: dsl
+        dsl:
+          - contains_all(body, "server_version", "teleport")


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

The version matching in the original template wouldn't match later minor versions on major versions before the v17 line.

- Fixed CVE-2025-49825
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)