### PR TITLE
Added CVE-2019-18935 Template

### DIFF
--- a/http/cves/2019/CVE-2019-18935.yaml
+++ b/http/cves/2019/CVE-2019-18935.yaml
@@ -26,7 +26,7 @@ info:
     epss-percentile: 0.99989
     cpe: cpe:2.3:a:progress:telerik_ui_for_asp.net_ajax:*:*:*:*:*:*:*:*
   metadata:
-    verified: true
+    verified: false
     max-request: 3
     vendor: progress
     product: telerik_ui_for_asp.net_ajax
@@ -35,6 +35,7 @@ info:
   tags: cve,cve2019,telerik,deserialization,rce,kev,progress,asp.net,fileupload
 
 flow: http(1) && (http(2) || http(3))
+cookie-reuse: true
 
 http:
   # Stage 1: Verify RadAsyncUpload handler is registered
@@ -42,6 +43,7 @@ http:
       - |
         GET /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
         Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
 
     matchers:
       - type: word
@@ -58,6 +60,7 @@ http:
       - |
         POST /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
         Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
         Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 
         ------WebKitFormBoundary7MA4YWxkTrZu0gW
@@ -87,6 +90,7 @@ http:
       - |
         POST /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
         Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
         Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 
         ------WebKitFormBoundary7MA4YWxkTrZu0gW


### PR DESCRIPTION
/claim #14278

### PR Information

- Added CVE-2019-18935
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2019-18935
    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-074a
    - https://bishopfox.com/blog/cve-2019-18935-remote-code-execution-in-telerik-ui
    - https://github.com/noperator/CVE-2019-18935
    - https://github.com/bao7uo/RAU_crypto

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Detection Methodology:** Behavior-based POC using pre-computed encrypted payloads with default Telerik keys (`PrivateKeyForEncryptionOfRadAsyncUploadConfiguration`).

| Target State | Response | Match |
|--------------|----------|-------|
| Vulnerable (default keys) | Assembly loading error + HTTP 500 | ✅ |
| Patched (>= 2020.1.114) | Type validation error | ❌ |
| Custom keys | Decryption error | ❌ |

**Limitation:** Requires default Telerik encryption keys. Documented in template description.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)