### PR TITLE
Add CVE-2019-9082 ThinkPHP RCE

### DIFF
--- a/http/cves/2019/CVE-2019-9082.yaml
+++ b/http/cves/2019/CVE-2019-9082.yaml
@@ -5,20 +5,21 @@ info:
   author: flame
   severity: high
   description: |
-    ThinkPHP < 5.0.24 allows remote command execution via the `_method=__construct` gadget combined
-    with attacker-controlled request filtering (e.g., `filter[]=system`), resulting in `system(id)` output.
+    ThinkPHP < 5.0.24 allows remote command execution via the `_method=__construct` gadget combined with attacker-controlled request filtering (e.g., `filter[]=system`), resulting in `system(id)` output.
   reference:
-    - https://github.com/projectdiscovery/nuclei-templates/issues/14501
-    - http://packetstormsecurity.com/files/157218/ThinkPHP-5.0.23-Remote-Code-Execution.html
     - https://www.exploit-db.com/exploits/46488/
+    - http://packetstormsecurity.com/files/157218/ThinkPHP-5.0.23-Remote-Code-Execution.html
     - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/webapp/thinkphp_rce.rb
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-9082
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
     cve-id: CVE-2019-9082
     cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 2
-  tags: cve,cve2019,thinkphp,rce,injection
+  tags: cve,cve2019,thinkphp,rce,injection,vuln,unauthenticated
 
 http:
   - method: POST
@@ -35,15 +36,13 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
-        condition: and
         words:
           - "uid="
           - "gid="
+        condition: and
 
-
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
CVE-2019-9082 - ThinkPHP RCE

### PR Information

Adds an exploit-based template for `CVE-2019-9082` (ThinkPHP RCE). The check triggers the public `_method=__construct` gadget chain and looks for `id` output (`uid=`/`gid=`).

/claim #14501

- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/14501
  - http://packetstormsecurity.com/files/157218/ThinkPHP-5.0.23-Remote-Code-Execution.html
  - https://www.exploit-db.com/exploits/46488/
  - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/webapp/thinkphp_rce.rb

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

