### PR TITLE
Add CVE-2025-64328: FreePBX Endpoint Manager Command Injection

### DIFF
--- a/http/cves/2025/CVE-2025-64328.yaml
+++ b/http/cves/2025/CVE-2025-64328.yaml
@@ -1,0 +1,67 @@
+id: CVE-2025-64328
+
+info:
+  name: FreePBX Endpoint Manager - OS Command Injection
+  author: optimus-fulcria
+  severity: high
+  description: |
+    Sangoma FreePBX Endpoint Manager (filestore module) versions 17.0.2.36 through 17.0.2.x contain a post-authentication OS command injection vulnerability in the testconnection function's check_ssh_connect() method. An authenticated administrator can inject arbitrary shell commands through the unsanitized path parameter in the SSH connection testing functionality, which are executed with the privileges of the asterisk user. This vulnerability is actively exploited in the wild and is listed in the CISA KEV catalog.
+  impact: |
+    Authenticated attackers can execute arbitrary operating system commands as the asterisk user, leading to full server compromise, data theft, or lateral network movement.
+  remediation: |
+    Update the FreePBX filestore module to version 17.0.3 or later. Restrict access to the FreePBX Administration Control Panel via firewall rules.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-64328
+    - https://github.com/FreePBX/security-reporting/security/advisories/GHSA-vm9p-46mv-5xvw
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-64328
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2025-64328
+    cwe-id: CWE-78
+    cpe: cpe:2.3:a:sangoma:freepbx:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: sangoma
+    product: freepbx
+    shodan-query:
+      - http.title:"freepbx"
+      - http.favicon.hash:"-1908328911"
+      - http.favicon.hash:"1574423538"
+    fofa-query:
+      - title="freepbx administration"
+      - icon_hash="-1908328911"
+  tags: cve,cve2025,freepbx,sangoma,cmdi,cisa-kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin/config.php"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FreePBX"
+
+      - type: regex
+        part: body
+        regex:
+          - '(?i)freepbx.*(?:administration|admin)'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: freepbx-version
+        part: body
+        group: 1
+        regex:
+          - '(?i)FreePBX[^0-9]*([0-9]+\.[0-9]+\.[0-9]+)'


### PR DESCRIPTION
## Summary

Adds a nuclei template for CVE-2025-64328, which detects FreePBX instances potentially vulnerable to OS command injection in the filestore module's SSH connection test functionality.

## Details

- **CVE:** CVE-2025-64328
- **Severity:** High (CVSS 7.2 / CVSS 4.0: 8.6)
- **CWE:** CWE-78 (OS Command Injection)
- **CISA KEV:** Yes (added 2026-02-03)
- **Affected:** FreePBX filestore module 17.0.2.36 through 17.0.2.x
- **Fixed:** 17.0.3

The filestore module's `check_ssh_connect()` function passes unsanitized user input to `ssh2_exec()`, allowing authenticated administrators to inject arbitrary OS commands executed as the asterisk user.

## Detection Logic

1. Requests the FreePBX admin login page at `/admin/config.php`
2. Matches on FreePBX administration panel indicators
3. Extracts FreePBX version if available in the response

This is a detection-only template (non-intrusive) since the vulnerability requires authenticated access. It identifies FreePBX instances that should be checked for the vulnerable filestore module version.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2025-64328
- https://github.com/FreePBX/security-reporting/security/advisories/GHSA-vm9p-46mv-5xvw
- https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-64328