### PR TITLE
Add CVE-2025-69981 — FUXA Unrestricted File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-69981.yaml
+++ b/http/cves/2025/CVE-2025-69981.yaml
@@ -2,7 +2,7 @@ id: CVE-2025-69981
 
 info:
   name: FUXA <= 1.2.7 - Unrestricted File Upload
-  author: wickers
+  author: trader642
   severity: critical
   description: |
     FUXA v1.2.7 and earlier contains an unrestricted file upload vulnerability in the /api/upload endpoint. The endpoint lacks authentication, allowing unauthenticated remote attackers to upload arbitrary files. This can be exploited to overwrite critical system files (including the SQLite user database) to gain administrative access, or to upload malicious scripts for code execution.

--- a/http/cves/2025/CVE-2025-69981.yaml
+++ b/http/cves/2025/CVE-2025-69981.yaml
@@ -1,0 +1,80 @@
+id: CVE-2025-69981
+
+info:
+  name: FUXA <= 1.2.7 - Unrestricted File Upload
+  author: wickers
+  severity: critical
+  description: |
+    FUXA v1.2.7 and earlier contains an unrestricted file upload vulnerability in the /api/upload endpoint. The endpoint lacks authentication, allowing unauthenticated remote attackers to upload arbitrary files. This can be exploited to overwrite critical system files (including the SQLite user database) to gain administrative access, or to upload malicious scripts for code execution.
+  impact: |
+    Unauthenticated remote attackers can upload arbitrary files to the server, potentially overwriting the user database to create admin accounts, or placing executable files for remote code execution on the FUXA SCADA/HMI system.
+  remediation: |
+    Update FUXA to a version that implements proper authentication on the upload endpoint and restricts allowed file types.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-69981
+    - https://github.com/frangoteam/FUXA/blob/master/server/api/projects/index.js#L193
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-69981
+    cwe-id: CWE-434
+    cpe: cpe:2.3:a:frangoteam:fuxa:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: frangoteam
+    product: fuxa
+    shodan-query: 'http.html:"FUXA"'
+    fofa-query: 'body="FUXA"'
+  tags: cve,cve2025,fuxa,upload,unauth,file-upload,scada,iot
+
+flow: |
+  http(1) && http(2)
+
+http:
+  - method: GET
+    id: fingerprint
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FUXA"
+
+      - type: status
+        status:
+          - 200
+
+  - raw:
+      - |
+        POST /api/upload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----nucleitest
+        
+        ------nucleitest
+        Content-Disposition: form-data; name="file"; filename="nuclei-test-{{randstr}}.txt"
+        Content-Type: text/plain
+        
+        nuclei-upload-test-{{randstr}}
+        ------nucleitest--
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "nuclei-test-"
+          - "uploaded"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"

--- a/http/cves/2025/CVE-2025-69981.yaml
+++ b/http/cves/2025/CVE-2025-69981.yaml
@@ -26,7 +26,7 @@ info:
     product: fuxa
     shodan-query: 'http.html:"FUXA"'
     fofa-query: 'body="FUXA"'
-  tags: cve,cve2025,fuxa,upload,unauth,file-upload,scada,iot
+  tags: cve,cve2025,fuxa,upload,unauth,file-upload,scada,iot,intrusive
 
 flow: |
   http(1) && http(2)
@@ -68,7 +68,7 @@ http:
         words:
           - "nuclei-test-"
           - "uploaded"
-        condition: or
+        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
## CVE-2025-69981 — FUXA <= 1.2.7 Unrestricted File Upload

### Description
FUXA v1.2.7 and earlier contains an unrestricted file upload vulnerability in the `/api/upload` endpoint. The endpoint lacks authentication, allowing unauthenticated attackers to upload arbitrary files, potentially leading to system compromise.

### Detection
- Step 1: Fingerprint — verify FUXA is running (GET /)
- Step 2: Attempt a benign file upload to `/api/upload` without authentication
- If upload succeeds (200 + JSON response), the endpoint is vulnerable

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-69981
- https://github.com/frangoteam/FUXA/blob/master/server/api/projects/index.js#L193

### Severity
- CVSS: 9.8 (Critical)
- CWE-434: Unrestricted Upload of File with Dangerous Type

### Notes
- Part of a cluster of FUXA vulnerabilities (CVE-2025-69971, 69981, 69983)
- Template uses non-intrusive detection: uploads a small text file with random name
- `verified: false` — tested against documentation and source code analysis only