### PR TITLE
Add an http/technologies template to detect server hosted in Iran

### DIFF
--- a/http/technologies/iran-hosting-detect.yaml
+++ b/http/technologies/iran-hosting-detect.yaml
@@ -1,0 +1,28 @@
+id: iran-hosting-detect
+
+info:
+  name: Iran hosting detection
+  author: p-l-
+  severity: info
+  description: Checks whether a site (even behind CDN) is hosted in Iran
+  reference:
+    - https://x.com/hkashfi/status/1995109785679573167
+  metadata:
+    max-request: 1
+  tags: waf,tech,misc,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/boobs.jpg"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '//10.10.34.'
+
+      - type: status
+        status:
+          - 403


### PR DESCRIPTION
### PR Information

This PR is based on a [message on X by @hkashfi](https://x.com/hkashfi/status/1995109785679573167) (@Hamid-K here).

It adds a template under http/technologies to detect when a server is hosted in Iran, even if behind CDN.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)