### PR TITLE
Fix FN (False Negative) CVE-2022-26143

### DIFF
--- a/http/cves/2022/CVE-2022-26143.yaml
+++ b/http/cves/2022/CVE-2022-26143.yaml
@@ -24,7 +24,7 @@ info:
     verified: true
     shodan-query: html:"MiCollab End User Portal"
     max-request: 1
-  tags: cve,cve2025,mitel,micollab,kev,passive,vkev
+  tags: cve,cve2022,mitel,micollab,kev,passive,vkev
 
 http:
   - raw:


### PR DESCRIPTION
Not every response contains `content-type: text/plain` header. Here's some example:
```
HTTP/1.1 200 OK
Connection: close
Content-Length: 21
Accept-Ranges: bytes
Date: Sun, 14 Dec 2025 13:54:06 GMT
Etag: "15-5d65095c50c80"
Last-Modified: Mon, 24 Jan 2022 09:28:02 GMT
Server: Apache
Strict-Transport-Security: max-age=63072000; includeSubdomains
Vary: User-Agent
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

{"version":"9.4.109"}
```