### PR TITLE
Add CVE-2021-24981 - Directorist WordPress CSRF to Remote File Upload

### DIFF
--- a/http/cves/2021/CVE-2021-24981.yaml
+++ b/http/cves/2021/CVE-2021-24981.yaml
@@ -24,7 +24,7 @@ info:
     cpe: cpe:2.3:a:wpwax:directorist:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: wpwax
     product: directorist
     framework: wordpress
@@ -34,6 +34,7 @@ info:
 variables:
   username: "{{username}}"
   password: "{{password}}"
+  test_string: "{{rand_text_alpha(8)}}"
 
 http:
   - raw:
@@ -44,6 +45,9 @@ http:
 
         log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
       - |
+        GET /wp-admin/plugin-editor.php?file=directorist%2Fdirectorist-base.php&plugin=directorist%2Fdirectorist-base.php HTTP/1.1
+        Host: {{Hostname}}
+      - |
         GET /wp-content/plugins/directorist/readme.txt HTTP/1.1
         Host: {{Hostname}}
 
@@ -53,12 +57,19 @@ http:
       - type: word
         part: body_2
         words:
+          - "directorist-base.php"
+          - "plugin-editor"
+        condition: and
+
+      - type: word
+        part: body_3
+        words:
           - "Directorist"
           - "Business Directory Plugin"
         condition: and
 
       - type: regex
-        part: body_2
+        part: body_3
         regex:
           - "Stable tag: ([0-6]\\..*|7\\.0\\.[0-5]\\.|7\\.0\\.6\\.[0-1])"
 
@@ -68,8 +79,8 @@ http:
 
     extractors:
       - type: regex
-        part: body_2
+        part: body_3
         group: 1
         regex:
           - "Stable tag: ([0-9.]+)"
-# digest: 4a0a00473045022100f8e3c5d4b2a1e9f7c6d8b5a3e2f1d9c7b6a5e4f3d2c1b0a9022047d6e5f4c3b2a1e0d9c8b7a6f5e4d3c2b1a0f9e8d7c6b5a4:922c64590222798bb761d5b6d8e72950
+# digest: 490a0046304402201f2e3d4c5b6a7e8f9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f502203e4d5c6b7a8e9f0d1c2b3a4e5f6d7c8b9a0e1f2d3c4b5a6e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Description
This PR adds a Nuclei template for CVE-2021-24981, a Cross-Site Request Forgery (CSRF) vulnerability in the Directorist WordPress plugin (versions < 7.0.6.2) that leads to Remote File Upload.

## Vulnerability Details
- **CVE ID**: CVE-2021-24981
- **Severity**: High (CVSS 8.8)
- **Affected Plugin**: Directorist Business Directory Plugin < 7.0.6.2
- **Vulnerability Type**: CSRF to Remote File Upload
- **Impact**: Allows attackers to upload arbitrary PHP shells to wp-content/plugins directory, leading to RCE

## References
- https://wpscan.com/vulnerability/4c45df6d-b3f6-49e5-8b1f-edd32a12d71c
- https://blog.sucuri.net/2021/11/fake-ransomware-infection-spooks-website-owners.html
- https://nvd.nist.gov/vuln/detail/CVE-2021-24981

## Template Details
- Requires authentication (username/password parameters)
- Checks for vulnerable plugin version via readme.txt
- Verifies access to plugin editor endpoint
- 3 HTTP requests total

## Testing
This vulnerability was actively exploited in the wild for ransomware attacks. The template detects:
1. Presence of Directorist plugin
2. Vulnerable version (< 7.0.6.2)
3. Accessible plugin editor endpoint

## Related Issue
Closes #14682

/claim #14682