### PR TITLE
Add CVE-2026-25938: FUXA Node-RED Unauthenticated RCE via JWT Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-25938.yaml
+++ b/http/cves/2026/CVE-2026-25938.yaml
@@ -11,7 +11,7 @@ info:
   remediation: |
     Update FUXA to version 1.2.11 or later which implements JWT token verification on proxied routes.
   reference:
-    - https://github.com/frangoteam/FUXA/security/advisories/GHSA-cvh3-wg5m-5xgv
+    - https://github.com/frangoteam/FUXA/security/advisories/GHSA-v4p5-w6r3-2x4f
     - https://nvd.nist.gov/vuln/detail/CVE-2026-25938
     - https://github.com/frangoteam/FUXA/commit/5e7679b
   classification:


### PR DESCRIPTION
## Description

Adds a nuclei template for CVE-2026-25938, a critical authentication bypass in FUXA SCADA/HMI platform versions 1.2.8 through 1.2.10.

## Vulnerability Details

- **CVE:** CVE-2026-25938
- **CVSS:** 9.5 (Critical)
- **CWE:** CWE-306 (Missing Authentication for Critical Function)
- **Product:** FUXA (frangoteam)
- **Affected Versions:** 1.2.8 - 1.2.10
- **Fixed Version:** 1.2.11

The application fails to verify JWT tokens on proxied routes to the Node-RED Admin API, allowing unauthenticated attackers to access the full Node-RED Admin API at `/nodered/flows` and deploy malicious flows containing arbitrary command execution logic via `child_process`.

## Detection Method

The template sends a GET request to `/nodered/flows` and checks if it returns a 200 response with JSON flow data, indicating that the Node-RED API is accessible without authentication.

## References

- https://github.com/frangoteam/FUXA/security/advisories/GHSA-cvh3-wg5m-5xgv
- https://nvd.nist.gov/vuln/detail/CVE-2026-25938
- https://github.com/frangoteam/FUXA/commit/5e7679b