### PR TITLE
chore: make matchers for weak-csp-detect more granular

### DIFF
--- a/http/misconfiguration/weak-csp-detect.yaml
+++ b/http/misconfiguration/weak-csp-detect.yaml
@@ -21,44 +21,43 @@ http:
     path:
       - "{{BaseURL}}"
 
-    matchers-condition: and
+    matchers-condition: or
     matchers:
-      - type: word
-        part: header
-        words:
-          - "Content-Security-Policy"
-        case-insensitive: true
-
-      - type: dsl
-        condition: or
-        dsl:
-          - "!regex('(?i)\\bscript-src\\b', header)"
-          - "!regex('(?i)\\bobject-src\\b', header)"
-          - "regex('(?i)script-src[^;]*(?:\\x27unsafe-inline\\x27|\\x27unsafe-eval\\x27|\\x27unsafe-hashes\\x27|\\*|data:|blob:)[^;]*(?:;|$)', header)"
-          - "regex('(?i)default-src[^;]*(?:\\x27unsafe-inline\\x27|\\x27unsafe-eval\\x27|\\x27unsafe-hashes\\x27|\\*|data:|blob:)[^;]*(?:;|$)', header)"
-
-    extractors:
-      - type: regex
-        part: header
-        name: script-src-directive
-        group: 1
-        regex:
-          - '(?i)(script-src[^;]+)'
-
-      - type: regex
-        part: header
-        name: default-src-directive
-        group: 1
-        regex:
-          - '(?i)(default-src[^;]+)'
-
       - type: dsl
         name: missing-script-src
         dsl:
-          - "!regex('(?i)\\bscript-src\\b', header)"
+          - "contains(to_lower(header), 'content-security-policy:')"
+          - "!contains(to_lower(header), 'script-src')"
+          - "!contains(to_lower(header), 'default-src')"
+        condition: and
 
       - type: dsl
         name: missing-object-src
         dsl:
-          - "!regex('(?i)\\bobject-src\\b', header)"
+          - "contains(to_lower(header), 'content-security-policy:')"
+          - "!contains(to_lower(header), 'object-src')"
+          - "!contains(to_lower(header), 'default-src')"
+        condition: and
+
+      - type: dsl
+        name: unsafe-script-src
+        dsl:
+          - "contains(to_lower(header), 'content-security-policy:')"
+          - "regex('(?i)script-src[^;]*(unsafe-inline|unsafe-eval|unsafe-hashes|\\\\*|data:|blob:)', header)"
+        condition: and
+
+      - type: dsl
+        name: unsafe-default-src
+        dsl:
+          - "contains(to_lower(header), 'content-security-policy:')"
+          - "regex('(?i)default-src[^;]*(unsafe-inline|unsafe-eval|unsafe-hashes|\\\\*|data:|blob:)', header)"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: header
+        name: csp-header
+        group: 1
+        regex:
+          - "(?i)content-security-policy:\\s*([^\\r\\n]+)"
 # digest: 4a0a00473045022056c9421a7105679da346301a5b4e87b69cbd5a000fb6145b70074f8fcc2373c3022100f11c39357107aa46cb31992db264e85ecb189066de4b1c9b30c187f1a72175b9:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

The current version of `week-scp-detect` reports two (or even four on the `main` branch) matching results when actually only one exists.

The problem occurred because two (or four on the `main` branch) extractors were used. The fix involves reducing the number of extractors to just one. This new extractor prints the entire CSP policy.
Example CSP:
```
default-src 'self'; script-src 'unsafe-hashes' 'nonce-ORW/wxuWg33lqqa9a4RPuw==' 'strict-dynamic'; base-uri 'self';
```
Before(v10.3.8):
<img width="2500" height="642" alt="Screenshot 2026-02-02 at 12 13 07" src="https://github.com/user-attachments/assets/c67e9d1e-c198-4f15-af1b-5e327475906a" />
Before(main):
<img width="2560" height="718" alt="Screenshot 2026-02-02 at 13 17 22" src="https://github.com/user-attachments/assets/d9d775a2-34b0-4c4a-a7f4-6ba359d7d009" />



After:
<img width="3058" height="604" alt="Screenshot 2026-02-02 at 12 11 37" src="https://github.com/user-attachments/assets/d8483b4d-cc21-4e46-8429-67c43bb7a57d" />

Please note that this template requires further adjustments. For example, the Google CSP Evaluator reports no violations for the above policy. On the other hand, `unsafe-hashes` is considered less mature than `nonce`, but it is allowed for legacy systems and during migration. See:

<img width="2016" height="2060" alt="Screenshot 2026-02-02 at 13 14 02" src="https://github.com/user-attachments/assets/1826ca31-7c76-4bf4-bc90-34f8aa0714cc" />


Additional Changes:
* `object-src` is required only if `default-src` is not present
* `script-scr` is required only if `default-scr` is not present


### Template validation


- [ x ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ x ] Validated with a host running a patched version and/or configuration (avoid False Positive)
