### PR TITLE
Fix reference list formatting in SeaDuke malware hash template

### DIFF
--- a/file/malware/hash/seaduke-malware-hash.yaml
+++ b/file/malware/hash/seaduke-malware-hash.yaml
@@ -4,8 +4,8 @@ info:
   author: pussycat0x
   severity: info
   reference:
-    http://goo.gl/MJ0c2M
-    https://github.com/Yara-Rules/rules/blob/master/malware/APT_Seaduke.yar
+    - http://goo.gl/MJ0c2M
+    - https://github.com/Yara-Rules/rules/blob/master/malware/APT_Seaduke.yar
   tags: malware,seaduke
 
 file:


### PR DESCRIPTION
### PR Information

- Updated template: [file/malware/hash/seaduke-malware-hash.yaml](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/App/Akin/nuclei-templates/file/malware/hash/seaduke-malware-hash.yaml:0:0-0:0)
- Fix: `info.reference` was not a valid YAML list. Converted the two reference URLs into a proper list format.
- References:
  - http://goo.gl/MJ0c2M
  - https://github.com/Yara-Rules/rules/blob/master/malware/APT_Seaduke.yar

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)