### PR TITLE
Added 4 new XPath based template for Android scans

### DIFF
--- a/file/android/deep-link-custom-scheme-detect.yaml
+++ b/file/android/deep-link-custom-scheme-detect.yaml
@@ -4,14 +4,13 @@ info:
   name: Android Deep Link - Detect Custom Schemes
   author: 7h3b4dger
   severity: info
-  description: Detect custom schemes in Deep Link activities
+  description: Detects custom URI schemes (non-http/https) declared in Deep Link intent filters.
   tags: android,file,deeplink
 
 file:
   - extensions:
       - xml
 
-    matchers-condition: and
     matchers:
       - type: xpath
         part: body
@@ -19,6 +18,7 @@ file:
           - "//activity/intent-filter/action[@android:name='android.intent.action.VIEW']"
           - "//activity/intent-filter/category[@android:name='android.intent.category.BROWSABLE']"
         condition: and
+
     extractors:
       - type: xpath
         part: body

--- a/file/android/exported-activities.yaml
+++ b/file/android/exported-activities.yaml
@@ -4,14 +4,13 @@ info:
   name: Android Exported Activities - Detect
   author: 7h3b4dger
   severity: info
-  description: Detect exported activities in AndroidManifest.xml (excluding launcher activities and Google/Jetpack libraries)
+  description: Detect exported (android:exported="true") activities in AndroidManifest.xml, excluding launcher activities and common Google/Jetpack libraries.
   tags: android,file,exportedcomponents
 
 file:
   - extensions:
       - xml
 
-    matchers-condition: and
     matchers:
       - type: xpath
         part: body
@@ -19,10 +18,10 @@ file:
           - "//activity[@android:exported='true']"
           - "//activity/intent-filter/action[@android:name!='android.intent.category.LAUNCHER']"
         condition: and
+
     extractors:
       - type: xpath
         part: body
         attribute: android:name
         xpath:
           - "//activity[@android:exported='true'and not(contains(@android:name, 'androidx')) and not(contains(@android:name, 'google'))]"
-

--- a/file/android/exported-broadcast-receivers.yaml
+++ b/file/android/exported-broadcast-receivers.yaml
@@ -11,7 +11,6 @@ file:
   - extensions:
       - xml
 
-    matchers-condition: and
     matchers:
       - type: xpath
         part: body
@@ -19,6 +18,7 @@ file:
           - "//receiver[@android:exported='true']"
           - "//receiver[@android:enabled!='false']"
         condition: and
+
     extractors:
       - type: xpath
         part: body

--- a/file/android/exported-providers.yaml
+++ b/file/android/exported-providers.yaml
@@ -4,23 +4,22 @@ info:
   name: Android Exported Providers - Detect
   author: 7h3b4dger
   severity: info
-  description: Detect exported providers in AndroidManifest.xml filtering out those included in Android libraries
+  description: Detects exported content providers declared in the app’s AndroidManifest.xml, excluding those added by dependency libraries.
   tags: android,file,exportedcomponents
 
 file:
   - extensions:
       - xml
 
-    matchers-condition: and
     matchers:
       - type: xpath
         part: body
         xpath:
           - "//provider[@android:exported='true']"
+
     extractors:
       - type: xpath
         part: body
         attribute: android:name
         xpath:
           - "//provider[@android:exported='true' and not(contains(@android:name, 'androidx')) and not(contains(@android:name, 'google'))]"
-

--- a/file/android/exported-services.yaml
+++ b/file/android/exported-services.yaml
@@ -4,23 +4,22 @@ info:
   name: Android Exported Services - Detect
   author: 7h3b4dger
   severity: info
-  description: Detect exported services in AndroidManifest.xml filtering out those included in Android libraries
+  description: Detect exported services in AndroidManifest.xml, excluding disabled and common Google/Jetpack library services.
   tags: android,file,exportedcomponents
 
 file:
   - extensions:
       - xml
 
-    matchers-condition: and
     matchers:
       - type: xpath
         part: body
         xpath:
           - "//service[@android:exported='true']"
+
     extractors:
       - type: xpath
         part: body
         attribute: android:name
         xpath:
           - "//service[@android:exported='true' and not(contains(@android:name, 'androidx')) and not(contains(@android:name, 'google'))]"
-

--- a/file/android/webview-file-access-fromfileurl-java.yaml
+++ b/file/android/webview-file-access-fromfileurl-java.yaml
@@ -10,14 +10,18 @@ info:
 file:
   - extensions:
       - java
+
     matchers-condition: and
     matchers:
       - type: word
-        words: ["setAllowFileAccessFromFileURLs(true)"]
+        words: 
+          - "setAllowFileAccessFromFileURLs(true)"
+
       - type: regex
         part: body
         regex:
           - package\s+(?:.*)
+
     extractors:
           - type: regex
             part: body

--- a/file/android/webview-file-access-java.yaml
+++ b/file/android/webview-file-access-java.yaml
@@ -10,14 +10,18 @@ info:
 file:
   - extensions:
       - java
+
     matchers-condition: and
     matchers:
       - type: word
-        words: ["setAllowFileAccess(true)"]
+        words:
+          - "setAllowFileAccess(true)"
+
       - type: regex
         part: body
         regex:
           - package\s+(?:.*)
+
     extractors:
           - type: regex
             part: body

--- a/file/android/webview-universal-access-java.yaml
+++ b/file/android/webview-universal-access-java.yaml
@@ -10,14 +10,18 @@ info:
 file:
   - extensions:
       - java
+
     matchers-condition: and
     matchers:
       - type: word
-        words: ["setAllowUniversalAccessFromFileURLs(true)"]
+        words:
+          - "setAllowUniversalAccessFromFileURLs(true)"
+
       - type: regex
         part: body
         regex:
           - package\s+(?:.*)
+
     extractors:
           - type: regex
             part: body


### PR DESCRIPTION
### Template / PR Information

Added 4 new templates in file/android. All new templates use XPath based filters.

Templates:
- **exported-activities.yaml**: Detect exported activities in AndroidManifest.xml (excluding launcher activities and Google/Jetpack libraries).
- **exported-broadcast-receivers.yaml**: Detect exported Broadcast Receivers in AndroidManifest.xml (excluding disabled receivers and Google/Jetpack libraries).
- **exported-services.yaml**: Detect exported services in AndroidManifest.xml filtering out those included in Android libraries..
-  **deep-link-custom-scheme-detect.yaml**: Detect custom schemes in Deep Link activities.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)