### PR TITLE
Add CVE-2025-52970 (Updated CVEs)

### DIFF
--- a/http/cves/2025/CVE-2025-52970.yaml
+++ b/http/cves/2025/CVE-2025-52970.yaml
@@ -10,7 +10,6 @@ info:
     - https://github.com/imbas007/POC-CVE-2025-52970/blob/main/README.md
     - https://github.com/34zY/CVE-2025-52970
     - https://github.com/Hex00-0x4/FortiWeb-CVE-2025-52970-Authentication-Bypass
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-52970
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.1
@@ -27,7 +26,7 @@ info:
       - http.title:"Fortinet"
     fofa-query: app="Fortinet-FortiWeb"
     google-query: intitle:"FortiWeb" "login"
-  tags: cve,fortinet,fortiweb,auth-bypass,priv-esc,vkev,intrusive
+  tags: cve,cve2025fortinet,fortiweb,auth-bypass,priv-esc,kev,vkev,intrusive
 
 variables:
   f_cgi: "{{rand_text_alpha(6)}}.cgi"


### PR DESCRIPTION
### PR Information

A improper handling of parameters in Fortinet FortiWeb versions 7.6.3 and below, versions 7.4.7 and below, versions 7.2.10 and below, and 7.0.10 and below may allow an unauthenticated remote attacker with non-public information pertaining to the device and targeted user to gain admin privileges on the device via a specially crafted request.

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
