### PR TITLE
feat: Added CVE-2026-25049 (n8n Expression Injection RCE)

### DIFF
--- a/http/cves/2026/CVE-2026-25049.yaml
+++ b/http/cves/2026/CVE-2026-25049.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-25049
+
+info:
+  name: n8n - Expression Injection Leading to RCE
+  author: s4e-io
+  severity: critical
+  description: |
+    n8n versions < 1.123.17 and >= 2.0.0 < 2.5.2 are vulnerable to expression injection. An authenticated user with permission to create or modify workflows could abuse crafted expressions in workflow parameters to trigger unintended system command execution on the host running n8n.
+  impact: |
+    Successful exploitation allows an authenticated attacker to execute arbitrary commands on the host system, potentially leading to complete system compromise.
+  remediation: |
+    Update to version 1.123.17, 2.5.2 or later.
+  reference:
+    - https://github.com/advisories/GHSA-6cqr-8cfr-67f8
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25049
+    - https://thehackernews.com/2026/02/critical-n8n-flaw-cve-2026-25049.html
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.4
+    cve-id: CVE-2026-25049
+    epss-score: 0.00027
+    epss-percentile: 0.07200
+    cwe-id: CWE-913
+    cpe: cpe:2.3:a:n8n:n8n:*:*:*:*:*:node.js:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+    shodan-query: http.favicon.hash:-831756631
+    fofa-query: icon_hash="-831756631"
+  tags: cve,cve2026,n8n,workflow,rce,authenticated,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/signin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>n8n.io"
+        case-insensitive: true
+
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - 'compare_versions(version, "< 1.123.17") || (compare_versions(version, ">= 2.0.0") && compare_versions(version, "< 2.5.2"))'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: base64_content
+        group: 1
+        regex:
+          - '<meta name="n8n:config:sentry" content="([A-Za-z0-9+/=]+)"'
+        internal: true
+
+      - type: dsl
+        name: version
+        dsl:
+          - 'replace_regex(base64_decode(base64_content), ".*n8n@([0-9]+\\.[0-9]+\\.[0-9]+).*", "$1")'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"n8n Version: " + version'


### PR DESCRIPTION
### PR Information

This PR introduces a high-quality detection template for **[CVE-2026-25049](https://nvd.nist.gov/vuln/detail/CVE-2026-25049)**, a critical **Expression Injection** vulnerability affecting **n8n** versions `< 1.123.17` and `>= 2.0.0 < 2.5.2`.

### 🚨 Vulnerability Summary

An authenticated attacker with access to create or modify workflows can leverage this vulnerability to execute arbitrary system commands on the host machine. This could lead to a complete system compromise, unauthorized data access, and lateral movement within the network.

- **Severity:** Critical (CVSS 9.4)
- **Impact:** Remote Code Execution (RCE) / System Compromise
- **Affected Components:** Workflow Engine

### 🔍 Detection Logic & Template Quality

This template is engineered for **precision** and **reliability**, moving beyond simple signature matching to robust version extraction.

- **Targeted Endpoint:** Scans the `/signin` endpoint, which is typically exposed without prior authentication.
- **Accurate Version Extraction:** Parses the `n8n:config:sentry` meta tag to extract the exact running version from the Base64-encoded configuration object.
  - *Regex:* `n8n@([0-9]+\.[0-9]+\.[0-9]+)`
- **False Positive Elimination:** Uses clear semantic version comparisons (`compare_versions`) against the known vulnerable ranges. It will **not** trigger on patched or unaffected versions.
- **Optimized:** Lightweight and fast, designed for large-scale scanning.

### ✅ Validation

I have rigorously tested this template against a variety of environments, including vulnerable instances, patched instances, and unrelated services.

- [x] **True Positive:** Successfully identified vulnerable versions (e.g., `1.121.3`).
- [x] **False Positive:** Confirmed no detection on patched versions (e.g., `1.123.17`, `2.5.2`).

#### Proof of Concept

> **Note:** The screenshot below verifies the template successfully identifying vulnerable instances. Target information has been redacted.

<img width="960" height="817" alt="vuln-asset" src="https://github.com/user-attachments/assets/df2a4e97-164f-436b-b86e-2a8485b19d74" />


**Reproduction Command:**
```bash
nuclei -t http/cves/2026/CVE-2026-25049.yaml -u https://REDACTED.com
```

### 📚 References

- [GitHub Advisory (GHSA-6cqr-8cfr-67f8)](https://github.com/advisories/GHSA-6cqr-8cfr-67f8)
- [NIST NVD (CVE-2026-25049)](https://nvd.nist.gov/vuln/detail/CVE-2026-25049)
- [The Hacker News Analysis](https://thehackernews.com/2026/02/critical-n8n-flaw-cve-2026-25049.html)
