### PR TITLE
Added default creds checking nuclei template for gude 2301 and 2302

### DIFF
--- a/default-logins/gude/gude-default-login.yaml
+++ b/default-logins/gude/gude-default-login.yaml
@@ -26,6 +26,8 @@ http:
       Authorization: "Basic YWRtaW46YWRtaW4="
 
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains(body, "Control Panel")'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
### PR Information

This is just a simple nuclei template to check if the default administrator creds were not changed on Gude Expert Net Control 2301 and 2302, which are PLC used in factories. It's for OT pen-testing.

- References: https://media.distrelec.com/Web/Downloads/_m/an/Gude_2302-1_ger_man.pdf

### Template validation

The template was verified on a working GUDE Expert Net Control 2302 and 2301. This is just a simple basic authentication to access the administration webpage called `ov.html?`

- [x ] Validated with a host running a vulnerable version and/or configuration (True Positive)

<img width="1529" height="367" alt="nucle" src="https://github.com/user-attachments/assets/de794b2e-cc83-46ea-97b8-7c0fb913a690" />