### PR TITLE
Add or fix cveYEAR tags 

### DIFF
--- a/http/cves/2024/CVE-2024-11972.yaml
+++ b/http/cves/2024/CVE-2024-11972.yaml
@@ -27,7 +27,7 @@ info:
     product: hunk_companion
     framework: wordpress
     fofa-query: body="/wp-content/plugins/hunk-companion/"
-  tags: cve,cve-2024,wordpress,wp,wp-plugin,hunk-companion,vkev,vuln
+  tags: cve,cve2024,wordpress,wp,wp-plugin,hunk-companion,vkev,vuln
 
 variables:
   plugin: "{{to_lower(rand_text_alpha(6))}}"

--- a/http/cves/2024/CVE-2024-37881.yaml
+++ b/http/cves/2024/CVE-2024-37881.yaml
@@ -22,7 +22,7 @@ info:
     verified: true
     max-request: 1
     publicwww-query: "/wp-content/plugins/siteguard/"
-  tags: cve,cve-2024,siteguard,wp-plugin,vuln
+  tags: cve,cve2024,siteguard,wp-plugin,vuln
 
 flow: http(1) && http(2)
 

--- a/http/cves/2024/CVE-2024-39646.yaml
+++ b/http/cves/2024/CVE-2024-39646.yaml
@@ -28,7 +28,7 @@ info:
     vendor: kunalnagar
     product: custom_404_pro
     framework: wordpress
-  tags: wordpress,wp-plugin,xss,authenticated,cve,custom-404-pro,vkev
+  tags: wordpress,wp-plugin,xss,authenticated,cve,cve2024,custom-404-pro,vkev
 
 flow: http(1) && http(2)
 

--- a/http/cves/2025/CVE-2025-4632.yaml
+++ b/http/cves/2025/CVE-2025-4632.yaml
@@ -27,7 +27,7 @@ info:
     vendor: samsung
     product: magicinfo_9_server
     shodan-query: "Server: magicinfo premium server"
-  tags: cve,cve-2025,file-upload,kev,rce,intrusive,vkev,vuln
+  tags: cve,cve2025,file-upload,kev,rce,intrusive,vkev,vuln
 
 variables:
   filename: "{{rand_text_alpha(6)}}"

--- a/http/cves/2025/CVE-2025-54249.yaml
+++ b/http/cves/2025/CVE-2025-54249.yaml
@@ -20,7 +20,7 @@ info:
     vendor: adobe
     product: experience_manager
     fofa-query: body="/libs/granite/core/content/login.html"
-  tags: cve,2025,adobe,aem,ssrf,oast,oob,vkev,vuln
+  tags: cve,cve2025,adobe,aem,ssrf,oast,oob,vkev,vuln
 
 http:
   - raw:

--- a/http/cves/2025/CVE-2025-54251.yaml
+++ b/http/cves/2025/CVE-2025-54251.yaml
@@ -31,7 +31,7 @@ info:
       - http.title:"aem sign in"
       - http.component:"adobe experience manager"
       - cpe:"cpe:2.3:a:adobe:experience_manager"
-  tags: cve,2025,adobe,aem,xxe,oast,oob,intrusive,vuln,vkev
+  tags: cve,cve2025,adobe,aem,xxe,oast,oob,intrusive,vuln,vkev
 
 variables:
   marker: "{{randstr}}"


### PR DESCRIPTION
### PR Information

This pull request fixes inconsistencies in CVE-related tags.

The project currently contains 
```
# grep -R --include \*.yaml cve, * | grep tags | grep -E "cve[0-9]+" | wc -l
3795
```
tags in the `cveYEAR` format, along with 
```
# grep -R --include \*.yaml cve, * | grep tags | grep -Ev "cve[0-9]+" | wc -l
6
```
tags that differ from this naming convention (`cve-YEAR`, `YEAR` or with no `cveYEAR` tag).

While unifying these tags is not critical for functionality, bringing them to a consistent format improves overall consistency and makes tag usage more uniform across the project.

### Template validation

```
[INF] Current nuclei version: v3.6.2 (latest)
[INF] Current nuclei-templates version: v10.3.7 (latest)
...
[VER] Started metrics server at localhost:9092
[INF] All templates validated successfully
```
