### PR TITLE
Add CVE-2025-12963 - LazyTasks Project Management Privilege Escalation

### DIFF
--- a/http/cves/2025/CVE-2025-12963.yaml
+++ b/http/cves/2025/CVE-2025-12963.yaml
@@ -1,0 +1,56 @@
+id: CVE-2025-12963
+
+info:
+  name: LazyTasks Project & Task Management <= 1.2.29 - Privilege Escalation
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The LazyTasks – Project & Task Management with Collaboration, Kanban and Gantt Chart plugin
+    for WordPress is vulnerable to privilege escalation via account takeover in all versions up
+    to, and including, 1.2.29. This is due to the plugin not properly validating user identity
+    during authentication, allowing unauthenticated attackers to escalate privileges.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/c6998185-0f9b-48ab-9dca-05adf5ae603a
+    - https://wordpress.org/plugins/lazytasks-project-task-management/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12963
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-12963
+    cwe-id: CWE-289
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: developer
+    product: lazytasks-project-task-management
+  tags: cve,cve2025,wordpress,wp-plugin,privesc,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/lazytasks-project-task-management/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "LazyTasks"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 1.2.29')


### PR DESCRIPTION
## CVE-2025-12963 — LazyTasks Privilege Escalation

**Product:** LazyTasks – Project & Task Management (WordPress Plugin)
**Affected Versions:** <= 1.2.29
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-289

### Description
Privilege escalation via account takeover in all versions up to 1.2.29 due to improper user identity validation.

### References
- [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/id/c6998185-0f9b-48ab-9dca-05adf5ae603a)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-12963)
