### PR TITLE
Add CVE-2026-1581: WordPress wpForo Forum Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-1581.yaml
+++ b/http/cves/2026/CVE-2026-1581.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-1581
+
+info:
+  name: WordPress wpForo Forum <= 2.4.14 - Unauthenticated Time-Based SQL Injection
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The wpForo Forum plugin for WordPress is vulnerable to unauthenticated time-based blind SQL injection via the wpfob parameter in all versions up to and including 2.4.14. Insufficient escaping of user-supplied parameters and lack of preparation on existing SQL queries allows unauthenticated attackers to extract sensitive information from the database.
+  impact: |
+    Unauthenticated attackers can extract sensitive information from the WordPress database including user credentials, email addresses, and private content.
+  remediation: |
+    Update wpForo Forum plugin to version 2.4.15 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpforo/wpforo-forum-2414-unauthenticated-sql-injection
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1581
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-1581
+    cwe-id: CWE-89
+  metadata:
+    verified: false
+    max-request: 2
+    publicwww-query: "/wp-content/plugins/wpforo/"
+    product: wpforo
+    vendor: gvectors
+  tags: cve,cve2026,wordpress,wp-plugin,wpforo,sqli,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wpforo/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "wpForo"
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(detected_version, "<= 2.4.14")'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Description
Adds a nuclei detection template for CVE-2026-1581, an unauthenticated time-based SQL injection in the wpForo Forum plugin for WordPress.

## CVE Details
- **CVE ID**: CVE-2026-1581
- **CVSS**: 7.5 (High)
- **Product**: wpForo Forum WordPress plugin
- **Affected versions**: <= 2.4.14
- **CWE**: CWE-89 (SQL Injection)

## Template Details
- Detection via plugin readme.txt version check
- Verifies plugin presence and extracts stable tag version
- Version-based detection (verified: false)