### PR TITLE
Add CVE-2026-20045: Cisco Unified CM Unauthenticated RCE

### DIFF
--- a/http/cves/2026/CVE-2026-20045.yaml
+++ b/http/cves/2026/CVE-2026-20045.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-20045
+
+info:
+  name: Cisco Unified Communications Manager - Unauthenticated RCE
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Cisco Unified Communications Manager (Unified CM), Unified CM Session Management Edition (SME), Unified CM IM & Presence Service (IM&P), Unity Connection, and Webex Calling Dedicated Instance contain an unauthenticated remote code execution vulnerability. Improper validation of user-supplied input in HTTP requests to the web-based management interface allows an unauthenticated remote attacker to execute arbitrary commands on the underlying operating system with user-level access, then escalate to root privileges.
+  impact: |
+    Unauthenticated remote attackers can achieve root-level code execution on the Cisco UCM server, enabling complete system compromise, call interception, and network lateral movement.
+  remediation: |
+    Apply Cisco patches - upgrade Unified CM to 14SU5 or 15SU4. Release 12.5 has no fix available and requires migration.
+  reference:
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ise-unauth-rce-ZAd2GnJ6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20045
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
+    cvss-score: 8.6
+    cve-id: CVE-2026-20045
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"Cisco Unified"
+    fofa-query: title="Cisco Unified Communications Manager"
+    product: unified_communications_manager
+    vendor: cisco
+  tags: cve,cve2026,cisco,ucm,rce,unauth,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ccmadmin/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Cisco Unified"
+          - "Communications Manager"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(detected_version, ">= 12.5.0", "< 12.6.0") || compare_versions(detected_version, ">= 14.0.0", "< 14.5.0") || compare_versions(detected_version, ">= 15.0.0", "< 15.4.0")'
+
+      - type: status
+        status:
+          - 200
+          - 302
+        condition: or
+
+    extractors:
+      - type: regex
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)(?:version|Version|ver)["\s:=]+([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)(?:version|Version|ver)["\s:=]+([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)'


### PR DESCRIPTION
## Description

Adds a nuclei template for **CVE-2026-20045** (CVSS 8.6, CISA KEV), an unauthenticated remote code execution vulnerability in Cisco Unified Communications Manager.

### Vulnerability Details

- **Product:** Cisco Unified CM, CM SME, CM IM&P, Unity Connection, Webex Calling Dedicated Instance
- **Type:** OS Command Injection (CWE-78)
- **Auth Required:** None
- **CISA KEV:** Yes (actively exploited zero-day)
- **Impact:** Root-level code execution via privilege escalation

Improper validation of user-supplied input in HTTP requests to the web management interface allows unauthenticated attackers to execute arbitrary commands.

### Affected Versions

| Product | Vulnerable | Patched |
|---------|-----------|---------|
| Unified CM | 12.5 (no fix), 14.x, 15.x | 14SU5, 15SU4 |

### Template Details

- Version-based detection via `/ccmadmin/` admin interface
- Cisco UCM product fingerprinting
- Non-intrusive detection

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-20045
- https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ise-unauth-rce-ZAd2GnJ6