### PR TITLE
Add CVE-2025-59718 - Fortinet FortiOS/FortiProxy SAML Auth Bypass (KEV)

### DIFF
--- a/http/cves/2025/CVE-2025-59718.yaml
+++ b/http/cves/2025/CVE-2025-59718.yaml
@@ -1,0 +1,77 @@
+id: CVE-2025-59718
+
+info:
+  name: Fortinet FortiOS/FortiProxy - FortiCloud SSO SAML Authentication Bypass
+  author: ohmygod20260203
+  severity: critical
+  description: |
+    An improper verification of cryptographic signature vulnerability in Fortinet FortiOS, FortiProxy, and FortiSwitchManager allows an unauthenticated attacker to bypass the FortiCloud SSO login authentication via a crafted SAML response message. Affected versions include FortiOS 7.6.0 through 7.6.3, FortiOS 7.4.0 through 7.4.8, FortiOS 7.2.0 through 7.2.11, FortiOS 7.0.0 through 7.0.17, FortiProxy 7.6.0 through 7.6.3, FortiProxy 7.4.0 through 7.4.10, FortiProxy 7.2.0 through 7.2.14, FortiProxy 7.0.0 through 7.0.21, and FortiSwitchManager 7.2.0 through 7.2.6 and 7.0.0 through 7.0.5. This vulnerability is actively exploited in the wild and is listed in CISA's Known Exploited Vulnerabilities Catalog.
+  impact: |
+    An unauthenticated remote attacker can bypass authentication and gain administrative access to FortiOS, FortiProxy, or FortiSwitchManager devices.
+  remediation: |
+    Upgrade to FortiOS 7.4.9+, 7.6.4+, FortiProxy 7.4.11+, 7.6.4+, or disable FortiCloud SSO login via 'config system global; set admin-forticloud-sso-login disable; end'.
+  reference:
+    - https://fortiguard.fortinet.com/psirt/FG-IR-25-647
+    - https://arcticwolf.com/resources/blog/arctic-wolf-observes-malicious-sso-logins-following-disclosure-cve-2025-59718-cve-2025-59719/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-59718
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-59718
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-59718
+    cwe-id: CWE-347
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"FortiGate"
+    fofa-query: app="Fortinet-FortiGate"
+    product: fortios
+    vendor: fortinet
+  tags: cve,cve2025,fortinet,fortios,fortiproxy,auth-bypass,saml,kev
+
+http:
+  - raw:
+      - |
+        GET /remote/logincheck HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /remote/saml/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        SAMLResponse=
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code_1 == 200 || status_code_1 == 401 || status_code_1 == 302
+
+      - type: word
+        part: body_1
+        words:
+          - "FortiGate"
+          - "FortiProxy"
+          - "fortinet"
+          - "SSLVPN"
+        condition: or
+        case-insensitive: true
+
+      - type: word
+        part: header_1
+        words:
+          - "SVPNCOOKIE"
+          - "APSCOOKIE"
+          - "fgt_lang"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - status_code_2 != 404
+
+    extractors:
+      - type: regex
+        part: body_1
+        group: 1
+        regex:
+          - "(?:FortiOS|FortiGate).*?([0-9]+\\.[0-9]+\\.[0-9]+)"


### PR DESCRIPTION
## CVE-2025-59718 — Fortinet FortiOS/FortiProxy SAML Authentication Bypass

**Severity:** Critical (CVSS 9.8) — **CISA KEV Listed**
**Impact:** Remote unauthenticated attacker can bypass SAML SSO authentication.
**Tags:** kev, actively exploited in the wild