### PR TITLE
Add CVE-2026-22444.yaml for Apache Solr file-access checking bypass

### DIFF
--- a/http/cves/2026/CVE-2026-22444.yaml
+++ b/http/cves/2026/CVE-2026-22444.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-22444
+
+info:
+  name: Apache Solr 8.6.0-9.10.0 - Insufficient File-Access Checking in Core Creation
+  author: epsilon-sh
+  severity: high
+  description: |
+    Apache Solr versions 8.6.0 through 9.10.0 contain insufficient input validation in the core creation API. The create core API does not properly validate the configSet, instanceDir, and dataDir parameters against the allowPaths security setting, allowing attackers to access filesystem paths that should be blocked. On Windows systems with UNC paths enabled, this can lead to NTLM hash disclosure. Combined with the Solr extraction module (SolrCell/Tika), this can also enable arbitrary file reads.
+  impact: |
+    Authenticated attackers with access to the CoreAdmin API can bypass allowPaths restrictions to read arbitrary files or trigger NTLM hash disclosure on Windows systems, potentially leading to credential theft and further compromise.
+  remediation: |
+    Upgrade to Apache Solr 9.10.1 or later. If immediate upgrade is not possible, ensure CoreAdmin API access requires authentication via RuleBasedAuthorizationPlugin and restrict network access to trusted clients only.
+  reference:
+    - https://lists.apache.org/thread/qkrb9dd4xrlqmmq73lrhkbfkttto2d1m
+    - https://www.openwall.com/lists/oss-security/2026/01/20/5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22444
+    - https://github.com/dptsec/CVE-2026-22444
+    - https://solr.apache.org/security.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+    cvss-score: 7.1
+    cve-id: CVE-2026-22444
+    cwe-id: CWE-20
+    epss-score: 0.00113
+    epss-percentile: 0.29943
+    cpe: cpe:2.3:a:apache:solr:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: solr
+    shodan-query: http.title:"Solr Admin"
+    fofa-query: title="Solr Admin"
+  tags: cve,cve2026,apache,solr,file-read,path-traversal
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/solr/admin/info/system'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"solr-spec-version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"solr-spec-version"'
+          - '"lucene"'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, ">=8.6.0", "<9.10.1")'


### PR DESCRIPTION
## CVE-2026-22444 — Apache Solr Insufficient File-Access Checking in Core Creation

**Severity:** High (CVSS 7.1)
**Affected:** Apache Solr 8.6.0 – 9.10.0
**Fixed in:** 9.10.1

### Detection

Version-based detection via `/solr/admin/info/system` JSON endpoint. Extracts `solr-spec-version` and checks against affected range using single-call `compare_versions`.

- 1 HTTP request (`max-request: 1`)
- No exploitation — passive version check only

### Verification

**Lab (podman, nuclei v3.7.0):**

| Image | Version | Expected | Result |
|-------|---------|----------|--------|
| solr:9.10.0 | 9.10.0 | Match | **True positive** |
| solr:9.10.1 | 9.10.1 | No match | **True negative** |
| solr:8.5.2 | 8.5.2 | No match | **True negative** |

**Live (FOFA, 5 targets):**
- 3 true positives (9.9.0, 8.11.3, 9.6.1 — all in affected range)
- 2 true negatives (8.5.2 below range, auth-required instance)

### References

- [Apache advisory](https://lists.apache.org/thread/qkrb9dd4xrlqmmq73lrhkbfkttto2d1m)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-22444)
- [PoC (dptsec)](https://github.com/dptsec/CVE-2026-22444)