### PR TITLE
Add CVE-2026-27574: OneUptime RCE via Node.js Sandbox Escape

### DIFF
--- a/http/cves/2026/CVE-2026-27574.yaml
+++ b/http/cves/2026/CVE-2026-27574.yaml
@@ -1,0 +1,65 @@
+id: CVE-2026-27574
+
+info:
+  name: OneUptime < 10.0.0 - Remote Code Execution via Node.js Sandbox Escape
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    OneUptime monitoring platform versions prior to 10.0.0 contain a critical remote code execution vulnerability in the custom JavaScript monitor feature. The application uses Node.js's node:vm module (which is not a security mechanism) to execute user-supplied monitor code. An attacker can register an account via open registration (enabled by default), create a custom JavaScript monitor with a sandbox escape payload, and achieve full system compromise. The probe process runs with host networking and holds all sensitive cluster credentials in environment variables.
+  impact: |
+    Authenticated attackers with the lowest privilege level (ProjectMember) can escape the JavaScript sandbox and execute arbitrary OS commands, leading to full cluster compromise including access to database, Redis, and ClickHouse credentials.
+  remediation: |
+    Upgrade OneUptime to version 10.0.0 or later which replaces node:vm with the isolated-vm library.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27574
+    - https://github.com/OneUptime/oneuptime
+    - https://github.com/mbanyamer/CVE-2026-27574-OneUptime-RCE
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-27574
+    cwe-id: CWE-94
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: title:"OneUptime"
+    fofa-query: title="OneUptime"
+    product: oneuptime
+    vendor: oneuptime
+  tags: cve,cve2026,oneuptime,rce,sandbox-escape,code-injection
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/accounts/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "OneUptime"
+          - "accounts"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(detected_version, "< 10.0.0")'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: detected_version
+        group: 1
+        regex:
+          - '(?:version|Version|VERSION)["\s:=]+v?([0-9]+\.[0-9]+\.[0-9]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?:version|Version|VERSION)["\s:=]+v?([0-9]+\.[0-9]+\.[0-9]+)'


### PR DESCRIPTION
## Description

Adds a nuclei template for **CVE-2026-27574** (CVSS 9.9 Critical), a remote code execution vulnerability in OneUptime monitoring platform.

### Vulnerability Details

- **Product:** OneUptime < 10.0.0
- **Type:** Code Injection / Sandbox Escape (CWE-94)
- **Auth Required:** Low (ProjectMember - lowest role, open registration by default)
- **Impact:** Full cluster compromise (database, Redis, ClickHouse credentials exposed)

The custom JavaScript monitor feature uses Node.js `node:vm` module (not a security mechanism) to execute user-supplied code. Trivial sandbox escape via constructor chain grants access to `process` and `child_process` modules.

### Template Details

- Detection via `/accounts/login` endpoint fingerprinting
- Version comparison to identify vulnerable instances (< 10.0.0)
- Non-intrusive detection (no exploitation attempted)

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-27574
- https://github.com/OneUptime/oneuptime
- https://github.com/mbanyamer/CVE-2026-27574-OneUptime-RCE