### PR TITLE
CVE-2025-8110 (KEV)

### DIFF
--- a/http/cves/2025/CVE-2025-8110.yaml
+++ b/http/cves/2025/CVE-2025-8110.yaml
@@ -6,6 +6,10 @@ info:
   severity: high
   description: |
     Gogs self-hosted Git service versions 0.13.3 and earlier contain a critical symlink bypass vulnerability that circumvents the fix for CVE-2024-55947. Authenticated users can exploit improper symbolic link handling in the PutContents API to overwrite files outside the repository by committing a symlink pointing to sensitive targets, leading to remote code execution. As of December 2025, this remains an unpatched zero-day with active exploitation ongoing. Approximately 1,400 exposed Gogs instances exist, with over 700 showing signs of compromise. The vulnerability stems from the API writing to file paths without checking if targets are symlinks pointing outside the repository. Gogs maintainers are working on a fix.
+  remediation: |
+    Update to the latest version of Gogs.
+  impact: |
+    Local attackers can execute arbitrary code, potentially leading to full system compromise.
   reference:
     - https://www.wiz.io/blog/wiz-research-gogs-cve-2025-8110-rce-exploit
     - https://thehackernews.com/2025/12/unpatched-gogs-zero-day-exploited.html
@@ -18,10 +22,11 @@ info:
     cwe-id: CWE-22
   metadata:
     verified: true
-    vendor: Gogs
-    product: Gogs
+    vendor: gogs
+    product: gogs
+    max-request: 1
     shodan-query: http.title:"Sign In - Gogs"
-  tags: cve,cve2025,gogs,git,symlink,rce,kev,passive
+  tags: cve,cve2025,gogs,git,symlink,rce,kev,vkev,passive
 
 http:
   - method: GET


### PR DESCRIPTION
### PR Information

Version detection template for CVE-2025-8110, recently added to the KEV yesterday. 

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
