### PR TITLE
Add gitness-default-login.yaml

### DIFF
--- a/http/default-logins/gitness-default-login.yaml
+++ b/http/default-logins/gitness-default-login.yaml
@@ -19,8 +19,6 @@ variables:
   username: "admin"
   password: "changeit"
 
-flow: http(1) && http(2)
-
 http:
   - raw:
       - |
@@ -30,31 +28,10 @@ http:
 
         {"login_identifier":"{{username}}","password":"{{password}}"}
 
-    extractors:
-      - type: json
-        name: token
-        part: body
-        internal: true
-        json:
-          - '.access_token'
-
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
           - 'contains_all(body, "access_token", "principal_id", "session")'
-        condition: and
-        internal: true
-
-  - raw:
-      - |
-        GET /api/v1/user HTTP/1.1
-        Host: {{Hostname}}
-        Cookie: token={{token}}
-
-    matchers:
-      - type: dsl
-        dsl:
+          - 'contains(content_type, "application/json")'
           - 'status_code == 200'
-          - 'contains_all(body, "\"admin\":true", "display_name", "email")'
         condition: and


### PR DESCRIPTION
Added a new YAML file for Gitness default login detection with HTTP flow and matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
