### PR TITLE
Detect exposed D-Tale endpoints related to CVE-2024-3408

### DIFF
--- a/http/exposures/dtale/dtale-dangerous-endpoints-exposure.yaml
+++ b/http/exposures/dtale/dtale-dangerous-endpoints-exposure.yaml
@@ -1,0 +1,19 @@
+id: dtale-dangerous-endpoints-exposure
+
+info:
+  name: D-Tale Dangerous Endpoints Exposure
+  author: Bittukr7479
+  severity: high
+  tags: dtale,misconfig,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dtale/web-upload"
+      - "{{BaseURL}}/dtale/test-filter/1"
+      - "{{BaseURL}}/dtale/update-settings/1"
+
+    matchers:
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

This pull request adds a nuclei template to detect exposed and dangerous D-Tale endpoints
associated with CVE-2024-3408. Improperly exposed endpoints can indicate insecure D-Tale
deployments that may lead to authentication bypass and unsafe server-side behaviors in
trusted or misconfigured environments.

- Added CVE-2024-3408
- References:
  - https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
  - https://github.com/man-group/dtale
  - https://github.com/projectdiscovery/nuclei-templates/issues/14488

---

### Template validation

- [x] Validated with a host running a vulnerable configuration (True Positive)
- [ ] Validated with a host running a patched version (avoid False Positive)

Validation was performed against a live D-Tale instance where the following endpoints
were accessible without authentication.

---

#### Additional Details

**Endpoints detected by the template:**
- `/dtale/web-upload`
- `/dtale/test-filter/{id}`
- `/dtale/update-settings/{id}`

**Observed behavior:**
- Endpoints respond successfully without authentication
- `/dtale/web-upload` returns a security warning indicating SSRF risk
- `/dtale/test-filter` and `/dtale/update-settings` respond with success status

**Nuclei validation:**
```bash
nuclei -validate -t http/exposures/dtale/dtale-dangerous-endpoints-exposure.yaml
