### PR TITLE
Add matcher for header to CVE-2020-9039

### DIFF
--- a/http/cves/2020/CVE-2020-9039.yaml
+++ b/http/cves/2020/CVE-2020-9039.yaml
@@ -31,4 +31,10 @@ http:
           - "status_code == 200"
           - "contains_any(body, 'indexer.settings','projector.settings','max_seckey_size')"
         condition: and
+      
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
 # digest: 4b0a00483046022100da7adbd98d63ca28f47de38fd4542da9bc32d6ca0ac75d2e05b03fa2b3cd2c11022100f007afe0c6ed9729ea6532e49b58a40a6e82707c79fe1f12952feb7ec068d5dc:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information
Added a word matcher for header containing "application/json" as the current template is broad (hits `/settings` endpoint) and creates false positives, including on HTML pages if redirected.
Per https://docs.couchbase.com/server/current/index-rest-settings/index.html, only JSON should be returned.

- Updated CVE-2020-9039

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
