### PR TITLE
Add Symfony Profiler SQL Injection template

### DIFF
--- a/http/vulnerabilities/symfony/symfony-profiler-sqli.yaml
+++ b/http/vulnerabilities/symfony/symfony-profiler-sqli.yaml
@@ -1,0 +1,51 @@
+id: symfony-profiler-sqli
+
+info:
+  name: Symfony Profiler < 2.5.4 - SQL Injection
+  author: rscq
+  severity: high
+  description: |
+    Symfony versions before 2.3.19, 2.4.9, and 2.5.4 are vulnerable to SQL injection through the web profiler's import/export feature. The export route was removed in patched versions, so its existence confirms the vulnerability.
+  impact: |
+    Successful exploitation allows attackers to extract sensitive data from the database through blind SQL injection.
+  remediation: |
+    Upgrade to Symfony 2.3.19+, 2.4.9+, or 2.5.4+. Never expose app_dev.php to production environments.
+  reference:
+    - https://symfony.com/blog/cve-2014-6072-csrf-vulnerability-in-the-web-profiler
+    - https://github.com/sysdream/sf2-profiler-exploit
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: sensiolabs
+    product: symfony
+    shodan-query: html:"app_dev.php"
+    fofa-query: body="app_dev.php"
+  tags: symfony,sqli,profiler,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/app_dev.php/_profiler/export/test.txt"
+      - "{{BaseURL}}/_profiler/export/test.txt"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "does not exist"
+
+      - type: word
+        part: body
+        words:
+          - "Token"
+
+      - type: status
+        status:
+          - 404


### PR DESCRIPTION
### PR Information

- Add Symfony Profiler < 2.5.4 SQL Injection detection template
- Detects vulnerable Symfony versions (< 2.3.19, 2.4.9, 2.5.4) with exposed profiler import feature
- Issue #4990
- References:
  - https://symfony.com/blog/cve-2014-6072-csrf-vulnerability-in-the-web-profiler
  - https://github.com/sysdream/sf2-profiler-exploit

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

**Debug Output:**

```bash
[symfony-profiler-sqli] [http] [high] http://web:80/app_dev.php/_profiler/export/test.txt
```

**Vulnerable Environment:**

- Symfony 2.5.3 with WebProfilerBundle enabled
- Docker environment available for testing

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)