### PR TITLE
Add CVE-2026-0629: TP-Link VIGI IP Camera Authentication Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-0629.yaml
+++ b/http/cves/2026/CVE-2026-0629.yaml
@@ -23,7 +23,7 @@ info:
   metadata:
     verified: false
     max-request: 1
-    shodan-query: "VIGI" camera
+    shodan-query: '"VIGI" camera'
     fofa-query: title="VIGI"
     product: vigi
     vendor: tp-link


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-0629
- **Severity**: High (CVSS 8.8)
- **Product**: TP-Link VIGI Series IP Cameras (28+ models: Cx45, Cx55, Cx85, C340S, C540S, InSight)
- **Type**: Authentication Bypass via Client-Side Validation (CWE-287)
- **CISA Advisory**: ICSA-26-036-01

## Description
TP-Link VIGI cameras perform critical security checks only in the browser JavaScript for the password recovery feature, allowing adjacent network attackers to reset admin credentials without verification.

## References
- https://www.cisa.gov/news-events/ics-advisories/icsa-26-036-01
- https://www.vigi.com/us/support/faq/4906/