### PR TITLE
Add CVE-2024-24882 (Updated CVEs)

### DIFF
--- a/http/cves/2024/CVE-2024-24882.yaml
+++ b/http/cves/2024/CVE-2024-24882.yaml
@@ -24,13 +24,11 @@ info:
   metadata:
     verified: true
     max-request: 4
-    vendor: Masteriyo
-    product: Masteriyo LMS
-    shodan-query:
-      - http.html:"/wp-content/plugins/learning-management-system/"
-    fofa-query: body=/wp-content/plugins/learning-management-system/
+    vendor: themegrill
+    product: masteriyo
+    fofa-query: body="/wp-content/plugins/learning-management-system/"
     google-query: inurl:"/wp-content/plugins/learning-management-system/"
-  tags: wordpress,wp,wp-plugin,lms,privilege-escalation,cve,cve2024
+  tags: cve,cve2024,wordpress,wp,wp-plugin,lms,priv-esc,learning-management-system,kev,vkev,intrusive
 
 variables:
   uname: "{{rand_base(4)}}"


### PR DESCRIPTION
### PR Information

The Masteriyo LMS – eLearning and Online Course Builder for WordPress plugin for WordPress is vulnerable to privilege escalation due to a missing capability check on the update_logged_in_user() function in all versions up to, and including, 1.7.2. This makes it possible for unauthenticated attackers to elevate their privileges to that of an administrator.

- References:
- https://wpscan.com/vulnerability/8407f428-12e7-4549-aa65-a241b7bdca41/
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/learning-management-system/masteriyo-lms-172-unauthenticated-privilege-escalation
- https://plugins.trac.wordpress.org/changeset/3022839/learning-management-system/tags/1.7.3/includes/RestApi/Controllers/Version1/UsersController.php?old=2959283&old_path=learning-management-system%2Ftrunk%2Fincludes%2FRestApi%2FControllers%2FVersion1%2FUsersController.php
  - https://nvd.nist.gov/vuln/detail/CVE-2024-24882
 
### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
