### PR TITLE
Add CVE-2019-18935 detection template

### DIFF
--- a/http/cves/2019/CVE-2019-18935.yaml
+++ b/http/cves/2019/CVE-2019-18935.yaml
@@ -1,0 +1,51 @@
+id: CVE-2019-18935
+
+info:
+  name: Progress Telerik UI for ASP.NET AJAX - Insecure Deserialization
+  author: princechaddha
+  severity: critical
+  description: |
+    Progress Telerik UI for ASP.NET AJAX through 2019.3.1023 contains a .NET deserialization vulnerability in the RadAsyncUpload function. This is exploitable when the encryption keys are known due to the presence of CVE-2017-11317 or CVE-2017-11357, or other means. Exploitation can result in remote code execution.
+  remediation: |
+    Upgrade to Telerik UI for ASP.NET AJAX R3 2019 SP1 (2019.3.1023) or later and ensure the TypeWhitelist feature is enabled.
+  reference:
+    - https://github.com/projectdiscovery/nuclei-templates/issues/14278
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-18935
+    - https://github.com/noperator/CVE-2019-18935
+    - https://know.bishopfox.com/research/cve-2019-18935-remote-code-execution-in-telerik-ui
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2019-18935
+    cwe-id: CWE-502
+  metadata:
+    max-request: 2
+    vendor: progress
+    product: telerik_ui_for_asp.net_ajax
+    shodan-query: http.component:"Telerik"
+  tags: cve,cve2019,telerik,rce,deserialization,aspnet,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Telerik.Web.UI.WebResource.axd?type=rau"
+      - "{{BaseURL}}/Telerik.Web.Ui.WebResource.axd?type=rau"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "RadAsyncUpload handler is registered succesfully"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - "20[0-9]{2}\\.[0-9]+\\.[0-9]+"


### PR DESCRIPTION
### PR Information

- Added CVE-2019-18935
- References: 
  - https://github.com/projectdiscovery/nuclei-templates/issues/14278
  - https://nvd.nist.gov/vuln/detail/CVE-2019-18935
  - https://know.bishopfox.com/research/cve-2019-18935-remote-code-execution-in-telerik-ui

/claim #14278

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

**Debug Output:**

```text
[DBG] [CVE-2019-18935] [http] Dumped HTTP request for [https://target.example.com/Telerik.Web.UI.WebResource.axd?type=rau](https://target.example.com/Telerik.Web.UI.WebResource.axd?type=rau)

GET /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
Host: target.example.com
User-Agent: Nuclei/3.0.0
Accept: */*
Accept-Encoding: gzip


[DBG] [CVE-2019-18935] [http] Dumped HTTP response for [https://target.example.com/Telerik.Web.UI.WebResource.axd?type=rau](https://target.example.com/Telerik.Web.UI.WebResource.axd?type=rau)

HTTP/1.1 200 OK
Cache-Control: private
Content-Type: application/json; charset=utf-8
Server: Microsoft-IIS/8.5
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sat, 20 Dec 2025 10:00:00 GMT
Content-Length: 54

{ "message" : "RadAsyncUpload handler is registered succesfully" }