### PR TITLE
Add Nuclei template for CVE-2022-24706 (Apache CouchDB Privilege Escalation)

### DIFF
--- a/http/cves/2022/CVE-2022-24706.yaml
+++ b/http/cves/2022/CVE-2022-24706.yaml
@@ -58,6 +58,13 @@ http:
         status:
           - 200
 
+      - type: regex
+        part: body
+        regex:
+          - '"version":"([0-2]\.[0-9]+\.[0-9]+)"'
+          - '"version":"(3\.[0-1]\.[0-9]+)"'
+          - '"version":"(3\.2\.[0-1])"'
+
     extractors:
       - type: regex
         name: version


### PR DESCRIPTION
## Description
This template detects CVE-2022-24706, a critical privilege escalation vulnerability in Apache CouchDB prior to version 3.2.2.

## Vulnerability Details
- **CVE**: CVE-2022-24706
- **Severity**: Critical (CVSS 9.8)
- **CWE**: CWE-1188 (Insecure Default Initialization of Resource)
- **Affected Versions**: Apache CouchDB < 3.2.2
- **Status**: Actively exploited in the wild (CISA KEV listed)

## Detection Method
The template performs unauthenticated requests to:
- `/_session` endpoint
- `/` (root) endpoint

It detects vulnerable CouchDB instances by:
1. Confirming CouchDB service via JSON response
2. Extracting version information
3. Identifying instances running versions prior to 3.2.2

## References
- https://nvd.nist.gov/vuln/detail/CVE-2022-24706
- https://docs.couchdb.org/en/stable/cve/2022-24706.html
- https://www.cisa.gov/known-exploited-vulnerabilities-catalog
- http://packetstormsecurity.com/files/167032/Apache-CouchDB-3.2.1-Remote-Code-Execution.html

## Testing
Tested against:
- Vulnerable CouchDB instances (versions < 3.2.2)
- Patched CouchDB instances (version 3.2.2+)
- Non-CouchDB services (no false positives)

Fixes #7549

---

?? Generated with Claude Code