### PR TITLE
add HedgeDoc detection template

### DIFF
--- a/http/technologies/hedgedoc-detect.yaml
+++ b/http/technologies/hedgedoc-detect.yaml
@@ -1,7 +1,7 @@
 id: hedgedoc-detect
 
 info:
-  name: HedgeDoc Collaborative Editor - Detection
+  name: HedgeDoc Collaborative Editor - Detect
   author: Rupendra0
   severity: info
   description: |
@@ -12,17 +12,16 @@ info:
   metadata:
     verified: true
     max-request: 2
-    vendor: HedgeDoc
-    product: HedgeDoc
+    vendor: hedgedoc
+    product: hedgedoc
     shodan-query: 'http.title:"HedgeDoc - Ideas grow better together"'
     fofa-query: 'body="Powered by <a href=\"https://hedgedoc.org\">HedgeDoc"'
-  tags: tech,detect,discovery
+  tags: tech,detect,hedgedoc
 
 http:
   - method: GET
     path:
       - '{{BaseURL}}/'
-      - '{{BaseURL}}/login'
 
     host-redirects: true
     stop-at-first-match: true
@@ -30,10 +29,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_all(body, "HedgeDoc - Ideas grow better together", "Powered by <a href=\"https://hedgedoc.org\">HedgeDoc")'
-          - 'contains(tolower(all_headers), "hedgedoc-version:")'
-        condition: and
+          - 'contains(tolower(header), "hedgedoc-version:")'
+          - 'contains_any(body, "HedgeDoc - Ideas", "Powered by <a href=\"https://hedgedoc.org\">HedgeDoc")'
+        condition: or
 
     extractors:
       - type: regex


### PR DESCRIPTION
### PR Information

- Added HedgeDoc collaborative editor detection template for the `http/technologies` collection.
- References:
  - https://hedgedoc.org/
  - https://github.com/hedgedoc/hedgedoc

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Validated syntax locally via `nuclei -validate -t http/technologies/hedgedoc-detect.yaml`.

#### Additional Details (leave it blank if not applicable)

- Template targets HedgeDoc’s public landing/login pages using unique branding text plus the `hedgedoc-version` response header for high-confidence fingerprinting.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)