### PR TITLE
Update CVE-2025-55182.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-55182.yaml
+++ b/http/cves/2025/CVE-2025-55182.yaml
@@ -8,7 +8,6 @@ info:
     React Server Components 19.0.0, 19.1.0, 19.1.1, and 19.2.0 including react-server-dom-parcel,
     react-server-dom-turbopack, and react-server-dom-webpack contain a remote code execution caused
     by unsafe deserialization of payloads from HTTP requests to Server Function endpoints.
-    
     This template performs a hybrid check:
     1. Sends a malformed RSC payload to a random path (bypassing root redirects) to trigger the React "Digest" error.
     2. Attempts to extract the exact Next.js version via headless browser for verification.
@@ -68,24 +67,24 @@ http:
         # Removed 'internal: true' to report Hardened targets that hide window.next.version
         # internal: true 
 
-headless:
-  - steps:
-      - args:
-          url: "{{BaseURL}}"
-        action: navigate
-
-      - action: waitstable
-
-      - action: script
-        name: nextjs_version
-        args:
-          code: |
-            () => {
-              if (!window.next || !window.next.version) {
-                return "";
-              }
-              return window.next.version;
-            }
+    headless:
+      - steps:
+          - args:
+              url: "{{BaseURL}}"
+            action: navigate
+    
+          - action: waitstable
+    
+          - action: script
+            name: nextjs_version
+            args:
+              code: |
+                () => {
+                  if (!window.next || !window.next.version) {
+                    return "";
+                  }
+                  return window.next.version;
+                }
 
     extractors:
       - type: dsl


### PR DESCRIPTION
This PR introduces three critical improvements to reduce False Negatives:

Redirect Bypass: Changed the HTTP target from / to /{{random-path}}.

Why: Next.js root paths often return 307/308 redirects (e.g., to /login), causing Nuclei to lose the POST body or convert it to GET. Hitting a random path forces the App Router (404 handler) to process the RSC payload directly.

Hardened Target Detection: Removed internal: true from the HTTP matcher and added Minified React error check.

Why: Many production environments strip the window.next.version object from the client-side code (Hardened). The previous template would fail silently on these targets even if the server was vulnerable. Now, if the HTTP step confirms the unique React 19 RSC "Digest" error, it will report the vulnerability immediately, even if the Headless step cannot find the version string.

Expanded Matchers: Added Minified React error as a fallback for the JSON digest response, covering different Next.js error reporting configurations.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
