### PR TITLE
feat: add CVE-2025-68926 - RustFS Hardcoded gRPC Authentication Token

### DIFF
--- a/code/cves/2025/CVE-2025-68926.yaml
+++ b/code/cves/2025/CVE-2025-68926.yaml
@@ -5,14 +5,14 @@ info:
   author: Chocapikk,bilisheep
   severity: critical
   description: |
-    RustFS before 1.0.0-alpha.77 uses a hardcoded gRPC authentication token "rustfs rpc" that cannot be changed without recompiling.
-    This allows unauthenticated remote attackers to gain full administrative access to the gRPC API.
+    RustFS before 1.0.0-alpha.77 used a hardcoded gRPC authentication token "rustfs rpc" that could not be changed without recompiling and this allowed unauthenticated remote attackers to gain full administrative access to the gRPC API.
   impact: |
     Full administrative access to RustFS including reading, writing, and deleting all stored data.
   remediation: |
     Upgrade to RustFS 1.0.0-alpha.77 or later.
   reference:
     - https://github.com/rustfs/rustfs/security/advisories/GHSA-h956-rh7x-ppgj
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-68926
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -23,7 +23,7 @@ info:
     max-request: 1
     vendor: rustfs
     product: rustfs
-  tags: cve,cve2025,rustfs,grpc,auth-bypass,hardcoded-credentials
+  tags: cve,cve2025,rustfs,grpc,auth-bypass,code
 
 variables:
   HOST: "{{Host}}"
@@ -85,4 +85,4 @@ code:
         name: version
         regex:
           - "(\\d+\\.\\d+\\.\\d+-alpha\\.\\d+|grpc-auth-bypass)"
-# digest: 4a0a00473045022044ca1a38c373dfea00acc161c68fc55ca9f4e3d49383834f03b824e1f78e2acb0221008e3884a7f2e2788c0648838ad0e5d524f2f1471f1381c9fc6f8b9c418c533134:3ebfdc4ea1f37636a2ce428217ae7f8d
+# digest: 4a0a00473045022015cbdaff0a72de87b3a5238a9133b95eac29d3445d27d1deb3b696b71739d4540221009846fa120f8cff6e1279f73606d6598fa0047298a7f9f01f29663ac5a6795925:2592222ea8b5b5922b8de61fd7ebe9f8


### PR DESCRIPTION
## CVE-2025-68926

**Product:** RustFS
**Severity:** Critical (9.8)

### Description
RustFS before 1.0.0-alpha.77 uses a hardcoded gRPC authentication token `rustfs rpc` that cannot be changed without recompiling. This allows unauthenticated remote attackers to gain full administrative access to the gRPC API.

### Reference
- https://github.com/rustfs/rustfs/security/advisories/GHSA-h956-rh7x-ppgj

### Template Type
`code` - Uses Python with h2 library for HTTP/2 gRPC request

### Tested
✅ Verified against RustFS 1.0.0-alpha.76