### PR TITLE
Add CVE-2026-27944 for Nginx UI vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-27944.yaml
+++ b/http/cves/2026/CVE-2026-27944.yaml
@@ -11,7 +11,7 @@ info:
   remediation: |
     Upgrade to version 2.3.3 or later.
   reference:
-    - https://github.com/advisories/GHSA-4x88-6m79-q5g5
+    - https://github.com/advisories/GHSA-g9w5-qffc-6762
     - https://www.tenable.com/security/research/tra-2026-17
     - https://vulnerabletarget.com/VT-2026-27944
   classification:


### PR DESCRIPTION
CVE-2026-27944 details the vulnerability in Nginx UI that allows unauthenticated backup downloads with encryption key disclosure, including relevant metadata and HTTP request matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Add CVE-2026-27944
- References: https://vulnerabletarget.com/VT-2026-27944

All details include [vulnerabletarget.com/VT-2026-27944](https://vulnerabletarget.com/VT-2026-27944)
 
---

<img width="1076" height="176" alt="image" src="https://github.com/user-attachments/assets/565faca8-b4e0-4835-b5a7-025d3bfb6969" />
