### PR TITLE
Add CVE-2025-13613 - Elated Membership Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-13613.yaml
+++ b/http/cves/2025/CVE-2025-13613.yaml
@@ -1,0 +1,54 @@
+id: CVE-2025-13613
+
+info:
+  name: Elated Membership <= 1.2 - Authentication Bypass
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The Elated Membership plugin for WordPress is vulnerable to Authentication Bypass in all
+    versions up to, and including, 1.2. This is due to the plugin not properly logging in a
+    user with the data that is provided during authentication. This makes it possible for
+    unauthenticated attackers to log in as any existing user on the site.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13613
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-13613
+    cwe-id: CWE-289
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: developer_developer
+    product: elated-membership
+  tags: cve,cve2025,wordpress,wp-plugin,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/elated-membership/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Elated Membership"
+          - "Stable tag:"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 1.2')


### PR DESCRIPTION
## CVE-2025-13613 - Elated Membership <= 1.2 Authentication Bypass

### Description
The Elated Membership plugin for WordPress is vulnerable to Authentication Bypass in all versions up to, and including, 1.2. This is due to the plugin not properly logging in a user with the data that is provided during authentication. This makes it possible for unauthenticated attackers to log in as any existing user on the site.

### Severity
- **CVSS Score:** 9.8 (Critical)
- **CVSS Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
- **CWE:** CWE-289

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-13613

### Template Details
- **Type:** Version detection via readme.txt
- **Vendor:** developer_developer
- **Product:** elated-membership
- **Affected Version:** <= 1.2