### PR TITLE
Add jakefile-disclosure.yaml

### DIFF
--- a/http/exposures/configs/jakefile-disclosure.yaml
+++ b/http/exposures/configs/jakefile-disclosure.yaml
@@ -1,0 +1,35 @@
+id: jakefile-disclosure
+
+info:
+  name: Jakefile Build Configuration - Disclosure
+  author: 0x_Akoko
+  severity: info
+  description: |
+    Detected Jakefile build configuration was found to be exposed, potentially having contained sensitive information including database credentials, API keys, and server configurations.
+  reference:
+    - https://jakejs.com/
+    - https://github.com/jakejs/jake
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: html:"Jakefile"
+  tags: exposure,devops,jakefile,nodejs,config
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Jakefile"
+      - "{{BaseURL}}/Jakefile.js"
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!contains_any(body, "<!DOCTYPE", "<html", "<HTML")'
+          - 'contains(body, "task(") && contains_any(body, "desc(", "jake.", "namespace(")'
+        condition: and


### PR DESCRIPTION
Added a configuration file for detecting exposed Jakefile build configurations that may contain sensitive information.

**Template check on Root path only**

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
