### PR TITLE
Add CVE-2019-13608 (KEV and vKEV)

### DIFF
--- a/http/cves/2019/CVE-2019-13608.yaml
+++ b/http/cves/2019/CVE-2019-13608.yaml
@@ -1,11 +1,15 @@
 id: CVE-2019-13608
 
 info:
-  name: Citrix StoreFront Server - XML External Entity (XXE)
+  name: Citrix StoreFront Server - XML External Entity
   author: daffainfo
   severity: high
   description: |
     Citrix StoreFront Server before 1903, 7.15 LTSR before CU4 (3.12.4000), and 7.6 LTSR before CU8 (3.0.8000) allows XXE attacks.
+  impact: |
+    Attackers can read arbitrary files, perform server-side request forgery, or cause denial of service through XXE attacks.
+  remediation: |
+    Update to version 1903 or later for StoreFront, CU4 or later for 7.15 LTSR, CU8 or later for 7.6 LTSR.
   reference:
     - https://www.exploit-db.com/exploits/47561
     - https://support.citrix.com/support-home/kbsearch/article?articleNumber=CTX251988


### PR DESCRIPTION
### PR Information

Citrix StoreFront Server before 1903, 7.15 LTSR before CU4 (3.12.4000), and 7.6 LTSR before CU8 (3.0.8000) allows XXE attacks.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)