### PR TITLE
feat: add CVE-2018-20753 Kaseya VSA Command Injection template

### DIFF
--- a/http/cves/2018/CVE-2018-20753.yaml
+++ b/http/cves/2018/CVE-2018-20753.yaml
@@ -1,0 +1,64 @@
+id: CVE-2018-20753
+
+info:
+  name: Kaseya VSA < R9.3.0.35/R9.4.0.36/R9.5.0.5 - PowerShell Command Injection
+  author: erdogan98
+  severity: critical
+  description: |
+    Kaseya VSA RMM before R9.3 9.3.0.35, R9.4 before 9.4.0.36, and R9.5 before 9.5.0.5 allows unprivileged remote attackers to execute PowerShell payloads on all managed devices due to insufficient input validation in PowerShell execution. In January 2018, attackers actively exploited this vulnerability in the wild to deploy cryptocurrency miners via malicious Agent Procedures on managed endpoints.
+  impact: |
+    Successful exploitation allows remote attackers to execute arbitrary PowerShell commands on all managed devices, leading to complete compromise of the entire managed infrastructure. Attackers exploited this to deploy cryptocurrency miners via scheduled tasks and registry persistence.
+  remediation: |
+    Update to Kaseya VSA version R9.3.0.35 or later (for R9.3), R9.4.0.36 or later (for R9.4), or R9.5.0.5 or later (for R9.5). For R9.2 or earlier, upgrade to R9.3 or higher.
+  reference:
+    - https://blog.huntresslabs.com/deep-dive-kaseya-vsa-mining-payload-c0ac839a0e88
+    - https://helpdesk.kaseya.com/hc/en-gb/articles/360000333152
+    - https://helpdesk.kaseya.com/hc/en-gb/articles/360000346651
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20753
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-20753
+    cwe-id: CWE-77
+    epss-score: 0.97316
+    epss-percentile: 0.99817
+    cpe: cpe:2.3:a:kaseya:virtual_system_administrator:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: kaseya
+    product: virtual_system_administrator
+    shodan-query: http.favicon.hash:-1445519482
+    fofa-query: icon_hash="-1445519482"
+  tags: cve,cve2018,kaseya,rce,kev,vkev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vsapres/web20/core/images/login/icon_kaseya.ico"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - '"-1445519482" == mmh3(base64(body))'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/dl.asp"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Download Agent</title>"
+          - "mkDefault.asp"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description
Adds nuclei template for CVE-2018-20753 - Kaseya VSA RMM PowerShell Command Injection.

## CVE Details
- **CVE:** CVE-2018-20753
- **Severity:** Critical (CVSS 9.8)
- **KEV:** Yes (CISA Known Exploited)
- **Affected:** Kaseya VSA < R9.3.0.35, R9.4.0.36, R9.5.0.5

## Template Details
- Detection via favicon hash (Shodan: http.favicon.hash:-1445519482)

## References
- https://blog.huntresslabs.com/deep-dive-kaseya-vsa-mining-payload-c0ac839a0e88
- https://nvd.nist.gov/vuln/detail/CVE-2018-20753

/claim #14535