### PR TITLE
Update external-service-interaction.yaml

### DIFF
--- a/http/miscellaneous/external-service-interaction.yaml
+++ b/http/miscellaneous/external-service-interaction.yaml
@@ -21,6 +21,7 @@ http:
         GET / HTTP/1.1
         Host: {{interactsh-url}}
 
+    redirects: false
     matchers:
       - type: word
         part: interactsh_protocol


### PR DESCRIPTION
### Template / PR Information

Add `redirects: false` to prevent the scanner from following redirects. This ensures only genuine Host Header Injection vulnerabilities (where the target server interacts with the OAST domain) are detected.

Issue https://github.com/projectdiscovery/nuclei-templates/issues/13765

- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)