### PR TITLE
Fixed flexnet-operations-panel false positive matcher

### DIFF
--- a/http/exposed-panels/flexnet-operations-panel.yaml
+++ b/http/exposed-panels/flexnet-operations-panel.yaml
@@ -2,7 +2,7 @@ id: flexnet-operations-panel
 
 info:
   name: FlexNet Operations Panel - Detect
-  author: righettod
+  author: righettod,s4e-io
   severity: info
   description: |
      FlexNet Operations was detected — a software monetization platform.
@@ -12,7 +12,11 @@ info:
   metadata:
     verified: true
     max-request: 1
+    vendor: flexera
+    product: flexnet_operations
     shodan-query: http.title:"FlexNet Login"
+    fofa-query: title="FlexNet Login"
+    google-query: intitle:"FlexNet Login"
   tags: panel,flexnet,login,detect
 
 http:
@@ -24,7 +28,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_all(to_lower(body), "flexnet", "login")'
+          - 'contains(to_lower(body), "flexnet login")'
         condition: and
 
     extractors:
@@ -33,4 +37,3 @@ http:
         group: 1
         regex:
           - 'ver=([0-9_.]+)'
-# digest: 4b0a00483046022100d7dc64cc7f264440433d0192f90bf8d80e3cd6b1a91a995ef302f059506ccd43022100c3fc87e9cb3a65213f3b5b14eaec1c46913131e089ee7fd9c6fa2ca485de859f:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

**Fix: `flexnet-operations-panel` — False Positive due to over-broad DSL matcher**

This PR fixes a confirmed false positive in the `flexnet-operations-panel` template.
The existing matcher `contains_all(to_lower(body), "flexnet", "login")` independently
checks for two generic words that can both appear on the response body of completely
unrelated hosts — resulting in incorrect detections, noisy reports, and wasted analyst
time. This fix requires zero additional requests and has no performance impact.

---

#### Root Cause

The template issues `GET /flexnet/logon.do`. When a non-FlexNet host receives this
request for an unknown path (e.g. **PRTG Network Monitor**), it returns HTTP `200 OK`
with its own login page while reflecting the original path in a hidden form field:

```html
<!-- PRTG reflects the requested path back into the page body -->
<input id="hiddenloginurl" type="hidden" name="loginurl" value="/flexnet/logon.do">

<!-- PRTG's own login form also contains the word "login" -->
<button class="loginbutton button big" type="submit">Log in</button>
```

Since `contains_all(..., "flexnet", "login")` checks for each word **independently**,
both conditions are satisfied simultaneously:

| Condition   | Source in PRTG body                         | Result               |
| ----------- | ------------------------------------------- | -------------------- |
| `"flexnet"` | `value="/flexnet/logon.do"` in hidden field | ✅ Match              |
| `"login"`   | Button text / form labels                   | ✅ Match              |
| **Overall** |                                             | ⚠️ **FALSE POSITIVE** |

This is a generic weakness: any host that redirects unknown paths to a login page and
reflects the original URL in the response body will trigger this template incorrectly.

---

#### Fix

Replace the two independent word checks with a single **combined phrase** match:

```diff
-  - 'contains_all(to_lower(body), "flexnet", "login")'
+  - 'contains(to_lower(body), "flexnet login")'
```

The phrase `"flexnet login"` appears in all real FlexNet pages as part of the HTML
`<title>` tag:

```html
<title>FlexNet Login</title>
```

This combined string is **never** present in redirect responses from unrelated products,
because those products reflect the path token (`/flexnet/logon.do`) but never produce
the human-readable product name `FlexNet Login` in their own markup.

---

#### Additional metadata enrichment

Standard fields missing from the original template have been added to align with the
current repository conventions used by similar panel templates:

| Field          | Value                     | Reason                             |
| -------------- | ------------------------- | ---------------------------------- |
| `vendor`       | `flexera`                 | Required by repo standard          |
| `product`      | `flexnet_operations`      | Required by repo standard          |
| `fofa-query`   | `title="FlexNet Login"`   | Discovery parity with shodan-query |
| `google-query` | `intitle:"FlexNet Login"` | Discovery parity                   |
| `author`       | added `s4e-io`            | Contributor attribution            |

---

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**✅ True Positive — Confirmed FlexNet Operations host (host information REDACTED)**

```
$ nuclei -t http/exposed-panels/flexnet-operations-panel.yaml \
         -u https://REDACTED -fhr -debug

[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1

[flexnet-operations-panel] Dumped HTTP request:

GET /flexnet/logon.do HTTP/1.1
Host: REDACTED
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) ...
Accept: */*

[flexnet-operations-panel] Dumped HTTP response:

HTTP/1.1 200 OK
Content-Type: text/html;charset=UTF-8
Server: jboss

<html>
<head>
<title>FlexNet Login</title>
...
<link rel="stylesheet" href="/flexnet/resources/operations/assets/css/pp-global.css?ver=17_2_0a">
...

[flexnet-operations-panel:dsl-1] [http] [info] https://REDACTED/flexnet/logon.do ["17_2_0"]
[INF] Scan completed in 655.645ms. 1 matches found.
```

**❌ False Positive eliminated — PRTG Network Monitor host (host information REDACTED)**

With the **old** template:
```
$ nuclei -t http/exposed-panels/flexnet-operations-panel.yaml \
         -u https://REDACTED -fhr -silent

[flexnet-operations-panel] [http] [info] https://REDACTED/public/login.htm?loginurl=%2Fflexnet%2Flogon.do&errorid=0
[INF] Scan completed. 1 matches found.   ← INCORRECT
```

With the **fixed** template:
```
$ nuclei -t http/exposed-panels/flexnet-operations-panel.yaml \
         -u https://REDACTED -fhr -silent

[INF] Scan completed. No results found.   ← CORRECT
```

---

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
- [FlexNet Operations Product Overview](https://resources.flexera.com/web/media/documents/Datasheet-FNO-Overview.pdf)
