### PR TITLE
chore: upate swagger-api.yaml template to detect more endpoints

### DIFF
--- a/http/exposures/apis/swagger-api.yaml
+++ b/http/exposures/apis/swagger-api.yaml
@@ -6,7 +6,7 @@ info:
   severity: info
   description: |
     Public Swagger API was detected.
-  reference: 
+  reference:
     - https://swagger.io/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N


### PR DESCRIPTION
### PR Information

This PR adds some common version API endpoints to search for Swagger docs, like: `/v1/api-docs` and `/v2/api-docs`. Also adds content-type "application/json" to avoid errors when Swagger was served by Springboot
<!-- Please include any reference to your template if available -->

- Updated template: `http/exposure/swagger-api.yaml`
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
