### PR TITLE
Add CVE-2026-1357 for WPvivid Backup & Migration

### DIFF
--- a/http/cves/2026/CVE-2026-1357.yaml
+++ b/http/cves/2026/CVE-2026-1357.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-1357
 
 info:
-  name: WPvivid Backup & Migration <= 0.9.123 - Unauthenticated Arbitrary File Upload
+  name: WPvivid Backup & Migration <= 0.9.123 - Arbitrary File Upload
   author: omarkurt
   severity: critical
   description: |
@@ -27,32 +27,11 @@ info:
     product: wpvivid-backuprestore
     shodan-query: http.component:"WordPress"
     fofa-query: body="wp-content/plugins/wpvivid-backuprestore"
-  tags: cve,cve2026,wordpress,wpvivid,file-upload,rce,vuln
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wpvivid,file-upload,rce
 
-flow: http(1) && http(2) && http(3)
+flow: http(1) && http(2)
 
 http:
-  - raw:
-      - |
-        GET /wp-content/plugins/wpvivid-backuprestore/readme.txt HTTP/1.1
-        Host: {{Hostname}}
-
-    matchers-condition: and
-    matchers:
-      - type: dsl
-        dsl:
-          - 'compare_versions(version, "<= 0.9.123")'
-        internal: true
-
-    extractors:
-      - type: regex
-        name: version
-        part: body
-        group: 1
-        regex:
-          - '(?i)Stable tag:\s*([0-9.]+)'
-        internal: true
-
   - raw:
       - |
         POST / HTTP/1.1


### PR DESCRIPTION
Added CVE-2026-1357 details including vulnerability description, remediation, and HTTP matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-1357
- References: 
- https://vulnerabletarget.com/VT-2026-1357
- https://www.wordfence.com/blog/2026/02/800000-wordpress-sites-affected-by-arbitrary-file-upload-vulnerability-in-wpvivid-backup-wordpress-plugin/


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

<img width="1129" height="297" alt="image" src="https://github.com/user-attachments/assets/5f02f372-679e-4ac6-a94c-f02679a92a14" />

