### PR TITLE
Add CVE-2023-38952 (Updated CVEs)

### DIFF
--- a/http/cves/2023/CVE-2023-38952.yaml
+++ b/http/cves/2023/CVE-2023-38952.yaml
@@ -18,8 +18,8 @@ info:
     cpe: cpe:2.3:a:zkteco:biotime:8.5.5:::::::*
   metadata:
     verified: true
-    vendor: ZKTeco
-    product: BioTime
+    vendor: zkteco
+    product: biotime
     max-request: 12
     shodan-query: http.html:"ZKTeco Security"
     fofa-query: body="ZKTeco Security"


### PR DESCRIPTION
### PR Information

Add CVE-2023-38952

Insecure access control in ZKTeco BioTime through 9.0.1 allows authenticated attackers to escalate their privileges due to the fact that session ids are not validated for the type of user accessing the application by default. Privilege restrictions between non-admin and admin users are not enforced and any authenticated user can leverage admin functions without restriction by making direct requests to administrative endpoints.


- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
