### PR TITLE
CVE-2026-25055: n8n SSH Node Path Traversal to Arbitrary File Write

### DIFF
--- a/http/cves/2026/CVE-2026-25055.yaml
+++ b/http/cves/2026/CVE-2026-25055.yaml
@@ -1,0 +1,96 @@
+id: CVE-2026-25055
+
+info:
+  name: n8n < 1.123.12 / < 2.4.0 - SSH Node Path Traversal to Arbitrary File Write
+  author: hevnsnt
+  severity: critical
+  description: |
+    n8n workflow automation platform contains a path traversal vulnerability in the Webhook node that allows attackers to write files to arbitrary locations on remote SSH servers. When workflows process uploaded files via multipart/form-data or Content-Disposition headers and transfer them to remote servers via the SSH node without validating filenames, attackers can use path traversal sequences (../) to escape the target directory. The vulnerability originates from the Webhook node's handleFormData() and handleBinaryData() functions passing unsanitized file.originalFilename or Content-Disposition filename values to copyBinaryFile(), which stores them as-is. When the SSH node's upload operation concatenates these filenames to the target path, path traversal sequences resolve to arbitrary locations on the remote server.
+  impact: |
+    An unauthenticated attacker who can reach a Webhook endpoint that uploads files via SSH can write files anywhere on remote servers that the n8n instance has SSH credentials for. This enables:
+    - Writing SSH authorized_keys for persistent access
+    - Dropping cron jobs or systemd services for code execution
+    - Overwriting application configs to inject backdoors
+    - Compromising deployment servers, databases, backup systems, and CI/CD infrastructure
+    Impact is highest on n8n Cloud and public self-hosted instances where webhooks are designed to receive external traffic with no authentication required by default.
+  remediation: |
+    Upgrade to n8n version 1.123.12 or 2.4.0 or later. If upgrading is not immediately possible:
+    - Disable or restrict access to workflows that accept file uploads via webhooks and transfer them via SSH
+    - Enable webhook authentication on all endpoints that handle file uploads
+    - Review and rotate SSH credentials if compromise is suspected
+    - Use n8n's node blocking feature to globally disable SSH nodes until patched
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-m82q-59gv-mcr9
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25055
+    - https://www.gecko.security/blog/cve-2026-25055
+    - https://docs.n8n.io/hosting/securing/blocking-nodes/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-25055
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:n8n:n8n:*:*:*:*:*:*:*:*
+    epss-score: 0.00043
+    epss-percentile: 0.05142
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: n8n
+    product: n8n
+    shodan-query: product:"n8n"
+    fofa-query: app="n8n"
+    publicwww-query: "/n8n.png"
+  tags: cve,cve2026,n8n,path-traversal,file-upload,ssh,rce,critical,unauth
+
+variables:
+  version_check_1: 'compare_versions(version, "< 1.123.12")'
+  version_check_2: 'compare_versions(version, ">= 2.0.0") && compare_versions(version, "< 2.4.0")'
+
+http:
+  - raw:
+      - |
+        GET /rest/settings HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"n8n"'
+          - '"versionCli"'
+        condition: or
+        
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        name: vulnerable_version
+        dsl:
+          - 'compare_versions(version, "< 1.123.12")'
+          - 'compare_versions(version, ">= 2.0.0") && compare_versions(version, "< 2.4.0")'
+        condition: or
+
+    extractors:
+      - type: regex
+        name: version
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"version":\s*"([0-9.]+)"'
+          - '"versionCli":\s*"([0-9.]+)"'
+          - '<meta[^>]+name="version"[^>]+content="([0-9.]+)"'
+          
+      - type: dsl
+        dsl:
+          - '"n8n " + version + " - Vulnerable to CVE-2026-25055"'
+          - '"Path: Webhook Node → SSH Node (arbitrary file write on remote systems)"'
+          - '"Patch: Upgrade to 1.123.12 or 2.4.0+"'


### PR DESCRIPTION
## Description

This PR adds a nuclei template for CVE-2026-25055, a critical path traversal vulnerability in n8n workflow automation platform that allows arbitrary file write on remote SSH servers.

## Vulnerability Details

- **Product:** n8n workflow automation platform
- **CVE:** CVE-2026-25055
- **Severity:** Critical (CVSS 10.0)
- **Affected Versions:** < 1.123.12, >= 2.0.0 and < 2.4.0
- **Patched Versions:** 1.123.12, 2.4.0+

## Vulnerability Summary

When workflows process uploaded files via the Webhook node and transfer them to remote servers via the SSH node without validating metadata, attackers can use path traversal sequences (../) to write files to arbitrary locations on remote systems. This can lead to RCE by writing to sensitive locations like authorized_keys, cron.d, or systemd services.

## Template Details

- Detects vulnerable n8n instances by version
- Checks /rest/settings and / endpoints for version information
- Validates version is in affected range
- Non-invasive detection (no exploitation attempted)

## References

- [GitHub Security Advisory GHSA-m82q-59gv-mcr9](https://github.com/n8n-io/n8n/security/advisories/GHSA-m82q-59gv-mcr9)
- [NVD CVE-2026-25055](https://nvd.nist.gov/vuln/detail/CVE-2026-25055)
- [Gecko Security Analysis](https://www.gecko.security/blog/cve-2026-25055)

## Testing

- [ ] Tested against vulnerable instance (version detection confirmed)
- [x] No false positives expected (version-based detection with strict matchers)
- [x] Follows projectdiscovery template standards