### PR TITLE
Update CVE-2016-10956.yaml

### DIFF
--- a/http/cves/2016/CVE-2016-10956.yaml
+++ b/http/cves/2016/CVE-2016-10956.yaml
@@ -37,6 +37,8 @@ http:
       - "{{BaseURL}}/wp-content/plugins/mail-masta/inc/campaign/count_of_send.php?pl=/etc/passwd"
       - "{{BaseURL}}/wp-content/plugins/mail-masta/inc/lists/csvexport.php?pl=/etc/passwd"
 
+    stop-at-first-match: true
+
     matchers-condition: and
     matchers:
       - type: regex


### PR DESCRIPTION
It causes two to appear in the output. I think adding stop-first-match makes more sense.

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
