### PR TITLE
Add CVE-2026-21859 for Mailpit SSRF vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-21859.yaml
+++ b/http/cves/2026/CVE-2026-21859.yaml
@@ -5,11 +5,11 @@ info:
   author: omarkurt
   severity: high
   description: |
-    Mailpit versions before 1.28.3 contain a Server-Side Request Forgery (SSRF) vulnerability in the /proxy endpoint. The endpoint allows requests to internal network resources without proper validation of destination IP addresses, enabling attackers to access internal services,cloud metadata endpoints, and other protected resources.
+    Mailpit <= 1.28.0 contains a server-side request forgery caused by insufficient validation of internal IP addresses in the /proxy endpoint, letting attackers make requests to internal network resources, exploit requires crafted HTTP GET requests.
   impact: |
-    An attacker can probe internal services, access cloud metadata endpoints (AWS/GCP/Azure),read captured emails via internal API, and perform lateral movement within the network.
+    Attackers can access internal network services and APIs, potentially exposing sensitive internal resources.
   remediation: |
-    Upgrade Mailpit to version 1.28.3 or later which implements IP address validation to block internal network access via the proxy endpoint.
+    Update to version 1.28.1 or later.
   reference:
     - https://rosecurify.com/advisories/RO-26-001-mailpit-server-side-request-forgery-ssrf/
     - https://github.com/axllent/mailpit/security/advisories/GHSA-8v65-47jx-7mfr


### PR DESCRIPTION
This YAML file describes a high-severity SSRF vulnerability in Mailpit versions before 1.28.3, detailing its impact, remediation steps, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-21859 

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
