### PR TITLE
Add CVE-2025-12707: WordPress Library Management System Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-12707.yaml
+++ b/http/cves/2025/CVE-2025-12707.yaml
@@ -1,0 +1,56 @@
+id: CVE-2025-12707
+
+info:
+  name: WordPress Library Management System <= 3.2.1 - Unauthenticated SQL Injection
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The Library Management System plugin for WordPress in versions up to and including 3.2.1 is vulnerable to unauthenticated SQL injection via the 'bid' parameter due to insufficient escaping and lack of prepared statements. This allows unauthenticated attackers to extract sensitive information from the database including user credentials.
+  impact: |
+    Unauthenticated attackers can extract sensitive database contents including WordPress user credentials, student records, and library data through SQL injection.
+  remediation: |
+    Update the Library Management System plugin to version 3.3 or later.
+  reference:
+    - https://www.redpacketsecurity.com/cve-alert-cve-2025-12707-owthub-library-management-system/
+    - https://wp-firewall.com/securing-wordpress-library-plugin-against-sql-injection-published-on-2026-02-21-cve-2025-12707-2/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12707
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-12707
+    cwe-id: CWE-89
+  metadata:
+    verified: false
+    max-request: 1
+    publicwww-query: "plugins/library-management-system/"
+    product: library-management-system
+    vendor: owthub
+  tags: cve,cve2025,wordpress,wp,wp-plugin,sqli,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/library-management-system/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Library Management System"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 3.2.1")'
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '(?i)Stable\s*tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2025-12707
- **Severity**: High (CVSS 7.5)
- **Product**: Library Management System WordPress Plugin (owthub)
- **Affected Versions**: <= 3.2.1
- **Type**: Unauthenticated SQL Injection (CWE-89)

## Description
The Library Management System plugin for WordPress is vulnerable to SQL injection via the `bid` parameter due to insufficient escaping and lack of prepared statements. Unauthenticated attackers can extract sensitive database contents.

## References
- https://www.redpacketsecurity.com/cve-alert-cve-2025-12707-owthub-library-management-system/
- https://wp-firewall.com/securing-wordpress-library-plugin-against-sql-injection-published-on-2026-02-21-cve-2025-12707-2/