### PR TITLE
feat: add template for CVE-2025-12139

### DIFF
--- a/http/cves/2025/CVE-2025-12139.yaml
+++ b/http/cves/2025/CVE-2025-12139.yaml
@@ -5,7 +5,7 @@ info:
   author: Meysam Bal-afkan
   severity: high
   description: |
-    File Manager for Google Drive – Integrate Google Drive with WordPress plugin for WordPress <= 1.5.3 contains sensitive information exposure caused by improper protection of the get_localize_data function, letting unauthenticated attackers extract Google OAuth credentials and account email addresses, exploit requires no authentication.
+    File Manager for Google Drive - Integrate Google Drive with WordPress plugin for WordPress <= 1.5.3 contains sensitive information exposure caused by improper protection of the get_localize_data function, letting unauthenticated attackers extract Google OAuth credentials and account email addresses, exploit requires no authentication.
   impact: |
     Unauthenticated attackers can extract sensitive Google OAuth credentials and email addresses, risking account compromise and data theft.
   remediation: |
@@ -28,15 +28,13 @@ http:
     path:
       - "{{BaseURL}}"
 
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "var igd") && (regex("\"clientSecret\":\"[^\"]+\"", body) || regex("\"accounts\":\"[A-Za-z0-9+/=]{20,}\"", body))'
-
-      - type: status
-        status:
-          - 200
+          - 'status_code == 200'
+          - 'contains(body, "var igd")'
+          - 'regex("\"clientSecret\":\"[^\"]+\"", body) || regex("\"accounts\":\"[A-Za-z0-9+/=]{20,}\"", body)'
+        condition: and
 
     extractors:
       - type: regex


### PR DESCRIPTION
Integrate Google Drive Plugin - Information Disclosure Vulnerability

### PR Information

This PR adds a new template for **CVE-2025-12139**, a high-severity Information Disclosure vulnerability in the **Integrate Google Drive** WordPress plugin (versions <= 1.5.3).
The vulnerability exposes sensitive Google API credentials (Client ID, Secret) and OAuth tokens via `wp_localize_script`.

- Added CVE-2025-12139
- References:
  - https://wordpress.org/plugins/integrate-google-drive/
  - https://github.com/Galaxy-sc/CVE-2025-12139-WordPress-Integrate-Google-Drive-Exploit

### Template validation

I have tested this template locally against a vulnerable instance setup with WordPress and the affected plugin version. It successfully detects the leaked `clientSecret` and `igd` variable.

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Tested on Localhost environment (XAMPP) against a vulnerable WordPress installation.