### PR TITLE
Fix False Positive: public-tomcat-manager Matches Plesk Panels

### DIFF
--- a/http/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/http/exposed-panels/apache/public-tomcat-manager.yaml
@@ -2,7 +2,7 @@ id: public-tomcat-manager
 
 info:
   name: Apache Tomcat Manager Login Panel - Detect
-  author: Ahmed Sherif,geeknik,sinKettu
+  author: Ahmed Sherif,geeknik,sinKettu,s4e-io
   severity: info
   description: Apache Tomcat Manager login panel was detected.
   classification:
@@ -33,7 +33,7 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: response
+        part: header
         words:
           - "Apache Tomcat"
           - "Tomcat Manager"
@@ -44,4 +44,3 @@ http:
           - 401
           - 200
         condition: or
-# digest: 4b0a00483046022100b2c773376750c5b02fb74f01635719fe9ccbfff38bcf919c9344770cc00454f4022100ee4579fdafb6faf5df8cc853e8fab54a6efa6ae531d3c117199b7f473ba23533:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## 👉 Description

The `public-tomcat-manager` template frequently produces generic false positives against default control panels (like **Plesk Obsidian**) that include "Apache Tomcat" strings in their broad HTML bodies or footer sections as supported technologies. When running with follow redirects (`-fhr`), Nuclei hits the generic `/manager/html` path, receives read redirects to standard landing pages (which reply `200 OK`), matches the "Apache Tomcat" term in the general page markup, and falsely assumes it's a Tomcat Manager. 

**Changes made:**
- Changed match `part` from `response` (which covered the entire HTML body) to `header` to strictly search for the explicit "Apache Tomcat" or "Tomcat Manager" headers, specifically designed to catch the standard Basic/Realm WWW-Authenticate header strings returned by genuine Tomcat Managers.
- Removed arbitrary `digest` and updated `author` list.

Relates to #15561
Resolves #15561

## 📋 Checklist

- [x] I have read the [guidelines](https://github.com/projectdiscovery/nuclei-templates/blob/main/CONTRIBUTING.md)
- [x] I have ensured the template has no runtime errors (`nuclei -validate`)
- [x] I have successfully tested the template against a local or remote target 

## 📝 Test Details

**Tested on (False Positive Case):**
- URL: `https://REDACTED` (Plesk Obsidian default panel)
- Before the fix: Triggers `public-tomcat-manager` natively due to HTTP redirect and generic Plesk "Tomcat" body string (`part: response`)
- After the fix: Scans correctly without matching the Plesk landing page (`part: header`)
