### PR TITLE
Urlencoding the XSS payload to decrease the number of FPs

### DIFF
--- a/dast/vulnerabilities/xss/reflected-xss.yaml
+++ b/dast/vulnerabilities/xss/reflected-xss.yaml
@@ -26,13 +26,13 @@ http:
         type: postfix
         mode: single
         fuzz:
-          - "{{reflection}}"
+          - "{{url_encode(reflection)}}"
 
       - part: path
         type: postfix
         mode: single
         fuzz:
-          - "{{reflection}}"
+          - "{{url_encode(reflection)}}"
 
     stop-at-first-match: true
 


### PR DESCRIPTION
### PR Information

Browsers urlencode the path before putting it in the HTTP GET request - the first line is `GET /%3Fid%3D%22%3E%3Caaa%3E HTTP/1.1`, not `GET /?id="><aaa> HTTP/1.1`. Therefore let's urlencode the input payload (as e.g. this template does: https://github.com/projectdiscovery/nuclei-templates/blob/main/http/vulnerabilities/generic/xss-fuzz.yaml) to decrease the number of false positives.

### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)
