### PR TITLE
Add CVE-2025-13329 - File Uploader for WooCommerce Arbitrary File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-13329.yaml
+++ b/http/cves/2025/CVE-2025-13329.yaml
@@ -1,0 +1,64 @@
+id: CVE-2025-13329
+
+info:
+  name: File Uploader for WooCommerce <= 1.0.3 - Arbitrary File Upload
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The File Uploader for WooCommerce plugin for WordPress is vulnerable to arbitrary file uploads
+    due to missing file type validation in the callback function for the 'add-image-data' REST API
+    endpoint in all versions up to, and including, 1.0.3. This makes it possible for unauthenticated
+    attackers to upload arbitrary files on the affected site's server which may make remote code
+    execution possible.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/da0f0e1a-bbf8-42a5-b330-b53134488ebd?source=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13329
+    - https://wordpress.org/plugins/file-uploader-for-woocommerce/
+    - https://github.com/projectdiscovery/nuclei-templates/issues/14586
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-13329
+    cwe-id: CWE-434
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: snowray
+    product: file-uploader-for-woocommerce
+    publicized: 2025-12-20
+  tags: cve,cve2025,wordpress,wp-plugin,fileupload,unauth,woocommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/file-uploader-for-woocommerce/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "File Uploader for WooCommerce"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 1.0.3')


### PR DESCRIPTION
## CVE-2025-13329 — File Uploader for WooCommerce Arbitrary File Upload

**Product:** File Uploader for WooCommerce (WordPress Plugin)
**Affected Versions:** <= 1.0.3
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-434 (Unrestricted Upload of File with Dangerous Type)

### Description
The File Uploader for WooCommerce plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type validation in the callback function for the 'add-image-data' REST API endpoint in all versions up to, and including, 1.0.3. This allows unauthenticated attackers to upload arbitrary files which may lead to remote code execution.

### References
- [Wordfence Advisory](https://www.wordfence.com/threat-intel/vulnerabilities/id/da0f0e1a-bbf8-42a5-b330-b53134488ebd)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-13329)

### Template
- Detection-only: checks for vulnerable plugin version via readme.txt
- Version comparison: <= 1.0.3
