### PR TITLE
Add CVE-2019-4061 (vKEV)

### DIFF
--- a/http/cves/2019/CVE-2019-4061.yaml
+++ b/http/cves/2019/CVE-2019-4061.yaml
@@ -21,11 +21,12 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:ibm:bigfix_platform:*:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 2
     vendor: ibm
     product: bigfix_platform
     shodan-query: port:52311 "BigFixHTTPServer"
-  tags: cve,cve2019,ibm,bigfix,disclosure
+  tags: cve,cve2019,ibm,bigfix,disclosure,kev,vkev
 
 flow: http(1) && http(2)
 


### PR DESCRIPTION
### PR Information

IBM BigFix Platform 9.2 and 9.5 contains an information disclosure vulnerability caused by not enabling authenticated access in relay, letting remote attackers query and gather update and fixlet information, exploit requires no authentication.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)
