### PR TITLE
Add CVE-2026-1490 - CleanTalk Anti-Spam Unauthorized Plugin Installation

### DIFF
--- a/http/cves/2026/CVE-2026-1490.yaml
+++ b/http/cves/2026/CVE-2026-1490.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-1490
+
+info:
+  name: CleanTalk Anti-Spam <= 6.71 - Unauthorized Plugin Installation
+  author: Bushi-gg
+  severity: critical
+  description: |
+    The Spam protection, Anti-Spam, FireWall by CleanTalk plugin for WordPress is vulnerable to unauthorized Arbitrary Plugin Installation due to an authorization bypass via reverse DNS (PTR record) spoofing on the 'checkWithoutToken' function in all versions up to, and including, 6.71. This makes it possible for unauthenticated attackers to install and activate arbitrary plugins which can be leveraged to achieve remote code execution if another vulnerable plugin is installed and activated. Note: This is only exploitable on sites with an invalid API key.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1490
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/cb603be6-4a12-49e1-b8cc-b2062eb97f16?source=cve
+    - https://plugins.trac.wordpress.org/browser/cleantalk-spam-protect/trunk/lib/Cleantalk/ApbctWP/RemoteCalls.php#L69
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-1490
+    cwe-id: CWE-350
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: cleantalk
+    product: cleantalk-spam-protect
+  tags: cve,cve2026,wordpress,wp-plugin,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/cleantalk-spam-protect/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "CleanTalk"
+          - "Anti-Spam"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "Stable tag:"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag: ([0-9.]+)'


### PR DESCRIPTION
## CVE-2026-1490 - CleanTalk Anti-Spam <= 6.71 - Unauthorized Plugin Installation

The Spam protection, Anti-Spam, FireWall by CleanTalk plugin for WordPress is vulnerable to unauthorized plugin installation leading to RCE.

- **CVSS:** 9.8 Critical
- **CWE:** CWE-350
- **Reference:** https://nvd.nist.gov/vuln/detail/CVE-2026-1490