### PR TITLE
Add CVE-2025-67303: ComfyUI-Manager Config Data Exposure

### DIFF
--- a/http/cves/2025/CVE-2025-67303.yaml
+++ b/http/cves/2025/CVE-2025-67303.yaml
@@ -5,11 +5,11 @@ info:
   author: YAshhh29,jarvis-survives
   severity: critical
   description: |
-    ComfyUI-Manager versions prior to V3.38 store sensitive configuration files in an unprotected location accessible via the web interface. An unauthenticated attacker can retrieve security settings, channel configurations, and snapshot information.
+    ComfyUI-Manager < 3.38 contains an insecure file storage vulnerability caused by storing files in an insufficiently protected location accessible via the web interface, letting remote attackers manipulate configuration and critical data, exploit requires web access.
   impact: |
-    An attacker can extract sensitive configuration data including security settings and internal paths, potentially leading to further exploitation.
+    Remote attackers can manipulate configuration and critical data, potentially compromising application integrity and security.
   remediation: |
-    Update ComfyUI-Manager to V3.38 or later which includes the userdata security migration.
+    Update to version 3.38 or later.
   reference:
     - https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/docs/en/v3.38-userdata-security-migration.md
     - https://github.com/Comfy-Org/ComfyUI-Manager/pull/2338/commits/e44c5cef58fb4973670b86433b9d24d077b44a26
@@ -35,23 +35,10 @@ http:
 
     stop-at-first-match: true
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "security_level"
-          - "channel_url"
-          - "ComfyUI"
-        condition: or
-
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: content_type
-        words:
-          - "text/"
-          - "application/octet-stream"
-        condition: or
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!contains(content_type, "text/html")'
+          - 'contains_any(body, "security_level", "ltdrdata/ComfyUI-Manager")'
+        condition: and


### PR DESCRIPTION
### PR Information

- CVE-2025-67303: ComfyUI-Manager < V3.38 stores config files in unprotected web-accessible location
- Critical (CVSS 9.1) — unauthenticated access to security settings and channel configs
- Based on template from @YAshhh29 in #14765 (credited as co-author)
- Closes #14765

### Template validation

- Checks two known config endpoints with proper matchers
- Verified against advisory and commit references