### PR TITLE
Add CVE-2026-26980: Ghost CMS Content API SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-26980.yaml
+++ b/http/cves/2026/CVE-2026-26980.yaml
@@ -1,0 +1,73 @@
+id: CVE-2026-26980
+
+info:
+  name: Ghost CMS < 6.19.1 - SQL Injection in Content API
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Ghost CMS versions 3.24.0 through 6.19.0 contain a SQL injection vulnerability in the Content API. The slug filter parameter in the posts endpoint directly interpolates user input into SQL queries without parameterization, allowing unauthenticated attackers to read arbitrary data from the database via crafted filter values.
+  impact: |
+    An unauthenticated attacker can extract arbitrary data from the Ghost database including user credentials, API keys, and all content, potentially leading to full compromise of the CMS.
+  remediation: |
+    Upgrade Ghost CMS to version 6.19.1 or later which uses parameterized queries for slug filter ordering.
+  reference:
+    - https://github.com/TryGhost/Ghost/security/advisories/GHSA-w52v-v783-gw97
+    - https://github.com/TryGhost/Ghost/commit/30868d632b2252b638bc8a4c8ebf73964592ed91
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26980
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
+    cvss-score: 9.4
+    cve-id: CVE-2026-26980
+    cwe-id: CWE-89
+    cpe: cpe:2.3:a:ghost:ghost:*:*:*:*:*:node.js:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: ghost
+    product: ghost
+    framework: node.js
+    shodan-query:
+      - http.component:"Ghost"
+      - http.component:"ghost"
+    fofa-query: app="Ghost"
+  tags: cve,cve2026,ghost,ghostcms,sqli,unauth,vuln
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    host-redirects: true
+    max-redirects: 2
+
+    extractors:
+      - type: regex
+        name: api_key
+        part: body
+        group: 1
+        regex:
+          - "key[\"']?\\s*[:=]\\s*[\"']([0-9a-f]{26})[\"']"
+        internal: true
+
+  - raw:
+      - |
+        GET /ghost/api/content/posts/?key={{api_key}}&filter=slug:%5Btest%27,test%5D HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SQLITE_ERROR"
+          - "ER_PARSE_ERROR"
+          - "syntax error"
+          - "InternalServerError"
+        condition: or
+
+      - type: status
+        status:
+          - 500


### PR DESCRIPTION
Adds detection template for CVE-2026-26980 - SQL injection in Ghost CMS Content API via slug filter parameter.

- Unauthenticated SQL injection via `/ghost/api/content/posts/?filter=slug:[` endpoint
- Affects Ghost CMS 3.24.0 through 6.19.0, fixed in 6.19.1
- CVSS 9.4 Critical
- Reference: https://github.com/TryGhost/Ghost/security/advisories/GHSA-w52v-v783-gw97

**Detection approach:**
1. Extracts the Ghost Content API key from the target's homepage JavaScript (Content API keys are intentionally public per Ghost's design)
2. Sends a crafted `filter=slug:[test',test]` request that triggers a SQL syntax error on vulnerable instances
3. Matches on 500 status code with database error indicators (SQLITE_ERROR, ER_PARSE_ERROR)

**Vulnerability details:**
The `slugFilterOrder` function in `ghost/core/core/server/api/endpoints/utils/serializers/input/utils/slug-filter-order.js` directly concatenated user-supplied slug values into SQL `CASE WHEN` expressions without parameterization. Fixed in commit `30868d6` by switching to parameterized queries with bindings.