### PR TITLE
Add CVE-2026-22778: vLLM Remote Code Execution via Malicious Video URL

### DIFF
--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-22778
+
+info:
+  name: vLLM - Remote Code Execution via Malicious Video URL
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    vLLM versions 0.8.3 through 0.14.0 are vulnerable to a heap-based buffer overflow during video frame processing. When multimodal models process video content via the video_url parameter in /v1/chat/completions or /v1/invocations endpoints, a specially crafted JPEG2000-encoded video with a malicious cdef channel definition box triggers a heap overflow in the OpenCV/FFmpeg decoder. An initial information disclosure stage leaks heap addresses via PIL exception messages, enabling ASLR bypass and subsequent code execution through overwritten function pointers.
+  impact: |
+    Unauthenticated remote code execution on the vLLM inference server, enabling full server takeover, model exfiltration, and data theft.
+  remediation: |
+    Update to vLLM version 0.14.1 or later.
+  reference:
+    - https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22778
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-22778
+    cwe-id: CWE-122
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: http.html:"vllm"
+  tags: cve,cve2026,vllm,rce,ai,llm,buffer-overflow
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/version"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "version"
+
+      - type: regex
+        part: body
+        regex:
+          - '"version"\s*:\s*"0\.(8\.[3-9]|9\.[0-9]|1[0-3]\.[0-9]|14\.0)'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        group: 0
+        regex:
+          - '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2026-22778 (CVSS 9.8) - critical RCE in vLLM AI inference framework
- Heap-based buffer overflow during JPEG2000 video frame processing via /v1/chat/completions endpoint
- Affects vLLM versions 0.8.3 through 0.14.0, fixed in 0.14.1
- Template performs safe version detection via /version endpoint

## References
- https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
- https://nvd.nist.gov/vuln/detail/CVE-2026-22778