### PR TITLE
Add CVE-2026-2635: MLflow Default Admin Credentials

### DIFF
--- a/http/cves/2026/CVE-2026-2635.yaml
+++ b/http/cves/2026/CVE-2026-2635.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-2635
+
+info:
+  name: MLflow - Default Admin Credentials
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    MLflow instances with basic authentication enabled use hardcoded default admin credentials (admin:password1234) in the basic_auth.ini configuration file. If these credentials are not changed after deployment, unauthenticated remote attackers can gain full admin access to the MLflow server, enabling experiment manipulation, model registry access, and potential remote code execution through model deserialization.
+  impact: |
+    Unauthenticated attackers can gain full admin access to MLflow servers, allowing manipulation of ML experiments, models, and potentially achieving remote code execution.
+  remediation: |
+    Change the default admin credentials in basic_auth.ini immediately after enabling authentication. Use strong, unique passwords.
+  reference:
+    - https://www.thehackerwire.com/mlflow-default-password-auth-bypass-leads-to-rce-cve-2026-2635/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2635
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-2635
+    cwe-id: CWE-1393
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"MLflow"
+    product: mlflow
+    vendor: lfprojects
+  tags: cve,cve2026,mlflow,default-login,unauth
+
+http:
+  - raw:
+      - |
+        GET /api/2.0/mlflow/users/get?username=admin HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46cGFzc3dvcmQxMjM0
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"is_admin"'
+          - '"username"'
+        condition: and


### PR DESCRIPTION
## Summary

Adds detection template for CVE-2026-2635 - MLflow instances with default admin credentials (admin:password1234) from basic_auth.ini configuration.

## Details

- **CVE:** CVE-2026-2635
- **Severity:** Critical (CVSS 9.8)
- **CWE:** CWE-1393 (Use of Default Password)
- **Product:** MLflow
- **Auth Required:** None (tests default credentials)

## Detection Method

1. Sends GET request to `/api/2.0/mlflow/users/get` with default Basic Auth credentials
2. Verifies successful authentication via HTTP 200 + JSON response with `is_admin` and `username` fields
3. Non-intrusive: read-only API call, no modification

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-2635
- https://www.thehackerwire.com/mlflow-default-password-auth-bypass-leads-to-rce-cve-2026-2635/