### PR TITLE
fix: Add additional path to Tomcat detection

### DIFF
--- a/http/technologies/apache/tomcat-detect.yaml
+++ b/http/technologies/apache/tomcat-detect.yaml
@@ -28,6 +28,7 @@ http:
       - "{{BaseURL}}"
       - "{{BaseURL}}/{{randstr}}"
       - "{{BaseURL}}/docs/introduction.html"
+      - "{{BaseURL}}/\\"
 
     stop-at-first-match: true
 


### PR DESCRIPTION
### PR Information

Tomcat fails with 400 status code if a malformed URL is accessed such as `/\`. The error page may disclosure the exact Apache Tomcat version in use, if error pages were not disabled during hardening.

<img width="1666" height="84" alt="image" src="https://github.com/user-attachments/assets/a5a2cdfd-1efa-4013-ba4b-d3f93455051f" />

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ x ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ x ] Validated with a host running a patched version and/or configuration (avoid False Positive)
