### PR TITLE
Add CVE-2026-24858: FortiOS FortiCloud SSO Auth Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-24858.yaml
+++ b/http/cves/2026/CVE-2026-24858.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-24858
+
+info:
+  name: FortiOS - FortiCloud SSO Authentication Bypass
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    An authentication bypass vulnerability (CWE-288) in Fortinet FortiOS, FortiManager, FortiAnalyzer, FortiWeb, and FortiProxy allows attackers with a FortiCloud account and a registered device to log in to separate devices registered to other users when FortiCloud SSO authentication is enabled. Affected versions include FortiOS 7.0.0-7.6.5, FortiManager 7.0.0-7.6.5, FortiAnalyzer 7.0.0-7.6.5, FortiProxy 7.0.0-7.6.4, and FortiWeb 7.4.0-8.0.3. This vulnerability is actively exploited in the wild and is listed in the CISA KEV catalog.
+  impact: |
+    Attackers can bypass authentication and gain unauthorized administrative access to Fortinet devices, allowing unauthorized firewall configuration changes, data exfiltration, and full device compromise.
+  remediation: |
+    Update FortiOS, FortiManager, FortiAnalyzer to version 7.6.6 or later. Update FortiProxy to version 7.6.5 or later. Update FortiWeb to version 8.0.4 or later. Disable FortiCloud SSO if not needed.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24858
+    - https://fortiguard.fortinet.com/psirt/FG-IR-26-060
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-24858
+    - https://www.fortinet.com/blog/psirt-blogs/analysis-of-sso-abuse-on-fortios
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24858
+    cwe-id: CWE-288
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: fortinet
+    product: fortios
+    shodan-query: http.html:"/remote/login" "xxxxxxxx"
+    fofa-query: body="/remote/login"
+  tags: cve,cve2026,fortinet,fortios,auth-bypass,cisa-kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login?redir=/ng"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "xxxxxxxx-xxxxx"
+
+      - type: word
+        part: body
+        words:
+          - "forticloud"
+          - "FortiCloud"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "/remote/login"
+          - "fortinet"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 301
+          - 302
+          - 403
+        condition: or


### PR DESCRIPTION
## Summary

Adds a nuclei template for CVE-2026-24858, which detects FortiOS instances with FortiCloud SSO enabled that are potentially vulnerable to the authentication bypass.

## Details

- **CVE:** CVE-2026-24858
- **Severity:** Critical (CVSS 9.8)
- **CWE:** CWE-288 (Authentication Bypass Using an Alternate Path or Channel)
- **CISA KEV:** Yes (added 2026-01-27)
- **Affected:** FortiOS 7.0.0-7.6.5, FortiManager 7.0.0-7.6.5, FortiAnalyzer 7.0.0-7.6.5, FortiProxy 7.0.0-7.6.4, FortiWeb 7.4.0-8.0.3

Attackers with a FortiCloud account and a registered device can log in to other devices registered to different users when FortiCloud SSO is enabled.

## Detection Logic

1. Requests the FortiOS login page at `/login?redir=/ng`
2. Identifies FortiOS by the characteristic `xxxxxxxx-xxxxx` Server header
3. Checks for FortiCloud SSO references in the login page body
4. Confirms FortiOS/Fortinet presence via additional body markers

This template identifies FortiOS instances with FortiCloud SSO enabled, flagging them as potentially vulnerable. Since the vulnerability requires FortiCloud SSO to be enabled, the presence of FortiCloud SSO references on the login page is a strong indicator.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-24858
- https://fortiguard.fortinet.com/psirt/FG-IR-26-060
- https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-24858