### PR TITLE
Add CVE-2024-8943 (vKEV)

### DIFF
--- a/http/cves/2024/CVE-2024-8943.yaml
+++ b/http/cves/2024/CVE-2024-8943.yaml
@@ -51,9 +51,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "application/json")'
           - 'contains_all(body, "[{\"id", "name\":")'
+          - 'contains(content_type, "application/json")'
+          - 'status_code == 200'
         condition: and
         internal: true
 


### PR DESCRIPTION
### PR Information

The LatePoint plugin for WordPress is vulnerable to authentication bypass in versions up to, and including, 5.0.12. This is due to insufficient verification on the user being supplied during the booking customer step. This makes it possible for unauthenticated attackers to log in as any existing user on the site, such as an administrator, if they have access to the user id. Note that logging in as a WordPress user is only possible if the "Use WordPress users as customers" setting is enabled, which is disabled by default. The vulnerability is partially patched in version 5.0.12 and fully patched in version 5.0.13.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)