### PR TITLE
Add CVE-2025-10738 - URL Shortener Plugin For WordPress SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-10738.yaml
+++ b/http/cves/2025/CVE-2025-10738.yaml
@@ -1,0 +1,57 @@
+id: CVE-2025-10738
+
+info:
+  name: URL Shortener Plugin For WordPress <= 3.0.7 - SQL Injection
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The URL Shortener Plugin For WordPress (exact-links) is vulnerable to SQL Injection via
+    the 'analytic_id' parameter in all versions up to, and including, 3.0.7 due to insufficient
+    escaping on the user supplied parameter and lack of sufficient preparation on the existing
+    SQL query. This makes it possible for unauthenticated attackers to append additional SQL
+    queries to extract sensitive information from the database.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/1b4acf11-114a-4e97-89cd-1d387f14a730
+    - https://wordpress.org/plugins/exact-links/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-10738
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-10738
+    cwe-id: CWE-89
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: flaviordev
+    product: url-shortener-plugin-for-wordpress
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/exact-links/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "URL Shortener"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 3.0.7')


### PR DESCRIPTION
## CVE-2025-10738 — URL Shortener Plugin SQL Injection

**Product:** URL Shortener Plugin For WordPress (exact-links)
**Affected Versions:** <= 3.0.7
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-89 (SQL Injection)

### Description
The URL Shortener Plugin For WordPress is vulnerable to unauthenticated SQL Injection via the 'analytic_id' parameter due to insufficient escaping and lack of prepared statements.

### References
- [Wordfence Advisory](https://www.wordfence.com/threat-intel/vulnerabilities/id/1b4acf11-114a-4e97-89cd-1d387f14a730)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-10738)

### Template
- Detection-only: checks for vulnerable plugin version via readme.txt
- Version comparison: <= 3.0.7
