### PR TITLE
Add CVE-2018-8011 (vKEV)

### DIFF
--- a/javascript/cves/2018/CVE-2018-8011.yaml
+++ b/javascript/cves/2018/CVE-2018-8011.yaml
@@ -27,7 +27,7 @@ info:
     vendor: apache
     product: http_server
     shodan-query: cpe:"cpe:2.3:a:apache:http_server"
-  tags: cve,cve2018,js,apache,httpd,dos,vkev
+  tags: cve,cve2018,js,apache,httpd,dos,vkev,kev
 
 javascript:
   - code: |
@@ -77,6 +77,8 @@ javascript:
       Host: "{{Host}}"
       Port: 80,443 # if port not specified, defaults to both 80 and 443
       exclude-ports: "0" # override default skip list of 80,443,8080,8443
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### PR Information

By specially crafting HTTP requests, the mod_md challenge handler would dereference a NULL pointer and cause the child process to segfault. This could be used to DoS the server. Fixed in Apache HTTP Server 2.4.34 (Affected 2.4.33)

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)