### PR TITLE
Add CVE-2023-35708 (vKEV)

### DIFF
--- a/http/cves/2023/CVE-2023-35708.yaml
+++ b/http/cves/2023/CVE-2023-35708.yaml
@@ -30,7 +30,7 @@ info:
     product: moveit_transfer
     shodan-query: http.favicon.hash:989289239
     fofa-query: icon_hash=989289239
-  tags: cve,cve2023,moveit,sqli,progress,vkev,vuln
+  tags: cve,cve2023,moveit,sqli,progress,vkev,kev,vuln
 
 http:
   - raw:


### PR DESCRIPTION
### PR Information

In Progress MOVEit Transfer before 2021.0.8 (13.0.8), 2021.1.6 (13.1.6), 2022.0.6 (14.0.6), 2022.1.7 (14.1.7), and 2023.0.3 (15.0.3), a SQL injection vulnerability has been identified in the MOVEit Transfer web application that could allow an unauthenticated attacker to gain unauthorized access to MOVEit Transfer's database. An attacker could submit a crafted payload to a MOVEit Transfer application endpoint that could result in modification and disclosure of MOVEit database content. These are fixed versions of the DLL drop-in: 2020.1.10 (12.1.10), 2021.0.8 (13.0.8), 2021.1.6 (13.1.6), 2022.0.6 (14.0.6), 2022.1.7 (14.1.7), and 2023.0.3 (15.0.3).

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Notes

Researched this with @jjchoNC