### PR TITLE
WordPress Twenty Seventeen - Full Path Disclosure

### DIFF
--- a/http/vulnerabilities/wordpress/wp-twenty-theme-fpd.yaml
+++ b/http/vulnerabilities/wordpress/wp-twenty-theme-fpd.yaml
@@ -26,5 +26,5 @@ http:
       - type: dsl
         dsl:
           - status_code == 200
-          - contains_all(body, "Index of", "twentyseventeen","Parent Directory") || contains_any(body, "Uncaught Error:", "Stack trace: #","Fatal error:")
+          - contains_all(body, "Index of", "twentyseventeen", "Parent Directory") || contains_any(body, "Uncaught Error:", "Stack trace:", "Fatal error:")
         condition: and


### PR DESCRIPTION
Added a YAML file for the WordPress Twenty Seventeen theme vulnerability that details a full path disclosure issue.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
