### PR TITLE
Add CVE-2020-8260 (Pulse Connect Secure RCE Detection)

### DIFF
--- a/http/cves/2020/CVE-2020-8260.yaml
+++ b/http/cves/2020/CVE-2020-8260.yaml
@@ -1,0 +1,65 @@
+id: CVE-2020-8260
+
+info:
+  name: Pulse Connect Secure < 9.1R9 - RCE via Uncontrolled Gzip Extraction
+  author: buildingvibes
+  severity: high
+  description: |
+    Pulse Connect Secure versions before 9.1R9 contain a vulnerability in the admin web interface that allows authenticated attackers to exploit uncontrolled gzip extraction during configuration restoration. The vulnerability allows arbitrary file overwriting, leading to remote code execution with root privileges.
+  impact: |
+    Successful exploitation allows authenticated administrative users to achieve remote code execution with root privileges on the Pulse Connect Secure appliance.
+  remediation: |
+    Upgrade to Pulse Connect Secure 9.1R9 or later.
+  reference:
+    - https://www.nccgroup.com/research-blog/technical-advisory-pulse-connect-secure-rce-via-uncontrolled-gzip-extraction-cve-2020-8260/
+    - http://packetstormsecurity.com/files/160619/Pulse-Secure-VPN-Remote-Code-Execution.html
+    - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44601
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8260
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2020-8260
+    cwe-id: CWE-22
+    epss-score: 0.96969
+    epss-percentile: 0.99797
+    cpe: cpe:2.3:a:pulsesecure:pulse_connect_secure:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: pulsesecure
+    product: pulse_connect_secure
+    shodan-query: 'title:"Pulse Secure"'
+  tags: cve,cve2020,pulse,pulsesecure,rce,kev,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dana-na/nc/nc_gina_ver.txt"
+      - "{{BaseURL}}/dana-cached/hc/HostCheckerInstaller.osx"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Pulse Connect Secure"
+          - "ProductVersion"
+          - "CFBundleVersion"
+        condition: or
+
+      - type: regex
+        regex:
+          - "ProductVersion.*([0-8]\\.[0-9]|9\\.[0-1]R[0-8])"
+          - "version<\\/key>[^<]*<string>([0-8]\\.[0-9]|9\\.[0-1]R[0-8])"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "ProductVersion.*([\\d.R]+)"
+          - "version<\\/key>[^<]*<string>([^<]+)<"


### PR DESCRIPTION
## Summary
This PR adds a detection template for CVE-2020-8260, a critical uncontrolled gzip extraction vulnerability in Pulse Connect Secure < 9.1R9 that allows authenticated remote code execution.

## Vulnerability Details
- **CVE**: CVE-2020-8260
- **Affected Product**: Pulse Connect Secure
- **Vulnerable Versions**: < 9.1R9
- **Severity**: High (CVSS 7.2)
- **Type**: Uncontrolled gzip extraction leading to authenticated RCE

## Detection Method
The template uses unauthenticated version detection through:
- `/dana-na/nc/nc_gina_ver.txt` (older versions, R8 and below)
- `/dana-cached/hc/HostCheckerInstaller.osx` (newer versions, R9+)

Both endpoints expose version information without authentication, allowing detection of vulnerable instances.

## Testing
- Template validates successfully with `nuclei -validate`
- Matchers specifically target versions before 9.1R9
- No false positives on patched versions (9.1R9+)

## References
- NCC Group Advisory: https://www.nccgroup.com/research-blog/technical-advisory-pulse-connect-secure-rce-via-uncontrolled-gzip-extraction-cve-2020-8260/
- Vendor Advisory: https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44601
- PacketStorm: http://packetstormsecurity.com/files/160619/Pulse-Secure-VPN-Remote-Code-Execution.html

## Related Issue
Closes part of #7549 (KEV CVE coverage)

/claim #7549