### PR TITLE
CVE-2023-25158: GeoServer SQL Injection (JDBCDataStore)

### DIFF
--- a/http/cves/2023/CVE-2023-25158.yaml
+++ b/http/cves/2023/CVE-2023-25158.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     GeoTools < 27.4, 28.2 contains a SQL injection vulnerability via unsanitized OGC Filter expressions.
     This template uses a valid CQL payload ('x''y') to bypass the initial parser and trigger a SQL syntax error in the backend database.
-    
+
     NOTE: Exploitation requires a specific configuration (Encode Functions Enabled + SQL Backend).
   reference:
     - https://github.com/geoserver/geoserver/security/advisories/GHSA-7g5f-wrx8-5ccf


### PR DESCRIPTION
### PR Information

- Added CVE-2023-25158

- References: https://github.com/geoserver/geoserver/security/advisories/GHSA-7g5f-wrx8-5ccf

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)

- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Additional Details

/claim #13933

**Differentiation from CVE-2023-25157:**
This template is **NOT** a duplicate of CVE-2023-25157. (as questioned here  #13937)
* **CVE-2023-25157:** Targets general SQL injection where the default parser fails. (this could lead to false positives as noted on #14127)
* **CVE-2023-25158 (This PR):** Targets a specific code path in **JDBCDataStore** that is only reachable when **"Encode Functions"** is enabled (a non-default configuration).
    * It uses a valid CQL payload (`'x''y'`) which bypasses standard WFS validation but generates malformed SQL (`Unterminated string literal`) when processed by the `strStartsWith` encoder.
    * My testing confirmed that standard invalid grammar payloads (like `'x''`) trigger false positives on patched versions. This template uses valid grammar to ensure high-fidelity detection.

**Automated Reproduction (Docker Compose):**
*Note: Vulnerability requires PostGIS Backend + "Encode Functions" Enabled.*

**1. Start Environment:**
```yaml
version: '3'
services:
  db:
    image: postgis/postgis:14-3.2
    environment:
      POSTGRES_DB: geoserver_data
      POSTGRES_USER: geoserver
      POSTGRES_PASSWORD: mysecretpassword
  geoserver:
    image: kartoza/geoserver:2.21.0
    ports: ["8080:8080"]
    environment:
      GEOSERVER_ADMIN_USER: admin
      GEOSERVER_ADMIN_PASSWORD: geoserver
    depends_on: [db]
```

**2. Configure & Enable Vulnerability (Bash/Curl):**

### Create Workspace & Store
```
curl -u admin:geoserver -X POST -H "Content-type: text/xml" -d "<workspace><name>vuln_space</name></workspace>" http://localhost:8080/geoserver/rest/workspaces
curl -u admin:geoserver -X POST -H "Content-type: application/json" -d '{"dataStore":{"name":"pg_store","connectionParameters":{"host":"db","port":"5432","database":"geoserver_data","user":"geoserver","passwd":"mysecretpassword","dbtype":"postgis","encode functions":"true"}}}' http://localhost:8080/geoserver/rest/workspaces/vuln_space/datastores
```
### Create Data & Publish
```
docker exec vulnerable-geoserver psql -h db -U geoserver -d geoserver_data -c "CREATE TABLE targets (id varchar(20) PRIMARY KEY, name varchar(20), geom geometry(Point,4326));"
curl -u admin:geoserver -X POST -H "Content-type: text/xml" -d "<featureType><name>targets</name><nativeName>targets</nativeName></featureType>" http://localhost:8080/geoserver/rest/workspaces/vuln_space/datastores/pg_store/featuretypes
```

Debug Output (Vulnerable 2.21.0):
```
<ServiceException>
error:Translator error ... Unterminated string literal started at position 125 in SQL ...
</ServiceException>
[CVE-2023-25158:word-1] [http] [critical] http://localhost:8080...
```
