### PR TITLE
Improve weak CSP detection logic and fix matcher conditions

### DIFF
--- a/http/misconfiguration/weak-csp-detect.yaml
+++ b/http/misconfiguration/weak-csp-detect.yaml
@@ -2,7 +2,7 @@ id: weak-csp-detect
 
 info:
   name: Weak Content Security Policy - Detect
-  author: pussycat0x (updated by celbahraoui)
+  author: pussycat0x,celbahraoui
   severity: info
   description: |
     Detected misconfigured CSP directives containing unsafe and overly permissive keywords that weakened resource loading restrictions. This configuration allowed high-risk script behaviors, resulting in reduced protection against XSS attacks.
@@ -32,7 +32,6 @@ http:
       - type: dsl
         condition: or
         dsl:
-          # Missing or weak directives
           - "!regex('(?i)\\bscript-src\\b', header)"
           - "!regex('(?i)\\bobject-src\\b', header)"
           - "regex('(?i)script-src[^;]*(?:\\x27unsafe-inline\\x27|\\x27unsafe-eval\\x27|\\x27unsafe-hashes\\x27|\\*|data:|blob:)[^;]*(?:;|$)', header)"
@@ -62,4 +61,3 @@ http:
         name: missing-object-src
         dsl:
           - "!regex('(?i)\\bobject-src\\b', header)"
-# digest: 4a0a00473045022100a55ffcf123e80406645f50656ac808c42cfb3ee59d99b3e6a61d9a4e84953f6302200f47cc2824d2d34cd12b7e16a229b44388c191853f80137460d8e78ac52cc78a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This PR improves the existing weak CSP detection template by fixing matcher logic and correcting a regex typo.

Changes:
- Fix matcher logic to trigger when CSP is weak or incomplete
- Correct a default-src regex typo ('unsafe-eval')
- Add detection for missing script-src and object-src directives, which are commonly recommended for XSS and plugin hardening
- Reduce false positives by excluding https: from weak-source detection, as it does not enable code execution by itself and is commonly used in legitimate CSP configurations
