### PR TITLE
Use boolean for verified metadata in BitRAT C2 template

### DIFF
--- a/ssl/c2/bitrat-c2.yaml
+++ b/ssl/c2/bitrat-c2.yaml
@@ -9,7 +9,7 @@ info:
   reference:
     https://github.com/thehappydinoa/awesome-censys-queries#bitrat--
   metadata:
-    verified: "true"
+    verified: true
     max-request: 1
     censys-query: 'services.tls.certificates.leaf_data.subject.common_name: "BitRAT"'
   tags: ssl,tls,c2,ir,osint,malware,bitrat,discovery


### PR DESCRIPTION
### PR Information

- Updated template: [ssl/c2/bitrat-c2.yaml](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/App/Akin/nuclei-templates/ssl/c2/bitrat-c2.yaml:0:0-0:0)
- Fix: `metadata.verified` was set as a quoted string (`"true"`). Changed it to a boolean (`true`) for schema consistency and to avoid tooling/parsing inconsistencies.
- References:
  - https://github.com/thehappydinoa/awesome-censys-queries#bitrat--

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)