### PR TITLE
Create leantime-detect.yaml

### DIFF
--- a/http/technologies/leantime-detect.yaml
+++ b/http/technologies/leantime-detect.yaml
@@ -13,28 +13,32 @@ info:
   metadata:
     vendor: leantime
     product: leantime
-    shodan-query:
-      - title:"Leantime"
+    shodan-query: title:"Leantime"
   tags: tech,leantime,detect
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/auth/login"
+
     matchers-condition: and
     matchers:
       - type: word
         words:
-          - '<title>Leantime</title>'
-          - 'leantime-version'
-          - 'Leantime'
-        condition: and
+          - 'content="Leantime'
+          - 'name="leantime-version'
+          - 'window.leantime.currentProject'
+          - '.leantimeLogo {'
+          - 'class="leantimeLogo'
+        condition: or
+
       - type: status
         status:
           - 200
+
     extractors:
-    - type: regex
-      name: version
-      group: 1
-      regex:
-        - '<meta name="leantime-version" content="(?<leantime_version>\d+\.\d+\.\d+)">'
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '<meta name="leantime-version" content="(?<leantime_version>\d+\.\d+\.\d+)">'


### PR DESCRIPTION
This nuclei templates:

* Detects a Leantime server, a project management system for non-project managers.

- References:

 https://github.com/Leantime/leantime

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Leantime Docker Container:**

1. Running the docker container:

`$ docker network create leantime-net`

`$ docker run -d -p 3306:3306 --network leantime-net \
-e MYSQL_ROOT_PASSWORD=321.qwerty \
-e MYSQL_DATABASE=leantime \
-e MYSQL_USER=admin \
-e MYSQL_PASSWORD=321.qwerty \
--name mysql_leantime mysql:5.7 --character-set-server=utf8 --collation-server=utf8_unicode_ci`

`$ docker run -d -p 80:80 --network leantime-net \
-e LEAN_DB_HOST=mysql_leantime \
-e LEAN_DB_USER=admin \
-e LEAN_DB_PASSWORD=321.qwerty \
-e LEAN_DB_DATABASE=leantime \
--name leantime leantime/leantime:latest`

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' leantime`

2. Register initial user information:

Access "http://<host_machine_IP_address>:8080/" and submit user information.

3. Deploy the Kali Linux on the Leantime Docker Network:

`$ docker run --rm --tty --interactive --name container_kali --network leantime-net kalilinux/kali-rolling:latest /bin/bash`

**Nuclei execution:**

`~/go/bin/nuclei -t leantime-detect.yaml -u "http://<host_machine_IP_address>:8080/" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="875" height="755" alt="image" src="https://github.com/user-attachments/assets/3572bf6e-3b03-42b3-a177-bae827d5ee71" />

<img width="1770" height="376" alt="image" src="https://github.com/user-attachments/assets/ae7563fd-5c1d-482f-a282-c3840daa5c8b" />
