### PR TITLE
Added CVE-2023-52163 Template

### DIFF
--- a/http/cves/2023/CVE-2023-52163.yaml
+++ b/http/cves/2023/CVE-2023-52163.yaml
@@ -16,7 +16,8 @@ info:
     - https://github.com/advisories/GHSA-mrvx-3qrr-qqxw
   metadata:
     max-request: 1
-  tags: cve,cve2023,digiever,rce,oast,kev,vkev
+    verified: false
+  tags: cve,cve2023,digiever,rce,oast,oob,kev,vkev
 
 http:
   - raw:


### PR DESCRIPTION
### PR Information

- Added CVE-2023-52163 - Digiever DS-2105 Pro OS Command Injection
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2023-52163
  - https://www.txone.com/blog/digiever-fixes-sorely-needed/
  - https://www.fortiguard.com/encyclopedia/ips/57266
  - https://github.com/advisories/GHSA-mrvx-3qrr-qqxw

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

**CVE Details:**
- Severity: HIGH (CVSS 8.8)
- Product: Digiever DS-2105 Pro NVR (v3.1.0.71-11)
- Type: OS Command Injection via `ntp` parameter in `time_tzsetup.cgi`
- KEV Status: Added to CISA KEV catalog on 2025-12-22

**Note:** Device is End-of-Life hardware. No vulnerable environment available for live testing. Template uses OAST (interactsh) for safe detection. Syntax validated with `nuclei -validate`.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
