### PR TITLE
Add CVE-2026-21877: n8n RCE via Arbitrary File Write

### DIFF
--- a/http/cves/2026/CVE-2026-21877.yaml
+++ b/http/cves/2026/CVE-2026-21877.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-21877
 
 info:
-  name: n8n - Remote Code Execution via Arbitrary File Write
+  name: n8n >= 0.123.0 and < 1.121.3 - Remote Code Execution
   author: s4e-io
   severity: critical
   description: |
@@ -27,12 +27,29 @@ info:
     product: n8n
     shodan-query: http.favicon.hash:-831756631
     fofa-query: icon_hash="-831756631"
-  tags: cve,cve2026,n8n,workflow,rce,authenticated,file-upload
+  tags: cve,cve2026,n8n,workflow,rce,authenticated,passive
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/signin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>n8n.io"
+        case-insensitive: true
+
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - compare_versions(version, '>= 0.123.0', '< 1.121.3')
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex
@@ -51,20 +68,3 @@ http:
       - type: dsl
         dsl:
           - '"n8n Version: " + version'
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "<title>n8n.io"
-        case-insensitive: true
-
-      - type: status
-        status:
-          - 200
-
-      - type: dsl
-        name: vulnerable
-        dsl:
-          - compare_versions(version, '>= 0.123.0', '< 1.121.3')


### PR DESCRIPTION
### PR Information

Added **CVE-2026-21877** - n8n Remote Code Execution via Arbitrary File Write

This template detects a critical authenticated RCE vulnerability in n8n, an open-source workflow automation platform. An authenticated user can exploit the Git node to overwrite critical files and execute untrusted code on the n8n server, potentially leading to full system compromise.

**References:**
- https://github.com/n8n-io/n8n/security/advisories/GHSA-v364-rw7m-3263
- https://nvd.nist.gov/vuln/detail/CVE-2026-21877

---

### Vulnerability Details

| Attribute             | Value                                                     |
| --------------------- | --------------------------------------------------------- |
| **CVE ID**            | CVE-2026-21877                                            |
| **Severity**          | Critical                                                  |
| **CVSS Score**        | 9.9                                                       |
| **CVSS Vector**       | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H              |
| **EPSS Score**        | 0.00047 (14.8 percentile)                                 |
| **CWE**               | CWE-434 (Unrestricted Upload of File with Dangerous Type) |
| **Affected Versions** | >= 0.123.0 and < 1.121.3                                  |
| **Fixed Version**     | 1.121.3                                                   |
| **Vendor**            | n8n-io                                                    |
| **Product**           | n8n                                                       |

---

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

---

### Additional Details

#### Detection Method

The template performs version-based detection via the `/signin` endpoint. It extracts the n8n version from the base64-encoded Sentry configuration meta tag and uses `compare_versions()` to check if the version falls within the vulnerable range.

#### Template Features

- ✅ Version extraction from base64-encoded meta tag
- ✅ Accurate version comparison using `compare_versions()`
- ✅ Single request (max-request: 1)
- ✅ Complete metadata (CVSS, EPSS, CWE, vendor, product)

#### Example Command

```bash
nuclei -t http/cves/2026/CVE-2026-21877.yaml -l targets.txt
```

#### Scan Results (Screenshot)

<img width="1068" height="895" alt="1" src="https://github.com/user-attachments/assets/9ad486cd-ad87-4198-9982-538609812dcd" />

> **Validation Summary:**
> - **True Positive:** Template correctly detected vulnerable n8n instances running versions within the affected range (>= 0.123.0 and < 1.121.3)
> - **No False Positive:** Template did not trigger on patched n8n instances running version 1.121.3 or later

#### Template Validation

```bash
nuclei -t http/cves/2026/CVE-2026-21877.yaml -validate
```

```
[INF] All templates validated successfully
```

---

### Additional References

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
