### PR TITLE
Add CVE-2026-2296: WordPress Product Addons for WooCommerce PHP Code Injection

### DIFF
--- a/http/cves/2026/CVE-2026-2296.yaml
+++ b/http/cves/2026/CVE-2026-2296.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-2296
+
+info:
+  name: WordPress Product Addons for WooCommerce <= 3.1.0 - PHP Code Injection via eval()
+  author: optimus-fulcria
+  severity: high
+  description: |
+    The Product Addons for WooCommerce plugin by Acowebs (versions up to and including 3.1.0) is vulnerable to PHP code injection. The evalConditions() function passes unsanitized user input from the operator field in conditional logic rules directly to PHP eval(), allowing authenticated attackers with Shop Manager-level access to execute arbitrary PHP code on the server.
+  impact: |
+    Authenticated attackers with Shop Manager role can execute arbitrary PHP code on the WordPress server, leading to complete site compromise.
+  remediation: |
+    Update Product Addons for WooCommerce to version 3.1.1 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2296
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/product-addons-woocommerce
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2026-2296
+    cwe-id: CWE-95
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: http.component:"WordPress"
+    publicwww-query: "/wp-content/plugins/product-addons-woocommerce/"
+    product: product-addons-woocommerce
+    vendor: acowebs
+    fofa-query: body="/wp-content/plugins/product-addons-woocommerce"
+  tags: cve,cve2026,wordpress,wp-plugin,woocommerce,code-injection
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/product-addons-woocommerce/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Product Addons"
+          - "Stable tag:"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - compare_versions(detected_version, "<= 3.1.0")
+
+    extractors:
+      - type: regex
+        part: body
+        name: detected_version
+        group: 1
+        regex:
+          - '(?i)Stable.tag:\s?([\w.]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable.tag:\s?([\w.]+)'


### PR DESCRIPTION
## Description

Adds nuclei template for CVE-2026-2296 - WordPress Product Addons for WooCommerce by Acowebs PHP code injection via eval() in evalConditions().

- **Product**: Product Addons for WooCommerce <= 3.1.0
- **Type**: PHP Code Injection (eval)
- **CVSS**: 7.2 High
- **CWE**: CWE-95
- **Detection**: Version-based detection via readme.txt

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-2296
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/product-addons-woocommerce