### PR TITLE
Add templates to detect credentials on remote spark gateways

### DIFF
--- a/http/exposures/configs/remote-spark-gateway-config.yaml
+++ b/http/exposures/configs/remote-spark-gateway-config.yaml
@@ -1,7 +1,7 @@
 id: remote-spark-gateway-config
 
 info:
-  name: Remote Spark Gateway Configuration - Detect
+  name: Remote Spark Gateway Configuration/Credentials - Exposure
   author: domwhewell-sage
   severity: medium
   description: Remote Spark Gateway config found via /gateway.conf.
@@ -14,9 +14,9 @@ info:
   metadata:
     verified: true
     max-request: 1
-    shodan-query: 'http.html:"SparkView"'
-    fofa-query: 'body="sparkview"'
-  tags: config,exposure,remote-spark,vuln
+    shodan-query: http.html:"SparkView"
+    fofa-query: body="sparkview"
+  tags: config,exposure,remote-spark
 
 http:
   - method: GET
@@ -25,13 +25,15 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: regex
-        condition: and
-        regex:
-          - 'credSSP\s*=\s*'
-          - 'html\s*=\s*'
-          - 'port\s*=\s*'
+      - type: dsl
+        dsl:
+          - 'regex("credSSP\s*=\s*", body) && regex("html\s*=\s*", body) && regex("port\s*=\s*", body)'
+          - 'regex("password\s*=\s*", body)'
+        condition: or
 
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'contains(content_type, "text/plain")'
+          - 'status_code == 200'
+          - '!contains_all(tolower(body), "<html", "<body")'
+        condition: and


### PR DESCRIPTION
### PR Information

Adding 2 templates to detect [remote spark gateway](https://www.remotespark.com/) configurations exposed to the internet. The credentials template extracts the config.html password and checks if remoteManagement is enabled. 

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->
```bash
> nuclei -u https://html.vulnsite.com -t ../github/nuclei-templates/http/exposures/configs/remote-spark-gateway-config.yaml -t ../github/nuclei-templates/http/exposures/configs/remote-spark-gateway-credential.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[INF] Current nuclei version: v3.7.0 (outdated)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 2
[WRN] Loading 2 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Templates clustered: 2 (Reduced 1 Requests)
[INF] [cluster-c200a0c591775333b5b78be1b25f2b0a3a5546f87372999d18c8472cd20220d3] Dumped HTTP request for https://html.vulnsite.com/gateway.conf

GET /gateway.conf HTTP/1.1
Host: html.vulnsite.com
User-Agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_2; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [cluster-c200a0c591775333b5b78be1b25f2b0a3a5546f87372999d18c8472cd20220d3] Dumped HTTP response https://html.vulnsite.com/gateway.conf

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Cf-Cache-Status: DYNAMIC
Cf-Ray: 9d78cff438d6ef59-LHR
Content-Type: text/plain; charset=UTF-8
Date: Thu, 05 Mar 2026 11:34:34 GMT
Feature-Policy: usb *
Last-Modified: Thu, 05 Mar 2026 11:34:34 GMT
Server: cloudflare
Set-Cookie: sv_cookieCORS=0aef8510213d74c0b74e5d9095615a37; Path=/; SameSite=None; Secure
Set-Cookie: sv_cookie=0aef8510213d74c0b74e5d9095615a37; Path=/
Set-Cookie: __cf_bm=cL3aadaXju7tjnYFP39aZKLch34Hw37GaNkh8czu.Oo-1772710474.91287-1.0.1.1-yuyVBQJZ0dVg17SvQs.IahtVxprzhYeVQWMEF_TMIhuzKK30nLti4eCEv7OJLGK5fG2aOkxb2Oj3HkK3JrF2innU5QhmE7X.1Fg3F2uS2Sz0waQAyjQOQhtMTbdzVEOE; HttpOnly; Secure; Path=/; Domain=vulnsite.com; Expires=Thu, 05 Mar 2026 12:04:34 GMT

#Thu Mar 23 12:33:52 UTC 2023
remoteManage=false
password=Password2026!
recording=0
cipherSuites=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_RSA_WITH_AES_256_CBC_SHA256, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384, TLS_DHE_DSS_WITH_AES_256_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_DHE_DSS_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256, TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384, TLS_DHE_DSS_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,  TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
mail.smtp.starttls.enable=false
plugin=com.example.www
logHttpHeader=true
copyTimeout=3000
sslProtocols=TLSv1, TLSv1.1, TLSv1.2
simpleFormatter=true
httpCookie=false
keepDays=3
port=443
html=C\:\\Program Files\\Remote Spark\\SparkGateway\\html\\
ssl=true
enableLookups=false
logfile=C\:\\Program Files\\Remote Spark\\SparkGateway\\logs\\gateway.log
remotefx=false
accessNotInList=false
directoryIndex=connect2site.html
app.id=190e8810-47ae-4175-8254-82d4ed45ecf6
buildTime=2022_11_06_01
credSSP=true
buildNumber=1017
printerDriver=Microsoft Print to PDF
tmpdir=D\:\\sparkview\\temp
mail.smtp.auth=false
recwarning=false
backlog=50
pluginFile=C\:\\Program Files\\Remote Spark\\SparkGateway\\ExamplePlugin.jar
[remote-spark-gateway-config:word-1] [http] [medium] https://html.vulnsite.com/gateway.conf
[remote-spark-gateway-config:status-2] [http] [medium] https://html.vulnsite.com/gateway.conf
[remote-spark-gateway-credential:word-1] [http] [high] https://html.vulnsite.com/gateway.conf ["remoteManage=false","password=Password2026!"]
[remote-spark-gateway-credential:dsl-2] [http] [high] https://html.vulnsite.com/gateway.conf ["remoteManage=false","password=Password2026!"]
[remote-spark-gateway-credential:status-3] [http] [high] https://html.vulnsite.com/gateway.conf ["remoteManage=false","password=Password2026!"]
[INF] Scan completed in 86.530951ms. 5 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
