### PR TITLE
Spring Boot `X-Application-Context` Header Exposure

### DIFF
--- a/http/misconfiguration/springboot/springboot-x-application-context.yaml
+++ b/http/misconfiguration/springboot/springboot-x-application-context.yaml
@@ -1,0 +1,41 @@
+id: springboot-x-application-context
+
+info:
+  name: Spring Boot `X-Application-Context` Header Exposure
+  author: DhiyaneshDK
+  severity: low
+  description: |
+    Detected the presence of the X-Application-Context header in HTTP responses, which can expose sensitive application context information.
+  reference:
+    - https://github.com/spring-projects/spring-boot/issues/1308
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: "X-Application-Context"
+  tags: springboot,misconfig,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - '^X-Application-Context:\s*\S.+$'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '^X-Application-Context:\s*\S.+$'


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
