### PR TITLE
Added template for CVE-2025-24354

### DIFF
--- a/http/cves/2025/CVE-2025-24354.yaml
+++ b/http/cves/2025/CVE-2025-24354.yaml
@@ -21,6 +21,7 @@ info:
     epss-score: 0.00057
     epss-percentile: 0.18025
   metadata:
+    verified: true
     max-request: 1
     product: imgproxy
     shodan-query: http.html:"imgproxy"


### PR DESCRIPTION
### Template / PR Information

- Adds a Nuclei-style template for CVE-2025-24354 — an SSRF in imgproxy (allows requests to 0.0.0.0) — supporting OAST verification via interactsh and basic response-based detection.
- References:

> - https://github.com/Admin9961/CVE-2025-24354-PoC/blob/main/CVE-2025-24354.py
> - GitHub Advisory / fix commit: https://github.com/imgproxy/imgproxy/commit/3d4fed6842aa8930ec224d0ad75b0079b858e081
> - GitHub Advisory / fix commit: https://github.com/imgproxy/imgproxy/security/advisories/GHSA-j2hp-6m75-v4j4

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)