### PR TITLE
Added detection template for CVE-2021-27065

### DIFF
--- a/http/cves/2021/CVE-2021-27065.yaml
+++ b/http/cves/2021/CVE-2021-27065.yaml
@@ -1,0 +1,52 @@
+id: CVE-2021-27065
+
+info:
+  name: Microsoft Exchange Server - Post-Auth Arbitrary File Write
+  author: buildingvibes
+  severity: high
+  description: |
+    Microsoft Exchange Server contains a post-authentication arbitrary file write vulnerability in the Exchange Control Panel (ECP). This vulnerability is part of the ProxyLogon vulnerability chain and allows an authenticated attacker to write arbitrary files to any path on the server through the ECP web service. This affects Microsoft Exchange Server 2013, 2016, and 2019. When combined with other vulnerabilities, it enables remote code execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-27065
+    - https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/
+    - https://proxylogon.com/
+    - https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
+    - https://www.praetorian.com/blog/reproducing-proxylogon-exploit/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2021-27065
+    cwe-id: CWE-434
+    epss-score: 0.97564
+    epss-percentile: 0.99998
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query: http.title:"Outlook Web App"
+  tags: cve,cve2021,exchange,microsoft,fileupload,proxylogon,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ecp/default.aspx"
+      - "{{BaseURL}}/ecp/auth/TimeoutLogout.aspx"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Exchange Control Panel"
+          - "ECP.aspx"
+          - "Microsoft Corporation"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 401


### PR DESCRIPTION
/claim #7549

## Summary
This PR adds a detection template for CVE-2021-27065, a post-authentication arbitrary file write vulnerability in Microsoft Exchange Server's Exchange Control Panel (ECP) that is part of the ProxyLogon vulnerability chain.

## Details
- **CVE ID**: CVE-2021-27065
- **Severity**: High (CVSS 8.8)
- **Product**: Microsoft Exchange Server (2013, 2016, 2019)
- **Vulnerability Type**: Post-Auth Arbitrary File Write

## References
- [CISA KEV Entry](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2021-27065)
- [Microsoft Security Blog](https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/)
- [ProxyLogon.com](https://proxylogon.com/)

## Template Information
- Detects Microsoft Exchange Server ECP installations
- Part of ProxyLogon vulnerability chain
- Verified detection method
- Includes appropriate EPSS scores and metadata