### PR TITLE
Add CVE-2023-27351 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-27351.yaml
+++ b/http/cves/2023/CVE-2023-27351.yaml
@@ -33,7 +33,7 @@ info:
     fofa-query:
       - body="papercut"
       - body="content=\"papercut\""
-  tags: cve2023,cve,papercut,bypass-auth,vkev
+  tags: cve2023,cve,papercut,auth-bypass,vkev
 
 flow: http(1) && http(2)
 
@@ -52,7 +52,7 @@ http:
 
     matchers:
       - type: dsl
-        words:
+        dsl:
           - "contains(body, 'rO0A')"
           - "contains(content_type, 'application/json')"
           - "status_code == 200"
@@ -69,7 +69,7 @@ http:
 
     matchers:
       - type: dsl
-        words:
+        dsl:
           - "contains_all(body, 'java.lang.String', 'HASH:', '{{username}}')"
           - "contains(content_type, 'application/json')"
           - "status_code == 200"


### PR DESCRIPTION
### PR Information

This vulnerability allows remote attackers to bypass authentication on affected installations of PaperCut NG 22.0.5 (Build 63914). Authentication is not required to exploit this vulnerability. The specific flaw exists within the SecurityRequestFilter class. The issue results from improper implementation of the authentication algorithm. An attacker can leverage this vulnerability to bypass authentication on the system. Was ZDI-CAN-19226.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Notes

Researched this with @jjchoNC