### PR TITLE
Add limesurvey-open-redirect

### DIFF
--- a/http/vulnerabilities/limesurvey/limesurvey-open-redirect.yaml
+++ b/http/vulnerabilities/limesurvey/limesurvey-open-redirect.yaml
@@ -31,6 +31,11 @@ http:
         regex:
           - '(?m)^(?:Location\s*?:\s*?)(?:https?://|//)(?:[a-zA-Z0-9\-_\.@]*)interact\.sh.*$'
 
+      - type: word
+        part: header
+        words:
+          - 'LS_AUTH_INIT'
+
       - type: status
         status:
           - 302


### PR DESCRIPTION
⏺ PR Information                

  - Added LimeSurvey Open Redirect via editorLink route (no CVE assigned yet)                                                                    
  - References: https://github.com/LimeSurvey/LimeSurvey/pull/4727
                                                                                                                                                 
  Template validation                                                                                                                          

  - [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
  - [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
