### PR TITLE
Add CVE-2017-14725 - WordPress < 4.8.2 - Authenticated Open Redirect

### DIFF
--- a/http/cves/2017/CVE-2017-14725.yaml
+++ b/http/cves/2017/CVE-2017-14725.yaml
@@ -33,7 +33,8 @@ info:
       - http.component:"wordpress"
       - cpe:"cpe:2.3:a:wordpress:wordpress"
     fofa-query: body="oembed" && body="wp-"
-  tags: cve,cve2017,wordpress,redirect,authenticated
+  tags: cve,cve2017,wpscan,wordpress,redirect,authenticated
+
 flow: http(1) && http(2) && http(3) && http(4)
 
 http:


### PR DESCRIPTION
This YAML file describes CVE-2017-14725, detailing the vulnerability in WordPress versions before 4.8.2, including its impact, remediation steps, and relevant metadata.

### PR Information

- Reference:
    - https://wordpress.org/news/2017/09/wordpress-4-8-2-security-and-maintenance-release/
    - https://core.trac.wordpress.org/changeset/41398
    - https://nvd.nist.gov/vuln/detail/CVE-2017-14725

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
