### PR TITLE
Add CVE-2024-35694 (Updated CVEs)

### DIFF
--- a/http/cves/2024/CVE-2024-35694.yaml
+++ b/http/cves/2024/CVE-2024-35694.yaml
@@ -1,14 +1,13 @@
 id: CVE-2024-35694
 
 info:
-  name: Wordpress WPMobile.App - Cross-Site Scripting
+  name: Wordpress WPMobile.App >= 11.42 - Cross-Site Scripting
   author: Sourabh-Sahu
   severity: high
   description: |
-    Improper Neutralization of Input During Web Page Generation (XSS or 'Cross-site Scripting') vulnerability in WPMobile.App allows Reflected XSS.This issue affects WPMobile.App: from n/a through 11.41.
+    WPMobile.App versions up to 11.41 contain a reflected cross-site scripting (XSS) caused by improper input neutralization during web page generation, letting attackers execute scripts in the victim's browser, exploit requires attacker to craft malicious input.
   reference:
     - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3082701%40wpappninja&new=3082701%40wpappninja&sfp_email=&sfph_mail=
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-35694
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
     cvss-score: 7.1


### PR DESCRIPTION
### Add CVE-2024-35694

Improper Neutralization of Input During Web Page Generation (XSS or 'Cross-site Scripting') vulnerability in WPMobile.App allows Reflected XSS.This issue affects WPMobile.App: from n/a through 11.41.


- References:
   - https://nvd.nist.gov/vuln/detail/CVE-2024-35694
    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3082701%40wpappninja&new=3082701%40wpappninja&sfp_email=&sfph_mail=


### Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)


debug
[debug.txt](https://github.com/user-attachments/files/24025632/debug.txt)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
