### PR TITLE
Add CVE-2020-5741 (Plex Media Server RCE Detection)

### DIFF
--- a/http/cves/2020/CVE-2020-5741.yaml
+++ b/http/cves/2020/CVE-2020-5741.yaml
@@ -1,0 +1,65 @@
+id: CVE-2020-5741
+
+info:
+  name: Plex Media Server < 1.19.3 - Authenticated Remote Code Execution
+  author: buildingvibes
+  severity: critical
+  description: |
+    Plex Media Server before version 1.19.3 contains an authenticated remote code execution vulnerability in the camera upload feature. An authenticated attacker can exploit this vulnerability by uploading a specially crafted file through the camera upload endpoint, allowing arbitrary code execution on the server.
+  impact: |
+    Successful exploitation allows an authenticated user to execute arbitrary code on the Plex Media Server with the privileges of the Plex process, potentially leading to complete system compromise.
+  remediation: |
+    Update Plex Media Server to version 1.19.3 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-5741
+    - https://forums.plex.tv/t/security-regarding-cve-2020-5741/586819
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2020-5741
+    cwe-id: CWE-434
+    epss-score: 0.00898
+    epss-percentile: 0.81295
+    cpe: cpe:2.3:a:plex:plex_media_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: plex
+    product: plex_media_server
+    shodan-query: 'product:"Plex Media Server"'
+  tags: cve,cve2020,plex,rce,authenticated,kev,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/identity"
+      - "{{BaseURL}}/:/prefs"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "MediaContainer"
+          - "machineIdentifier"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - 'version="(0\.\d+\.\d+\.\d+|1\.(0|1[0-8])\.\d+\.\d+|1\.19\.[0-2])'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'version="([0-9.]+)"'


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2020-5741
- Plex Media Server before 1.19.3 authenticated RCE via camera upload feature
- Detects vulnerable versions through version fingerprinting
- Part of KEV CVE coverage effort (#7549)

## Details
This template identifies Plex Media Server instances vulnerable to CVE-2020-5741, an authenticated remote code execution vulnerability affecting versions before 1.19.3. The vulnerability allows authenticated users to execute arbitrary code through the camera upload feature.

## Test Plan
- Template follows nuclei-templates contributing guidelines
- Uses proper matchers for version detection
- Includes KEV tag as this CVE is in CISA's Known Exploited Vulnerabilities catalog
- References NVD and official Plex security advisory

/claim #7549