### PR TITLE
Add CVE-2025-12500: WooCommerce Checkout Manager Unauthenticated File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-12500.yaml
+++ b/http/cves/2025/CVE-2025-12500.yaml
@@ -1,0 +1,59 @@
+id: CVE-2025-12500
+
+info:
+  name: WordPress Checkout Field Manager for WooCommerce <= 7.8.1 - Unauthenticated File Upload
+  author: optimus-fulcria
+  severity: medium
+  description: |
+    The Checkout Field Manager (Checkout Manager) for WooCommerce plugin for WordPress in versions up to and including 7.8.1 is vulnerable to unauthenticated arbitrary file upload. The ajax_checkout_attachment_upload AJAX action lacks proper authorization checks, allowing unauthenticated attackers to upload files to the WordPress uploads directory. File types are limited to WordPress default allowed MIME types.
+  impact: |
+    Unauthenticated attackers can upload arbitrary files within WordPress allowed MIME types to the server, potentially leading to storage exhaustion or further exploitation when combined with other vulnerabilities.
+  remediation: |
+    Update the Checkout Field Manager for WooCommerce plugin to version 7.8.2 or later.
+  reference:
+    - https://www.tenable.com/cve/CVE-2025-12500
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woocommerce-checkout-manager
+    - https://wpscan.com/vulnerability/4dc72cd2-81d7-4a66-86bd-c9cfaf690eed/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12500
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-12500
+    cwe-id: CWE-434
+  metadata:
+    verified: false
+    max-request: 1
+    publicwww-query: "plugins/woocommerce-checkout-manager/"
+    product: woocommerce-checkout-manager
+    vendor: quadlayers
+  tags: cve,cve2025,wordpress,wp,wp-plugin,woocommerce,file-upload,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-checkout-manager/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Checkout"
+          - "WooCommerce"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 7.8.1")'
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '(?i)Stable\s*tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2025-12500
- **Severity**: Medium (CVSS 5.3)
- **Product**: Checkout Field Manager (Checkout Manager) for WooCommerce (QuadLayers)
- **Affected Versions**: <= 7.8.1
- **Type**: Unauthenticated Arbitrary File Upload (CWE-434)

## Description
The plugin's `ajax_checkout_attachment_upload` AJAX action lacks authorization checks, allowing unauthenticated file uploads limited to WordPress default MIME types.

## References
- https://www.tenable.com/cve/CVE-2025-12500
- https://wpscan.com/vulnerability/4dc72cd2-81d7-4a66-86bd-c9cfaf690eed/