### PR TITLE
Add CVE-2025-8572 - Truelysell Core Privilege Escalation

### DIFF
--- a/http/cves/2025/CVE-2025-8572.yaml
+++ b/http/cves/2025/CVE-2025-8572.yaml
@@ -1,0 +1,52 @@
+id: CVE-2025-8572
+
+info:
+  name: Truelysell Core <= 1.8.7 - Privilege Escalation
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The Truelysell Core plugin for WordPress is vulnerable to privilege escalation in versions less than, or equal to, 1.8.7. This is due to insufficient validation of the user_role parameter during user registration. This makes it possible for unauthenticated attackers to create accounts with elevated privileges, including administrator access.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-8572
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/b027c9f9-3144-4783-b646-ee1e02cd27ef?source=cve
+    - https://themeforest.net/item/truelysell-service-booking-wordpress-theme/43398124
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-8572
+    cwe-id: CWE-269
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: purethemes
+    product: truelysell-core
+  tags: cve,cve2025,wordpress,wp-plugin,privesc
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/truelysell-core/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "truelysell"
+
+      - type: word
+        part: body
+        words:
+          - "Stable tag:"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag: ([0-9.]+)'


### PR DESCRIPTION
## CVE-2025-8572 - Truelysell Core <= 1.8.7 - Privilege Escalation

The Truelysell Core plugin for WordPress is vulnerable to privilege escalation in versions up to 1.8.7.

- **CVSS:** 9.8 Critical
- **CWE:** CWE-269
- **Reference:** https://nvd.nist.gov/vuln/detail/CVE-2025-8572