### PR TITLE
Add CVE-2024-33939 (Updated CVEs)

### DIFF
--- a/http/cves/2024/CVE-2024-33939.yaml
+++ b/http/cves/2024/CVE-2024-33939.yaml
@@ -27,7 +27,7 @@ info:
     shodan-query: http.html:"/wp-content/plugins/learning-management-system/"
     fofa-query: body=/wp-content/plugins/learning-management-system/
     google-query: inurl:"/wp-content/plugins/learning-management-system/"
-  tags: cve,cve2024,wordpress,wp-plugin,lms,idor,unauth,learning-management-system
+  tags: cve,cve2024,wordpress,wp-plugin,lms,idor,unauth,learning-management-system,kev,vkev
 
 http:
   - raw:


### PR DESCRIPTION
### PR Information

Authentication Bypass Using an Alternate Path or Channel vulnerability in Masteriyo Masteriyo - LMS. Unauth access to course progress.This issue affects Masteriyo - LMS: from n/a through 1.7.3.

- References:

    - https://nvd.nist.gov/vuln/detail/CVE-2024-33939
    - https://wpscan.com/vulnerability/57c0054a-b713-4f7c-8e41-c009b07624a6/
    
### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
