### PR TITLE
Add CVE-2026-25939: FUXA Unauthenticated Scheduler Manipulation

### DIFF
--- a/http/cves/2026/CVE-2026-25939.yaml
+++ b/http/cves/2026/CVE-2026-25939.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-25939
+
+info:
+  name: FUXA 1.2.8-1.2.10 - Unauthenticated Scheduler Manipulation
+  author: optimus-fulcria
+  severity: high
+  description: |
+    FUXA SCADA/HMI platform versions 1.2.8 through 1.2.10 contain an authorization bypass vulnerability that allows unauthenticated remote attackers to create and modify arbitrary schedulers via the API. This can expose connected ICS/SCADA environments to follow-on actions including disruption of industrial processes.
+  impact: |
+    Unauthenticated remote attackers can create and modify schedulers in FUXA, potentially disrupting connected industrial control systems and SCADA processes.
+  remediation: |
+    Update FUXA to version 1.2.11 or later which implements proper authorization checks on scheduler endpoints.
+  reference:
+    - https://github.com/frangoteam/FUXA/security/advisories
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25939
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 8.2
+    cve-id: CVE-2026-25939
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"FUXA"
+    fofa-query: title="FUXA"
+    product: fuxa
+    vendor: frangoteam
+  tags: cve,cve2026,fuxa,scada,hmi,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/schedulers"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"name"'
+          - '"interval"'
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description

Adds a nuclei template for CVE-2026-25939, an authorization bypass vulnerability in FUXA SCADA/HMI platform versions 1.2.8 through 1.2.10.

## Vulnerability Details

- **CVE:** CVE-2026-25939
- **CVSS:** 8.2 (High)
- **CWE:** CWE-862 (Missing Authorization)
- **Product:** FUXA (frangoteam)
- **Affected Versions:** 1.2.8 - 1.2.10
- **Fixed Version:** 1.2.11

The application allows unauthenticated remote attackers to create and modify arbitrary schedulers via the `/api/schedulers` endpoint, exposing connected ICS/SCADA environments to follow-on actions.

## Detection Method

The template sends a GET request to `/api/schedulers` and checks if it returns a 200 response with scheduler JSON data, indicating that the scheduler API is accessible without authentication.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-25939
- https://github.com/frangoteam/FUXA/security/advisories