### PR TITLE
[FIX ISSUE FALSE-POSITIVE] postgres-history-exposure.yaml

### DIFF
--- a/http/exposures/files/postgres-history-exposure.yaml
+++ b/http/exposures/files/postgres-history-exposure.yaml
@@ -2,7 +2,7 @@ id: postgres-history-exposure
 
 info:
   name: PostgreSQL History - Exposure
-  author: theamanrawat
+  author: theamanrawat,0x_Akoko
   severity: low
   description: |
     Exposed PostgreSQL history files (.psql_history) were detected. These files contain a record of executed SQL commands and may disclose sensitive information like passwords, database schemas, and query logic.
@@ -21,24 +21,12 @@ http:
       - "{{BaseURL}}/.postgresql_history"
 
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
-      - type: regex
-        part: body
-        regex:
-          - '(?m)^\\(q|h|\?|g|d|dt|du|l|c|connect|copy)'
-          - '(?i)(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\s+'
-
-      - type: word
-        part: body
-        words:
-          - "select"
-          - "from"
-          - "\\connect"
-          - "\\d"
-        condition: or
-
-      - type: status
-        status:
-          - 200
-# digest: 490a00463044022007c85a7dc13df8edea4b338a5d21408d15d952eb6388d312c8acc9c6e3c4629d0220720781a08304301c247a898868a40da60417ade0d970d373ec84857255dddb11:922c64590222798bb761d5b6d8e72950
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!contains(content_type, "text/html")'
+          - 'contains_all(to_lower(body), "select", "from", "where")'
+          - 'contains_any(body, "select * from", "SELECT * FROM", "insert into", "INSERT INTO", "update ", "UPDATE ")'
+          - 'regex("(?m)^\\\\(q|h|\\?|g|d|dt|du|l|c|connect|copy)", body)'
+        condition: and


### PR DESCRIPTION
### PR Information

**Updated matchers to exclude HTML responses and require psql-specific patterns to reduce false positives.**
**Fix issue https://github.com/projectdiscovery/nuclei-templates/issues/14844**

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
