### PR TITLE
Add CVE-2026-21962 - Oracle HTTP Server/WebLogic Unauth Access Control Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-21962.yaml
+++ b/http/cves/2026/CVE-2026-21962.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-21962
+
+info:
+  name: Oracle HTTP Server / WebLogic Proxy Plugin - Unauthenticated Access Control Bypass
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    A vulnerability in the Oracle HTTP Server and Oracle WebLogic Server Proxy Plug-in product of Oracle Fusion Middleware allows an unauthenticated attacker with network access via HTTP to compromise the affected system. While the vulnerability is in Oracle HTTP Server / WebLogic Proxy Plug-in, attacks may significantly impact additional products (scope change). Successful exploitation can result in unauthorized creation, deletion or modification access to critical data as well as unauthorized access to all accessible data. Affected versions include Oracle HTTP Server 12.2.1.4.0, WebLogic Proxy Plug-in 12.2.1.4.0, 14.1.1.0.0, and 14.1.2.0.0. CVSS 3.1 Base Score 10.0.
+  impact: |
+    An unauthenticated remote attacker can compromise the confidentiality and integrity of all data accessible through the Oracle HTTP Server or WebLogic Proxy Plugin.
+  remediation: |
+    Apply the Oracle Critical Patch Update from January 2026. See https://www.oracle.com/security-alerts/cpujan2026.html
+  reference:
+    - https://www.oracle.com/security-alerts/cpujan2026.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21962
+    - https://github.com/advisories/GHSA-4wp9-cf5h-v2g5
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-21962
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: "Oracle-HTTP-Server"
+    fofa-query: header="Oracle-HTTP-Server"
+    product: oracle-http-server
+    vendor: oracle
+  tags: cve,cve2026,oracle,ohs,weblogic,proxy,access-control
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - "(?i)Oracle-HTTP-Server"
+
+      - type: regex
+        part: header
+        regex:
+          - "Oracle-HTTP-Server[-/]?12\\.2\\.1\\.4"
+          - "14\\.1\\.1\\.0\\.0"
+          - "14\\.1\\.2\\.0\\.0"
+          - "mod_wl_ohs"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 301
+          - 403
+          - 404
+
+    extractors:
+      - type: regex
+        part: header
+        regex:
+          - "Server: ([^\r\n]+)"


### PR DESCRIPTION
## CVE-2026-21962 — Oracle HTTP Server / WebLogic Proxy Bypass

**Severity:** Critical (CVSS 10.0)
**Impact:** Unauthenticated access control bypass in Oracle HTTP Server's mod_wl_ohs proxy module.