### PR TITLE
Add CVE-2026-1306 - midi-Synth Arbitrary File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-1306.yaml
+++ b/http/cves/2026/CVE-2026-1306.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-1306
+
+info:
+  name: midi-Synth <= 1.1.0 - Arbitrary File Upload
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The midi-Synth plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type and file extension validation in the 'export' AJAX action in all versions up to, and including, 1.1.0. This makes it possible for unauthenticated attackers to upload arbitrary files on the affected site's server which may make remote code execution possible granted the attacker can obtain a valid nonce. The nonce is exposed in frontend JavaScript making it trivially accessible to unauthenticated attackers.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1306
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/d5b695d7-c690-4748-b218-5699d1aa63bf?source=cve
+    - https://plugins.trac.wordpress.org/browser/midi-synth/tags/1.1.0/midiSynth.php#L110
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-1306
+    cwe-id: CWE-434
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: midi-synth
+    product: midi-synth
+  tags: cve,cve2026,wordpress,wp-plugin,file-upload,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/midi-synth/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "midi-synth"
+
+      - type: word
+        part: body
+        words:
+          - "Stable tag:"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag: ([0-9.]+)'


### PR DESCRIPTION
## CVE-2026-1306 - midi-Synth <= 1.1.0 - Arbitrary File Upload

The midi-Synth plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type validation, allowing unauthenticated remote code execution.

- **CVSS:** 9.8 Critical
- **CWE:** CWE-434
- **Reference:** https://nvd.nist.gov/vuln/detail/CVE-2026-1306