### PR TITLE
Add Nuclei template for CVE-2018-20753 (Kaseya VSA Command Injection)

### DIFF
--- a/http/cves/2018/CVE-2018-20753.yaml
+++ b/http/cves/2018/CVE-2018-20753.yaml
@@ -54,7 +54,7 @@ http:
         part: body
         group: 1
         regex:
-          - 'kVersion\s*=\s*["\']([0-9.]+)["\']'
+          - "kVersion\\s*=\\s*[\"']([0-9.]+)[\"']"
 
       - type: dsl
         dsl:


### PR DESCRIPTION
## Description
Adds detection template for CVE-2018-20753 - OS Command Injection in Kaseya VSA.

## Vulnerability Details
- **CVE:** CVE-2018-20753
- **Severity:** Critical (CVSS 9.8)
- **Type:** OS Command Injection (CWE-78)
- **Affected:** Kaseya VSA R9.3 < 9.3.0.35, R9.4 < 9.4.0.36, R9.5 < 9.5.0.5

## References
- https://nvd.nist.gov/vuln/detail/CVE-2018-20753
- https://www.cisa.gov/known-exploited-vulnerabilities-catalog

/claim #14535