### PR TITLE
Add CVE-2025-7384: WordPress Contact Form Entries PHP Object Injection

### DIFF
--- a/http/cves/2025/CVE-2025-7384.yaml
+++ b/http/cves/2025/CVE-2025-7384.yaml
@@ -1,0 +1,56 @@
+id: CVE-2025-7384
+
+info:
+  name: WordPress Database for Contact Form 7 <= 1.4.3 - Unauthenticated PHP Object Injection
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    The Database for Contact Form 7, WPforms, Elementor forms plugin for WordPress is vulnerable to unauthenticated PHP Object Injection via the get_lead_detail function in all versions up to and including 1.4.3. Unsafe deserialization of untrusted user input allows unauthenticated attackers to inject arbitrary PHP objects. Combined with a POP chain available via Contact Form 7, this can lead to arbitrary file deletion including wp-config.php, enabling full site takeover.
+  impact: |
+    Unauthenticated attackers can delete critical files such as wp-config.php on affected WordPress sites, leading to complete site compromise and administrative takeover.
+  remediation: |
+    Update the Database for Contact Form 7, WPforms, Elementor forms plugin to version 1.4.4 or later.
+  reference:
+    - https://zeropath.com/blog/cve-2025-7384-wordpress-contact-form-entries-php-object-injection
+    - https://github.com/advisories/GHSA-46v8-4jxx-4x39
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-7384
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-7384
+    cwe-id: CWE-502
+  metadata:
+    verified: false
+    max-request: 1
+    publicwww-query: "/wp-content/plugins/contact-form-entries/"
+    product: contact-form-entries
+    vendor: jesweb
+  tags: cve,cve2025,wordpress,wp-plugin,contact-form-7,deserialization,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/contact-form-entries/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Contact Form Entries"
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(detected_version, "<= 1.4.3")'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Description
Adds a nuclei detection template for CVE-2025-7384, an unauthenticated PHP Object Injection vulnerability in the Database for Contact Form 7, WPforms, Elementor forms plugin for WordPress.

## CVE Details
- **CVE ID**: CVE-2025-7384
- **CVSS**: 9.8 (Critical)
- **Product**: Database for Contact Form 7, WPforms, Elementor forms (70,000+ installs)
- **Affected versions**: <= 1.4.3
- **CWE**: CWE-502 (Deserialization of Untrusted Data)

## Template Details
- Detection via plugin readme.txt version check at `/wp-content/plugins/contact-form-entries/readme.txt`
- Version-based detection (verified: false)