### PR TITLE
Add CVE-2020-8816 (Pi-hole Web RCE Detection)

### DIFF
--- a/http/cves/2020/CVE-2020-8816.yaml
+++ b/http/cves/2020/CVE-2020-8816.yaml
@@ -1,0 +1,68 @@
+id: CVE-2020-8816
+
+info:
+  name: Pi-hole Web < 4.3.3 - RCE via DHCP Static Lease
+  author: buildingvibes
+  severity: high
+  description: |
+    Pi-hole Web v4.3.2 and earlier (AdminLTE) allows Remote Code Execution by privileged dashboard users via a crafted DHCP static lease. The vulnerability exploits command execution when adding a new DHCP static lease with a MAC address that includes malicious code. DHCP server is not required to be running for exploitation.
+  impact: |
+    Successful exploitation allows authenticated administrative users to achieve remote code execution on the Pi-hole server.
+  remediation: |
+    Upgrade to Pi-hole Web Interface version 4.3.3 or later.
+  reference:
+    - https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/
+    - http://packetstormsecurity.com/files/157861/Pi-Hole-4.3.2-DHCP-MAC-OS-Command-Execution.html
+    - https://github.com/pi-hole/AdminLTE/releases/tag/v4.3.3
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8816
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2020-8816
+    cwe-id: CWE-78
+    epss-score: 0.0043
+    epss-percentile: 0.68999
+    cpe: cpe:2.3:a:pi-hole:web:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: pi-hole
+    product: web
+    shodan-query: 'title:"Pi-hole"'
+  tags: cve,cve2020,pihole,rce,kev,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin/"
+      - "{{BaseURL}}/admin/api.php?summaryRaw"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Pi-hole"
+          - "AdminLTE"
+        condition: or
+
+      - type: word
+        words:
+          - "gravity_last_updated"
+          - "dns_queries_today"
+          - "ads_blocked_today"
+        condition: or
+
+      - type: regex
+        regex:
+          - "version.*v?([0-3]\\.[0-9]|4\\.[0-2]|4\\.3\\.[0-2])"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "version.*v?([\\d.]+)"


### PR DESCRIPTION
## Summary
This PR adds a detection template for CVE-2020-8816, a vulnerability in Pi-hole Web < 4.3.3 that allows authenticated remote code execution via crafted DHCP static lease.

## Vulnerability Details
- **CVE**: CVE-2020-8816
- **Affected Product**: Pi-hole Web (AdminLTE)
- **Vulnerable Versions**: <= 4.3.2
- **Severity**: High (CVSS 7.2)
- **Type**: Command execution via DHCP static lease

## Detection Method
The template detects Pi-hole installations and identifies vulnerable versions through:
- Checking for Pi-hole/AdminLTE presence in the admin interface
- Querying the unauthenticated API endpoint `/admin/api.php?summaryRaw`
- Extracting and validating version information against vulnerable range

## Testing
- Template validates successfully with `nuclei -validate`
- Matchers target versions 4.3.2 and earlier
- Identifies Pi-hole installations via characteristic API responses

## References
- Original Research: https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/
- PacketStorm: http://packetstormsecurity.com/files/157861/Pi-Hole-4.3.2-DHCP-MAC-OS-Command-Execution.html
- Fix Release: https://github.com/pi-hole/AdminLTE/releases/tag/v4.3.3

## Related Issue
Closes part of #7549 (KEV CVE coverage)

/claim #7549