### PR TITLE
Add AirWatch SEG Microsoft ActiveSync detection template

### DIFF
--- a/http/technologies/airwatch-seg-activesync-detect.yaml
+++ b/http/technologies/airwatch-seg-activesync-detect.yaml
@@ -1,0 +1,31 @@
+id: airwatch-seg-activesync-detect
+
+info:
+  name: AirWatch SEG Microsoft ActiveSync Detection
+  author: Sean Verity
+  severity: info
+  description: |
+    Detects AirWatch Secure Email Gateway (SEG) Microsoft ActiveSync endpoints.
+  reference:
+    - https://www.vmware.com/products/workspace-one.html
+  metadata:
+    max-request: 1
+    shodan-query: http.headers:"X-Aw-Seg-Server-Info"
+  tags: tech,airwatch,vmware,activesync,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Microsoft-Server-ActiveSync"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "X-Aw-Seg-Server-Info"
+
+      - type: word
+        part: header
+        words:
+          - "Www-Authenticate"


### PR DESCRIPTION
## Description
This PR adds a detection template for AirWatch Secure Email Gateway (SEG) Microsoft ActiveSync endpoints.

### Template Details
- **Severity**: Info
- **Detection Method**: Checks for X-Aw-Seg-Server-Info and Www-Authenticate headers on /Microsoft-Server-ActiveSync endpoint

### Use Case
Helps identify VMware Workspace ONE / AirWatch SEG deployments during reconnaissance.

Closes #13910