### PR TITLE
Create apache-kvrocks-exposed.yaml

### DIFF
--- a/javascript/misconfiguration/apache-kvrocks-exposed.yaml
+++ b/javascript/misconfiguration/apache-kvrocks-exposed.yaml
@@ -11,7 +11,6 @@ info:
   metadata:
     verified: true
     max-request: 1
-    shodan-query: product:"apache kvrocks"
   tags: apache,kvrocks,network,unauth,js,exposed
 
 javascript:


### PR DESCRIPTION
This nuclei template:

* Detects if an Apache Kvrocks server is exposed with no authentication credentials, this application is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol.

- References:

https://github.com/apache/kvrocks

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Kvrocks Docker:**

1. Running container:

`$ docker run -it -p 6666:6666 --name apache-kvrocks-container apache/kvrocks  --bind 0.0.0.0`

2. Acessing the Apache Kvrocks service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-kvrocks-container`

And the access URL will be http://<obteined_inspect_IP_Address>/

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-kvrocks-exposed.yaml  -u "http://<obteined_inspect_IP_Address>:6666/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1842" height="858" alt="image" src="https://github.com/user-attachments/assets/a5a45bf2-cd1d-4807-999a-609412c41524" />

<img width="1818" height="336" alt="image" src="https://github.com/user-attachments/assets/e5be746f-009f-4267-98bb-7d4cf088b79d" />