### PR TITLE
Add a template for windows unquoted service paths

### DIFF
--- a/code/windows/enumeration/unquoted-service-paths.yaml
+++ b/code/windows/enumeration/unquoted-service-paths.yaml
@@ -38,13 +38,7 @@ code:
         }
       }
 
-    matchers:
-      - type: word
-        words:
-          - " : "
-        part: response
-
     extractors:
-      - type: dsl
-        dsl:
-          - response
+      - type: regex
+        regex:
+          - ".+ : .+"


### PR DESCRIPTION
### PR Information

Adds a template for detecting unquoted service paths on windows machines

### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

```bash
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[INF] Current nuclei version: v3.7.0 (latest)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from sage
[unquoted-service-paths] [code] [high]  ["Vulnerable Service 1 : C:\\Program Files (x86)\\Common Files\\VulnService1.exe\r\nVulnerable Service 2 : C:\\Program Files (x86)\\Common Files\\VulnService2.exe"]
[INF] Scan completed in 1.9279916s. 1 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
