### PR TITLE
feat: add template for CVE-2025-60188

### DIFF
--- a/http/cves/2025/CVE-2025-60188.yaml
+++ b/http/cves/2025/CVE-2025-60188.yaml
@@ -42,6 +42,8 @@ http:
         group: 1
         regex:
           - '"wpf_site_id":"([0-9]+)"'
+        internal: true
+
 
       - type: regex
         name: username
@@ -49,3 +51,9 @@ http:
         group: 1
         regex:
           - '\\?"username\\?":\\?"([^"\\]+)'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"username: "+ username'
+          - '"Site_ID: "+ site_id'


### PR DESCRIPTION
PR Information
This PR adds a new template for CVE-2025-60188, a high-severity Sensitive Information Exposure vulnerability in the Atarim – Visual Website Collaboration WordPress plugin (versions <= 4.2.1).

The vulnerability exposes the critical wpf_site_id via an unauthenticated REST API endpoint (/wp-json/atarim/v1/db/vc). The leaked site_id is used as the secret key for HMAC signatures. By obtaining this ID, attackers can forge valid request signatures to bypass authentication and retrieve sensitive administrative data, including license keys, system configurations, and user PII.

Note: This template focuses on detection by extracting the critical site_id. The full exploitation logic (HMAC forgery, PII exfiltration, and config dumping) is available in the linked Proof of Concept repository.

Added CVE-2025-60188

References:

https://wordpress.org/plugins/atarim-visual-collaboration/

https://github.com/m4sh-wacker/CVE-2025-60188-Atarim-Plugin-Exploit

Template validation
I have tested this template locally against a vulnerable instance setup with WordPress and the affected plugin version. It successfully detects the endpoint and extracts the wpf_site_id.

[x] Validated with a host running a vulnerable version and/or configuration (True Positive)

[x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Additional Details (leave it blank if not applicable)
Tested on a Localhost environment against a vulnerable WordPress installation. Debug Output:

```shell

[INF] [CVE-2025-60188] [http] [high] http://localhost/wp-json/atarim/v1/db/vc

```
```shell
EXTRACTED:
atarim_site_id: 192837465
```