### PR TITLE
Add CVE-2023-37999.yaml (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-37999.yaml
+++ b/http/cves/2023/CVE-2023-37999.yaml
@@ -13,13 +13,13 @@ info:
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/ht-mega-for-elementor/ht-mega-absolute-addons-for-elementor-220-missing-authorization-to-privilege-escalation
     - https://plugins.trac.wordpress.org/changeset/2934204/ht-mega-for-elementor/trunk/includes/helper-function.php?contextall=1&old=2899662&old_path=%2Fht-mega-for-elementor%2Ftrunk%2Fincludes%2Fhelper-function.php
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-37999
     - https://patchstack.com/database/vulnerability/ht-mega-for-elementor/wordpress-ht-mega-absolute-addons-for-elementor-plugin-2-2-0-unauthenticated-privilege-escalation-vulnerability?_s_id=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-37999
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2023-37999
-    cwe-id: CWE-269,NVD-CWE-noinfo
+    cwe-id: CWE-269
     epss-score: 0.00846
     epss-percentile: 0.73794
     cpe: cpe:2.3:a:hasthemes:ht_mega:*:*:*:*:free:wordpress:*:*
@@ -31,6 +31,7 @@ info:
     framework: wordpress
     publicwww-query: "/wp-content/plugins/ht-mega-for-elementor"
   tags: cve,cve2023,wordpress,wp,wp-plugin,hasthemes,ht_mega,vkev,ht-mega-for-elementor
+
 variables:
   username: "{{rand_base(6)}}"
   password: "{{rand_base(8)}}"
@@ -66,7 +67,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(header,"wordpress_logged_in","/wp-admin")'
+          - 'contains_all(header,"wordpress_logged_in", "/wp-admin")'
           - 'status_code == 302'
         condition: and
 


### PR DESCRIPTION
### PR Information

The HT Mega plugin for WordPress is vulnerable to Missing Authorization in versions up to, and including, 2.2.0. This is due to missing validation of the reg_role parameter on the htmega_ajax_register function. This makes it possible for unauthenticated attackers to create administrator accounts.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
