### PR TITLE
Add CVE-2025-55749 for XWiki information disclosure

### DIFF
--- a/http/cves/2025/CVE-2025-55749.yaml
+++ b/http/cves/2025/CVE-2025-55749.yaml
@@ -12,11 +12,17 @@ info:
     Update to versions 16.10.11, 17.4.4, or 17.7.0 or later.
   reference:
     - https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-53gx-j3p6-2rw9
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-55749
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-55749
+    cwe-id: CWE-284
   metadata:
     verified: true
     max-request: 1
     fofa-query: app="XWIKI-Platform"
-  tags: cve,cve2025,xwiki,info-leak,vuln
+  tags: cve,cve2025,xwiki,exposure,vuln
 
 http:
   - method: GET


### PR DESCRIPTION
Added CVE-2025-55749 entry detailing an information disclosure vulnerability in XWiki.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
