### PR TITLE
Add CVE-2025-6384 - CrafterCMS Groovy Sandbox Bypass RCE

### DIFF
--- a/http/cves/2025/CVE-2025-6384.yaml
+++ b/http/cves/2025/CVE-2025-6384.yaml
@@ -1,0 +1,67 @@
+id: CVE-2025-6384
+
+info:
+  name: CrafterCMS 4.0.0-4.2.2 - Authenticated RCE via Groovy Sandbox Bypass
+  author: ohmygod20260203
+  severity: high
+  description: |
+    CrafterCMS versions 4.0.0 through 4.2.2 are vulnerable to authenticated Remote Code Execution (RCE) via a Groovy sandbox bypass in Crafter Studio. The sandbox fails to block the instantiation of a new GroovyShell, which can be used to create a new unrestricted execution environment. An authenticated user with developer privileges can execute arbitrary OS commands on the underlying server by inserting malicious Groovy elements that bypass sandbox restrictions.
+  impact: |
+    An authenticated attacker with developer privileges can execute arbitrary OS commands on the server, leading to full server compromise.
+  remediation: |
+    Update CrafterCMS to version 4.2.3 or later. Apply the vendor security advisory fix at https://docs.craftercms.org/current/security/advisory.html.
+  reference:
+    - https://docs.craftercms.org/current/security/advisory.html#cv-2025061901
+    - https://github.com/maestro-ant/CrafterCMS-CVE-2025-6384
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-6384
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2025-6384
+    cwe-id: CWE-913
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Crafter Studio"
+    fofa-query: title="Crafter Studio"
+    product: craftercms
+    vendor: craftercms
+  tags: cve,cve2025,craftercms,rce,groovy,sandbox-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/studio/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "CrafterCMS"
+          - "Crafter Studio"
+          - "crafter-studio"
+        condition: or
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+          - 302
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '>= 4.0.0', '<= 4.2.2')
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "(?:CrafterCMS|Crafter Studio|crafter)[\\s/-]*v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+        internal: true
+
+      - type: regex
+        group: 1
+        regex:
+          - "(?:CrafterCMS|Crafter Studio|crafter)[\\s/-]*v?([0-9]+\\.[0-9]+\\.[0-9]+)"


### PR DESCRIPTION
## CVE-2025-6384 — CrafterCMS 4.0-4.2.2 Groovy Sandbox Bypass → RCE

**Severity:** High (CVSS 9.1)
**Impact:** Authenticated user can bypass Groovy sandbox to achieve remote code execution.