### PR TITLE
feat(file): add CVE-2019-18426 WhatsApp Desktop XSS to LFI template

### DIFF
--- a/file/electron/whatsapp-desktop-xss-lfi.yaml
+++ b/file/electron/whatsapp-desktop-xss-lfi.yaml
@@ -1,0 +1,61 @@
+id: whatsapp-desktop-xss-lfi
+
+info:
+  name: WhatsApp Desktop < 0.3.9309 - XSS to Local File Read
+  author: KrE80r
+  severity: high
+  description: |
+    WhatsApp Desktop before version 0.3.9309, when paired with WhatsApp for iPhone before 2.20.10,
+    contains a reflected cross-site scripting and local file reading vulnerability. The vulnerability
+    chain exploits message metadata tampering, open redirect via rich preview, persistent XSS bypassing
+    CSP (missing object-src directive), and local file system access through the Electron environment
+    running outdated Chromium 69. Successful exploitation requires user interaction (clicking a
+    malicious link preview in a crafted message).
+  impact: |
+    An attacker can execute arbitrary JavaScript in the context of WhatsApp Desktop and read local
+    files from the victim's system using the Fetch API with file:// protocol.
+  remediation: |
+    Update WhatsApp Desktop to version 0.3.9309 or later, and WhatsApp for iPhone to version 2.20.10
+    or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-18426
+    - http://weizmangal.com/2020/02/14/whatsapp-vuln/
+    - https://www.exploit-db.com/exploits/48295
+    - https://www.facebook.com/security/advisories/cve-2019-18426
+    - http://packetstormsecurity.com/files/157097/WhatsApp-Desktop-0.3.9308-Cross-Site-Scripting.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:L/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2019-18426
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 0
+    vendor: meta
+    product: whatsapp_desktop
+    shodan-query: ""
+  tags: cve,cve2019,electron,whatsapp,xss,lfi,file,kev
+
+file:
+  # Detection via Squirrel RELEASES file
+  # This is the only reliable method for detecting installed WhatsApp Desktop
+  # The RELEASES file is located at: %LOCALAPPDATA%\WhatsApp\packages\RELEASES
+  - extensions:
+      - all
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'WhatsApp-0\.3\.(0|[0-8][0-9]{0,2}|9[0-2][0-9]{0,2}|930[0-8])-(full|delta)\.nupkg'
+          - 'WhatsApp-0\.[0-2]\.[0-9]+-(full|delta)\.nupkg'
+        condition: or
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'WhatsApp-([0-9.]+)-(full|delta)\.nupkg'


### PR DESCRIPTION
## Summary

- Adds file-based detection template for CVE-2019-18426
- WhatsApp Desktop < 0.3.9309 XSS leading to local file read via Chromium 69

## Detection Method

Uses Squirrel RELEASES file pattern matching - the only reliable method for detecting **installed** WhatsApp Desktop. The RELEASES file is located at `%LOCALAPPDATA%\WhatsApp\packages\RELEASES` and contains version information in plain text.

### Why RELEASES file only?

- `package.json` is inside `app.asar` (binary archive) - cannot be scanned by nuclei
- `.nuspec` files only exist in installer packages, not installed applications
- RELEASES file is always present in installed WhatsApp and contains version info

## Vulnerability Details

| Field | Value |
|-------|-------|
| CVE | CVE-2019-18426 |
| CVSS | 8.2 (High) |
| Affected | WhatsApp Desktop < 0.3.9309 + WhatsApp iOS < 2.20.10 |
| Type | XSS → Local File Read |
| Root Cause | Missing CSP object-src + Chromium 69 Fetch API file:// |

## Test Results

```
✅ Validates: nuclei -validate passes
✅ Detects: Real WhatsApp 0.3.9308 RELEASES file detected
✅ No FP: WhatsApp 0.3.9309+ correctly ignored
```

## References

- https://nvd.nist.gov/vuln/detail/CVE-2019-18426
- http://weizmangal.com/2020/02/14/whatsapp-vuln/
- https://www.exploit-db.com/exploits/48295

Closes #14257