### PR TITLE
Add CVE-2025-54253 - Adobe AEM Forms Struts DevMode RCE

### DIFF
--- a/http/cves/2025/CVE-2025-54253.yaml
+++ b/http/cves/2025/CVE-2025-54253.yaml
@@ -1,0 +1,75 @@
+id: CVE-2025-54253
+
+info:
+  name: Adobe Experience Manager Forms - RCE via Struts DevMode OGNL Injection
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Adobe Experience Manager Forms on JEE versions 6.5.23 and earlier contain a critical
+    misconfiguration where Apache Struts devMode is enabled in the admin UI, allowing
+    unauthenticated attackers to execute arbitrary code via OGNL injection through devMode
+    debug endpoints.
+  impact: |
+    Unauthenticated remote code execution leading to complete system compromise.
+  remediation: |
+    Update Adobe Experience Manager Forms to the latest patched version per Adobe Security Bulletin
+    APSB25-82. Restrict access to /adminui/* and /lc/bin/* endpoints from external networks.
+  reference:
+    - https://helpx.adobe.com/security/products/aem-forms/apsb25-82.html
+    - https://slcyber.io/research-center/struts-devmode-in-2025-critical-pre-auth-vulnerabilities-in-adobe-experience-manager-forms/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54253
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-54253
+    cwe-id: CWE-94
+    epss-score: 0.43112
+    epss-percentile: 0.97
+  metadata:
+    verified: false
+    max-request: 3
+    vendor: adobe
+    product: experience_manager
+    shodan-query: title:"Adobe Experience Manager"
+  tags: cve,cve2025,adobe,aem,struts,rce,kev
+
+flow: http(1) && http(2)
+
+http:
+  # Step 1: Identify AEM Forms installation
+  - method: GET
+    path:
+      - "{{BaseURL}}/lc/libs/livecycle/core/content/login.html"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(tolower(body), "adobe") || contains(tolower(body), "experience manager") || contains(tolower(body), "livecycle")'
+        condition: and
+        internal: true
+
+  # Step 2: Detect Struts devMode exposure via debug endpoints
+  - method: GET
+    path:
+      - "{{BaseURL}}/adminui/debug?debug=browser"
+      - "{{BaseURL}}/lc/bin/adminui/debug?debug=browser"
+      - "{{BaseURL}}/adminui/struts/webconsole.html"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "devMode"
+          - "struts.devMode"
+          - "OGNL"
+          - "ValueStack"
+        condition: or


### PR DESCRIPTION
## Template: CVE-2025-54253

### Vulnerability
- **CVE:** CVE-2025-54253
- **Product:** Adobe Experience Manager Forms on JEE <= 6.5.23
- **Type:** Remote Code Execution via Struts DevMode OGNL Injection
- **Severity:** Critical (CVSS 10.0)
- **CISA KEV:** Yes (added 2025-10-16)

### Description
Adobe Experience Manager Forms on JEE contains a critical misconfiguration where Apache Struts devMode is enabled in the admin UI. Unauthenticated attackers can exploit this to execute arbitrary code via OGNL injection through debug endpoints.

### Detection Method
Two-step safe detection:
1. Fingerprint AEM Forms installation via `/lc/libs/livecycle/core/content/login.html`
2. Check for Struts devMode exposure via `/adminui/debug?debug=browser` endpoints

No OGNL payloads are executed — detection is based on devMode indicator presence only.

### Testing
- Template validated via YAML syntax and structure review
- Based on Assetnote security research (original disclosure)
- No public vulnerable Docker image available for AEM (proprietary software)
- Marked as `verified: false`

### References
- https://helpx.adobe.com/security/products/aem-forms/apsb25-82.html
- https://slcyber.io/research-center/struts-devmode-in-2025-critical-pre-auth-vulnerabilities-in-adobe-experience-manager-forms/
- https://nvd.nist.gov/vuln/detail/CVE-2025-54253
- https://www.cisa.gov/known-exploited-vulnerabilities-catalog

Closes: https://github.com/projectdiscovery/nuclei-templates/issues/12896