### PR TITLE
Add CVE-2026-22769: Dell RecoverPoint for VMs Hardcoded Tomcat Manager Credentials

### DIFF
--- a/http/cves/2026/CVE-2026-22769.yaml
+++ b/http/cves/2026/CVE-2026-22769.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-22769
+
+info:
+  name: Dell RecoverPoint for VMs < 6.0.3.1 HF1 - Hardcoded Tomcat Manager Credentials
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Dell RecoverPoint for Virtual Machines prior to 6.0.3.1 HF1 contains hardcoded credentials for the Apache Tomcat Manager application. An unauthenticated remote attacker can use these credentials to access the Tomcat Manager and deploy arbitrary WAR files, leading to remote code execution.
+  impact: |
+    Unauthenticated attackers can gain full administrative access to the Tomcat Manager and achieve remote code execution through WAR file deployment.
+  remediation: |
+    Upgrade to RecoverPoint for VMs 6.0.3.1 HF1 or later. Dell advisory DSA-2026-079.
+  reference:
+    - https://www.dell.com/support/kbdoc/en-us/000426773/dsa-2026-079
+    - https://cloud.google.com/blog/topics/threat-intelligence/unc6201-exploiting-dell-recoverpoint-zero-day
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22769
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-22769
+    cwe-id: CWE-798
+    epss-score: 0.94
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"RecoverPoint"
+  tags: cve,cve2026,dell,recoverpoint,default-login,tomcat,kev
+
+http:
+  - raw:
+      - |
+        GET /manager/text/list HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46a2FzaHlh
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "OK - Listed applications"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description
Adds detection template for CVE-2026-22769 (CVSS 10.0) - Dell RecoverPoint for Virtual Machines hardcoded Apache Tomcat Manager credentials.

- **CISA KEV**: Yes, actively exploited by UNC6201 (China-linked APT) since mid-2024
- **Detection**: Non-destructive authentication test against `/manager/text/list` with known hardcoded credentials (`admin:kashya`)
- **Affected**: RecoverPoint for VMs prior to 6.0.3.1 HF1
- **CWE**: CWE-798 (Use of Hard-coded Credentials)

## References
- [Dell DSA-2026-079](https://www.dell.com/support/kbdoc/en-us/000426773/dsa-2026-079)
- [Google Cloud / Mandiant Blog](https://cloud.google.com/blog/topics/threat-intelligence/unc6201-exploiting-dell-recoverpoint-zero-day)
- [Dell KB000191335 - Tomcat Default Passwords](https://www.dell.com/support/kbdoc/en-us/000191335/)

Template validated with `nuclei -validate`.