### PR TITLE
Add CVE-2017-18365 GitHub Enterprise RCE detection template

### DIFF
--- a/http/cves/2017/CVE-2017-18365.yaml
+++ b/http/cves/2017/CVE-2017-18365.yaml
@@ -1,0 +1,60 @@
+id: CVE-2017-18365
+
+info:
+  name: GitHub Enterprise - Insecure Deserialization RCE
+  author: NandanKopplu  
+  severity: critical
+  description: |
+    GitHub Enterprise 2.8.x before 2.8.7 contains an insecure deserialization vulnerability 
+    caused by a static enterprise session secret in the Management Console. This allows 
+    unauthenticated attackers to execute arbitrary code by crafting a signed cookie.
+  reference:
+    - https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-18365
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2017-18365
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"github debug"
+  tags: cve,cve2017,github,rce,deserialization,kev
+
+http:
+  - raw:
+      - |
+        GET /setup/unlock HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        GET /setup/unlock HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: _gh_manage={{base64('test')}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Management Console"
+          - "GitHub Enterprise"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "_gh_manage"
+        negative: true
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'GitHub Enterprise ([0-9.]+)'


### PR DESCRIPTION
## Description
This PR adds a Nuclei template to detect CVE-2017-18365 - GitHub Enterprise Insecure Deserialization RCE vulnerability.

## Changes
- Added detection template for CVE-2017-18365
- Tests for GitHub Enterprise Management Console vulnerability
- Detects the insecure deserialization flaw in versions before 2.8.7

## Testing
Template has been validated using `nuclei -validate` command.

## References
- https://www.exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
- https://nvd.nist.gov/vuln/detail/CVE-2017-18365
- https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/github_enterprise_secret.rb

/claim #14451

## Checklist
- [x] Template follows Nuclei template guidelines
- [x] Template validated locally
- [x] All matchers tested
- [x] References included