### PR TITLE
Add CVE-2022-38130 (vKEV)

### DIFF
--- a/http/cves/2022/CVE-2022-38130.yaml
+++ b/http/cves/2022/CVE-2022-38130.yaml
@@ -45,5 +45,5 @@ http:
           - 'status_code == 200'
           - "contains(interactsh_protocol, 'dns')"
           - "contains(content_type, 'application/x-java-serialized-object')"
-          - "contains_all(body, 'org.springframework','RemoteInvocationResult')"      
+          - "contains_all(body, 'org.springframework','RemoteInvocationResult')"
         condition: and


### PR DESCRIPTION
### PR Information

The com.keysight.tentacle.config.ResourceManager.smsRestoreDatabaseZip() method is used to restore the HSQLDB database used in SMS. It takes the path of the zipped database file as the single parameter. An unauthenticated, remote attacker can specify an UNC path for the database file (i.e., \\<attacker-host>\sms\<attacker-db.zip>), effectively controlling the content of the database to be restored.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Notes
Researched this with @jjchoNC