### PR TITLE
Enrich the "GITBLIT" template.

### DIFF
--- a/http/exposed-panels/gitblit-panel.yaml
+++ b/http/exposed-panels/gitblit-panel.yaml
@@ -2,9 +2,13 @@ id: gitblit-panel
 
 info:
   name: Gitblit Login Panel - Detect
-  author: tess
+  author: tess,righettod
   severity: info
-  description: Gitblit login panel was detected.
+  description: |
+    Gitblit login panel was detected — a pure Java stack for managing, viewing, and serving Git repositories.
+  reference:
+    - https://www.gitblit.com/
+    - https://github.com/gitblit-org/gitblit
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
@@ -44,4 +48,10 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022028b3bc924822180b51b5b2d785e12b3aadf52d706f8a3b13d5387ea1c940a834022100b57264fb2720c0bcb2f15d869586be60847bcabd7d6287d8286d8b70e81eef74:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<span>v([0-9\.]+)</span>'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little enhancing of the template to detect the presence of an instance of the **GITBLIT** software.

References:
- https://www.gitblit.com/
- https://github.com/gitblit-org/gitblit

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

Tested against the following hosts found via shodan:

```text
https://8.208.15.169:8443
https://62.210.137.184:8443
http://39.99.130.85:8080
https://106.15.224.79:8443
https://114.119.188.191:8443
http://47.93.203.148:8080
https://8.130.30.194:8443
http://113.45.243.195
http://8.142.153.155:8080
https://113.44.38.87:8443
https://119.29.86.93:8443
https://110.42.205.11:8443
http://8.137.90.36:8080
http://35.194.121.121:8080
http://47.103.50.10:8080
http://47.98.18.230:8080
```

<img width="825" height="969" alt="image" src="https://github.com/user-attachments/assets/459b9d01-cbd9-4da7-9443-57cf32fecb49" />

### Additional Details (leave it blank if not applicable)

I used the Shodan query present into the template: https://www.shodan.io/search?query=http.title%3A%22gitblit%22

<img width="1425" height="762" alt="image" src="https://github.com/user-attachments/assets/6fce0ec0-6ebe-48a6-be11-9824d9b6966b" />

### Additional References:

None