### PR TITLE
add: CVE-2023-28725 General Bytes CAS RCE detection template

### DIFF
--- a/cves/2023/CVE-2023-28725.yaml
+++ b/cves/2023/CVE-2023-28725.yaml
@@ -5,7 +5,7 @@ info:
   author: akhmittra
   severity: critical
   description: |
-    General Bytes CAS Bitcoin ATM server is vulnerable to remote code execution 
+    General Bytes CAS Bitcoin ATM server is vulnerable to remote code execution
     due to an unsafe file write mechanism exposed via the /extensions endpoint.
     This template safely detects the vulnerability by simulating file write parameters
     without actually dropping a shell or modifying server state.
@@ -43,4 +43,3 @@ http:
           - "success"
           - "written"
           - "extension"
-


### PR DESCRIPTION
This PR adds a nuclei template for **CVE-2023-28725 - General Bytes CAS Remote Code Execution** as part of the **ProjectDiscovery Nuclei Template Bug Bounty Program**.

The vulnerability allows remote file-write behavior via CAS using the `/extensions/performAction` endpoint.  
This template performs a safe, non-destructive test by sending a simulated file write request and 
identifies potentially vulnerable instances based on the success response.

📌 **File Location**  
`cves/2023/CVE-2023-28725.yaml`

📌 **Validation**  
The template was validated locally with:
```bash
nuclei -validate -t cves/2023/CVE-2023-28725.yaml

📌 **Debug Output (sanitized test run)**

```bash
$ nuclei -t cves/2023/CVE-2023-28725.yaml -u https://example.com -debug

[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] [CVE-2023-28725] Dumped HTTP request for https://example.com/extensions/performAction

POST /extensions/performAction HTTP/1.1
Host: example.com
...

{
  "action": "write",
  "file": "../webapps/ROOT/test.jsp",
  "contents": "TEST_PAYLOAD"
}

[DBG] [CVE-2023-28725] Dumped HTTP response https://example.com/extensions/performAction

HTTP/1.1 403 Forbidden
...

[INF] Scan completed in 804ms. No results found.


📌 **Bounty Metadata**
- `projectdiscovery-bounty`
- `community`

📌 **Reference**
- https://nvd.nist.gov/vuln/detail/CVE-2023-28725

Closes #13915