### PR TITLE
fix(fp): reduce false positives in wp-wps-hide-login-log

### DIFF
--- a/http/exposures/logs/wp-wps-hide-login-log.yaml
+++ b/http/exposures/logs/wp-wps-hide-login-log.yaml
@@ -22,6 +22,6 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200 || status_code == 500'
-          - 'contains_any(body, "Uncaught Error","Fatal error","Warning") && contains(body, "wp-content/plugins/wps-hide-login")'
+          - 'contains_any(body, "PHP Fatal error:", "PHP Warning:", "PHP Parse error:")'
+          - 'contains(body, "wp-content/plugins/wps-hide-login")'
         condition: and
-# digest: 4a0a00473045022054d0c697ae994796ca1d71a8b7d8372054b25017a0d1935b5c94a8ae432b48ba0221008c06557f1820623ba19f24d2d2148cb43910d24b04c6b357a30042276637b125:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

Related to #15089

Fixes false positives in http/exposures/logs/wp-wps-hide-login-log.yaml on SPA applications that return HTTP 200 for arbitrary paths (catch-all routing) and reflect the requested path in HTML.


- Tighten matcher to PHP-specific error patterns only: "PHP Fatal error:", "PHP Warning:", "PHP Parse error:" while keeping the plugin path check.


### Template validation

Validation (local docker lab):
- SPA FP case (200 OK, Content-Type: text/html, contains console.warn("Warning") and reflected /wp-content/plugins/wps-hide-login/...):
  - Before: match
  - After: no match
- TP sanity check (body contains "PHP Warning:" and wp-content/plugins/wps-hide-login):
  - After: match

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details
### Additional References:
