### PR TITLE
Add CVE-2022-34487 (Updated CVE)

### DIFF
--- a/http/cves/2022/CVE-2022-34487.yaml
+++ b/http/cves/2022/CVE-2022-34487.yaml
@@ -1,7 +1,7 @@
 id: CVE-2022-34487
 
 info:
-  name: ShortCode Addons - Unauthenticated Settings Update
+  name: ShortCode Addons - Unauthenticated Options Update
   author: Sourabh-Sahu
   severity: critical
   description: |
@@ -13,23 +13,24 @@ info:
   reference:
     - https://wpscan.com/vulnerability/c8dd91d5-fdc4-4852-9823-6d0047b214fe/
     - https://patchstack.com/database/vulnerability/shortcode-addons/wordpress-shortcode-addons-plugin-3-0-3-unauthenticated-arbitrary-option-update-vulnerability
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-34487
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2022-34487
-    cwe-id: CWE-264,NVD-CWE-Other
+    cwe-id: CWE-264
     epss-score: 0.00305
     epss-percentile: 0.53222
     cpe: cpe:2.3:a:oxilab:shortcode_addons:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
     max-request: 2
-  tags: cve,cve2022,wordpress,shortcodeaddons,misconfig,unauthenticated
+  tags: cve,cve2022,wp,wp-plugin,wordpress,shortcode-addons
+
+flow: http(1) && http(2)
 
 variables:
   rand: "{{randstr}}"
-
-flow: http(1) && http(2)
 
 http:
   - raw:
@@ -56,7 +57,6 @@ http:
     matchers:
       - type: dsl
         dsl:
+          - contains_all(body, rand, "/wp-")
           - status_code == 200
-          - contains(body, rand)
-          - contains(tolower(body), 'wordpress')
         condition: and


### PR DESCRIPTION
### PR Information

Unauthenticated Arbitrary Option Update vulnerability in biplob018's Shortcode Addons plugin <= 3.0.2 at WordPress.

- References:

https://wpscan.com/vulnerability/c8dd91d5-fdc4-4852-9823-6d0047b214fe/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
