### PR TITLE
Add CVE-2026-27645  Changedetection.io RSS Single Watch - Reflected XSS

### DIFF
--- a/http/cves/2026/CVE-2026-27645.yaml
+++ b/http/cves/2026/CVE-2026-27645.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-27645
 
 info:
-  name: Changedetection.io RSS Single Watch - Reflected XSS
+  name: Changedetection.io RSS Single Watch - Cross-Site Scripting
   author: 0x_Akoko
   severity: medium
   description: |
@@ -13,6 +13,7 @@ info:
   reference:
     - https://github.com/dgtlmoon/changedetection.io/security/advisories/GHSA-mw8m-398g-h89w
     - https://github.com/dgtlmoon/changedetection.io/commit/a385c89abf44b52fcfa20c7c6a6dd3047c4c1eb5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27645
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
@@ -32,7 +33,7 @@ flow: http(1) && http(2)
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     matchers:
       - type: dsl


### PR DESCRIPTION
Added CVE-2026-27645 entry detailing a reflected XSS vulnerability in changedetection.io.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
