### PR TITLE
Add CVE-2026-1529: Keycloak Invitation Token JWT Signature Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-1529.yaml
+++ b/http/cves/2026/CVE-2026-1529.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-1529
+
+info:
+  name: Keycloak - Invitation Token JWT Signature Bypass
+  author: optimus-fulcria
+  severity: high
+  description: |
+    Keycloak versions prior to 26.1.0 contain an improper verification of cryptographic signature vulnerability in the organization invitation token parsing flow. The Organizations.parseInvitationToken function decodes JWT invitation tokens without verifying their cryptographic signatures. An attacker can modify the organization ID and target email within a legitimate invitation token's payload and re-encode it without the signing key, enabling unauthorized self-registration into any organization.
+  impact: |
+    An attacker with any valid invitation token can forge tokens to join arbitrary organizations, completely undermining Keycloak's organization trust model and potentially accessing sensitive resources.
+  remediation: |
+    Update Keycloak to version 26.1.0 or later.
+  reference:
+    - https://github.com/keycloak/keycloak/issues/46145
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1529
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2026-1529
+    cwe-id: CWE-347
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: redhat
+    product: keycloak
+    shodan-query: http.title:"Keycloak"
+  tags: cve,cve2026,keycloak,auth-bypass,jwt
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/realms/master/.well-known/openid-configuration"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "issuer"
+          - "authorization_endpoint"
+          - "token_endpoint"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"issuer"\s*:\s*"[^"]*keycloak[^"]*"'


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2026-1529 (CVSS 8.1) - JWT signature verification bypass in Keycloak < 26.1.0
- Organization invitation tokens parsed without cryptographic signature verification
- Template detects Keycloak instances via OpenID Connect discovery endpoint

## References
- https://github.com/keycloak/keycloak/issues/46145
- https://nvd.nist.gov/vuln/detail/CVE-2026-1529