### PR TITLE
Create CVE-2021-22881 - Ruby on Rails - Open Redirect via Host Header Injection

### DIFF
--- a/http/cves/2021/CVE-2021-22881.yaml
+++ b/http/cves/2021/CVE-2021-22881.yaml
@@ -1,0 +1,43 @@
+id: CVE-2021-22881
+
+info:
+  name: Ruby on Rails - Open Redirect via Host Header Injection
+  author: theamanrawat
+  severity: medium
+  description: |
+    Ruby on Rails action pack before 6.1.2.1, 6.0.3.5 contains an open redirect caused by special crafted Host headers in combination with allowed host formats, letting attackers redirect users to malicious websites, exploit requires attacker to control Host headers.
+  impact: |
+    Attackers can redirect users to malicious sites, potentially leading to phishing or malware distribution.
+  remediation: |
+    Update to version 6.1.2.1, 6.0.3.5 or later versions.
+  reference:
+    - https://hackerone.com/reports/1047447
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-22881
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2021-22881
+    cwe-id: CWE-601
+  metadata:
+    verified: false
+    max-request: 1
+  tags: cve,cve2021,ruby,rails,host-header,redirect,vuln
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: interact.sh#{{randstr}}.{{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)?(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'
+
+      - type: status
+        condition: or
+        status:
+          - 302
+          - 301


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
