### PR TITLE
Create apache-tika-detect.yaml

### DIFF
--- a/http/technologies/apache/apache-tika-detect.yaml
+++ b/http/technologies/apache/apache-tika-detect.yaml
@@ -16,6 +16,7 @@ info:
     vendor: apache
     product: tika
   tags: tech,tika,apache,detect
+
 http:
   - method: GET
     path:
@@ -24,6 +25,7 @@ http:
       - "{{BaseURL}}/version"
 
     stop-at-first-match: true
+
     matchers-condition: and
     matchers:
       - type: word
@@ -31,9 +33,11 @@ http:
           - 'Apache Tika'
           - 'apache.tika'
         condition: and
+
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         part: response


### PR DESCRIPTION
This nuclei template:

* Detects an Apache Tika server, a toolkit that detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).

- References:

https://github.com/apache/tika/

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Tika Docker:**

1. Running container:

`$ docker run -d -p 9998:9998 --name apache_tika apache/tika:latest`

2. Acessing the Apache Tika service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache_tika`

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-tika-detect.yaml -u "http://<obteined_inspect_IP_Address>:9998/" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1468" height="775" alt="image" src="https://github.com/user-attachments/assets/01c1eff9-3619-4efb-bf67-544138982f01" />

<img width="1844" height="359" alt="image" src="https://github.com/user-attachments/assets/18640952-13aa-4afb-ae8f-f254b12963ad" />
