### PR TITLE
Add .env and .git HEAD exposure templates

### DIFF
--- a/http/exposures/exposed-env.yaml
+++ b/http/exposures/exposed-env.yaml
@@ -1,0 +1,20 @@
+id: exposed-env-file
+
+info:
+  name: Exposed Environment File
+  author: aryan-mrrobot
+  severity: high
+  description: Detects exposed environment files with sensitive credentials.
+  tags: exposure,env,config,sensitive
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.env"
+
+    matchers:
+      - type: word
+        words:
+          - "DB_PASSWORD="
+          - "AWS_SECRET_ACCESS_KEY"
+          - "MAIL_HOST="

--- a/http/exposures/git-head-disclosure.yaml
+++ b/http/exposures/git-head-disclosure.yaml
@@ -1,0 +1,18 @@
+id: git-head-disclosure
+
+info:
+  name: Git HEAD Exposure
+  author: aryan-mrrobot
+  severity: medium
+  description: Detects exposed .git repository HEAD file.
+  tags: git,info-leak,config
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.git/HEAD"
+
+    matchers:
+      - type: word
+        words:
+          - "refs/heads"


### PR DESCRIPTION
### **This PR adds two new templates under exposures/ to detect sensitive configuration leaks:**
- exposed-env-file.yaml
- git-head-disclosure.yaml

**These help identify exposed environment secrets and repo structure disclosure commonly seen in bug bounty targets.**
