### PR TITLE
Add CVE-2026-24858: Fortinet FortiOS/FortiProxy Auth Bypass via FortiCloud SSO

### DIFF
--- a/http/cves/2026/CVE-2026-24858.yaml
+++ b/http/cves/2026/CVE-2026-24858.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-24858
+
+info:
+  name: Fortinet FortiOS/FortiProxy - Authentication Bypass via FortiCloud SSO
+  author: jarvis-survives
+  severity: critical
+  description: |
+    An authentication bypass using an alternate path or channel vulnerability (CWE-288) affecting FortiOS, FortiProxy, FortiManager, FortiAnalyzer, and FortiWeb may allow an attacker who has a FortiCloud account to log into other FortiGate devices registered to different accounts when FortiCloud SSO is enabled as an authentication method.
+  impact: |
+    An attacker with any valid FortiCloud account can bypass authentication and gain administrative access to FortiGate appliances belonging to other organizations, leading to full network compromise.
+  remediation: |
+    Update to FortiOS 7.6.1, 7.4.7, 7.2.12, 7.0.17 or later. Alternatively, disable FortiCloud SSO as an authentication method.
+  reference:
+    - https://fortiguard.fortinet.com/psirt/FG-IR-26-060
+    - https://www.fortinet.com/blog/psirt-blogs/analysis-of-sso-abuse-on-fortios
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24858
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-24858
+    cwe-id: CWE-288
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"FortiGate" || http.title:"FortiProxy"
+    fofa-query: title="FortiGate" || title="FortiProxy"
+    vendor: fortinet
+    product: fortios
+  tags: cve,cve2026,fortinet,fortios,fortiproxy,auth-bypass,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2/cmdb/system/forticloud"
+      - "{{BaseURL}}/login"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FortiGate"
+          - "FortiProxy"
+          - "fortinet"
+          - "forticloud"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 401
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)(?:version|ver)["\s:=]+["\s]*v?(\d+\.\d+\.\d+)'


### PR DESCRIPTION
### PR Information

- Added template for CVE-2026-24858: Authentication bypass via FortiCloud SSO in FortiOS, FortiProxy, FortiManager, FortiAnalyzer, and FortiWeb
- Critical severity — attacker with any FortiCloud account can access other organizations FortiGate devices
- CISA KEV: Added 2026-01-27
- Affected: FortiOS <7.6.1, <7.4.7, <7.2.12, <7.0.17

### Template validation

- Detects FortiGate/FortiProxy instances and extracts version information
- Checks FortiCloud SSO configuration endpoint