### PR TITLE
Add CVE-2024-3408 D-Tale RCE template

### DIFF
--- a/http/cves/2024/CVE-2024-3408.yaml
+++ b/http/cves/2024/CVE-2024-3408.yaml
@@ -14,14 +14,13 @@ info:
     - https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
     - https://github.com/man-group/dtale/commit/32bd6fb4a63de779ff1e51823a456865ea3cbd13
     - https://nvd.nist.gov/vuln/detail/CVE-2024-3408
-    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2024-3408
     cwe-id: CWE-94,CWE-798
-    epss-score: 0.04
-    epss-percentile: 0.5
+    epss-score: 0.83522
+    epss-percentile: 0.9924
     cpe: cpe:2.3:a:man-group:dtale:*:*:*:*:*:python:*:*
   metadata:
     verified: true


### PR DESCRIPTION
 /claim #14488

**Vulnerable environment shared privately** 

- Added CVE-2024-3408 - D-Tale Authentication Bypass and RCE
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-3408
  - https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
  - https://github.com/man-group/dtale/commit/32bd6fb4a63de779ff1e51823a456865ea3cbd13

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Tested against D-Tale 3.10.0 Docker environment.
<img width="1777" height="350" alt="image" src="https://github.com/user-attachments/assets/989e7b8d-7d85-4640-b050-1f68bdd34914" />


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)