### PR TITLE
Add CVE-2026-1868: GitLab AI Gateway SSTI Remote Code Execution

### DIFF
--- a/http/cves/2026/CVE-2026-1868.yaml
+++ b/http/cves/2026/CVE-2026-1868.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-1868
+
+info:
+  name: GitLab AI Gateway < 18.6.2 / < 18.7.1 / < 18.8.1 - Server-Side Template Injection RCE
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    GitLab AI Gateway (Duo Workflow Service) in versions 18.1.6, 18.2.6, 18.3.1 through 18.6.1, 18.7.0, and 18.8.0 is vulnerable to server-side template injection via crafted Duo Agent Platform Flow definitions. An authenticated attacker can inject template directives that are evaluated by the template engine, leading to remote code execution on the AI Gateway server.
+  impact: |
+    Authenticated attackers can execute arbitrary code on the GitLab AI Gateway server, potentially compromising the entire self-managed GitLab deployment including access to source code repositories and CI/CD pipelines.
+  remediation: |
+    Update GitLab AI Gateway to version 18.6.2, 18.7.1, or 18.8.1 or later. GitLab.com and GitLab Dedicated instances are already patched.
+  reference:
+    - https://about.gitlab.com/releases/2026/02/06/patch-release-gitlab-ai-gateway-18-8-1-released/
+    - https://github.com/advisories/GHSA-jfr3-cr47-9vqq
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1868
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-1868
+    cwe-id: CWE-1336
+  metadata:
+    verified: false
+    max-request: 2
+    shodan-query: "gitlab"
+    fofa-query: title="GitLab"
+    product: gitlab
+    vendor: gitlab
+  tags: cve,cve2026,gitlab,rce,ssti,ai-gateway
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}:8082/metrics"
+      - "{{BaseURL}}:8083/metrics"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "duo"
+          - "ai_gateway"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - 'version="([0-9.]+)"'


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-1868
- **Severity**: Critical (CVSS 9.9)
- **Product**: GitLab AI Gateway (Duo Workflow Service)
- **Affected Versions**: 18.1.6, 18.2.6, 18.3.1-18.6.1, 18.7.0, 18.8.0
- **Fixed Versions**: 18.6.2, 18.7.1, 18.8.1
- **Type**: Server-Side Template Injection (CWE-1336)

## Description
GitLab AI Gateway is vulnerable to SSTI via crafted Duo Agent Platform Flow definitions. Authenticated attackers can inject template directives leading to RCE.

## References
- https://about.gitlab.com/releases/2026/02/06/patch-release-gitlab-ai-gateway-18-8-1-released/
- https://github.com/advisories/GHSA-jfr3-cr47-9vqq