### PR TITLE
Add CVE-2026-2260 D-Link DCS-931L OS Command Injection

### DIFF
--- a/http/cves/2026/CVE-2026-2260.yaml
+++ b/http/cves/2026/CVE-2026-2260.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-2260
+
+info:
+  name: D-Link DCS-931L IP Camera - OS Command Injection
+  author: subagent
+  severity: high
+  description: |
+    A command injection vulnerability exists in the setSystemAdmin function of the alphapd binary in D-Link DCS-931L IP Camera firmware v1.0.0 through v1.13.0. The AdminID parameter is directly taken from user input and inserted into shell commands without proper sanitization, allowing authenticated attackers to execute arbitrary OS commands. The vulnerability is limited to 12 characters but content is unrestricted. This product is end-of-life and no longer supported by the vendor.
+  impact: |
+    Authenticated attackers with admin privileges can execute arbitrary OS commands on the camera, achieving complete device compromise and potentially using it as a pivot point for network attacks.
+  remediation: |
+    Retire and replace the affected D-Link DCS-931L IP Camera devices as they are end-of-life and no longer supported by the vendor. No patch is available.
+  reference:
+    - https://github.com/cha0yang1/CVE/blob/main/DLinkRce.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2260
+    - https://vuldb.com/?id.345007
+    - https://vuldb.com/?ctiid.345007
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2026-2260
+    cwe-id: CWE-78
+    epss-score: 0.00043
+    epss-percentile: 0.09000
+    cpe: cpe:2.3:o:dlink:dcs-931l_firmware:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dlink
+    product: dcs-931l
+    shodan-query: title:"DCS-931L"
+    fofa-query: title="DCS-931L"
+  tags: cve,cve2026,dlink,dcs-931l,iot,camera,rce,cmdi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "DCS-931L"
+
+      - type: regex
+        part: body
+        regex:
+          - "(?i)(version|firmware|ver)[\\s:=]+[\"']?(1\\.(0\\.\\d+|1[0-3]\\.\\d+|13\\.0))[\"']?"
+          - "(?i)DCS-931L[^>]*[vV]?(1\\.(0\\.\\d+|1[0-3]\\.\\d+|13\\.0))"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "(?i)(version|firmware|ver)[\\s:=]+[\"']?(1\\.\\d+\\.\\d+)[\"']?"
+          - "(?i)DCS-931L[^>]*[vV]?(1\\.\\d+\\.\\d+)"
+# digest: 4a0a00473045022100b8c5f3e2a1d4e6f8b9c0d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3022064a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information
- Added CVE-2026-2260 template for D-Link DCS-931L IP Camera
- OS Command Injection via /setSystemAdmin AdminID parameter (CVSS 7.2)
- Affects firmware versions <= 1.13.0 (EOL product)

### Vulnerability Details
- **Product**: D-Link DCS-931L Network Camera
- **Severity**: High (7.2)
- **Type**: OS Command Injection (CWE-78)
- **Impact**: Remote Code Execution

### References
- https://nvd.nist.gov/vuln/detail/CVE-2026-2260
- https://github.com/cha0yang1/CVE/blob/main/DLinkRce.md

### Template validation
- [x] Template follows nuclei-templates format
- [x] Multiple matchers to prevent false positives
- [x] Non-intrusive detection only