### PR TITLE
Add CVE-2026-26988: LibreNMS SQL Injection in ajax_table.php

### DIFF
--- a/http/cves/2026/CVE-2026-26988.yaml
+++ b/http/cves/2026/CVE-2026-26988.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-26988
+
+info:
+  name: LibreNMS <= 25.12.0 - SQL Injection via IPv6 Address Search
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    LibreNMS versions 25.12.0 and below contain a SQL injection vulnerability in the ajax_table.php endpoint. When processing IPv6 address searches, the application splits user input on the "/" delimiter via explode() and directly concatenates the prefix portion into the SQL query string without parameterization. An authenticated attacker can inject arbitrary SQL commands via the address parameter with search_type=ipv6, potentially leading to unauthorized data access or database manipulation.
+  impact: |
+    An authenticated attacker can execute arbitrary SQL queries against the database, potentially extracting sensitive information including user credentials, SNMP community strings, API tokens, and device configurations.
+  remediation: |
+    Upgrade LibreNMS to version 26.2.0 or later which uses parameterized queries for the prefix value.
+  reference:
+    - https://github.com/librenms/librenms/security/advisories/GHSA-h3rv-q4rq-pqcv
+    - https://github.com/librenms/librenms/commit/32f72bc1ab7e980e4070e826a89d0d36a5ba62dd
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26988
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-26988
+    cwe-id: CWE-89
+    cpe: cpe:2.3:a:librenms:librenms:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: librenms
+    product: librenms
+    shodan-query: http.title:"LibreNMS"
+    fofa-query: title="LibreNMS"
+  tags: cve,cve2026,librenms,sqli,authenticated,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>LibreNMS</title>"
+
+      - type: word
+        part: body
+        words:
+          - "csrf-token"
+          - "laravel_session"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2026-26988 - SQL injection in LibreNMS ajax_table.php via IPv6 address search
- The prefix portion of the address parameter is directly concatenated into SQL without parameterization
- Affects LibreNMS <= 25.12.0, fixed in 26.2.0
- CVSS 9.1 Critical (CWE-89)
- Passive detection via login page identification (authenticated vulnerability)

## References
- GHSA: https://github.com/librenms/librenms/security/advisories/GHSA-h3rv-q4rq-pqcv
- Fix commit: https://github.com/librenms/librenms/commit/32f72bc1ab7e980e4070e826a89d0d36a5ba62dd
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-26988