### PR TITLE
fix port used on CVE-2014-0160 (Heartbleed)

### DIFF
--- a/code/cves/2014/CVE-2014-0160.yaml
+++ b/code/cves/2014/CVE-2014-0160.yaml
@@ -111,7 +111,7 @@ code:
           # Parse the URL
           parsed_url = urlparse(url)
           host = parsed_url.hostname
-          port = parsed_url.port if parsed_url.port else 443
+          port = parsed_url.port if parsed_url.port else 80 if parsed_url.scheme == "http" else 443
 
           if not host:
               return


### PR DESCRIPTION
### PR Information

When using template for Heartbleed, it would incorrectly test (and report) port 443 twice when given the entries:
```
http://10.0.0.1
https://10.0.0.1
```

This PR changes the port used for plain HTTP URLs. It is still useful to test this vuln on a plain HTTP port given some of them do answer to SSL/TLS Client Hello packets and then establish a TLS connection. 

- Fixed CVE-2014-01460

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
