### PR TITLE
Add CVE-2020-20627 (vKEV)

### DIFF
--- a/http/cves/2020/CVE-2020-20627.yaml
+++ b/http/cves/2020/CVE-2020-20627.yaml
@@ -14,18 +14,25 @@ info:
     - https://blog.nintechnet.com/multiple-vulnerabilities-fixed-in-wordpress-givewp-plugin/
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/give/givewp-259-missing-authorization-to-settings-update
     - https://nvd.nist.gov/vuln/detail/CVE-2020-20627
+    - https://github.com/20142995/nuclei-templates
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
     cvss-score: 5.3
     cve-id: CVE-2020-20627
     cwe-id: CWE-306
+    epss-score: 0.00272
+    epss-percentile: 0.50315
     cpe: cpe:2.3:a:givewp:givewp:*:*:*:*:*:wordpress:*:*
   metadata:
+    verified: true
     max-request: 2
     vendor: givewp
     product: givewp
     framework: wordpress
-  tags: cve,cve2020,wp,wordpress,wp-plugin,givewp,unauth,intrusive
+    publicwww-query: "wp-content/plugins/give"
+    shodan-query: http.html:"/wp-content/plugins/give/"
+    fofa-query: body="/wp-content/plugins/give/"
+  tags: cve,cve2020,wp,wordpress,wp-plugin,givewp,unauth,intrusive,kev,vkev
 
 flow: http(1) && http(2)
 


### PR DESCRIPTION
### PR Information

GiveWP plugin through 2.5.9 for WordPress contains an unauthenticated settings change caused by insecure access in includes/gateways/stripe/includes/admin/admin-actions.php, letting attackers modify settings without authentication, exploit requires no authentication.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)
