### PR TITLE
Add detection of CASCADE CMS login panel instances.

### DIFF
--- a/http/exposed-panels/cascade-cms-panel.yaml
+++ b/http/exposed-panels/cascade-cms-panel.yaml
@@ -1,0 +1,34 @@
+id: cascade-cms-panel
+
+info:
+  name: Cascade CMS Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+     Cascade CMS was detected — a web content management system for managing stand-out websites.
+  reference:
+    - https://www.hannonhill.com/products/cascade-cms-web-content-management/index.html
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Cascade CMS"
+  tags: panel,cascade,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login.act"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "cascade cms</title>", "window.cascade_")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)\-\s*v([0-9\.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **Cascade CMS** software.

References:

- https://www.hannonhill.com/products/cascade-cms-web-content-management/index.html

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

<img width="830" height="674" alt="image" src="https://github.com/user-attachments/assets/890cdf48-2423-43d2-bd2c-c407e20f2c94" />

Hosts used for the test found via Shodan and/or https://crt.sh :

```text
https://216.244.115.147:7443
https://34.237.236.17
https://3.224.73.231
https://208.103.170.4:8443
https://150.250.77.63
http://71.10.116.20:8080
http://216.54.215.132:8080
http://216.54.215.130:8080
http://216.54.215.72:8080
```

### Additional Details (leave it blank if not applicable)

Shodan query: https://www.shodan.io/search?query=http.title%3A%22Cascade+CMS%22

<img width="1406" height="778" alt="image" src="https://github.com/user-attachments/assets/424f2103-9155-4357-819c-77beb9f59ab7" />

### Additional References

None