### PR TITLE
Refactor the "Open WebUI" template.

### DIFF
--- a/http/exposed-panels/openwebui-panel.yaml
+++ b/http/exposed-panels/openwebui-panel.yaml
@@ -12,12 +12,12 @@ info:
     verified: true
     max-request: 1
     shodan-query: http.favicon.hash:-286484075 http.title:"Open WebUI"
-  tags: panel,openwebui,login,detect
+  tags: panel,openwebui,login,detect,discovery
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
       - "{{BaseURL}}/api/config"
       - "{{BaseURL}}/auth"
       - "{{BaseURL}}/opensearch.xml"


### PR DESCRIPTION
### Template / PR Information

Hi,

This PR propose a little refactoring of the template to make it more generic to detect the presence of an instance of the **Open WebUI** software.

### Template Validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Tested against the following hosts found via shodan:

```text
https://195.154.197.220
https://195.218.3.201
https://51.159.172.172
https://194.47.18.238:8443
http://78.69.152.8:8080
https://64.74.160.204
http://154.12.245.101:8080
https://49.231.27.74
https://143.107.183.82
http://35.80.202.109
http://34.142.159.110
https://108.61.162.109
https://140.109.34.32:8443
https://202.29.4.74
```

<img width="826" height="886" alt="image" src="https://github.com/user-attachments/assets/e99b9903-6ca4-4849-96c9-8df90bebcda2" />

### Additional Details (leave it blank if not applicable)

Shodan query used: https://www.shodan.io/search?query=http.title%3A%22Open+WebUI%22

<img width="1677" height="822" alt="image" src="https://github.com/user-attachments/assets/99d9c8fc-bd4b-4dbf-a897-7fc93affe7af" />

### Additional References:

None