### PR TITLE
fix: improve port handling in ldap-anonymous-login-detect

### DIFF
--- a/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
+++ b/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
@@ -5,7 +5,7 @@ info:
   author: pussycat0x,s0obi
   severity: medium
   description: |
-    Detects whether an LDAP server allows anonymous bind (login without credentials).Anonymous access can expose sensitive directory information and should be restricted
+    Detects whether an LDAP server allows anonymous bind (login without credentials). Anonymous access can expose sensitive directory information and should be restricted
     unless explicitly intended.
   reference:
     - https://ldap.com/ldapv3-wire-protocol-reference-bind/#anonymous
@@ -18,20 +18,31 @@ info:
 
 javascript:
   - code: |
-      let ldap = require('nuclei/ldap');
-      let cfg = ldap.Config();
-      cfg.Upgrade = true;
-      let client = ldap.Client(Host, Port, cfg);
-      let result = client.Authenticate('', '');
-      let metadata = client.CollectMetadata();
-      Export(metadata);
+      try {
+        let ldap = require('nuclei/ldap');
+
+        let port = Port ? Port : "389";
+        let host = "ldap://" + Hostname + ":" + port;
+
+        let cfg = ldap.Config();
+        cfg.Upgrade = true;
+
+        let client = ldap.Client(host, Realm, cfg);
+        let result = client.Authenticate('', '');
+        let metadata = client.CollectMetadata();
+
+        Export(metadata);
+
+      } catch (e) {
+        // ignore errors
+      }
 
     args:
-      Host: "ldap://{{Host}}"
-      Port: 389
+      Hostname: "{{Hostname}}"
+      Port: "{{Port}}"
+      Realm: "anonymous"
 
     matchers:
       - type: dsl
         dsl:
           - "success == true"
-# digest: 4a0a0047304502200d97a1da36ebd37f8565b06571bbc4c981e2bd0feaca3dfbf58fcbc16fe92560022100a2acf40f456c88741b6a0447dc1951b0a1e6ae7ff83f0b20a26bcd81b252d507:922c64590222798bb761d5b6d8e72950

--- a/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
+++ b/javascript/misconfiguration/ldap/ldap-anonymous-login-detect.yaml
@@ -21,8 +21,8 @@ javascript:
       try {
         let ldap = require('nuclei/ldap');
 
-        let port = Port ? Port : "389";
-        let host = "ldap://" + Hostname + ":" + port;
+        let port = TargetPort ? TargetPort : "389";
+        let host = "ldap://" + Host + ":" + port;
 
         let cfg = ldap.Config();
         cfg.Upgrade = true;
@@ -38,8 +38,8 @@ javascript:
       }
 
     args:
-      Hostname: "{{Hostname}}"
-      Port: "{{Port}}"
+      Host: "{{Host}}"
+      TargetPort: "{{Port}}"
       Realm: "anonymous"
 
     matchers:


### PR DESCRIPTION
This PR fixes port handling in the ldap-anonymous-login-detect template.

### Changes
- Adds fallback to default LDAP port (389) when `Port` is not provided
- Ensures consistent connection string construction for LDAP targets
- Wraps client execution in a try/catch block to prevent runtime failures on connection issues

### Impact
- Improves reliability when scanning targets without explicit ports
- Reduces false negatives caused by malformed host strings
- Keeps behavior consistent across different scan environments

This change is submitted separately as requested in previous review.
