### PR TITLE
cve-2025-64446 safety update

### DIFF
--- a/http/cves/2025/CVE-2025-64446.yaml
+++ b/http/cves/2025/CVE-2025-64446.yaml
@@ -47,8 +47,6 @@ http:
                 "name": "{{username}}",
                 "access-profile": "prof_admin",
                 "access-profile_val": "0",
-                "trusthostv4": "0.0.0.0/0",
-                "trusthostv6": "::/0",
                 "last-name": "",
                 "first-name": "",
                 "email-address": "",


### PR DESCRIPTION
I made a suggestion for a change in the original PR for the template on Friday which was accepted. However, it seems the change was added as a duplicate rather than updating the values:
https://github.com/projectdiscovery/nuclei-templates/pull/13929#issuecomment-3533201143

This PR removes the values that would create an account which can login from the internet.