### PR TITLE
Create CVE-2025-13970.yaml for OpenPLC_v3 CSRF

### DIFF
--- a/http/cves/2025/CVE-2025-13970.yaml
+++ b/http/cves/2025/CVE-2025-13970.yaml
@@ -1,45 +1,46 @@
 id: CVE-2025-13970
 
 info:
-  name: OpenPLC_v3 PR<#310 CSRF
+  name: OpenPLC_v3 - Cross-Site Request Forgery (CSRF)
   author: shriyanss
   severity: high
   description: |
-    Identifies CSRF vulnerability on OpenPLC_v3 with instances running code from Pull Request < #310
-  metadata:
-    verified: true
-    max-request: 2
-    shodan-query: html:"OpenPLC"
+    OpenPLC_V3 contains a cross-site request forgery caused by absence of proper CSRF validation, letting unauthenticated attackers trick logged-in administrators into unauthorized modification of PLC settings or upload of malicious programs, exploit requires logged-in administrator interaction.
+  impact: |
+    Attackers can cause unauthorized modification of PLC settings or upload malicious programs, potentially disrupting or damaging connected systems.
+  remediation: |
+    Update to the latest version with proper CSRF validation.
   reference:
     - https://www.cisa.gov/news-events/ics-advisories/icsa-25-345-10
-    - https://www.cve.org/CVERecord?id=CVE-2025-13970
     - https://github.com/thiagoralves/OpenPLC_v3/pull/310
+    - https://www.cve.org/CVERecord?id=CVE-2025-13970
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:N/I:H/A:H
     cvss-score: 8.0
     cve-id: CVE-2025-13970
     cwe-id: CWE-352
-  tags: openplc,csrf,iot,vuln
+    cpe: cpe:2.3:a:openplcproject:openplc_v3:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: openplcproject
+    product: openplc_v3
+    shodan-query: html:"OpenPLC"
+    fofa-query: body="OpenPLC Webserver"
+  tags: cve,cve2025,openplc,csrf,iot,scada,vuln
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
+
     redirects: true
     max-redirects: 3
-    matchers-condition: and
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - "OpenPLC"
-
-      - type: regex
-        part: body
-        negative: true
-        regex:
-          - '<input[^>]+csrf_token'
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "OpenPLC", "login-form")'
+          - '!regex("(?i)<input[^>]+csrf_token", body)'
+        condition: and


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2025-13970
- References:
  - https://www.cisa.gov/news-events/ics-advisories/icsa-25-345-10
  - https://www.cve.org/CVERecord?id=CVE-2025-13970
  - https://github.com/thiagoralves/OpenPLC_v3/pull/310

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
