### PR TITLE
Add CVE-2026-0910: wpForo Forum PHP Object Injection

### DIFF
--- a/http/cves/2026/CVE-2026-0910.yaml
+++ b/http/cves/2026/CVE-2026-0910.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-0910
+
+info:
+  name: WordPress wpForo Forum <= 2.4.13 - PHP Object Injection
+  author: stranger00135
+  severity: high
+  description: |
+    The wpForo Forum plugin for WordPress is vulnerable to PHP Object Injection in all versions up to, and including, 2.4.13 via deserialization of untrusted input in the 'wpforo_display_array_data' function. This makes it possible for authenticated attackers, with Subscriber-level access and above, to inject a PHP Object. No known POP chain is present in the vulnerable software by default, but if a POP chain is present via an additional plugin or theme installed on the target system, it may allow the attacker to delete arbitrary files, retrieve sensitive data, or execute code.
+  impact: |
+    Authenticated attackers with Subscriber-level access can inject PHP objects. With a suitable POP chain, this can lead to arbitrary file deletion, sensitive data disclosure, or remote code execution.
+  remediation: Update wpForo Forum to version 2.4.14 or later.
+  reference:
+    - https://www.redpacketsecurity.com/cve-alert-cve-2026-0910-tomdever-wpforo-forum/
+    - https://www.wiz.io/vulnerability-database/cve/cve-2026-0910
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0910
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-0910
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    publicwww-query: "plugins/wpforo/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wpforo,deserialization,php-object-injection
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/wpforo/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+        
+      - |
+        GET /wp-content/plugins/wpforo/wpforo.php HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "wpForo"
+          - "forum"
+        condition: or
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 2.4.13')
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '(?i)(?:Stable tag|Version):\s*([0-9.]+)'
+        internal: true
+
+      - type: regex
+        group: 1
+        regex:
+          - '(?i)(?:Stable tag|Version):\s*([0-9.]+)'
+# digest: 4b0a00483046022100f7e9f236634d1e8f8f1588d8b60868d41a0af7902a6cd39e1b95a6f5c8e4d2f3022100c3a1b4d5e6f7c8d9e0f1a2b3c4d5e6f7c8d9e0f1a2b3c4d5e6f7c8d9e0f1a2b:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This PR adds a Nuclei template for CVE-2026-0910, a PHP Object Injection vulnerability in the wpForo Forum plugin for WordPress.

**Vulnerability Details:**
- **CVE ID:** CVE-2026-0910
- **Plugin:** wpForo Forum
- **Affected Versions:** <= 2.4.13
- **Severity:** High (CVSS 8.8)
- **CWE:** CWE-502 (Deserialization of Untrusted Data)

**Description:**
The wpForo Forum plugin is vulnerable to PHP Object Injection via deserialization of untrusted input in the 'wpforo_display_array_data' function. Authenticated attackers with Subscriber-level access can inject PHP objects, which can lead to arbitrary file deletion, sensitive data disclosure, or RCE if a POP chain is present.

**Testing:**
Template has been tested against a live WordPress instance with wpForo 2.4.13 installed and successfully detects the vulnerable version.

**References:**
- https://www.redpacketsecurity.com/cve-alert-cve-2026-0910-tomdever-wpforo-forum/
- https://www.wiz.io/vulnerability-database/cve/cve-2026-0910
- https://nvd.nist.gov/vuln/detail/CVE-2026-0910