### PR TITLE
Add CVE-2026-2329: Grandstream GXP1600 Unauthenticated Stack Buffer Overflow RCE

### DIFF
--- a/http/cves/2026/CVE-2026-2329.yaml
+++ b/http/cves/2026/CVE-2026-2329.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-2329
+
+info:
+  name: Grandstream GXP1600 VoIP Phones - Unauthenticated Stack Buffer Overflow RCE
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Grandstream GXP1600 series VoIP phones running firmware versions prior to 1.0.7.81 are vulnerable to an unauthenticated stack-based buffer overflow in the /cgi-bin/api.values.get endpoint. The request parameter, which accepts a colon-delimited list of configuration identifiers, is processed using strcpy without proper bounds checking. This allows unauthenticated remote attackers to achieve remote code execution with root privileges.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary code with root privileges, enabling credential theft, call interception and eavesdropping, and full device compromise.
+  remediation: |
+    Upgrade firmware to version 1.0.7.81 or later for affected GXP1610, GXP1615, GXP1620, GXP1625, GXP1628, and GXP1630 models.
+  reference:
+    - https://www.rapid7.com/blog/post/ve-cve-2026-2329-critical-unauthenticated-stack-buffer-overflow-in-grandstream-gxp1600-voip-phones-fixed/
+    - https://github.com/rapid7/metasploit-framework/pull/20983
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2329
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-2329
+    cwe-id: CWE-121
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: "Grandstream GXP"
+  tags: cve,cve2026,grandstream,rce,buffer-overflow,voip,iot
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/cgi-bin/api.values.get"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: "request=68"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "GXP1"
+          - "Response"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '(?:GXP1[0-9]+)'


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2026-2329 (CVSS 9.8) - critical unauthenticated stack-based buffer overflow in Grandstream GXP1600 series VoIP phones
- Firmware < 1.0.7.81 vulnerable via `/cgi-bin/api.values.get` endpoint
- Metasploit module already available (rapid7/metasploit-framework#20983)
- Detection uses safe API query to confirm device model

## References
- https://www.rapid7.com/blog/post/ve-cve-2026-2329-critical-unauthenticated-stack-buffer-overflow-in-grandstream-gxp1600-voip-phones-fixed/
- https://nvd.nist.gov/vuln/detail/CVE-2026-2329