### PR TITLE
Add CVE-2026-25548: InvoicePlane RCE via LFI and Log Poisoning

### DIFF
--- a/http/cves/2026/CVE-2026-25548.yaml
+++ b/http/cves/2026/CVE-2026-25548.yaml
@@ -1,0 +1,76 @@
+id: CVE-2026-25548
+
+info:
+  name: InvoicePlane <= 1.7.0 - Remote Code Execution via LFI and Log Poisoning
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    InvoicePlane version 1.7.0 and earlier is vulnerable to Remote Code Execution through a chained Local File Inclusion (LFI) and Log Poisoning attack. An authenticated administrator can manipulate the public_invoice_template setting to include arbitrary files, including poisoned log files containing PHP code, leading to arbitrary command execution on the server.
+  impact: |
+    An authenticated administrator can achieve remote code execution by injecting PHP code into log files and including them via the public_invoice_template setting, potentially leading to full server compromise.
+  remediation: |
+    Update InvoicePlane to version 1.7.1 or later which properly validates template paths.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25548
+    - https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-g6rw-m9mf-33ch
+    - https://github.com/InvoicePlane/InvoicePlane/commit/93622f2df88a860d89bfee56012cabb2942061d6
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2026-25548
+    cwe-id: CWE-98
+  metadata:
+    verified: false
+    max-request: 2
+    shodan-query: http.html:"InvoicePlane"
+    fofa-query: body="InvoicePlane"
+  tags: cve,cve2026,invoiceplane,lfi,rce,authenticated
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php/sessions/login"
+      - "{{BaseURL}}/sessions/login"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "InvoicePlane"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'InvoicePlane[^0-9]*([0-9]+\.[0-9]+\.[0-9]+)'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php/guest/view/invoice/test"
+      - "{{BaseURL}}/guest/view/invoice/test"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "InvoicePlane"
+          - "invoice"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+          - 302
+          - 404
+        condition: or


### PR DESCRIPTION
## Summary
- Adds nuclei template for CVE-2026-25548
- InvoicePlane <= 1.7.0 is vulnerable to Remote Code Execution through chained LFI and Log Poisoning
- Authenticated admin can manipulate `public_invoice_template` setting to include poisoned log files containing PHP code
- CVSS 9.1 (Critical), CWE-98
- Template detects InvoicePlane installations via login page and guest invoice endpoints for version fingerprinting

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-25548
- https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-g6rw-m9mf-33ch