### PR TITLE
fix: prevent false positives in CVE-2021-35042 matcher

### DIFF
--- a/dast/cves/2021/CVE-2021-35042.yaml
+++ b/dast/cves/2021/CVE-2021-35042.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-35042        
+id: CVE-2021-35042
 
 info:
   name: Django QuerySet.order_by - SQL Injection
@@ -11,13 +11,13 @@ info:
   remediation: |
     Update to Django 3.1.13 or 3.2.5 or later versions.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-35042        
-    - https://github.com/zer0qs/CVE-2021-35042        
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-35042
+    - https://github.com/zer0qs/CVE-2021-35042
     - https://github.com/django/django/commit/a34a5f724c5d5adb2109374ba3989ebb7b11f81f
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2021-35042        
+    cve-id: CVE-2021-35042
     cwe-id: CWE-89
     epss-score: 0.87374
     epss-percentile: 0.99437


### PR DESCRIPTION
### PR Information

This PR fixes false positives in `dast/cves/2021/CVE-2021-35042.yaml`.

The DSL matcher contained multiple expressions without an explicit `condition`, which defaults to `or`. As a result, `status_code == 500` alone was enough to match, triggering on any generic 500 page even when Django/DB error indicators were absent.

Fix: add `condition: and` to the DSL matcher so all checks must be satisfied.

- Fixed CVE-2021-35042.yaml
- References:
  - Issue: #15241

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

Note: validation was performed using a local lab reproducing the matching conditions (generic 500 vs Django-like DB error). Not validated against a real vulnerable Django instance.

#### Additional Details (leave it blank if not applicable)

Reproduction (local lab):
- Generic 500 endpoint without `ORDER BY`/`ProgrammingError`/DB drivers triggered with the old template, no longer triggers after this change.
- Django-like 500 endpoint containing `ORDER BY` + `ProgrammingError` + `sqlite3` still triggers.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
