### PR TITLE
fix(CVE-2024-2473): false positives due to missing "condition: and"

### DIFF
--- a/http/cves/2024/CVE-2024-2473.yaml
+++ b/http/cves/2024/CVE-2024-2473.yaml
@@ -60,6 +60,7 @@ http:
           - 'status_code == 200'
           - 'contains_all(body, "lostpasswordform", "action=")'
           - '!contains(body, "wp-login.php")'
+        condition: and
 
     extractors:
       - type: regex
@@ -80,4 +81,5 @@ http:
           - "status_code == 302"
           - "contains(header, 'Location')"
           - "contains_any(header, 'reauth=1', '/login')"
+        condition: and
 # digest: 4a0a00473045022008e5aed1b63541fb5c02e607fb6248e165ace2de75a514b8dd22781cc5d8f0b0022100b5f65ac9524568046976f8ed68390fd5de49c726691a75feb25f3b17bf13c251:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2024-2473

Due to the lack on `condition: and` in the DSL matcher specifications, a lot of hosts would match, particularly with `http(2)` since "status: 200" is enough.

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)
