### PR TITLE
Add CVE-2026-1357 WPvivid Backup & Migration RCE detection

### DIFF
--- a/http/cves/2026/CVE-2026-1357.yaml
+++ b/http/cves/2026/CVE-2026-1357.yaml
@@ -21,7 +21,7 @@ info:
     cwe-id: CWE-434
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: wpvivid
     product: wpvivid-backuprestore
     framework: wordpress
@@ -29,23 +29,19 @@ info:
     publicwww-query: "/wp-content/plugins/wpvivid-backuprestore/"
   tags: cve,cve2026,wp-plugin,wordpress,wpvivid,rce,fileupload,unauth,vuln
 
+flow: http(1) && http(2)
+
 http:
   - raw:
       - |
         GET /wp-content/plugins/wpvivid-backuprestore/readme.txt HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - "WPvivid"
-          - "Stable tag:"
-        condition: and
-
       - type: dsl
         dsl:
           - compare_versions(version, '<= 0.9.123')
+        internal: true
 
     extractors:
       - type: regex
@@ -55,7 +51,28 @@ http:
           - "(?i)Stable.tag:\\s?([\\w.]+)"
         internal: true
 
-      - type: regex
-        group: 1
-        regex:
-          - "(?i)Stable.tag:\\s?([\\w.]+)"
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        wpvivid_action=send_to_site&wpvivid_content=dGVzdA==
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"result"'
+          - '"The key is invalid."'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"version: " + version'


### PR DESCRIPTION
## Template Details

- **CVE**: CVE-2026-1357
- **Severity**: Critical (CVSS 9.8)
- **Product**: WPvivid Backup & Migration WordPress plugin (<= 0.9.123)
- **Type**: Unauthenticated Arbitrary File Upload → RCE
- **Installs**: 900K+
- **Detection**: Version check via plugin readme.txt

## Vulnerability Summary

Cryptographic fail-open in RSA decryption (`openssl_private_decrypt()` returns `false` on failure, passed as null key to phpseclib AES) combined with path traversal in filename parameter allows unauthenticated attackers to upload PHP webshells.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-1357
- https://github.com/LucasM0ntes/POC-CVE-2026-1357
- https://www.bleepingcomputer.com/news/security/wordpress-plugin-with-900k-installs-vulnerable-to-critical-rce-flaw/

## Template Validation

```
nuclei -validate -t http/cves/2026/CVE-2026-1357.yaml
[INF] All templates validated successfully
```