### PR TITLE
Upper bound on .* in error-based SQLi regular expressions

### DIFF
--- a/dast/vulnerabilities/sqli/sqli-error-based.yaml
+++ b/dast/vulnerabilities/sqli/sqli-error-based.yaml
@@ -44,8 +44,8 @@ http:
       - type: regex
         regex:
           # MySQL
-          - "SQL syntax.*?MySQL"
-          - "Warning.*?\\Wmysqli?_"
+          - "SQL syntax.{0,500}?MySQL"
+          - "Warning.{0,500}?\\Wmysqli?_"
           - "MySQLSyntaxErrorException"
           - "valid MySQL result"
           - "check the manual that (corresponds to|fits) your MySQL server version"
@@ -65,8 +65,8 @@ http:
           - "is not supported by MemSQL"
           - "unsupported nested scalar subselect"
           # PostgreSQL
-          - "PostgreSQL.*?ERROR"
-          - "Warning.*?\\Wpg_"
+          - "PostgreSQL.{0,500}?ERROR"
+          - "Warning.{0,500}?\\Wpg_"
           - "valid PostgreSQL result"
           - "Npgsql\\."
           - "PG::SyntaxError:"
@@ -78,13 +78,13 @@ http:
           - "Pdo[./_\\\\]Pgsql"
           - "PSQLException"
           # Microsoft SQL Server
-          - "Driver.*? SQL[\\-\\_\\ ]*Server"
-          - "OLE DB.*? SQL Server"
+          - "Driver.{0,500}? SQL[\\-\\_\\ ]*Server"
+          - "OLE DB.{0,500}? SQL Server"
           - "\\bSQL Server[^&lt;&quot;]+Driver"
-          - "Warning.*?\\W(mssql|sqlsrv)_"
+          - "Warning.{0,500}?\\W(mssql|sqlsrv)_"
           - "\\bSQL Server[^&lt;&quot;]+[0-9a-fA-F]{8}"
           - "System\\.Data\\.SqlClient\\.SqlException\\.(SqlException|SqlConnection\\.OnError)"
-          - "(?s)Exception.*?\\bRoadhouse\\.Cms\\."
+          - "(?s)Exception.{0,500}?\\bRoadhouse\\.Cms\\."
           - "Microsoft SQL Native Client error '[0-9a-fA-F]{8}"
           - "\\[SQL Server\\]"
           - "ODBC SQL Server Driver"
@@ -106,8 +106,8 @@ http:
           # Oracle
           - "\\bORA-\\d{5}"
           - "Oracle error"
-          - "Oracle.*?Driver"
-          - "Warning.*?\\W(oci|ora)_"
+          - "Oracle.{0,500}?Driver"
+          - "Warning.{0,500}?\\W(oci|ora)_"
           - "quoted string not properly terminated"
           - "SQL command not properly ended"
           - "macromedia\\.jdbc\\.oracle"
@@ -116,7 +116,7 @@ http:
           - "Pdo[./_\\\\](Oracle|OCI)"
           - "OracleException"
           # IBM DB2
-          - "CLI Driver.*?DB2"
+          - "CLI Driver.{0,500}?DB2"
           - "DB2 SQL error"
           - "\\bdb2_\\w+\\("
           - "SQLCODE[=:\\d, -]+SQLSTATE"
@@ -126,8 +126,8 @@ http:
           - "DB2Exception"
           - "ibm_db_dbi\\.ProgrammingError"
           # Informix
-          - "Warning.*?\\Wifx_"
-          - "Exception.*?Informix"
+          - "Warning.{0,500}?\\Wifx_"
+          - "Exception.{0,500}?Informix"
           - "Informix ODBC Driver"
           - "ODBC Informix driver"
           - "com\\.informix\\.jdbc"
@@ -136,14 +136,14 @@ http:
           - "IfxException"
           # Firebird
           - "Dynamic SQL Error"
-          - "Warning.*?\\Wibase_"
+          - "Warning.{0,500}?\\Wibase_"
           - "org\\.firebirdsql\\.jdbc"
           - "Pdo[./_\\\\]Firebird"
           # SQLite
           - "SQLite/JDBCDriver"
           - "SQLite\\.Exception"
           - "(Microsoft|System)\\.Data\\.SQLite\\.SQLiteException"
-          - "Warning.*?\\W(sqlite_|SQLite3::)"
+          - "Warning.{0,500}?\\W(sqlite_|SQLite3::)"
           - "SQLITE_ERROR"
           - "SQLite error \\d+:"
           - "sqlite3.OperationalError:"
@@ -152,23 +152,23 @@ http:
           - "Pdo[./_\\\\]Sqlite"
           - "SQLiteException"
           # SAP MaxDB
-          - "SQL error.*?POS([0-9]+)"
-          - "Warning.*?\\Wmaxdb_"
+          - "SQL error.{0,500}?POS([0-9]+)"
+          - "Warning.{0,500}?\\Wmaxdb_"
           - "DriverSapDB"
-          - "-3014.*?Invalid end of SQL statement"
+          - "-3014.{0,500}?Invalid end of SQL statement"
           - "com\\.sap\\.dbtech\\.jdbc"
-          - "\\[-3008\\].*?: Invalid keyword or missing delimiter"
+          - "\\[-3008\\].{0,500}?: Invalid keyword or missing delimiter"
           # Sybase
-          - "Warning.*?\\Wsybase_"
+          - "Warning.{0,500}?\\Wsybase_"
           - "Sybase message"
-          - "Sybase.*?Server message"
+          - "Sybase.{0,500}?Server message"
           - "SybSQLException"
           - "Sybase\\.Data\\.AseClient"
           - "com\\.sybase\\.jdbc"
           # Ingres
-          - "Warning.*?\\Wingres_"
+          - "Warning.{0,500}?\\Wingres_"
           - "Ingres SQLSTATE"
-          - "Ingres\\W.*?Driver"
+          - "Ingres\\W.{0,500}?Driver"
           - "com\\.ingres\\.gcf\\.jdbc"
           # FrontBase
           - "Exception (condition )?\\d+\\. Transaction rollback"
@@ -177,7 +177,7 @@ http:
           - "(Semantic|Syntax) error [1-4]\\d{2}\\."
           # HSQLDB
           - "Unexpected end of command in statement \\["
-          - "Unexpected token.*?in statement \\["
+          - "Unexpected token.{0,500}?in statement \\["
           - "org\\.hsqldb\\.jdbc"
           # H2
           - "org\\.h2\\.jdbc"
@@ -230,8 +230,8 @@ http:
       - type: regex
         name: mysql
         regex:
-          - "SQL syntax.*?MySQL"
-          - "Warning.*?\\Wmysqli?_"
+          - "SQL syntax.{0,500}?MySQL"
+          - "Warning.{0,500}?\\Wmysqli?_"
           - "MySQLSyntaxErrorException"
           - "valid MySQL result"
           - "check the manual that (corresponds to|fits) your MySQL server version"
@@ -263,8 +263,8 @@ http:
       - type: regex
         name: postgresql
         regex:
-          - "PostgreSQL.*?ERROR"
-          - "Warning.*?\\Wpg_"
+          - "PostgreSQL.{0,500}?ERROR"
+          - "Warning.{0,500}?\\Wpg_"
           - "valid PostgreSQL result"
           - "Npgsql\\."
           - "PG::SyntaxError:"
@@ -279,13 +279,13 @@ http:
       - type: regex
         name: microsoftsqlserver
         regex:
-          - "Driver.*? SQL[\\-\\_\\ ]*Server"
-          - "OLE DB.*? SQL Server"
+          - "Driver.{0,500}? SQL[\\-\\_\\ ]*Server"
+          - "OLE DB.{0,500}? SQL Server"
           - "\\bSQL Server[^&lt;&quot;]+Driver"
-          - "Warning.*?\\W(mssql|sqlsrv)_"
+          - "Warning.{0,500}?\\W(mssql|sqlsrv)_"
           - "\\bSQL Server[^&lt;&quot;]+[0-9a-fA-F]{8}"
           - "System\\.Data\\.SqlClient\\.SqlException\\.(SqlException|SqlConnection\\.OnError)"
-          - "(?s)Exception.*?\\bRoadhouse\\.Cms\\."
+          - "(?s)Exception.{0,500}?\\bRoadhouse\\.Cms\\."
           - "Microsoft SQL Native Client error '[0-9a-fA-F]{8}"
           - "\\[SQL Server\\]"
           - "ODBC SQL Server Driver"
@@ -313,8 +313,8 @@ http:
         regex:
           - "\\bORA-\\d{5}"
           - "Oracle error"
-          - "Oracle.*?Driver"
-          - "Warning.*?\\W(oci|ora)_"
+          - "Oracle.{0,500}?Driver"
+          - "Warning.{0,500}?\\W(oci|ora)_"
           - "quoted string not properly terminated"
           - "SQL command not properly ended"
           - "macromedia\\.jdbc\\.oracle"
@@ -326,7 +326,7 @@ http:
       - type: regex
         name: ibmdb2
         regex:
-          - "CLI Driver.*?DB2"
+          - "CLI Driver.{0,500}?DB2"
           - "DB2 SQL error"
           - "\\bdb2_\\w+\\("
           - "SQLCODE[=:\\d, -]+SQLSTATE"
@@ -339,8 +339,8 @@ http:
       - type: regex
         name: informix
         regex:
-          - "Warning.*?\\Wifx_"
-          - "Exception.*?Informix"
+          - "Warning.{0,500}?\\Wifx_"
+          - "Exception.{0,500}?Informix"
           - "Informix ODBC Driver"
           - "ODBC Informix driver"
           - "com\\.informix\\.jdbc"
@@ -352,7 +352,7 @@ http:
         name: firebird
         regex:
           - "Dynamic SQL Error"
-          - "Warning.*?\\Wibase_"
+          - "Warning.{0,500}?\\Wibase_"
           - "org\\.firebirdsql\\.jdbc"
           - "Pdo[./_\\\\]Firebird"
 
@@ -362,7 +362,7 @@ http:
           - "SQLite/JDBCDriver"
           - "SQLite\\.Exception"
           - "(Microsoft|System)\\.Data\\.SQLite\\.SQLiteException"
-          - "Warning.*?\\W(sqlite_|SQLite3::)"
+          - "Warning.{0,500}?\\W(sqlite_|SQLite3::)"
           - "SQLITE_ERROR"
           - "SQLite error \\d+:"
           - "sqlite3.OperationalError:"
@@ -374,19 +374,19 @@ http:
       - type: regex
         name: sapmaxdb
         regex:
-          - "SQL error.*?POS([0-9]+)"
-          - "Warning.*?\\Wmaxdb_"
+          - "SQL error.{0,500}?POS([0-9]+)"
+          - "Warning.{0,500}?\\Wmaxdb_"
           - "DriverSapDB"
-          - "-3014.*?Invalid end of SQL statement"
+          - "-3014.{0,500}?Invalid end of SQL statement"
           - "com\\.sap\\.dbtech\\.jdbc"
-          - "\\[-3008\\].*?: Invalid keyword or missing delimiter"
+          - "\\[-3008\\].{0,500}?: Invalid keyword or missing delimiter"
 
       - type: regex
         name: sybase
         regex:
-          - "Warning.*?\\Wsybase_"
+          - "Warning.{0,500}?\\Wsybase_"
           - "Sybase message"
-          - "Sybase.*?Server message"
+          - "Sybase.{0,500}?Server message"
           - "SybSQLException"
           - "Sybase\\.Data\\.AseClient"
           - "com\\.sybase\\.jdbc"
@@ -394,9 +394,9 @@ http:
       - type: regex
         name: ingres
         regex:
-          - "Warning.*?\\Wingres_"
+          - "Warning.{0,500}?\\Wingres_"
           - "Ingres SQLSTATE"
-          - "Ingres\\W.*?Driver"
+          - "Ingres\\W.{0,500}?Driver"
           - "com\\.ingres\\.gcf\\.jdbc"
 
       - type: regex
@@ -411,7 +411,7 @@ http:
         name: hsqldb
         regex:
           - "Unexpected end of command in statement \\["
-          - "Unexpected token.*?in statement \\["
+          - "Unexpected token.{0,500}?in statement \\["
           - "org\\.hsqldb\\.jdbc"
 
       - type: regex


### PR DESCRIPTION
### PR Information

It's very easy for a website to contain `PostgreSQL` and `ERROR` separated by several kilobytes of other things. At CERT PL we have identified some such cases which led to false positives. This change eliminates them.

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)
