### PR TITLE
Add CVE-2026-1357: WordPress WPvivid Backup & Migration Unauthenticated RCE

### DIFF
--- a/http/cves/2026/CVE-2026-1357.yaml
+++ b/http/cves/2026/CVE-2026-1357.yaml
@@ -89,16 +89,13 @@ http:
         part: body
         words:
           - "wpvivid"
+          - "result"
+        condition: and
 
       - type: regex
         part: body
         regex:
-          - '"result"\s*:\s*"(failed|error|success)"'
-
-      - type: regex
-        part: body
-        regex:
-          - 'send_to_site|transfer|backup|decrypt|migration'
+          - '(?:send_to_site|transfer|decrypt|migration)'
 
       - type: word
         part: header


### PR DESCRIPTION
## CVE Details

- **CVE ID:** CVE-2026-1357
- **Severity:** Critical (CVSS 9.8)
- **Affected:** WPvivid Backup & Migration <= 0.9.123 (900K+ active installs)
- **CWE:** CWE-434 (Unrestricted Upload of File with Dangerous Type)
- **Attack Vector:** Unauthenticated, Network

## Description

Detects WordPress sites running vulnerable versions of the WPvivid Backup & Migration plugin. The vulnerability chains two flaws:

1. **Cryptographic fail-open:** `openssl_private_decrypt()` returns `false` for malformed RSA keys, which phpseclib interprets as a 16-byte null AES key
2. **Path traversal:** Unsanitized `name` parameter allows escaping the backup directory

This enables unauthenticated arbitrary PHP file upload and RCE via `/?wpvivid_action=send_to_site`.

## Detection Method

- Step 1: Version detection via `readme.txt` (Stable tag <= 0.9.123)
- Step 2: Verifies the vulnerable `send_to_site` action handler responds with JSON

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-1357
- https://plugins.trac.wordpress.org/changeset/3448386
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpvivid-backuprestore/