### PR TITLE
Add CVE-2012-10018 detection template

### DIFF
--- a/http/cves/2012/CVE-2012-10018.yaml
+++ b/http/cves/2012/CVE-2012-10018.yaml
@@ -28,7 +28,7 @@ info:
     max-request: 4
     vendor: mapplic
     product: mapplic
-  tags: cve,cve2012,wordpress,wp-plugin,xss,mapplic,authenticated
+  tags: cve,cve2012,wordpress,wp-plugin,xss,mapplic,kev,vkev,authenticated
 
 flow: http(1) && http(2) && http(3) && http(4)
 


### PR DESCRIPTION
/claim 14478

## Summary
Adds nuclei template for detecting CVE-2012-10018 (WordPress Mapplic/Mapplic Lite Stored XSS via SVG file upload).

Vulnerable environment shared privately 

## Testing
- [x] Syntax validation: passed
- [x] Manual testing: passed

### Test Evidence
Validated against WordPress 5.5 + Mapplic Lite 1.0 in Docker environment (shared privately).

<img width="994" height="344" alt="image" src="https://github.com/user-attachments/assets/60a3082e-599d-4c9e-8c98-2b04c2c0e9ec" />