### PR TITLE
add CVE-2024-8852 template

### DIFF
--- a/http/cves/2024/CVE-2024-8852.yaml
+++ b/http/cves/2024/CVE-2024-8852.yaml
@@ -5,26 +5,48 @@ info:
   author: FLX
   severity: medium
   description: |
-    The All-in-One WP Migration and Backup plugin for WordPress is vulnerable to unauthenticated information disclosure
-    due to its error.log file being publicly accessible in versions before 7.87.
+    The All-in-One WP Migration and Backup plugin for WordPress is vulnerable to unauthenticated information disclosure due to its error.log file being publicly accessible in versions before 7.87.
   impact: |
-    An unauthenticated attacker can access the error.log file, which may contain sensitive information
-    such as full server path disclosures, backup filenames, and other debugging details.
-    This information could be used in further attacks.
+    An unauthenticated attacker can access the error.log file, which may contain sensitive information such as full server path disclosures, backup filenames, and other debugging details. This information could be used in further attacks.
   remediation: |
     Update the All-in-One WP Migration and Backup plugin to version 7.87 or later.
   reference:
     - https://wpscan.com/vulnerability/9f533098-8435-4ee1-a423-5142070ceefc/
-    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2024-8852
     - https://wordpress.org/plugins/all-in-one-wp-migration/#developers
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cve-id: cve-2024-8852
     cwe-id: CWE-532
-  tags: wpscan,cve,cve2024,wp,wordpress,wp-plugin,all-in-one-wp-migration,ai1wm,disclosure,logs
+  metadata:
+    verified: true
+    fofa-query: body="/wp-content/plugins/all-in-one-wp-migration"
+  tags: cve,cve2024,wpscan,wp,wordpress,wp-plugin,all-in-one-wp-migration,disclosure
+
+flow: http(1) && http(2)
 
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/all-in-one-wp-migration/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - compare_versions(version, '< 7.87')
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - "(?mi)Stable tag: ([0-9.]+)"
+        internal: true
+
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/all-in-one-wp-migration/storage/error.log"
@@ -33,7 +55,6 @@ http:
       - type: dsl
         dsl:
           - status_code == 200
-          - contains(body, 'Number')
-          - contains(body, 'Message')
+          - contains_all(body, 'Number', 'Message')
           - contains(tolower(header), 'text/plain')
         condition: and


### PR DESCRIPTION
### PR Information

This pull request adds a new template to detect CVE-2024-8852, an unauthenticated information disclosure vulnerability in the "All-in-One WP Migration" WordPress plugin (versions < 7.87).

The template checks for the publicly accessible `error.log` file created by the plugin, which can leak sensitive information like server paths and backup filenames.

- Added CVE-2024-8852
- References:
  - [https://wpscan.com/vulnerability/9f533098-8435-4ee1-a423-5142070ceefc/](https://wpscan.com/vulnerability/9f533098-8435-4ee1-a423-5142070ceefc/)
  - [https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2024-8852](https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2024-8852)
  - [https://wordpress.org/plugins/all-in-one-wp-migration/#developers](https://wordpress.org/plugins/all-in-one-wp-migration/#developers)

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Tested against a vulnerable instance of the plugin. The matcher correctly identifies the log file and does not trigger on a patched instance where the file is no longer accessible.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)