### PR TITLE
Add CVE-2025-10211 - ChanCMS SSRF template

### DIFF
--- a/http/cves/2025/CVE-2025-10211.yaml
+++ b/http/cves/2025/CVE-2025-10211.yaml
@@ -5,7 +5,11 @@ info:
   author: Yu_Bao
   severity: medium
   description: |
-    A security vulnerability has been detected in yanyutao0402 ChanCMS 3.3.0. The affected element is the function CollectController of the file /cms/collect/getArticle. The manipulation of the argument taskUrl leads to server-side request forgery. The attack may be initiated remotely.
+    yanyutao0402 ChanCMS 3.3.0 contains a server-side request forgery caused by manipulation of the "taskUrl" argument in /cms/collect/getArticle, letting remote attackers make arbitrary requests, exploit requires no special privileges.
+  impact: |
+    Remote attackers can make arbitrary requests from the server, potentially accessing internal resources or sensitive data.
+  remediation: |
+    Update to the latest version of ChanCMS.
   reference:
     - https://gitee.com/yanyutao0402/ChanCMS
     - https://vuldb.com/?id.323484
@@ -19,7 +23,7 @@ info:
     max-request: 1
     shodan-query: http.html:"ChanCMS"
     fofa-query: body="ChanCMS"
-  tags: cve,cve2025,chancms,ssrf,oast
+  tags: cve,cve2025,chancms,ssrf,oast,oob
 
 http:
   - method: POST
@@ -37,13 +41,10 @@ http:
         "parseData": "return data;"
       }
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - contains(interactsh_protocol, 'dns')
+          - contains_all(response, 'success','article')
+          - status_code == 200
+        condition: and


### PR DESCRIPTION
## Description
This PR adds a Nuclei template for CVE-2025-10211 - ChanCMS Server-Side Request Forgery vulnerability.

### CVE Details
- **CVE ID**: CVE-2025-10211
- **Affected Product**: ChanCMS <= 3.3.0
- **Vulnerability Type**: Server-Side Request Forgery (CWE-918)
- **Severity**: Medium (CVSS 6.3)
- **Attack Vector**: Remote

### Template Details
- Detects SSRF in the collect API endpoint (/cms/collect/getArticle)
- Uses interactsh for out-of-band detection
- Verified: true

### References
- https://vuldb.com/?id.323484
- https://gitee.com/yanyutao0402/ChanCMS

Closes #14064