### PR TITLE
Create CVE-2022-26318.yaml

### DIFF
--- a/http/cves/2022/CVE-2022-26318.yaml
+++ b/http/cves/2022/CVE-2022-26318.yaml
@@ -1,0 +1,67 @@
+id: CVE-2022-26318
+
+info:
+  name: WatchGuard Firebox/XTM - Unauthenticated Remote Code Execution
+  author: projectdiscovery
+  severity: critical
+  description: |
+    WatchGuard Firebox and XTM appliances are vulnerable to unauthenticated remote code execution (RCE) via the /agent/login endpoint.
+    The vulnerability allows attackers to execute arbitrary code with root privileges by sending a malicious XML-RPC payload.
+  reference:
+    - https://www.watchguard.com/wgrd-psirt/advisory/wgsa-2022-00002
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-26318
+    - https://www.assetnote.io/resources/research/diving-deeper-into-watchguard-pre-auth-rce-cve-2022-26318
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-26318
+    cwe-id: CWE-787
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"WatchGuard"
+  tags: cve,cve2022,watchguard,rce,firebox,unauth,kev
+
+http:
+  - raw:
+      - |
+        POST /agent/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml
+
+        <?xml version="1.0"?>
+        <methodCall>
+          <methodName>login</methodName>
+          <params>
+            <param>
+              <value>
+                <struct>
+                  <member>
+                    <name>user</name>
+                    <value><string>admin</string></value>
+                  </member>
+                  <member>
+                    <name>password</name>
+                    <value><string>test</string></value>
+                  </member>
+                </struct>
+              </value>
+            </param>
+          </params>
+        </methodCall>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "text/xml"
+
+      - type: word
+        part: body
+        words:
+          - "methodResponse"
+          - "faultCode"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Fixes #6185

Added Nuclei detection template for CVE-2022-26318 (WatchGuard Firebox RCE).

### Logic
* Targets the vulnerable `/agent/login` XML-RPC endpoint.
* Sends a structured XML `login` request to verify the service is active.
* Matches for the specific `methodResponse` and `faultCode` returned by the WatchGuard `wgagent`.

### References
* AssetNote Research: https://www.assetnote.io/resources/research/diving-deeper-into-watchguard-pre-auth-rce-cve-2022-26318

### Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)