### PR TITLE
Create zen-cart-log-exposure.yaml

### DIFF
--- a/http/exposures/logs/zen-cart-log-exposure.yaml
+++ b/http/exposures/logs/zen-cart-log-exposure.yaml
@@ -1,0 +1,50 @@
+id: zen-cart-log-exposure
+
+info:
+  name: Zen Cart Log File Exposure
+  author: 0x_Akoko
+  severity: medium
+  description: |
+    Detected exposed Zen Cart log files that may contain sensitive information including error messages, file paths, database queries, and customer data.
+  reference:
+    - https://www.zen-cart.com/
+    - https://docs.zen-cart.com/user/troubleshooting/debug_logs/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  metadata:
+    max-request: 5
+    shodan-query: http.html:"zen-cart" || http.html:"Zen Cart"
+    fofa-query: body="zen-cart" || body="Zen Cart"
+  tags: zencart,exposure,logs,ecommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/logs/"
+      - "{{BaseURL}}/cache/"
+      - "{{BaseURL}}/includes/logs/"
+      - "{{BaseURL}}/admin/logs/"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Index of"
+          - "myDEBUG"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: log-files
+        part: body
+        regex:
+          - 'myDEBUG[a-zA-Z0-9_-]+\.log'


### PR DESCRIPTION
### PR Information

Log filenames contain unpredictable Unix timestamps and PIDs (e.g., myDEBUG-adm-1499797711-657006.log), making direct access impossible. Template detects directory listing exposure instead.
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
