### PR TITLE
fix(CVE-2025-14847): add matchers-condition to prevent false positive…

### DIFF
--- a/javascript/cves/2025/CVE-2025-14847.yaml
+++ b/javascript/cves/2025/CVE-2025-14847.yaml
@@ -419,6 +419,7 @@ tcp:
     port: 27017
     read-size: 2048
 
+    matchers-condition: and
     matchers:
       - type: word
         part: raw


### PR DESCRIPTION
### PR Information

- Fixed CVE-2025-14847 TCP fallback matcher producing false positives on patched MongoDB versions
- The TCP section has two matchers (word check + version range DSL) but no `matchers-condition`, which defaults to OR in nuclei. This causes the word matcher to flag ANY MongoDB instance
regardless of version.
- Added `matchers-condition: and` so both matchers must pass: confirm it's MongoDB AND version is in vulnerable range.
- References: https://github.com/projectdiscovery/nuclei-templates/issues/15519

- Fixed CVE-2025-14847
- References:

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Reproduce false positive (before fix):
1. Run patched MongoDB 7.0.28: `docker run -d -p 27017:27017 mongo:7.0.28`
2. Scan: `nuclei -t CVE-2025-14847.yaml -u host:27017` → detected (false positive)

After fix:
1. MongoDB 7.0.28 (patched): `nuclei -t CVE-2025-14847.yaml -u host:27017` → not detected (correct)
2. MongoDB 8.0.0 (vulnerable): `nuclei -t CVE-2025-14847.yaml -u host:27018` → detected (correct)

Root cause:
TCP matchers default to OR without `matchers-condition`. The word matcher (`"version"` + `"maxBsonObjectSize"`) matches any MongoDB buildinfo response, bypassing the DSL version range check (`<= 7.0.27`, `<= 8.0.16`, etc.).

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

https://github.com/projectdiscovery/nuclei-templates/issues/15519