### PR TITLE
Add CVE-2024-37656.yaml - GnuBoard5 5.5.16 - Open Redirect

### DIFF
--- a/http/cves/2024/CVE-2024-37656.yaml
+++ b/http/cves/2024/CVE-2024-37656.yaml
@@ -11,25 +11,36 @@ info:
   remediation: |
     Update to the latest version of Gnuboard5.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-37656
     - https://github.com/gnuboard/gnuboard5/issues/318
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-37656
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:N/A:N
     cvss-score: 6.1
     cve-id: CVE-2024-37656
-  tags: cve,cve2024,redirect,gnuboard5,open-redirect
+    cwe-id: CWE-601
+    cpe: cpe:2.3:a:sir:gnuboard:5.5.16:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: sir
+    product: gnuboard
+    shodan-query: html:"GnuBoard5"
+    fofa-query: body:"GnuBoard5"
+  tags: cve,cve2024,redirect,gnuboard5
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/gnuboard5/bbs/logout.php?url=/\\oast.pro"
+      - "{{BaseURL}}/bbs/logout.php?url=/\\oast.pro"
 
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: regex
         part: header
         regex:
-          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@\\/]*)oast\.pro.*$'
+          - '(?m)^(?:Location\s*?:\s*)(?:https?://|//|/\\\\)?[a-zA-Z0-9._@-]*oast\.pro.*$'
 
       - type: status
         status:


### PR DESCRIPTION
GnuBoard5 5.5.16 - Open Redirect

  reference:
    - https://nvd.nist.gov/vuln/detail/CVE-2024-37656
    - https://github.com/gnuboard/gnuboard5/issues/318
    - https://github.com/gnuboard/gnuboard5
    
### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
