### PR TITLE
[ENHANCEMENT] Duplicate Template ID: gradio-lfi

### DIFF
--- a/http/vulnerabilities/gradio/gradio-lfi.yaml
+++ b/http/vulnerabilities/gradio/gradio-lfi.yaml
@@ -1,4 +1,4 @@
-id: gradio-lfi
+id: gradio-component-server-lfi
 
 info:
   name: Gradio 3.47/3.50.2 - Local File Inclusion


### PR DESCRIPTION
### PR Information

The template by `nvn1729` renamed to gradio-component-server-lfi because:
It's more specific - targets Gradio versions 3.47/3.50.2 via `/component_server` endpoint

Fix [ENHANCEMENT] [Duplicate Template ID: gradio-lfi](https://github.com/projectdiscovery/nuclei-templates/issues/13917)

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
