### PR TITLE
Add CVE-2026-26369 - eNet SMART HOME Server Privilege Escalation

### DIFF
--- a/http/cves/2026/CVE-2026-26369.yaml
+++ b/http/cves/2026/CVE-2026-26369.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-26369
+
+info:
+  name: eNet SMART HOME Server 2.2.1/2.3.1 - Privilege Escalation
+  author: Bushi-gg
+  severity: critical
+  description: |
+    eNet SMART HOME server 2.2.1 and 2.3.1 contains a privilege escalation vulnerability due to insufficient authorization checks in the setUserGroup JSON-RPC method. A low-privileged user (UG_USER) can send a crafted POST request to /jsonrpc/management specifying their own username to elevate their account to the UG_ADMIN group, bypassing intended access controls and gaining administrative capabilities such as modifying device configurations, network settings, and other smart home system functions.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26369
+    - https://www.vulncheck.com/advisories/jung-enet-smart-home-server-privilege-escalation-v
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2026-5975.php
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-26369
+    cwe-id: CWE-269
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: jung
+    product: enet-smart-home-server
+  tags: cve,cve2026,privesc,enet,iot
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 401
+          - 403
+
+      - type: word
+        part: body
+        words:
+          - "eNet"
+          - "SMART HOME"
+        condition: or
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'version["\s:]+([0-9.]+)'
+          - 'v([0-9.]+)'


### PR DESCRIPTION
## CVE-2026-26369 - eNet SMART HOME Server Privilege Escalation

eNet SMART HOME server 2.2.1 and 2.3.1 contains a privilege escalation vulnerability due to insufficient access controls.

- **CVSS:** 9.8 Critical
- **CWE:** CWE-269
- **Reference:** https://nvd.nist.gov/vuln/detail/CVE-2026-26369