### PR TITLE
Add CVE-2025-13773 - Print Invoice & Delivery Notes for WooCommerce Unauth RCE

### DIFF
--- a/http/cves/2025/CVE-2025-13773.yaml
+++ b/http/cves/2025/CVE-2025-13773.yaml
@@ -1,0 +1,58 @@
+id: CVE-2025-13773
+
+info:
+  name: Print Invoice and Delivery Notes for WooCommerce - Unauthenticated RCE
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Print Invoice and Delivery Notes for WooCommerce plugin for WordPress versions up to and including 5.8.0
+    contains an unauthenticated remote code execution vulnerability. The vulnerability exists due to a missing
+    capability check in the WooCommerce_Delivery_Notes::update function combined with PHP code execution
+    enabled in Dompdf and missing output escaping. This allows unauthenticated attackers to execute arbitrary
+    PHP code on the server.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e52b34fe-2414-4d6f-bf43-9c5b65ebf769?source=cve
+    - https://plugins.trac.wordpress.org/changeset/3426119/woocommerce-delivery-notes
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13773
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-13773
+    cwe-id: CWE-862
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: tyche-softwares
+    product: print-invoice-and-delivery-notes-for-woocommerce
+    publicwww-query: "/wp-content/plugins/woocommerce-delivery-notes/"
+  tags: cve,cve2025,wordpress,wp-plugin,rce,unauth,woocommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-delivery-notes/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Print Invoice & Delivery Notes for WooCommerce"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 5.8.0')


### PR DESCRIPTION
## CVE-2025-13773 — Print Invoice & Delivery Notes for WooCommerce RCE

**Product:** Print Invoice & Delivery Notes for WooCommerce (WordPress Plugin)
**Affected Versions:** <= 5.8.0
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-862 (Missing Authorization)

### Description
The Print Invoice & Delivery Notes for WooCommerce plugin for WordPress is vulnerable to unauthenticated remote code execution in all versions up to and including 5.8.0. The vulnerability exists due to a missing capability check in the `WooCommerce_Delivery_Notes::update` function, combined with PHP execution enabled in Dompdf and missing output escaping in template.php.

### References
- [Wordfence Advisory](https://www.wordfence.com/threat-intel/vulnerabilities/id/e52b34fe-2414-4d6f-bf43-9c5b65ebf769)
- [WordPress Changeset](https://plugins.trac.wordpress.org/changeset/3426119/woocommerce-delivery-notes)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-13773)

### Template
- Detection-only: checks for vulnerable plugin version via readme.txt
- Version comparison: <= 5.8.0
