### PR TITLE
Add CVE-2026-26337: Alfresco Transform Service Path Traversal and SSRF

### DIFF
--- a/http/cves/2026/CVE-2026-26337.yaml
+++ b/http/cves/2026/CVE-2026-26337.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-26337
+
+info:
+  name: Alfresco Transform Service < 4.3.0 - Unauthenticated Path Traversal and SSRF
+  author: optimus-fulcria
+  severity: high
+  description: |
+    Alfresco Transformation Service (Enterprise) before 4.3.0 and Alfresco Community Transform Core before 5.3.0 contain an unauthenticated absolute path traversal vulnerability in the transform endpoint. An attacker can read arbitrary files from the server and perform server-side request forgery (SSRF) to access internal resources without authentication.
+  impact: |
+    Unauthenticated remote attackers can read sensitive files from the server filesystem and access internal network resources via SSRF through the transformation service.
+  remediation: |
+    Upgrade Alfresco Transformation Service to version 4.3.0 or later, or Alfresco Community Transform Core to version 5.3.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26337
+    - https://github.com/Alfresco/alfresco-transform-core
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2026-26337
+    cwe-id: CWE-36
+  metadata:
+    verified: false
+    max-request: 2
+    shodan-query: http.html:"T-Engine" port:8090
+    product: alfresco_transformation_service
+    vendor: hyland
+  tags: cve,cve2026,alfresco,hyland,lfi,ssrf,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /transform/config HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "transformOptions"
+          - "supportedDefaults"
+        condition: or
+        internal: true
+
+  - raw:
+      - |
+        GET /live HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "UP"
+
+    extractors:
+      - type: regex
+        part: header
+        regex:
+          - 'X-Application-Context:\s*(.+)'


### PR DESCRIPTION
## Description

Adds detection template for CVE-2026-26337, an unauthenticated path traversal and SSRF vulnerability in Alfresco Transformation Service.

## Details

- **Severity**: High (CVSS 8.2)
- **CWE**: CWE-36 (Absolute Path Traversal)
- **Affected**: Alfresco Transformation Service (Enterprise) < 4.3.0, Community Transform Core < 5.3.0
- **Researcher**: Piotr Bazydlo (@chudyPB) of watchTowr

## Detection Method

Two-step fingerprinting:
1. Checks `/transform/config` for transformation service configuration (confirms T-Engine)
2. Verifies service is running via `/live` health endpoint
3. Marked `verified: false` as full path traversal PoC not publicly available

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-26337
- https://github.com/Alfresco/alfresco-transform-core

Related CVEs in same advisory: CVE-2026-26338 (SSRF via argument injection), CVE-2026-26339 (RCE)