### PR TITLE
Add CVE-2026-24423: SmarterMail Unauthenticated RCE via ConnectToHub

### DIFF
--- a/http/cves/2026/CVE-2026-24423.yaml
+++ b/http/cves/2026/CVE-2026-24423.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-24423
+
+info:
+  name: SmarterMail < Build 9511 - Unauthenticated RCE via ConnectToHub API
+  author: jarvis-survives
+  severity: critical
+  description: |
+    SmarterTools SmarterMail versions prior to build 9511 contain an unauthenticated remote code execution vulnerability in the ConnectToHub API method. An attacker can point the SmarterMail instance to a malicious HTTP server which serves a malicious OS command that will be executed by the vulnerable application.
+  impact: |
+    An unauthenticated attacker can achieve remote code execution on the mail server, leading to full system compromise and potential access to all email data.
+  remediation: |
+    Update SmarterMail to build 9511 or later.
+  reference:
+    - https://www.vulncheck.com/advisories/smartertools-smartermail-unauthenticated-rce-via-connecttohub-api
+    - https://code-white.com/public-vulnerability-list/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24423
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24423
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"SmarterMail"
+    fofa-query: title="SmarterMail"
+    vendor: smartertools
+    product: smartermail
+  tags: cve,cve2026,smartermail,rce,unauth,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/about/checkup"
+      - "{{BaseURL}}/interface/root"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SmarterMail"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)(?:version|build)["\s:]+["\s]*(\d+[\.\d]*)'


### PR DESCRIPTION
### PR Information

- Added template for CVE-2026-24423: SmarterTools SmarterMail unauthenticated RCE via ConnectToHub API
- Critical severity (CVSS 9.8) — missing authentication allows unauth attackers to trigger OS command execution
- CISA KEV: Added 2026-02-05, confirmed ransomware usage in the wild
- Credits: Sina Kheirkhah & Piotr Bazydlo (watchTowr), Markus Wulftange (CODE WHITE), Cale Black (VulnCheck)

### Template validation

- Detects SmarterMail instances and extracts version/build information
- Version-based detection for instances below build 9511