### PR TITLE
Add CVE-2022-31678 (vKEV)

### DIFF
--- a/http/cves/2022/CVE-2022-31678.yaml
+++ b/http/cves/2022/CVE-2022-31678.yaml
@@ -25,9 +25,22 @@ info:
     product: cloud_foundation
     shodan-query: title:"VMware Appliance Management"
     fofa-query: title="VMware Appliance Management"
-  tags: cve,cve2022,vmware,nsx,xxe,vkev
+  tags: cve,cve2022,vmware,nsx,xxe,vkev,kev
+
+flow: http(1) && http(2)
 
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login.jsp"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>VMware Appliance Management"
+        internal: true
+
   - raw:
       - |
         POST /api/3.0/services/auth/token HTTP/1.1


### PR DESCRIPTION
### PR Information

VMware Cloud Foundation (NSX-V) contains an XML External Entity (XXE) vulnerability. On VCF 3.x instances with NSX-V deployed, this may allow a user to exploit this issue leading to a denial-of-service condition or unintended information disclosure.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)