### PR TITLE
FIX [FALSE-NEGATIVE] error-logs template fails to detect exposed log files without Content-Type header

### DIFF
--- a/http/exposures/logs/error-logs.yaml
+++ b/http/exposures/logs/error-logs.yaml
@@ -46,23 +46,22 @@ http:
         - "/{{Hostname}}/errors.log"
 
     stop-at-first-match: true
+
     matchers-condition: and
     matchers:
       - type: word
-        part: body
-        condition: or
         words:
           - "Segmentation Fault"
           - "coredump"
           - "Broken pipe"
           - "FastCGI sent in stderr"
-          - "PHP Fatal error:"
-          - "PHP Warning:"
-          - "PHP Notice:"
-          - "PHP Parse error:"
-          - "Stack trace:"
-          - "[error]"
           - "Fatal error:"
+          - "Stack trace:"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - "contains(tolower(header), 'content-type: text/plain') || contains(tolower(header), 'content-type: application/octet-stream') || !contains(tolower(header), 'content-type:')"
 
       - type: status
         status:


### PR DESCRIPTION
FIx header matcher causing false negatives.

The Old template cant detect [REDACTED]/error.log it required Content-Type header to be text/plain or 
application/octet-stream, causing false negatives even response body clearly contains log indicators (e.g. Exception, Fatal, Array, etc.).

Fixes [#13519](https://github.com/projectdiscovery/nuclei-templates/issues/13519)

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation


- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
