### PR TITLE
Add CVE-2025-14388 - PhastPress Unauthenticated Arbitrary File Read

### DIFF
--- a/http/cves/2025/CVE-2025-14388.yaml
+++ b/http/cves/2025/CVE-2025-14388.yaml
@@ -1,0 +1,59 @@
+id: CVE-2025-14388
+
+info:
+  name: PhastPress <= 3.7 - Unauthenticated Arbitrary File Read
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The PhastPress plugin for WordPress is vulnerable to Unauthenticated Arbitrary File Read
+    via null byte injection in all versions up to, and including, 3.7. This is due to a discrepancy
+    between the extension validation in getExtensionForURL() which operates on URL-decoded paths,
+    and appendNormalized() which strips everything after a null byte before constructing the
+    filesystem path. Unauthenticated attackers can read arbitrary files from the webroot, including
+    wp-config.php, by appending a double URL-encoded null byte (%2500) followed by an allowed
+    extension to the file path.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/eec9bbc0-5a68-4624-a672-bd6227d6fa45
+    - https://plugins.trac.wordpress.org/changeset/3418139
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14388
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 9.8
+    cve-id: CVE-2025-14388
+    cwe-id: CWE-158
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: nicholaslam
+    product: phastpress
+  tags: cve,cve2025,wordpress,wp-plugin,lfi,fileread,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/phastpress/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "PhastPress"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 3.7')


### PR DESCRIPTION
## CVE-2025-14388 — PhastPress Arbitrary File Read

**Product:** PhastPress (WordPress Plugin)
**Affected Versions:** <= 3.7
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-158 (Improper Neutralization of Null Byte)

### Description
The PhastPress plugin for WordPress is vulnerable to Unauthenticated Arbitrary File Read via null byte injection in all versions up to 3.7. Attackers can read arbitrary files from the webroot including wp-config.php.

### References
- [Wordfence Advisory](https://www.wordfence.com/threat-intel/vulnerabilities/id/eec9bbc0-5a68-4624-a672-bd6227d6fa45)
- [WordPress Changeset](https://plugins.trac.wordpress.org/changeset/3418139)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-14388)

### Template
- Detection-only: checks for vulnerable plugin version via readme.txt
- Version comparison: <= 3.7
