### PR TITLE
Add CVE-2019-19006: Sangoma FreePBX Remote Admin Auth Bypass

### DIFF
--- a/http/cves/2019/CVE-2019-19006.yaml
+++ b/http/cves/2019/CVE-2019-19006.yaml
@@ -83,7 +83,7 @@ http:
         name: version
         group: 1
         regex:
-          - '(?i)(?:FreePBX|framework)\s*[:\-v]?\s*(\d+\.\d+\.\d+\.\d+)'
+          - '(?i)(?:FreePBX|framework)\s*[:\-v]?\s*(\d+\.\d+\.\d+(?:\.\d+)?)'
         internal: true
         part: body
 


### PR DESCRIPTION
## Description
Adds a nuclei detection template for CVE-2019-19006, a remote admin authentication bypass in Sangoma FreePBX.

## CVE Details
- **CVE ID**: CVE-2019-19006
- **CVSS**: 9.8 (Critical)
- **CISA KEV**: Yes (added Feb 2026 - actively exploited)
- **Product**: Sangoma FreePBX
- **Affected versions**: 15.0.16.26 and below, 14.0.13.11 and below, 13.0.197.13 and below
- **CWE**: CWE-863 (Incorrect Authorization)

## Template Details
- Detection via FreePBX admin interface version extraction
- Checks `/admin/` and `/admin/config.php` endpoints
- Extracts FreePBX version string from response