### PR TITLE
Add detection of  "RESA VISTA software suite" login panel instances.

### DIFF
--- a/http/exposed-panels/resa-vista-panel.yaml
+++ b/http/exposed-panels/resa-vista-panel.yaml
@@ -1,0 +1,33 @@
+id: resa-vista-panel
+
+info:
+  name: RESA Vista Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+     RESA Vista was detected — an automated multimedia display system for airports.
+  reference:
+    - https://resa.aero/en/solutions-operations-billing/vista-staff-fids/
+  metadata:
+    verified: true
+    max-request: 1
+  tags: panel,resa,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/account/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "vista", "resa airport", "login")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'v=([0-9.]+)'


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **RESA VISTA software suite** software.

I know that this software is quite specific. However, I think that it can be interesting to have a template to detect instances due to the business purpose of the software.

References:

- https://resa.aero/en/solutions-operations-billing/vista-staff-fids/

### Template Validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)


<img width="928" height="705" alt="image" src="https://github.com/user-attachments/assets/311f0acd-5587-4fcc-8e80-c9bc0f420a28" />

I tested the template against `https://vistaweb.lux-airport.lu`.

### Additional Details (leave it blank if not applicable)

I did not found a valid Shodan query.

### Additional References

None