### PR TITLE
Added pocketbase-detect technology template

### DIFF
--- a/http/technologies/pocketbase-detect.yaml
+++ b/http/technologies/pocketbase-detect.yaml
@@ -21,6 +21,9 @@ http:
     path:
       - "{{BaseURL}}"
 
+    host-redirects: true
+    max-redirects: 3
+
     matchers-condition: and
     matchers:
       - type: word


### PR DESCRIPTION
This template detects the presence of the PocketBase backend by checking the page title and status code. Tested locally against PocketBase v0.20+ running on port 8090.