### PR TITLE
Add WordPress WP Super Edit 2.5.4 File Upload template

### DIFF
--- a/http/vulnerabilities/wordpress/wp-super-edit-file-upload.yaml
+++ b/http/vulnerabilities/wordpress/wp-super-edit-file-upload.yaml
@@ -1,0 +1,45 @@
+id: wordpress-wp-super-edit-file-upload
+
+info:
+  name: WordPress WP Super Edit 2.5.4 - Arbitrary File Upload via FCKeditor
+  author: 0xr2r,jarvis-survives
+  severity: high
+  description: |
+    WordPress Plugin WP Super Edit version 2.5.4 and earlier contains an arbitrary file upload vulnerability caused by the bundled FCKeditor file manager. An unauthenticated attacker can access the FCKeditor file browser and upload malicious files, potentially leading to remote code execution.
+  impact: |
+    An attacker can upload web shells or other malicious files to the server, leading to full system compromise.
+  remediation: |
+    Remove or update the WP Super Edit plugin. The plugin has been closed on the WordPress plugin repository.
+  reference:
+    - https://www.exploit-db.com/exploits/49839
+    - https://wordpress.org/plugins/wp-super-edit/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wordpress
+    product: wp-super-edit
+    framework: wordpress
+  tags: wordpress,wp-plugin,file-upload,rce,fckeditor,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wp-super-edit/superedit/tinymce_plugins/mse/fckeditor/editor/filemanager/browser/default/browser.html"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FCKeditor"
+          - "File Browser"
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "text/html"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- WP Super Edit 2.5.4 arbitrary file upload via bundled FCKeditor file manager
- High severity — unauthenticated file upload leading to RCE
- Based on template from @0xr2r in #12709 (credited as co-author), improved with proper matchers and metadata
- Closes #12709

### Template validation

- Checks for exposed FCKeditor file browser endpoint
- Matches both FCKeditor and File Browser keywords to avoid false positives