### PR TITLE
Updated CVE-2019-17444.yaml template: correction of tags: '-' is not …

### DIFF
--- a/http/cves/2019/CVE-2019-17444.yaml
+++ b/http/cves/2019/CVE-2019-17444.yaml
@@ -30,7 +30,7 @@ info:
     product: artifactory
     framework: "-"
     shodan-query: cpe:"cpe:2.3:a:jfrog:artifactory"
-  tags: cve,cve2019,jfrog,default-login,-,vuln
+  tags: cve,cve2019,jfrog,default-login,vuln
 
 http:
   - raw:


### PR DESCRIPTION
…a tag

### PR Information

I have done a workaround of listing the tags. There was the tag '-' shown. So I saw this in this template, which might be false.

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
