### PR TITLE
http(cve): reduce false positives in CVE-2024-27198 TeamCity template

### DIFF
--- a/http/cves/2024/CVE-2024-27198.yaml
+++ b/http/cves/2024/CVE-2024-27198.yaml
@@ -46,7 +46,9 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(header, "application/xml")'
+          - '(contains(header, "application/xml") || contains(header, "text/xml"))'
           - 'contains_all(body, "buildNumber", "server version", "internalId")'
+          - '!contains(body, "Authentication required")'
+          - '!contains(body, "login.html")'
         condition: and
 # digest: 490a0046304402206ee1779e6cc7d91164169f7ab6b0395383fb4f6483c4f16f11f1f780263bee32022025325869974ec7de6a12ab564f4b193e1279a766c4db0304bd6e9f0ffe4610c6:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
This PR hardens the existing CVE-2024-27198 TeamCity auth bypass template to reduce false positives while preserving detection coverage.

## Changes
- Accepts both `application/xml` and `text/xml` response headers
- Adds negative checks to avoid auth-gated/login responses:
  - `Authentication required`
  - `login.html`

## Why
Some deployments return `text/xml` instead of `application/xml`, while patched/auth-gated instances can still return misleading pages. These checks improve signal quality and reduce noisy matches.

## Safety
- Detection remains a single non-intrusive GET request
- No state-changing operations
