### PR TITLE
Add IBM Cloud Object Storage bucket exposure check

### DIFF
--- a/http/misconfiguration/ibm/ibm-cloud-bucket-exposure.yaml
+++ b/http/misconfiguration/ibm/ibm-cloud-bucket-exposure.yaml
@@ -5,15 +5,10 @@ info:
   author: 0x_Akoko
   severity: unknown
   description: |
-    IBM Cloud Object Storage bucket is publicly accessible, potentially exposing
-    sensitive files and data. Public bucket listing allows enumeration of stored objects.
+    IBM Cloud Object Storage bucket is publicly accessible, potentially exposing sensitive files and data. Public bucket listing allows enumeration of stored objects.
   reference:
     - https://cloud.ibm.com/docs/cloud-object-storage
     - https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-iam-bucket-permissions
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-    cvss-score: 5.3
-    cwe-id: CWE-284
   metadata:
     verified: true
     max-request: 2
@@ -42,6 +37,6 @@ http:
       - type: regex
         name: bucket-name
         part: body
+        group: 1
         regex:
           - "<Name>([^<]+)</Name>"
-        group: 1


### PR DESCRIPTION
This YAML file defines a misconfiguration check for IBM Cloud Object Storage, identifying publicly accessible buckets that may expose sensitive data.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
