### PR TITLE
Add CVE-2026-2576: WordPress Business Directory Plugin Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-2576.yaml
+++ b/http/cves/2026/CVE-2026-2576.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-2576
+
+info:
+  name: WordPress Business Directory Plugin <= 6.4.2 - Unauthenticated SQL Injection
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The Business Directory Plugin for WordPress is vulnerable to time-based SQL injection via the payment parameter in all versions up to and including 6.4.2. The vulnerability is due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This allows unauthenticated attackers to extract sensitive information from the database.
+  impact: |
+    Unauthenticated attackers can extract sensitive database information including user credentials, payment data, and private content through time-based SQL injection.
+  remediation: |
+    Update Business Directory Plugin to version 6.4.3 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2576
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/business-directory-plugin
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-2576
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.component:"WordPress"
+    publicwww-query: "/wp-content/plugins/business-directory-plugin/"
+    product: business-directory-plugin
+    vendor: businessdirectoryplugin
+    fofa-query: body="/wp-content/plugins/business-directory-plugin"
+  tags: cve,cve2026,wordpress,wp-plugin,sqli,unauth
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/business-directory-plugin/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Business Directory"
+          - "Stable tag:"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - compare_versions(detected_version, "<= 6.4.2")
+
+    extractors:
+      - type: regex
+        part: body
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)Stable.tag:\s?([\w.]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable.tag:\s?([\w.]+)'


### PR DESCRIPTION
## CVE Details

- **CVE ID:** CVE-2026-2576
- **Severity:** High (CVSS 7.5)
- **Affected:** Business Directory Plugin <= 6.4.2
- **CWE:** CWE-89 (SQL Injection)
- **Attack Vector:** Unauthenticated, Network

## Description

Detects WordPress sites running vulnerable versions of the Business Directory Plugin. The plugin is vulnerable to time-based SQL injection via the `payment` parameter due to insufficient escaping and lack of prepared statement on the SQL query, allowing unauthenticated attackers to extract sensitive database information.

## Detection Method

Version detection via `readme.txt` (Stable tag <= 6.4.2). Verifies plugin identity through "Business Directory" keyword matching.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-2576
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/business-directory-plugin