### PR TITLE
SRV Service Detect

### DIFF
--- a/dns/srv-service-detect.yaml
+++ b/dns/srv-service-detect.yaml
@@ -5,12 +5,13 @@ info:
   author: rxerium
   severity: info
   description: |
-    Detects services via SRV (Service) DNS records. SRV records define the location of servers for specified services.
+    Detected services via SRV (Service) DNS records. SRV records defined the location of servers for specified services.
   reference:
     - https://www.rfc-editor.org/rfc/rfc2srv
     - https://en.wikipedia.org/wiki/SRV_record
   metadata:
     max-request: 15
+    verified: true
   tags: dns,srv,service,discovery
 
 dns:


### PR DESCRIPTION
Detects services via SRV (Service) DNS records. SRV records define the location of servers for specified services. Happy to provide the output from the scan I conducted. 