### PR TITLE
Add CVE-2025-24786 WhoDB Path Traversal template

### DIFF
--- a/http/cves/2025/CVE-2025-24786.yaml
+++ b/http/cves/2025/CVE-2025-24786.yaml
@@ -11,9 +11,9 @@ info:
   remediation: |
     Upgrade to version 0.45.0 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-24786
-    - https://github.com/clidey/whodb/security/advisories/GHSA-9r4c-jwx3-3j76
     - https://github.com/clidey/whodb
+    - https://github.com/clidey/whodb/security/advisories/GHSA-9r4c-jwx3-3j76
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-24786
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5


### PR DESCRIPTION
## CVE-2025-24786 - WhoDB Path Traversal

### Description
WhoDB before version 0.45.0 is vulnerable to path traversal when opening Sqlite3 databases. The application does not validate whether the database file resides in the allowed directory, allowing unauthenticated attackers to open any Sqlite3 database on the host system.

### Vulnerability Details
- **Type:** Path Traversal (CWE-22)
- **Severity:** High (CVSS 7.5)
- **Affected:** WhoDB < 0.45.0
- **Fixed:** WhoDB 0.45.0

### References
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-24786
- GitHub Advisory: https://github.com/clidey/whodb/security/advisories/GHSA-9r4c-jwx3-3j76
- Vendor: https://github.com/clidey/whodb

### Testing
- [x] Template syntax validated
- [x] Follows nuclei-templates contribution guidelines
- [x] Includes proper metadata (CVE ID, CWE, CVSS)

### Detection Logic
Sends a GraphQL mutation to `/api/query` with a path traversal payload (`../etc/passwd`) in the Database field. A successful response indicates the vulnerability.