### PR TITLE
Add CVE-2025-69983 — FUXA RCE via Project Import

### DIFF
--- a/http/cves/2025/CVE-2025-69983.yaml
+++ b/http/cves/2025/CVE-2025-69983.yaml
@@ -1,0 +1,77 @@
+id: CVE-2025-69983
+
+info:
+  name: FUXA <= 1.2.7 - Remote Code Execution via Project Import
+  author: wickers
+  severity: critical
+  description: |
+    FUXA v1.2.7 and earlier allows Remote Code Execution (RCE) via the project import functionality. The application does not properly sanitize or sandbox user-supplied scripts within imported project files. An attacker can upload a malicious project containing system commands via the /api/projectimport endpoint, leading to full system compromise.
+  impact: |
+    Remote attackers can execute arbitrary system commands on the server by importing a malicious project file containing embedded scripts, potentially leading to complete system compromise of the FUXA SCADA/HMI platform.
+  remediation: |
+    Update FUXA to a version that properly sanitizes and sandboxes scripts within imported project files, and adds authentication to the import endpoint.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-69983
+    - https://github.com/frangoteam/FUXA/blob/master/server/api/projects/index.js
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-69983
+    cwe-id: CWE-94
+    cpe: cpe:2.3:a:frangoteam:fuxa:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: frangoteam
+    product: fuxa
+    shodan-query: 'http.html:"FUXA"'
+    fofa-query: 'body="FUXA"'
+  tags: cve,cve2025,fuxa,rce,code-injection,scada,iot
+
+flow: |
+  http(1) && http(2)
+
+http:
+  - method: GET
+    id: fingerprint
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FUXA"
+
+      - type: status
+        status:
+          - 200
+
+  - raw:
+      - |
+        POST /api/projectimport HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"prjFile":"test"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "error"
+          - "project"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 400
+          - 500
+        condition: or


### PR DESCRIPTION
Closing this PR — the template does not properly demonstrate RCE. It only proves the endpoint exists and rejects bad input, which a patched instance would also do. Matching on error strings is an anti-pattern. Withdrawing.