### PR TITLE
Add CVE-2026-27542: WooCommerce Wholesale Lead Capture Unauthenticated Privilege Escalation

### DIFF
--- a/http/cves/2026/CVE-2026-27542.yaml
+++ b/http/cves/2026/CVE-2026-27542.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-27542
+
+info:
+  name: WordPress WooCommerce Wholesale Lead Capture <= 1.17.8 - Unauthenticated Privilege Escalation
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    WooCommerce Wholesale Lead Capture plugin for WordPress in versions up to and including 1.17.8 is vulnerable to unauthenticated privilege escalation. The plugin fails to properly validate user role assignments during registration, allowing unauthenticated attackers to create accounts with arbitrary roles including administrator, leading to complete site takeover.
+  impact: |
+    Unauthenticated attackers can create administrator accounts and gain full control of the WordPress site, including the ability to modify content, install plugins, and access sensitive WooCommerce customer and payment data.
+  remediation: |
+    Update the WooCommerce Wholesale Lead Capture plugin to version 2.0.2 or later where user role validation has been addressed.
+  reference:
+    - https://wp-firewall.com/critical-privilege-escalation-in-woocommerce-wholesale-plugin-published-on-2026-02-22-cve-2026-27542-3/
+    - https://managed-wp.com/blogs/critical-privilege-escalation-in-woocommerce-wholesale-plugin-cve202627542-2026-02-22
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27542
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-27542
+    cwe-id: CWE-269
+  metadata:
+    verified: false
+    max-request: 1
+    publicwww-query: "plugins/woocommerce-wholesale-lead-capture/"
+    product: woocommerce-wholesale-lead-capture
+    vendor: rymera-web-co
+  tags: cve,cve2026,wordpress,wp,wp-plugin,woocommerce,privilege-escalation,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-wholesale-lead-capture/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Wholesale Lead Capture"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 1.17.8")'
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '(?i)Stable\s*tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-27542
- **Severity**: Critical (CVSS 9.8)
- **Product**: WooCommerce Wholesale Lead Capture WordPress Plugin
- **Affected Versions**: <= 1.17.8
- **Type**: Unauthenticated Privilege Escalation (CWE-269)

## Description
The WooCommerce Wholesale Lead Capture plugin fails to properly validate user role assignments during registration, allowing unauthenticated attackers to create accounts with arbitrary roles including administrator.

## References
- https://wp-firewall.com/critical-privilege-escalation-in-woocommerce-wholesale-plugin-published-on-2026-02-22-cve-2026-27542-3/
- https://nvd.nist.gov/vuln/detail/CVE-2026-27542