### PR TITLE
Add missing Content-Type check and update charset specification matcher

### DIFF
--- a/http/misconfiguration/http-missing-security-headers.yaml
+++ b/http/misconfiguration/http-missing-security-headers.yaml
@@ -97,7 +97,7 @@ http:
           - "status_code != 301 && status_code != 302"
         condition: and
 
-            - type: dsl
+      - type: dsl
         name: missing-content-type
         dsl:
           - "!regex('(?i)^content-type:', header)"
@@ -111,4 +111,3 @@ http:
           - "!regex('(?i)^content-type:.*charset=', header)"
           - "status_code == 200"
         condition: and
-# digest: 4a0a004730450221009501511aaa9b56f04bfd197d04580e858e5320a6acc9c83b53a3d0f0885c72e8022028b7161b9946e275a7c36696f0cc2c8f54f886ff3a97b138aafe166090443e4e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This MR replaces the charset logic with a precise check that only flags text/html 200 responses missing charset. It also adds a separate check to detect responses missing the Content-Type header entirely.


