### PR TITLE
Add CVE-2021-37415 (vKEV)

### DIFF
--- a/http/cves/2021/CVE-2021-37415.yaml
+++ b/http/cves/2021/CVE-2021-37415.yaml
@@ -3,7 +3,7 @@ id: CVE-2021-37415
 info:
   name: Zoho ManageEngine ServiceDesk Plus - Authentication Bypass
   author: daffainfo,jjcho
-  severity: high
+  severity: critical
   description: |
     Zoho ManageEngine ServiceDesk Plus before 11302 is vulnerable to authentication bypass that allows a few REST-API URLs without authentication.
   remediation: |


### PR DESCRIPTION
### PR Information

Zoho ManageEngine ServiceDesk Plus before 11302 is vulnerable to authentication bypass that allows a few REST-API URLs without authentication.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Notes

Researched this with @jjchoNC