### PR TITLE
Add CVE-2025-27506 - NocoDB < 0.258.0 - Reflected XSS in Password Reset

### DIFF
--- a/http/cves/2025/CVE-2025-27506.yaml
+++ b/http/cves/2025/CVE-2025-27506.yaml
@@ -24,7 +24,7 @@ info:
     max-request: 1
     shodan-query: http.title:"NocoDB" || http.favicon.hash:"-1123780655"
     fofa-query: title="NocoDB" || body="nocodb"
-  tags: cve,cve2025,nocodb,xss,reflected
+  tags: cve,cve2025,nocodb,xss,reflected,unauth
 
 http:
   - method: GET


### PR DESCRIPTION
CVE-2025-27506 details the reflected XSS vulnerability in NocoDB versions before 0.258.0, including remediation steps and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
