### PR TITLE
Add CVE-2026-2731: DynamicWeb Unauthenticated RCE via JobRunnerBackground

### DIFF
--- a/http/cves/2026/CVE-2026-2731.yaml
+++ b/http/cves/2026/CVE-2026-2731.yaml
@@ -14,7 +14,7 @@ info:
     - https://doc.dynamicweb.dev/documentation/fundamentals/dw10release/security-reports.html
     - https://nvd.nist.gov/vuln/detail/CVE-2026-2731
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
     cvss-score: 10.0
     cve-id: CVE-2026-2731
     cwe-id: CWE-22
@@ -40,12 +40,12 @@ http:
       - type: dsl
         name: webconfig-traversal
         dsl:
-          - 'status_code_1 == 200 && contains(body_1, "<connectionStrings>") && contains(body_1, "<configuration")'
+          - 'status_code_1 == 200 && contains(body_1, "<connectionStrings>") && contains(body_1, "<configuration") && contains(body_1, "appSettings")'
 
       - type: dsl
         name: winini-traversal
         dsl:
-          - 'status_code_2 == 200 && contains(body_2, "[extensions]")'
+          - 'status_code_2 == 200 && contains(body_2, "[extensions]") && contains(body_2, "[fonts]")'
 
     extractors:
       - type: regex


### PR DESCRIPTION
## Description

Adds detection template for CVE-2026-2731, a critical path traversal and RCE vulnerability in DynamicWeb CMS.

## Details

- **Severity**: Critical (CVSS 10.0)
- **CWE**: CWE-22 (Path Traversal)
- **Affected**: DynamicWeb 8 (all), DynamicWeb 9 < 9.19.7 / < 9.20.3
- **CAPEC**: CAPEC-650 (Upload Web Shell)

## Detection Method

Detects exposed `/Admin/Public/JobRunnerBackground.aspx` endpoint accessible without authentication. Matches DynamicWeb-specific content and ASP.NET headers to confirm the target platform.

## References

- https://doc.dynamicweb.dev/documentation/fundamentals/dw10release/security-reports.html
- https://nvd.nist.gov/vuln/detail/CVE-2026-2731