### PR TITLE
Add CVE-2026-22778 vLLM Information Disclosure Template

### DIFF
--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-22778
+
+info:
+  name: vLLM - Information Disclosure via PIL Exception Memory Leak
+  author: epsilon-sh
+  severity: critical
+  description: |
+    vLLM versions 0.8.3 through 0.14.0 contain a vulnerability chain starting with an information disclosure flaw. When processing invalid image input via the OpenAI-compatible chat completions API, PIL raises an exception that includes the memory address of a BytesIO object, leaking heap addresses. This enables ASLR bypass, which is a prerequisite for exploiting a subsequent heap overflow in the JPEG2000 decoder (via crafted cdef box in .mov files) to achieve remote code execution. Default vLLM instances have no authentication. This template detects the information disclosure prerequisite.
+  impact: |
+    Unauthenticated attackers can leak heap memory addresses from vLLM instances by sending malformed image data to the chat completions endpoint. This information disclosure enables ASLR bypass, which combined with a JPEG2000 heap overflow vulnerability allows full remote code execution on the host system.
+  remediation: |
+    Upgrade vLLM to version 0.14.1 or later. If immediate upgrade is not possible, enable authentication on the vLLM API server and restrict network access to trusted clients only.
+  reference:
+    - https://github.com/advisories/GHSA-4r2x-xpjr-7cvv
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22778
+    - https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
+    - https://github.com/vllm-project/vllm/pull/31987
+    - https://github.com/vllm-project/vllm/pull/32319
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-22778
+    cwe-id: CWE-209
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: vllm-project
+    product: vllm
+    shodan-query: http.html:"vllm"
+    fofa-query: body="vllm" && port="8000"
+  tags: cve,cve2026,vllm,info-leak,rce,ai,ml
+
+http:
+  - raw:
+      - |
+        GET /v1/models HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: json
+        name: model_id
+        part: body
+        internal: true
+        json:
+          - '.data[0].id'
+
+    stop-at-first-match: true
+
+  - raw:
+      - |
+        POST /v1/chat/completions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"model":"{{model_id}}","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,AAAA"}}]}],"max_tokens":1}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'BytesIO\s+object\s+at\s+0x[0-9a-fA-F]{8,16}'
+
+      - type: word
+        part: body
+        words:
+          - "cannot identify image file"
+          - "UnidentifiedImageError"
+        condition: or
+
+      - type: status
+        status:
+          - 400
+          - 500
+
+    extractors:
+      - type: regex
+        name: leaked_address
+        part: body
+        group: 1
+        regex:
+          - 'BytesIO\s+object\s+at\s+(0x[0-9a-fA-F]{8,16})'

--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -22,7 +22,7 @@ info:
     cve-id: CVE-2026-22778
     cwe-id: CWE-209
   metadata:
-    verified: false
+    verified: true
     max-request: 2
     vendor: vllm-project
     product: vllm

--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -35,18 +35,6 @@ http:
       - |
         GET /v1/models HTTP/1.1
         Host: {{Hostname}}
-
-    extractors:
-      - type: json
-        name: model_id
-        part: body
-        internal: true
-        json:
-          - '.data[0].id'
-
-    stop-at-first-match: true
-
-  - raw:
       - |
         POST /v1/chat/completions HTTP/1.1
         Host: {{Hostname}}
@@ -74,6 +62,13 @@ http:
           - 500
 
     extractors:
+      - type: json
+        name: model_id
+        part: body
+        internal: true
+        json:
+          - '.data[0].id'
+
       - type: regex
         name: leaked_address
         part: body


### PR DESCRIPTION
## Description

Adds nuclei template for CVE-2026-22778 - vLLM information disclosure via PIL exception memory leak.

## Details
- **CVE**: CVE-2026-22778
- **CVSS**: 9.8 (Critical)
- **CWE**: CWE-209 (Information exposure through an error message)
- **Product**: vLLM
- **Affected Versions**: 0.8.3 through 0.14.0
- **Fixed**: 0.14.1

## Detection Method
Non-destructive two-step API probe:
1. GET /v1/models to retrieve model ID
2. POST malformed base64 image to /v1/chat/completions
3. Match PIL BytesIO memory address leak in error response

## Validation
- [x] Validated with a host running a vulnerable version
- [x] Validated with a host running a patched version

## References
- https://github.com/advisories/GHSA-4r2x-xpjr-7cvv
- https://nvd.nist.gov/vuln/detail/CVE-2026-22778
- https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
- https://github.com/vllm-project/vllm/pull/31987
- https://github.com/vllm-project/vllm/pull/32319