### PR TITLE
Add CVE-2025-27817 - Apache Kafka Client - Arbitrary File Read and SSRF

### DIFF
--- a/http/cves/2025/CVE-2025-27817.yaml
+++ b/http/cves/2025/CVE-2025-27817.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-27817
 
 info:
-  name: Apache Kafka Client - Arbitrary File Read and SSRF
+  name: Apache Kafka Client - Arbitrary File Read
   author: 0x_Akoko
   severity: high
   description: |
@@ -13,7 +13,6 @@ info:
   reference:
     - https://github.com/kk12-30/CVE-2025-27817
     - https://nvd.nist.gov/vuln/detail/CVE-2025-27817
-    - https://kafka.apache.org/cve-list
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -41,26 +40,14 @@ http:
         part: body
         words:
           - "Malformed JWT provided"
-          - "root:"
+          - "RecordSupplier"
         condition: and
 
-      - type: word
+      - type: regex
         part: body
-        words:
-          - "/bin/bash"
-          - "/bin/sh"
-          - "/sbin/nologin"
-          - "nobody"
-        condition: or
+        regex:
+          - "root:.*:0:0:"
 
       - type: status
         status:
           - 400
-
-    extractors:
-      - type: regex
-        name: leaked_content
-        part: body
-        group: 1
-        regex:
-          - 'Malformed JWT provided \(([^)]+)\)'


### PR DESCRIPTION
Added details about CVE-2025-27817 including its impact, remediation, and HTTP request examples.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
