### PR TITLE
Add CVE-2026-1056 - WordPress Snow Monkey Forms Unauth File Deletion

### DIFF
--- a/http/cves/2026/CVE-2026-1056.yaml
+++ b/http/cves/2026/CVE-2026-1056.yaml
@@ -1,0 +1,85 @@
+id: CVE-2026-1056
+
+info:
+  name: WordPress Snow Monkey Forms <= 12.0.3 - Unauthenticated Arbitrary File Deletion
+  author: ohmygod20260203
+  severity: high
+  description: |
+    The Snow Monkey Forms plugin for WordPress is vulnerable to unauthenticated arbitrary file deletion via path traversal in versions up to and including 12.0.3. The vulnerability exists in the REST API handler at /wp-json/snow-monkey-form/v1/view. The send() method bypasses CSRF validation when the 'method' parameter is set to 'input', and the 'form_id' parameter is used unsanitized in path construction, allowing directory traversal sequences (e.g., ../../../../) to target arbitrary files for deletion on the server.
+  impact: |
+    An unauthenticated attacker can delete arbitrary files on the server, potentially leading to denial of service or site takeover by deleting critical files like wp-config.php.
+  remediation: |
+    Update Snow Monkey Forms to version 12.0.4 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/37a8642d-07f5-4b1b-8419-e30589089162
+    - https://plugins.trac.wordpress.org/browser/snow-monkey-forms/tags/12.0.3/App/Rest/Route/View.php#L189
+    - https://plugins.trac.wordpress.org/changeset/3448278/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1056
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2026-1056
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.component:"WordPress"
+    product: snow-monkey-forms
+    vendor: inc2734
+  tags: cve,cve2026,wordpress,wp-plugin,snow-monkey-forms,lfi,path-traversal,file-deletion
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/snow-monkey-forms/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Snow Monkey Forms"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 12.0.3')
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "(?i)Stable tag:\\s*([0-9.]+)"
+        internal: true
+
+      - type: regex
+        group: 1
+        regex:
+          - "(?i)Stable tag:\\s*([0-9.]+)"
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/snow-monkey-form/v1/view"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    body: "snow-monkey-forms-meta[method]=input&snow-monkey-forms-setting[form_id]=1"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 400
+          - 500
+
+      - type: word
+        part: body
+        words:
+          - "snow_monkey_forms"
+          - "snow-monkey"
+          - "smf"
+        condition: or


### PR DESCRIPTION
## CVE-2026-1056 — WordPress Snow Monkey Forms ≤12.0.3 Unauth File Deletion

**Severity:** High (CVSS 9.1)
**Impact:** Unauthenticated path traversal allowing arbitrary file deletion on the server.
**Verification:** Attempts to detect the vulnerability without destructive action.