### PR TITLE
Add CVE-2024-9643: Four-Faith F3x36 Hardcoded Credentials Authentication Bypass

### DIFF
--- a/http/cves/2024/CVE-2024-9643.yaml
+++ b/http/cves/2024/CVE-2024-9643.yaml
@@ -39,5 +39,5 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains_all(body, "Four-Faith","Status")'
-          - 'contains(header, "Server: httpd_four-faith")'
+          - 'contains(server, "httpd_four-faith")'
         condition: and


### PR DESCRIPTION
## Description

Adds nuclei template for CVE-2024-9643 - Four-Faith F3x36 router firmware v2.0.0 hardcoded credentials vulnerability.

## Details
- **CVE**: CVE-2024-9643
- **CVSS**: 9.8 (Critical)
- **Product**: Four-Faith F3x36 router
- **Type**: Hardcoded credentials (ffadmin:ffadminff)

## Detection Method
Non-destructive detection via GET request to /Status_Router.asp with hardcoded Basic auth credentials.

## References
- https://vulncheck.com/advisories/four-faith-hard-coded-creds
- https://talosintelligence.com/vulnerability_reports/TALOS-2023-1752
- https://nvd.nist.gov/vuln/detail/CVE-2024-9643