### PR TITLE
Add CVE-2025-40536

### DIFF
--- a/http/cves/2025/CVE-2025-40536.yaml
+++ b/http/cves/2025/CVE-2025-40536.yaml
@@ -5,8 +5,7 @@ info:
   author: inokii
   severity: high
   description: |
-    SolarWinds Web Help Desk versions prior to 12.8.8 Hotfix 1 (HF1) contain a security control bypass vulnerability
-    that allows a remote, unauthenticated attacker to gain access to certain restricted functionality.
+    SolarWinds Web Help Desk was found to be susceptible to a security control bypass vulnerability that if exploited, could allow an unauthenticated attacker to gain access to certain restricted functionality.
   impact: |
     Attackers can gain access to certain restricted functionality.
   remediation: |
@@ -24,17 +23,16 @@ info:
   metadata:
     verified: true
     max-request: 1
-    vendor: SolarWinds
+    vendor: solarwinds
     product: web_help_desk
     shodan-query: http.favicon.hash:"1895809524"
-  tags: cve,cve2025,kev,solarwinds,webhelpdesk
+  tags: cve,cve2025,solarwinds,webhelpdesk,kev,vkev,passive
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/helpdesk/WebObjects/Helpdesk.woa"
 
-    stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
 


### PR DESCRIPTION
### PR Information

Adds template for SolarWinds Web Help Desk < [12.8.8 Hotfix 1 (HF1)](https://documentation.solarwinds.com/en/success_center/whd/content/release_notes/whd_12-8-8-hotfix-1_release_notes.htm) Security Control Bypass (CVE-2025-40536).

### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

* Test against WHD version 12.8.8.2528
```
nuclei -duc -t http/cves/2025/CVE-2025-40536.yaml -u whd.lan:8081
...
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[CVE-2025-40536:version] [http] [high] http://whd.lan:8081/helpdesk/WebObjects/Helpdesk.woa ["12.8.8.2528"]
[INF] Scan completed in 1.316977584s. 1 matches found.
```

* Test against WHD version 12.8.8 Hotfix 1 (HF1)
```
nuclei -duc -t http/cves/2025/CVE-2025-40536.yaml -u whd.lan:8081
...
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] Scan completed in 544.238209ms. No results found.
```
