### PR TITLE
Add CVE-2022-33198 (Updated CVEs)

### DIFF
--- a/http/cves/2022/CVE-2022-33198.yaml
+++ b/http/cves/2022/CVE-2022-33198.yaml
@@ -29,7 +29,7 @@ info:
     vendor: oxilab
     product: accordions
     framework: wordpress
-  tags: cve2022,cve,wp-plugin,wp,wordpress,unauth,accordions,vuln
+  tags: cve2022,cve,wp-plugin,wp,wordpress,unauth,accordions,vuln,kev,vkev
 variables:
   marker: '{{rand_text_alpha(10, "abc")}}'
 


### PR DESCRIPTION
### Add CVE-2022-33198

Unauthenticated WordPress Options Change vulnerability in Biplob Adhikari's Accordions plugin <= 2.0.2 at WordPress.

- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2022-33198

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
