### PR TITLE
Fixed header-command-injection template false positives

### DIFF
--- a/http/fuzzing/header-command-injection.yaml
+++ b/http/fuzzing/header-command-injection.yaml
@@ -2,7 +2,7 @@ id: header-command-injection
 
 info:
   name: Header - Remote Command Injection
-  author: geeknik
+  author: geeknik,s4e-io
   severity: critical
   description: Headers were tested for remote command injection vulnerabilities.
   classification:
@@ -29,14 +29,10 @@ http:
 
     matchers-condition: or
     matchers:
-      - type: word
-        words:
-          - "uid="
-          - "gid="
-          - "groups="
-        condition: and
+      - type: regex
+        regex:
+          - "uid=[0-9]+.*gid=[0-9]+.*"
 
       - type: regex
         regex:
           - "root:.*:0:0:"
-# digest: 4a0a00473045022100eafec99827893ac236d9ecc25126b35fc2b206e65bbbb162a03539955f9e0f4602200e5fd3d7144526be4c439c6f3bb825fc47b2813210ad6c250f1defab93580c13:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

**Fix false positives in `header-command-injection.yaml` fuzzing template**

---

### Problem

The current template uses word-based matching that causes false positives on web applications containing JavaScript code.

**Current matcher:**
```yaml
- type: word
  words:
    - "uid="
    - "gid="
    - "groups="
  condition: and
```

The pattern `groups=` is extremely common in JavaScript:
```javascript
s.groups = {}
scope.groups = []  
if(!s.groups) s.groups = {}
```

When scanning web applications (e.g., streaming media servers, dashboards), the template incorrectly matches JavaScript code instead of actual command execution output.

---

### Solution

Replace the word matcher with a regex pattern that specifically matches the `id` command output format:

```yaml
- type: regex
  regex:
    - "uid=[0-9]+.*gid=[0-9]+.*"
```

This regex ensures:
- `uid=` must be followed by numeric value (e.g., `uid=0`, `uid=1000`)
- `gid=` must also be followed by numeric value
- Both patterns must appear together in sequence

| Input                                    | Word Matcher   | Regex Matcher |
| ---------------------------------------- | -------------- | ------------- |
| `uid=0(root) gid=0(root) groups=0(root)` | Match          | Match         |
| `s.groups = {}`                          | False Positive | No Match      |

---

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

---

### Verification

**Real `id` command output (should match):**
```bash
$ echo "uid=0(root) gid=0(root) groups=0(root)" | grep -E "uid=[0-9]+.*gid=[0-9]+.*"
uid=0(root) gid=0(root) groups=0(root)
```

**JavaScript code (should NOT match):**
```bash
$ echo "s.groups={}" | grep -E "uid=[0-9]+.*gid=[0-9]+.*"
(no output - false positive prevented)
```

---

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)