### PR TITLE
Add CVE-2021-20617 (vKEV)

### DIFF
--- a/http/cves/2021/CVE-2021-20617.yaml
+++ b/http/cves/2021/CVE-2021-20617.yaml
@@ -28,7 +28,7 @@ info:
     product: acmailer,acmailer_db
     shodan-query: title="ACMAILER4.0"
     fofa-query: title="ACMAILER4.0"
-  tags: cve,cve2021,acmailer,rce,vkev,oast,oob
+  tags: cve,cve2021,acmailer,rce,vkev,oast,oob,kev
 
 variables:
   admin_name: "{{randbase(5)}}"


### PR DESCRIPTION
### PR Information

Improper access control vulnerability in acmailer ver. 4.0.1 and earlier, and acmailer DB ver. 1.1.3 and earlier allows remote attackers to execute an arbitrary OS command, or gain an administrative privilege which may result in obtaining the sensitive information on the server via unspecified vectors.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)
