### PR TITLE
Add CVE-2025-14440 - JAY Login & Register Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-14440.yaml
+++ b/http/cves/2025/CVE-2025-14440.yaml
@@ -1,0 +1,54 @@
+id: CVE-2025-14440
+
+info:
+  name: JAY Login & Register <= 2.4.01 - Authentication Bypass
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The JAY Login & Register plugin for WordPress is vulnerable to authentication bypass in
+    versions up to, and including, 2.4.01. This is due to incorrect authentication checking
+    in the login/register functionality. This makes it possible for unauthenticated attackers
+    to bypass authentication mechanisms.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14440
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-14440
+    cwe-id: CWE-565
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: developer_developer
+    product: jay-login-register
+  tags: cve,cve2025,wordpress,wp-plugin,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/jay-login-register/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "JAY Login"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 2.4.01')


### PR DESCRIPTION
## CVE-2025-14440 — JAY Login & Register Auth Bypass

**Product:** JAY Login & Register (WordPress Plugin)
**Affected Versions:** <= 2.4.01
**CVSS Score:** 9.8 (Critical)
**CWE:** CWE-565

### Description
Authentication bypass in all versions up to 2.4.01 due to incorrect authentication checking in the login/register functionality.

### References
- [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/id/928877a6-eeeb-4ed5-900b-9b1560e1bf87)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-14440)
