### PR TITLE
Create dmarc-weak-policy.yaml

### DIFF
--- a/dns/dmarc-weak-policy.yaml
+++ b/dns/dmarc-weak-policy.yaml
@@ -26,20 +26,17 @@ info:
     cwe-id: CWE-290
   metadata:
     max-request: 1
-    verified: true
   tags: dns,dmarc,misconfig,email,spoof,phishing
 
 dns:
   - name: "_dmarc.{{FQDN}}"
     type: TXT
-
     matchers-condition: and
     matchers:
       - type: word
         part: answer
         words:
           - "v=DMARC1"
-
       - type: regex
         part: answer
         regex:


### PR DESCRIPTION
### PR Information
**Added dns/dmarc-weak-policy.yaml** - Detection template for weak DMARC configurations that enable email spoofing attacks.
This template queries the `_dmarc` TXT record and identifies the following misconfigurations:
- `p=none` - Policy set to none, meaning failed authentication has no consequences
- `sp=none` - Subdomain policy set to none
- `pct<100` - Policy only applied to a percentage of emails, not all

These weak configurations are commonly found during penetration tests and allow attackers to spoof emails from the target domain for phishing campaigns.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)


<img width="1733" height="1073" alt="Screenshot 2026-01-10 at 1 35 32 am" src="https://github.com/user-attachments/assets/0fa4a46c-1372-4e16-aa19-cf8aee112bb5" />

Template correctly identifies `p=none` weak policy configuration.