### PR TITLE
Add RosarioSIS 6.7.2 Reflected XSS template

### DIFF
--- a/http/vulnerabilities/other/rosariosis-xss.yaml
+++ b/http/vulnerabilities/other/rosariosis-xss.yaml
@@ -1,8 +1,8 @@
 id: rosariosis-xss
 
 info:
-  name: RosarioSIS 6.7.2 - Reflected Cross-Site Scripting
-  author: jarvis-survives
+  name: RosarioSIS 6.7.2 - Cross-Site Scripting
+  author: 0xr2r,jarvis-survives
   severity: medium
   description: |
     RosarioSIS version 6.7.2 and earlier contains a reflected cross-site scripting (XSS) vulnerability in the Preferences module. The 'tab' parameter in Modules.php is not properly sanitized, allowing an attacker to inject arbitrary JavaScript code via a crafted URL.
@@ -10,9 +10,6 @@ info:
     An attacker can execute arbitrary JavaScript in the context of a victim's browser session, potentially leading to session hijacking, credential theft, or other malicious actions.
   remediation: |
     Update RosarioSIS to the latest version where input validation has been improved.
-  reference:
-    - https://github.com/RosarioSIS/rosern/issues/4348
-    - https://www.exploit-db.com/exploits/52019
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -23,7 +20,7 @@ info:
     shodan-query: http.html:"RosarioSIS"
     product: rosariosis
     vendor: rosariosis
-  tags: xss,rosariosis,reflected
+  tags: rosarios,xss,rosariosis
 
 http:
   - method: GET
@@ -35,9 +32,10 @@ http:
       - type: word
         part: body
         words:
-          - 'onmouseover=alert(document.domain)'
+          - '" onmouseover=alert(document.domain)'
           - 'RosarioSIS'
         condition: and
+        case-insensitive: true
 
       - type: word
         part: content_type


### PR DESCRIPTION
### PR Information

- Added template for RosarioSIS 6.7.2 Reflected XSS vulnerability
- The tab parameter in Modules.php (Preferences module) is not sanitized, allowing reflected XSS via crafted URL
- Source: https://gitlab.com/francoisjacquet/rosariosis
- Upstream fix reference: https://gitlab.com/francoisjacquet/rosariosis/-/tags/v12.7.2
- Closes #14869

### Template validation

- Template follows nuclei-templates format guidelines
- Matchers verify both XSS payload reflection AND RosarioSIS presence to avoid false positives
- Uses alert(document.domain) instead of alert(1) per best practices