### PR TITLE
patch: fix max-request metadata in CVE-2019-9082

### DIFF
--- a/http/cves/2019/CVE-2019-9082.yaml
+++ b/http/cves/2019/CVE-2019-9082.yaml
@@ -25,7 +25,7 @@ info:
     epss-percentile: 0.99875
   metadata:
     verified: true
-    max-request: true
+    max-request: 2
     fofa-query: app="ThinkPHP"
     google-query: inurl:"index.php?s=" "thinkphp"
   tags: cve,cve2019,thinkphp,open_source_bms,none_cms,rce,kev,vkev


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed max-request in CVE-2019-9082
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

This data bug was creating issues with some of my automation that was expecting max-request values to always be an integer or NULL

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
