### PR TITLE
[CVE-2025-34291] Langflow AI CORS Misconfiguration

### DIFF
--- a/http/cves/2025/CVE-2025-34291.yaml
+++ b/http/cves/2025/CVE-2025-34291.yaml
@@ -26,7 +26,9 @@ info:
     product: langflow
     shodan-query: html:"Langflow"
     fofa-query: body="Langflow"
-  tags: cve,cve2025,langflow,cors,misconfiguration,token-theft,rce
+  tags: cve,cve2025,langflow,cors,misconfig,token-theft
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -34,35 +36,38 @@ http:
         GET / HTTP/1.1
         Host: {{Hostname}}
 
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Langflow"
+        internal: true
+
+  - raw:
       - |
         OPTIONS /api/v1/refresh HTTP/1.1
         Host: {{Hostname}}
-        Origin: https://evil.com
+        Origin: https://scanme.sh
         Access-Control-Request-Method: POST
         Access-Control-Request-Headers: content-type
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body_1
+        part: header
         words:
-          - "Langflow"
-
-      - type: word
-        part: header_2
-        words:
-          - "Access-Control-Allow-Origin: https://evil.com"
+          - "Access-Control-Allow-Origin: https://scanme.sh"
           - "Access-Control-Allow-Credentials: true"
         condition: and
 
       - type: status
-        part: header_2
+        part: header
         status:
           - 200
 
     extractors:
       - type: kval
-        part: header_2
+        part: header
         kval:
           - Access_Control_Allow_Origin
           - Access_Control_Allow_Credentials


### PR DESCRIPTION
Hey!

First of all, thanks to the ProjectDiscovery team and the community for all the amazing work on nuclei. It's been a great tool to learn and contribute to.

## What's this about?

I'm submitting a template for **CVE-2025-34291**, a CORS misconfiguration vulnerability in Langflow AI (versions <= 1.6.9).

## The vulnerability

Langflow's API has a misconfigured CORS policy:
- `Access-Control-Allow-Origin` reflects any origin sent by the client
- `Access-Control-Allow-Credentials: true` is always set

This combo, paired with `SameSite=None` cookies, allows an attacker to steal authentication tokens cross-origin and chain it to RCE via `/api/v1/validate/code`.

## How the template works

1. First request confirms it's a Langflow instance
2. Second request (OPTIONS to `/api/v1/refresh`) checks if the origin is reflected with credentials allowed

## Testing

Tested locally against the vulnerable Docker image:

```
docker run -d -p 7860:7860 langflowai/langflow:1.6.9
```

## Debug output

```
[INF] [CVE-2025-34291] Dumped HTTP request for http://localhost:7860

GET / HTTP/1.1
Host: localhost:7860

[DBG] [CVE-2025-34291] Dumped HTTP response http://localhost:7860

HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
<title>Langflow</title>

[INF] [CVE-2025-34291] Dumped HTTP request for http://localhost:7860/api/v1/refresh

OPTIONS /api/v1/refresh HTTP/1.1
Host: localhost:7860
Origin: https://evil.com
Access-Control-Request-Method: POST
Access-Control-Request-Headers: content-type

[DBG] [CVE-2025-34291] Dumped HTTP response http://localhost:7860/api/v1/refresh

HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: content-type
Access-Control-Allow-Methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
Access-Control-Allow-Origin: https://evil.com

[CVE-2025-34291] [http] [critical] http://localhost:7860/api/v1/refresh
```

## References
- https://www.obsidiansecurity.com/blog/three-authentication-bypasses-in-langflow-ai/
- https://nvd.nist.gov/vuln/detail/CVE-2025-34291

Thanks for reviewing! Happy to make any changes if needed.