### PR TITLE
Add CVE-2025-54322 - Xspeeder SXZOS Unauthenticated Root RCE

### DIFF
--- a/http/cves/2025/CVE-2025-54322.yaml
+++ b/http/cves/2025/CVE-2025-54322.yaml
@@ -1,0 +1,54 @@
+id: CVE-2025-54322
+
+info:
+  name: Xspeeder SXZOS - Unauthenticated Root RCE via vLogin.py
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Xspeeder SXZOS through 2025-12-26 allows root remote code execution via base64-encoded
+    Python code in the chkid parameter to vLogin.py. The title and oIP parameters are also
+    used in the attack chain. This vulnerability affects approximately 70,000 hosts.
+  impact: |
+    An unauthenticated attacker can achieve root-level remote code execution on affected devices.
+  reference:
+    - https://pwn.ai/blog/cve-2025-54322-zeroday-unauthenticated-root-rce-affecting-70-000-hosts
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54322
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-54322
+    cwe-id: CWE-94
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: xspeeder
+    product: sxzos
+    shodan-query: title:"Xspeeder"
+  tags: cve,cve2025,xspeeder,rce,unauth,iot
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vLogin.py"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Xspeeder"
+          - "SXZOS"
+        condition: or
+        case-insensitive: true
+
+      - type: word
+        part: body
+        words:
+          - "chkid"
+          - "login"
+        condition: or
+        case-insensitive: true


### PR DESCRIPTION
## CVE-2025-54322 — Xspeeder SXZOS Root RCE

**Product:** Xspeeder SXZOS
**Affected Versions:** Through 2025-12-26
**CVSS Score:** 10.0 (Critical)
**CWE:** CWE-94 (Code Injection)

### Description
Xspeeder SXZOS allows root remote code execution via base64-encoded Python code in the chkid parameter to vLogin.py. Affects ~70,000 hosts.

### References
- [PoC Blog](https://pwn.ai/blog/cve-2025-54322-zeroday-unauthenticated-root-rce-affecting-70-000-hosts)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-54322)

### Template
- Detection-only: checks for exposed vLogin.py endpoint with Xspeeder/SXZOS markers
