### PR TITLE
Fix regex indentation in credentials.yaml

### DIFF
--- a/file/keys/credentials.yaml
+++ b/file/keys/credentials.yaml
@@ -19,5 +19,4 @@ file:
         regex:
           - "(http|https|ftp)://[a-zA-Z0-9][^/\\s:@]{2,19}:[^/\\s:@]{3,50}@[a-zA-Z0-9.-]{3,100}(:[0-9]{2,5})?(/|$)[\"'\\s]"
 
-# Enhanced by md on 2023/05/04
 # digest: 4a0a00473045022100adab349203f3598a0410c8f3c1001334e81f7234bdc2a08b635ac94e1235f58b022058d28c28d56d9c932f402b4e1b8eb2288a650b28dcdf417ca5e93efae90b402e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

The line is edited at https://github.com/projectdiscovery/nuclei-templates/commit/ddc751271d920fc6dfe1e5d2f5ae395f74c5d799 .
I'm not familiar with the format and the intention of the commit, but It seems like just a wrong indentation, doesn't it?

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
