### PR TITLE
Add CVE-2018-20753: Kaseya VSA Remote Code Execution

### DIFF
--- a/http/cves/2018/CVE-2018-20753.yaml
+++ b/http/cves/2018/CVE-2018-20753.yaml
@@ -1,0 +1,61 @@
+id: CVE-2018-20753
+
+info:
+  name: Kaseya VSA < R9.5.0.5 - Remote Code Execution
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    Kaseya VSA RMM before R9.3 9.3.0.35, R9.4 before 9.4.0.36, and R9.5 before 9.5.0.5 allows unprivileged remote attackers to execute PowerShell payloads on all managed devices via the agent procedure functionality. In January 2018, this vulnerability was actively exploited in the wild to deploy cryptocurrency mining payloads through scheduled tasks and PowerShell persistence mechanisms.
+  impact: |
+    An unauthenticated remote attacker can execute arbitrary PowerShell commands on all devices managed by the vulnerable Kaseya VSA instance, leading to full compromise of the managed infrastructure.
+  remediation: |
+    Upgrade Kaseya VSA to R9.3 9.3.0.35, R9.4 9.4.0.36, R9.5 9.5.0.5 or later. Review managed devices for signs of compromise including suspicious scheduled tasks and PowerShell-based persistence.
+  reference:
+    - https://helpdesk.kaseya.com/hc/en-gb/articles/360000333152
+    - https://www.huntress.com/blog/deep-dive-kaseya-vsa-mining-payload-c0ac839a0e88
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20753
+    - https://www.rapid7.com/db/vulnerabilities/kaseya-vsa-cve-2018-20753/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-20753
+    cwe-id: CWE-94
+    epss-score: 0.97436
+    epss-percentile: 0.99932
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: kaseya
+    product: vsa
+    shodan-query: title:"Kaseya"
+    fofa-query: title="Kaseya"
+  tags: cve,cve2018,kaseya,vsa,rce,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vsapres/web20/core/login.asp"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Kaseya"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "(?i)(9\\.[0-4]\\.[0-9]+\\.[0-9]+|9\\.5\\.0\\.[0-4])"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "(?i)(?:version|v)\\s*[:=]?\\s*([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)"


### PR DESCRIPTION
/claim #14535

## CVE-2018-20753 - Kaseya VSA RCE

Adds a nuclei template for [CVE-2018-20753](https://nvd.nist.gov/vuln/detail/CVE-2018-20753) - Kaseya VSA Remote Code Execution via agent procedure functionality.

### Detection Approach
1. **Login Page**: Checks Kaseya VSA login page at `/vsapres/web20/core/login.asp`
2. **Branding**: Confirms "Kaseya" branding in response body
3. **Version Match**: Extracts version and checks against vulnerable versions (< R9.3 9.3.0.35, R9.4 < 9.4.0.36, R9.5 < 9.5.0.5)

### Context
- CISA KEV (Known Exploited Vulnerabilities Catalog) entry
- Actively exploited in the wild since January 2018
- Used to deploy cryptocurrency mining payloads via PowerShell persistence
- [Huntress deep dive](https://www.huntress.com/blog/deep-dive-kaseya-vsa-mining-payload-c0ac839a0e88)

### Vulnerable Versions
- Kaseya VSA R9.3 < 9.3.0.35
- Kaseya VSA R9.4 < 9.4.0.36
- Kaseya VSA R9.5 < 9.5.0.5

### References
- [Kaseya Security Update](https://helpdesk.kaseya.com/hc/en-gb/articles/360000333152)
- [Rapid7 Vulnerability DB](https://www.rapid7.com/db/vulnerabilities/kaseya-vsa-cve-2018-20753/)