### PR TITLE
Add CVE-2018-8581: Microsoft Exchange PrivExchange SSRF to Privilege Escalation

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,74 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF to Privilege Escalation (PrivExchange)
+  author: ohmygod20260203
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a Server-Side Request Forgery (SSRF) vulnerability in the Exchange Web Services (EWS) PushSubscription feature. An attacker with valid credentials can abuse the PushSubscription API to force the Exchange server to authenticate to an attacker-controlled host with NTLM. By relaying the Exchange machine account credentials to LDAP on a domain controller, the attacker can escalate to Domain Admin via DCSync. Affected versions include Exchange Server 2010 SP3, 2013 (< CU22), 2016 (< CU12), and 2019 (< CU1) prior to the February 2019 security updates.
+  impact: |
+    A low-privileged user with a mailbox can escalate to Domain Admin by relaying Exchange's NTLM authentication via the PushSubscription SSRF, modifying ACLs on the Active Directory domain object to gain DCSync privileges.
+  remediation: |
+    Apply the February 2019 (or later) cumulative update for the affected Exchange Server version. Remove the Exchange Windows Permissions group's WriteDacl privileges on the Domain object. Disable EWS push/pull subscriptions if not required.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/
+    - https://github.com/dirkjanm/privexchange/
+    - https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 7.4
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.97249
+    epss-percentile: 0.99875
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: http.title:"Outlook" "X-OWA-Version"
+    fofa-query: header="X-OWA-Version"
+  tags: cve,cve2018,exchange,ssrf,privexchange,microsoft,kev
+
+http:
+  - raw:
+      - |
+        GET /owa/auth/logon.aspx HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "/owa/auth/"
+
+      - type: regex
+        part: header_1
+        regex:
+          - "(?i)X-OWA-Version:\\s*(14\\.3\\.|15\\.0\\.(([0-9]{1,3}|1[0-3][0-9]{2}|14[0-8][0-9]|1496)\\.[0-9]+)|15\\.1\\.(([0-9]{1,3}|1[0-6][0-9]{2}|170[0-9]|171[0-2])\\.[0-9]+)|15\\.2\\.(([0-2][0-9]{0,2}|3[0-2][0-9])\\.[0-9]+))"
+
+      - type: word
+        part: header_2
+        words:
+          - "WWW-Authenticate"
+          - "Negotiate"
+        condition: and
+
+    extractors:
+      - type: kval
+        part: header_1
+        kval:
+          - x_owa_version
+
+      - type: regex
+        part: body_1
+        group: 1
+        regex:
+          - "/owa/auth/([0-9.]+)/"


### PR DESCRIPTION
/claim #14576

## CVE-2018-8581 - Microsoft Exchange Server SSRF (PrivExchange)

Adds a nuclei template for [CVE-2018-8581](https://nvd.nist.gov/vuln/detail/CVE-2018-8581) - Exchange Server SSRF to Domain Admin escalation via PushSubscription NTLM relay.

### Detection Approach
1. **OWA Login Page**: Checks `/owa/auth/logon.aspx` for Exchange version from `X-OWA-Version` header
2. **Version Match**: Regex matches vulnerable Exchange versions (2010 SP3 14.3.x, 2013 < CU22, 2016 < CU12, 2019 < CU1)
3. **EWS Endpoint**: Confirms `/EWS/Exchange.asmx` is accessible with NTLM authentication (WWW-Authenticate: Negotiate)

### Vulnerable Versions
- Exchange 2010 SP3: 14.3.x (all before RU26)
- Exchange 2013: 15.0.x < 15.0.1497.2 (CU22)
- Exchange 2016: 15.1.x < 15.1.1713.5 (CU12)
- Exchange 2019: 15.2.x < 15.2.330.5 (CU1)

### References
- [PrivExchange writeup](https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/)
- [PrivExchange PoC tool](https://github.com/dirkjanm/privexchange/)
- [ZDI blog](https://www.thezdi.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange)
- [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
- [Microsoft Advisory](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581)