### PR TITLE
CVE-2025-13329: File Uploader for WooCommerce <= 1.0.3 - Arbitrary File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-13329.yaml
+++ b/http/cves/2025/CVE-2025-13329.yaml
@@ -1,0 +1,29 @@
+id: CVE-2025-13329
+
+info:
+  name: File Uploader for WooCommerce <= 1.0.3 - Arbitrary File Upload
+  author: ritik-prajapati
+  severity: critical
+  description: The File Uploader for WooCommerce plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type validation in the callback function for the 'add-image-data' REST API endpoint in all versions up to, and including, 1.0.3.
+  reference:
+    - https://patchstack.com/database/vulnerability/file-uploader-for-woocommerce/wordpress-file-uploader-for-woocommerce-plugin-1-0-3-arbitrary-file-upload-vulnerability
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-13329
+  metadata:
+    verified: true
+  tags: cve,cve2025,wordpress,wp-plugin,rce,unauth,file-uploader-for-woocommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/file-uploader-for-woocommerce/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "Stable tag:")'
+          - 'regex("Stable tag:\\s*(1\\.0\\.[0-3]|0\\.[0-9\\.]+)", body)'
+        condition: and
+        


### PR DESCRIPTION
Adds a new template for CVE-2025-13329.

### Validation
- ✅ Validated against local vulnerable instance.
- ✅ See attached screenshot for proof.
![Proof 4](https://github.com/user-attachments/assets/ed7a9061-c744-4d36-8467-a99e4235885d)

/claim