### PR TITLE
Add CVE-2026-1670: Honeywell CCTV Unauthenticated Account Takeover

### DIFF
--- a/http/cves/2026/CVE-2026-1670.yaml
+++ b/http/cves/2026/CVE-2026-1670.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-1670
+
+info:
+  name: Honeywell CCTV - Unauthenticated Account Takeover via Recovery Email Change
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Multiple Honeywell CCTV products are vulnerable to an unauthenticated API endpoint exposure (CWE-306) that allows a remote attacker to change the forgot-password recovery email address without authentication. Successful exploitation could lead to full account takeover and unauthorized access to camera feeds.
+  impact: |
+    An unauthenticated remote attacker can change the account recovery email address, leading to full account takeover, unauthorized access to camera feeds, modification of security settings, and potential lateral movement within the network.
+  remediation: |
+    Contact Honeywell support for firmware patches. Isolate CCTV devices from the internet. Place remote access devices behind VPNs and firewalls.
+  reference:
+    - https://www.cisa.gov/news-events/ics-advisories/icsa-26-048-04
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1670
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-1670
+    cwe-id: CWE-306
+  metadata:
+    verified: false
+    max-request: 2
+    shodan-query: http.title:"Honeywell" http.html:"camera"
+    fofa-query: title="Honeywell" && body="camera"
+  tags: cve,cve2026,honeywell,cctv,iot,unauth,ics,account-takeover
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ISAPI/System/deviceInfo"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Honeywell"
+          - "deviceName"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/ISAPI/Security/users"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "userName"
+          - "userLevel"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<userName>(.*?)</userName>'


### PR DESCRIPTION
## Summary
- Adds nuclei template for CVE-2026-1670
- Multiple Honeywell CCTV products are vulnerable to unauthenticated API endpoint exposure (CWE-306)
- Allows remote attacker to change the forgot-password recovery email without authentication
- CVSS 9.8 (Critical), CISA ICS Advisory ICSA-26-048-04
- Detects Honeywell CCTV web interface via ISAPI endpoints and checks for unauthenticated access to security user listing

## References
- https://www.cisa.gov/news-events/ics-advisories/icsa-26-048-04
- https://nvd.nist.gov/vuln/detail/CVE-2026-1670