### PR TITLE
Add CVE-2022-3236 (vKEV and KEV)

### DIFF
--- a/http/cves/2022/CVE-2022-3236.yaml
+++ b/http/cves/2022/CVE-2022-3236.yaml
@@ -1,11 +1,11 @@
 id: CVE-2022-3236
 
 info:
-  name: Sophos Firewall - Command Injection
+  name: Sophos Firewall <= 19.0 MR1 - Remote Code Execution
   author: daffainfo
   severity: critical
   description: |
-    A code injection vulnerability in the User Portal and Webadmin allows a remote attacker to execute code in Sophos Firewall version v19.0 MR1 and older.
+    Sophos Firewall version v19.0 MR1 and older is vulnerable to code injection in the User Portal and Webadmin, allowing a remote unauthenticated attacker to execute arbitrary code.
   impact: |
     Remote attackers can execute arbitrary code on the system, potentially leading to full system compromise.
   remediation: |
@@ -23,12 +23,12 @@ info:
     cpe: cpe:2.3:a:sophos:firewall:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-requests: 1
+    max-request: 2
     vendor: sophos
     product: firewall
     shodan-query: http.title:"Sophos"
     fofa-query: title="sophos"
-  tags: cve,cve2018,sophos,firewall,rce,intrusive,oast,vkev,kev
+  tags: cve,cve2022,sophos,firewall,rce,intrusive,oast,kev
 
 flow: http(1) || http(2)
 
@@ -45,11 +45,11 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(interactsh_protocol, "dns")
-          - contains(content_type, "text/plain")
-          - contains(header, "Server: xxxx")
-          - status_code == 200
-          - contains(body, "redirectionURL")
+          - 'contains(interactsh_protocol, "dns")'
+          - 'contains(content_type, "text/plain")'
+          - 'contains(header, "Server: xxxx")'
+          - 'status_code == 200'
+          - 'contains(body, "redirectionURL")'
         condition: and
 
   - raw:
@@ -64,9 +64,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(interactsh_protocol, "dns")
-          - contains(content_type, "text/plain")
-          - contains(header, "Server: xxxx")
-          - status_code == 200
-          - contains(body, "redirectionURL")
+          - 'contains(interactsh_protocol, "dns")'
+          - 'contains(content_type, "text/plain")'
+          - 'contains(header, "Server: xxxx")'
+          - 'status_code == 200'
+          - 'contains(body, "redirectionURL")'
         condition: and


### PR DESCRIPTION
### PR Information

A code injection vulnerability in the User Portal and Webadmin allows a remote attacker to execute code in Sophos Firewall version v19.0 MR1 and older.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
