### PR TITLE
added CVE-2025-15467

### DIFF
--- a/http/cves/2025/CVE-2025-15467.yaml
+++ b/http/cves/2025/CVE-2025-15467.yaml
@@ -5,10 +5,10 @@ info:
   author: zierax
   severity: critical
   description: |
-    OpenSSL versions 3.0.0 through 3.0.16, 3.1.0 through 3.1.8, 3.2.0 through 3.2.4, and 3.3.0 through 3.3.3 
-    are vulnerable to a stack buffer overflow in the CMS (Cryptographic Message Syntax) AuthEnvelopedData 
-    processing. When decrypting a maliciously crafted CMS file with AES-GCM, an attacker can overflow a 
-    stack buffer by providing an oversized IV (initialization vector) in the GCM parameters. This can lead 
+    OpenSSL versions 3.0.0 through 3.0.16, 3.1.0 through 3.1.8, 3.2.0 through 3.2.4, and 3.3.0 through 3.3.3
+    are vulnerable to a stack buffer overflow in the CMS (Cryptographic Message Syntax) AuthEnvelopedData
+    processing. When decrypting a maliciously crafted CMS file with AES-GCM, an attacker can overflow a
+    stack buffer by providing an oversized IV (initialization vector) in the GCM parameters. This can lead
     to remote code execution by overwriting the return address with a ROP chain.
   impact: |
     Successful exploitation allows:
@@ -62,7 +62,6 @@ http:
 
     matchers-condition: or
     matchers:
-      # Detect vulnerable OpenSSL versions in headers
       - type: regex
         name: vulnerable-version-header
         part: header
@@ -72,7 +71,6 @@ http:
           - "OpenSSL/3\\.2\\.[0-4]($|[^0-9])"
           - "OpenSSL/3\\.3\\.[0-3]($|[^0-9])"
 
-      # Detect in body content (phpinfo, server status pages)
       - type: regex
         name: vulnerable-version-body
         part: body


### PR DESCRIPTION
### PR Information

Added CVE-2025-15467 - OpenSSL CMS AuthEnvelopedData Stack Buffer Overflow

**References:**
- https://nvd.nist.gov/vuln/detail/CVE-2025-15467

**Affected:** OpenSSL 3.0.0-3.0.16, 3.1.0-3.1.8, 3.2.0-3.2.4, 3.3.0-3.3.3

### Template validation

- [x] Validated with a host running a vulnerable version (True Positive)
- [x] Validated with a host running a patched version (avoid False Positive)

#### Additional Details

**Testing:**
```bash
# Vulnerable (3.0.15) - DETECTED ✓
Server: Apache/2.4.41 OpenSSL/3.0.15

# Patched (3.0.17) - NOT DETECTED ✓
Server: Apache/2.4.41 OpenSSL/3.0.17
```

**Shodan Query:**
```
http.html:"OpenSSL/3.0" OR http.html:"OpenSSL/3.1"
```

**Sample Output:**
```
[CVE-2025-15467] [critical] https://target.com [OpenSSL/3.0.15]
```