### PR TITLE
Add CVE-2026-27180: MajorDoMo Supply Chain RCE via Update Poisoning

### DIFF
--- a/http/cves/2026/CVE-2026-27180.yaml
+++ b/http/cves/2026/CVE-2026-27180.yaml
@@ -42,6 +42,7 @@ http:
           - 200
           - 302
         condition: or
+        internal: true
 
   - raw:
       - |


### PR DESCRIPTION
## Summary
- **CVE:** CVE-2026-27180
- **CVSS:** 9.8 Critical
- **CWE:** CWE-494 (Download of Code Without Integrity Check)
- **Product:** MajorDoMo home automation
- **Auth Required:** None (unauthenticated)

Detection template for supply chain RCE via the saverestore module. Unauthenticated users can change the auto-update URL and trigger forced updates without SSL verification or integrity checking.

## References
- https://chocapikk.com/posts/2026/majordomo-revisited/
- https://nvd.nist.gov/vuln/detail/CVE-2026-27180