### PR TITLE
Add CVE-2021-4073 (vKEV)

### DIFF
--- a/http/cves/2021/CVE-2021-4073.yaml
+++ b/http/cves/2021/CVE-2021-4073.yaml
@@ -5,7 +5,11 @@ info:
   author: daffainfo
   severity: critical
   description: |
-    The RegistrationMagic WordPress plugin made it possible for unauthenticated users to log in as any site user, including administrators, if they knew a valid username on the site due to missing identity validation in the social login function social_login_using_email() of the plugin. This affects versions equal to, and less than, 5.0.1.7.
+    RegistrationMagic WordPress plugin versions <= 5.0.1.7 contain an authentication bypass caused by missing identity validation in social_login_using_email(), letting unauthenticated users log in as any site user, exploit requires knowing a valid username.
+  impact: |
+    Unauthenticated attackers can log in as any user, including administrators, potentially leading to full site compromise.
+  remediation: |
+    Update to the latest version of the plugin where the issue is fixed.
   reference:
     - https://www.wordfence.com/blog/2021/12/authentication-bypass-vulnerability-patched-in-user-registration-plugin/
     - https://nvd.nist.gov/vuln/detail/CVE-2021-4073


### PR DESCRIPTION
### PR Information

The RegistrationMagic WordPress plugin made it possible for unauthenticated users to log in as any site user, including administrators, if they knew a valid username on the site due to missing identity validation in the social login function social_login_using_email() of the plugin. This affects versions equal to, and less than, 5.0.1.7.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
