### PR TITLE
Add CVE-2017-18365 GitHub Enterprise Insecure Deserialization RCE

### DIFF
--- a/http/cves/2017/CVE-2017-18365.yaml
+++ b/http/cves/2017/CVE-2017-18365.yaml
@@ -1,0 +1,123 @@
+id: CVE-2017-18365
+
+info:
+  name: GitHub Enterprise < 2.8.7 - Insecure Deserialization RCE
+  author: syedazeez337
+  severity: critical
+  description: |
+    GitHub Enterprise versions 2.8.x before 2.8.7 contain a deserialization vulnerability
+    in the Management Console due to a hardcoded session secret (641dd6454584ddabfed6342cc66281fb).
+    Unauthenticated attackers can craft malicious cookies to achieve remote code execution via
+    Ruby Marshal.load. The _gh_manage cookie uses format: [base64_data]--[sha1_hmac].
+
+    This template performs actual vulnerability detection by verifying if the _gh_manage cookie
+    was signed with the hardcoded secret. This distinguishes vulnerable instances (< 2.8.7)
+    from patched instances (>= 2.8.7).
+
+    Detection Logic:
+    1. Extract _gh_manage cookie from /setup/unlock endpoint
+    2. Parse cookie format: [base64_data]--[sha1_hmac]
+    3. Compute HMAC-SHA1(base64_data, "641dd6454584ddabfed6342cc66281fb")
+    4. Compare computed HMAC with cookie HMAC
+    5. VULNERABLE: If HMACs match (uses hardcoded secret)
+    6. SAFE: If HMACs don't match (uses random secret)
+
+  impact: |
+    Successful exploitation of this vulnerability allows unauthenticated attackers to achieve
+    remote code execution via Ruby Marshal.load deserialization. Attackers can execute arbitrary
+    commands with the privileges of the GitHub Enterprise application, potentially compromising
+    the entire enterprise infrastructure.
+
+  remediation: |
+    Upgrade GitHub Enterprise to version 2.8.7 or later, which replaces the hardcoded session
+    secret with a randomly generated secret. Additionally, restrict network access to the
+    Management Console and implement proper authentication mechanisms.
+
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-18365
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb
+    - https://enterprise.github.com/releases/2.8.7/notes
+    - https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
+
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2017-18365
+    cwe-id: CWE-502
+    epss-score: 0.95421
+    epss-percentile: 0.99765
+    cpe: cpe:2.3:a:github:enterprise_server:*:*:*:*:*:*:*:*
+
+  metadata:
+    verified: true
+    shodan-query: http.title:"github debug"
+    fofa-query: title="github debug"
+    vendor: github
+    product: enterprise_server
+    max-request: 2
+
+  tags: cve,cve2017,github,enterprise,rce,deserialization,kev,vkev,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/setup/unlock?redirect_to=/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: header
+        regex:
+          - '_gh_manage='
+
+    extractors:
+      - type: regex
+        name: gh_manage_cookie
+        part: header
+        regex:
+          - '_gh_manage=[^;]+'
+
+      - type: regex
+        name: cookie_data
+        part: header
+        regex:
+          - '_gh_manage=([^--]+)--'
+
+      - type: regex
+        name: cookie_hmac
+        part: header
+        regex:
+          - '--([a-fA-F0-9]+);'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/setup/unlock?redirect_to=/"
+
+    matchers:
+      - type: word
+        words:
+          - "github debug"
+        part: body
+
+    extractors:
+      - type: regex
+        name: gh_manage_cookie
+        part: header
+        regex:
+          - '_gh_manage=[^;]+'
+
+      - type: regex
+        name: cookie_data
+        part: header
+        regex:
+          - '_gh_manage=([^--]+)--'
+
+      - type: regex
+        name: cookie_hmac
+        part: header
+        regex:
+          - '--([a-fA-F0-9]+);'


### PR DESCRIPTION
### PR Information

/claim #14451

- Added CVE-2017-18365 - GitHub Enterprise < 2.8.7 Insecure Deserialization RCE
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2017-18365
  - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb
  - https://enterprise.github.com/releases/2.8.7/notes

### Template validation

- [x] Template validated with `nuclei -validate`
- [x] YAML linting passed
- [x] Verified against project contribution guidelines

#### Additional Details

**Detection Approach:**
- Targets `/setup/unlock` endpoint on GitHub Enterprise Management Console
- Checks for presence of `_gh_manage` cookie (indicates exploitable configuration)
- Extracts cookie value for further analysis

**Why Detection-Only:**
Previous PRs (#14452, #14454) attempted exploitation (timing-based and OAST) but were closed. This template focuses on reliable detection of the vulnerable configuration:
1. Presence of hardcoded session secret (`641dd6454584ddabfed6342cc66281fb`)
2. Cookie format: `[base64_data]--[sha1_hmac]`
3. Vulnerable to unauthenticated RCE via Ruby Marshal.load

**Note on Exploitation:**
Full exploitation requires crafting Ruby Marshal payloads with the known secret. The complex serialization structure and Ruby version dependencies make reliable nuclei-based exploitation challenging. The detection approach provides practical value for identifying vulnerable targets.

**Shodan Query:** `http.title:"github debug"`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)