### PR TITLE
fix: CVE-2019-11253

### DIFF
--- a/http/cves/2019/CVE-2019-11253.yaml
+++ b/http/cves/2019/CVE-2019-11253.yaml
@@ -2,7 +2,7 @@ id: CVE-2019-11253
 
 info:
   name: Kubernetes API Server - YAML Parsing DoS (Billion Laughs)
-  author: ritikchaddha
+  author: ritikchaddha,staicnoise
   severity: high
   description: |
     The Kubernetes API server is vulnerable to a denial of service attack via YAML/JSON parsing. An attacker can send a specially crafted YAML/JSON payload that causes exponential memory consumption (Billion Laughs attack), leading to API server crash.
@@ -30,20 +30,23 @@ info:
   tags: cve,cve2019,kubernetes,yaml,k8s
 
 http:
-  - raw:
-      - |
-        POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/yaml
-
+  - method: GET
+    path:
+      - "{{BaseURL}}/version"
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Invalid value"
-          - "FieldValueInvalid"
-          - "422"
-        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.1.0', '<= 1.12.10')"
+          - "compare_versions(version, '>= 1.13.0', '< 1.13.12')"
+          - "compare_versions(version, '>= 1.14.0', '< 1.14.8')"
+          - "compare_versions(version, '>= 1.15.0', '< 1.15.5')"
+          - "compare_versions(version, '>= 1.16.0', '< 1.16.2')"
+
+    extractors:
+      - type: json
+        name: version
+        json:
+          - '.gitVersion | ltrimstr("v")'
 # digest: 4a0a004730450221008818348ef06d1310076738b84e545c95ccf8c8d08353d4eb45ae26dd05b49b1602202a0670de5049000ec1ad6586ccb9be8f4a09f51b2744118fe470730c41eef6d0:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
k8s responds with error code 422 to any malformed request. The template previously triggered on any kubernetes API endpoint that was configured to allow unauthenticated users to access the endpoint. It created many false positives. Although accessing the endpoint is necessary to exploit, it does not mean it is vulnerable. To check if a service is vulnerable, we have to compare the version.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2019-11253
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
