### PR TITLE
Create CVE-2025-12543.yaml for Undertow vulnerability

### DIFF
--- a/http/cves/2025/CVE-2025-12543.yaml
+++ b/http/cves/2025/CVE-2025-12543.yaml
@@ -8,6 +8,7 @@ info:
     Undertow-core prior to 2.3.8.Final does not properly validate HTTP Host headers, accepting malformed or ambiguous host values. Attackers can exploit this flaw to bypass host-based access controls, trigger cache poisoning, facilitate SSRF conditions, or circumvent security policies in upstream deployments.
   impact: Bypass of host header validation, leading to SSRF and cache poisoning.
   reference:
+    - https://www.cve.org/CVERecord?id=CVE-2025-12543
     - https://access.redhat.com/security/cve/CVE-2025-12543
     - https://bugzilla.redhat.com/show_bug.cgi?id=2261577
     - https://github.com/undertow-io/undertow/pull/1536
@@ -30,6 +31,8 @@ http:
         Host: {{hostpayload}}
         User-Agent: test
         Connection: close
+
+    unsafe: true
 
     payloads:
       hostpayload:
@@ -58,7 +61,7 @@ http:
   - raw:
       - |
         GET / HTTP/1.1
-        Host:
+        Host: 
         User-Agent: test
         Connection: close
 
@@ -68,6 +71,8 @@ http:
         Host: b.com
         User-Agent: test
         Connection: close
+    
+    unsafe: true
 
     matchers-condition: and
     matchers:

--- a/http/cves/2025/CVE-2025-12543.yaml
+++ b/http/cves/2025/CVE-2025-12543.yaml
@@ -61,7 +61,7 @@ http:
   - raw:
       - |
         GET / HTTP/1.1
-        Host: 
+        Host:
         User-Agent: test
         Connection: close
 
@@ -71,7 +71,7 @@ http:
         Host: b.com
         User-Agent: test
         Connection: close
-    
+
     unsafe: true
 
     matchers-condition: and

--- a/http/cves/2025/CVE-2025-12543.yaml
+++ b/http/cves/2025/CVE-2025-12543.yaml
@@ -1,0 +1,86 @@
+id: CVE-2025-12543
+
+info:
+  name: Undertow Host Header Validation Bypass (Malformed Host Accepted)
+  author: ahmetartuc
+  severity: critical
+  description: |
+    Undertow-core fails to properly validate the Host header and may accept malformed or
+    ambiguous Host headers that should be rejected, enabling cache poisoning, SSRF-like
+    behavior, or upstream policy bypass.
+  reference:
+    - https://www.cve.org/CVERecord?id=CVE-2025-12543
+    - https://access.redhat.com/security/cve/CVE-2025-12543
+  classification:
+    cwe-id:
+      - CWE-20
+    cvss-score: 9.6
+  tags: cve,cve2025,undertow,wildfly,jboss,host-header,http
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    headers:
+      Host: "{{hostpayload}}"
+      User-Agent: nuclei
+      Connection: close
+
+    payloads:
+      hostpayload:
+        - "valid.local:2$"
+        - "valid.local%20"
+        - "valid.local "
+        - "valid.local\t"
+        - "valid.local:80%20"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 301
+          - 302
+          - 401
+          - 403
+
+      - type: word
+        part: header
+        words:
+          - "Undertow"
+          - "WildFly"
+          - "JBoss"
+        condition: or
+
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host:
+        User-Agent: nuclei
+        Connection: close
+
+      - |
+        GET / HTTP/1.1
+        Host: a.com
+        Host: b.com
+        User-Agent: nuclei
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 301
+          - 302
+          - 401
+          - 403
+
+      - type: word
+        part: header
+        words:
+          - "Undertow"
+          - "WildFly"
+          - "JBoss"
+        condition: or

--- a/http/cves/2025/CVE-2025-12543.yaml
+++ b/http/cves/2025/CVE-2025-12543.yaml
@@ -1,31 +1,35 @@
 id: CVE-2025-12543
 
 info:
-  name: Undertow Host Header Validation Bypass (Malformed Host Accepted)
+  name: Undertow Host Header Validation Bypass
   author: ahmetartuc
   severity: critical
   description: |
-    Undertow-core fails to properly validate the Host header and may accept malformed or
-    ambiguous Host headers that should be rejected, enabling cache poisoning, SSRF-like
-    behavior, or upstream policy bypass.
+    Undertow-core prior to 2.3.8.Final does not properly validate HTTP Host headers, accepting malformed or ambiguous host values. Attackers can exploit this flaw to bypass host-based access controls, trigger cache poisoning, facilitate SSRF conditions, or circumvent security policies in upstream deployments.
+  impact: Bypass of host header validation, leading to SSRF and cache poisoning.
   reference:
-    - https://www.cve.org/CVERecord?id=CVE-2025-12543
     - https://access.redhat.com/security/cve/CVE-2025-12543
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2261577
+    - https://github.com/undertow-io/undertow/pull/1536
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12543
   classification:
-    cwe-id:
-      - CWE-20
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.6
-  tags: cve,cve2025,undertow,wildfly,jboss,host-header,http
+    cve-id: CVE-2025-12543
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-requests: 3
+    shodan-query: html:"Undertow"
+  tags: cve,cve2025,undertow,wildfly,jboss,cache-poisoning,bypass
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/"
-
-    headers:
-      Host: "{{hostpayload}}"
-      User-Agent: nuclei
-      Connection: close
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{hostpayload}}
+        User-Agent: test
+        Connection: close
 
     payloads:
       hostpayload:
@@ -42,8 +46,6 @@ http:
           - 200
           - 301
           - 302
-          - 401
-          - 403
 
       - type: word
         part: header
@@ -57,14 +59,14 @@ http:
       - |
         GET / HTTP/1.1
         Host:
-        User-Agent: nuclei
+        User-Agent: test
         Connection: close
 
       - |
         GET / HTTP/1.1
         Host: a.com
         Host: b.com
-        User-Agent: nuclei
+        User-Agent: test
         Connection: close
 
     matchers-condition: and
@@ -74,8 +76,6 @@ http:
           - 200
           - 301
           - 302
-          - 401
-          - 403
 
       - type: word
         part: header


### PR DESCRIPTION
Added CVE-2025-12543 YAML file detailing a critical vulnerability in Undertow related to Host header validation.

### PR Information

This template detects a security boundary inconsistency in Undertow (WildFly/JBoss) where malformed or ambiguous Host headers are accepted instead of being rejected with a 400 Bad Request. This behavior can be exploited to bypass upstream security policies (WAF/Proxy).

* **Added CVE-2025-12543**
* **References:** - [https://www.cve.org/CVERecord?id=CVE-2025-12543](https://www.cve.org/CVERecord?id=CVE-2025-12543)
* [https://access.redhat.com/security/cve/CVE-2025-12543](https://access.redhat.com/security/cve/CVE-2025-12543)



### Template validation

* [x] Validated with a host running a vulnerable version (WildFly vanilla Docker deployment) - **True Positive**
* [x] Validated with a host running a patched version - **False Positive avoidance**

#### Additional Details

The template uses both standard HTTP and raw requests to verify:

1. Acceptance of malformed port suffixes (e.g., `:2$`).
2. Acceptance of trailing whitespace and encoded spaces in Host headers.
3. Acceptance of empty Host headers and multiple Host headers.

In all vulnerable cases, the server responds with a 200/300/400-series status code while identifying as Undertow/WildFly, rather than a hard 400 Bad Request rejection.