### PR TITLE
Add CVE-2025-62521 - ChurchCRM Pre-Auth RCE via Setup Wizard

### DIFF
--- a/http/cves/2025/CVE-2025-62521.yaml
+++ b/http/cves/2025/CVE-2025-62521.yaml
@@ -1,0 +1,68 @@
+id: CVE-2025-62521
+
+info:
+  name: ChurchCRM < 5.21.0 - Pre-Authentication RCE via Setup Wizard
+  author: Bushi-gg
+  severity: critical
+  description: |
+    ChurchCRM prior to version 5.21.0 contains a pre-authentication remote code execution vulnerability
+    in the setup wizard. The vulnerability exists in setup/routes/setup.php where user input from the
+    setup form is directly concatenated into a PHP configuration template without any validation or
+    sanitization. An unauthenticated attacker can inject arbitrary PHP code during the installation
+    process, which gets written to Include/Config.php and executed on every page load, leading to
+    complete server compromise.
+  impact: |
+    An attacker can achieve pre-authentication remote code execution, leading to complete server compromise.
+  reference:
+    - https://github.com/ChurchCRM/CRM/security/advisories/GHSA-m8jq-j3p9-2xf3
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-62521
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-62521
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: churchcrm
+    product: churchcrm
+    shodan-query: http.title:"ChurchCRM"
+  tags: cve,cve2025,churchcrm,rce,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/setup/"
+      - "{{BaseURL}}/setup/index.php"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "ChurchCRM"
+          - "setup"
+        condition: and
+        case-insensitive: true
+
+      - type: word
+        part: body
+        words:
+          - "sRootPath"
+          - "sSERVERNAME"
+          - "DB_PASSWORD"
+          - "sNEWDB_PASS"
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'ChurchCRM\s+([0-9]+\.[0-9]+\.[0-9]+)'


### PR DESCRIPTION
## CVE-2025-62521 — ChurchCRM Pre-Authentication Remote Code Execution

**Product:** ChurchCRM (Open-source Church Management System)
**Affected Versions:** < 5.21.0
**CVSS Score:** 10.0 (Critical)
**CWE:** CWE-94 (Code Injection)

### Description
ChurchCRM prior to version 5.21.0 contains a pre-authentication remote code execution vulnerability in the setup wizard. User input from the setup form is directly concatenated into a PHP configuration template without validation or sanitization in `setup/routes/setup.php`. This allows unauthenticated attackers to inject arbitrary PHP code that gets written to `Include/Config.php` and executed on every page load.

### References
- [GHSA-m8jq-j3p9-2xf3](https://github.com/ChurchCRM/CRM/security/advisories/GHSA-m8jq-j3p9-2xf3)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-62521)

### Template
- Detection-only: checks for exposed setup wizard with configuration form parameters
- Shodan query: `http.title:"ChurchCRM"`
