### PR TITLE
Update superset-login.yaml

### DIFF
--- a/http/exposed-panels/superset-login.yaml
+++ b/http/exposed-panels/superset-login.yaml
@@ -28,30 +28,17 @@ http:
     path:
       - '{{BaseURL}}'
       - '{{BaseURL}}/login'
-
     stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - 'alt="Superset"'
-          - '<title>Superset</title>'
-          - 'SUPERSET'
-          - 'superset'
-        condition: or
-
-      - type: word
-        part: header
-        words:
-          - "text/html"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "text/html")'
+          - 'contains_any(body, "alt=\"Superset\"", "<title>Superset</title>", "SUPERSET", "superset")'
+        condition: and
 
     extractors:
       - type: regex


### PR DESCRIPTION
**This update:**

* Adding the detection also to the Superset version 6.0.0 (latest) that removed the strings "<title>Superset</title>" and "alt="Superset".

**Steps to test:**

**Apache Superset Docker:**

1. Running container:

```
$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=your_secret_key_here" --name superset apache/superset:latest

$ docker exec -it superset superset fab create-admin \
              --username admin \
              --firstname Superset \
              --lastname Admin \
              --email admin@superset.com \
              --password admin

$ docker exec -it superset superset db upgrade

$ docker exec -it superset superset load_examples

$ docker exec -it superset superset init
```

2. Acessing the Apache Superset service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' superset`

**Nuclei execution:**

`~/go/bin/nuclei -t superset-login.yaml --silent -u "http://172.17.0.2:8088" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1842" height="806" alt="image" src="https://github.com/user-attachments/assets/aeec4b46-652d-4bf2-92c5-431afd5a8b58" />
