### PR TITLE
working mongodb version enum template

### DIFF
--- a/network/enumeration/mongodb-info-enum.yaml
+++ b/network/enumeration/mongodb-info-enum.yaml
@@ -1,14 +1,22 @@
-id: mongodb-version
+id: mongodb-info-enum
 
 info:
-  name: MongoDB Version Check
-  author: h4sh5
+  name: MongoDB Information - Detect
+  author: pussycat0x,h4sh5
   severity: info
-  description: MongoDB Version Check
+  description: |
+    MongoDB build and server information was detected.
+  reference:
+    - https://nmap.org/nsedoc/scripts/mongodb-info.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
   metadata:
+    verified: true
     max-request: 1
     shodan-query: mongodb server information
-  tags: network,mongodb,enum,tcp,discovery,detect,version
+  tags: network,mongodb,enum,tcp,discovery
+
 tcp:
   - inputs:
       - data: 3b0000003c300000ffffffffd40700000000000061646d696e2e24636d640000000000ffffffff14000000106275696c64696e666f000100000000
@@ -18,6 +26,14 @@ tcp:
       - "{{Hostname}}"
     port: 27017
     read-size: 2048
+
+    matchers:
+      - type: word
+        part: raw
+        words:
+          - "version"
+          - "maxBsonObjectSize"
+        condition: and
 
     extractors:
       - type: regex


### PR DESCRIPTION
### PR Information

- Fixed non-working mongodb enum template; the old one no longer works

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

