### PR TITLE
Add detection of "YPAREO" login panel instances.

### DIFF
--- a/http/exposed-panels/ypareo-panel.yaml
+++ b/http/exposed-panels/ypareo-panel.yaml
@@ -29,7 +29,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>ypareo", "/net-ypareo/", "/netypareo/")'
+          - 'contains_any(to_lower(body), "<title>ypareo", "<title>NetYParéo")'
         condition: and
 
     extractors:


### PR DESCRIPTION
### PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **YPAREO**, an  Enterprise Resource Planning system developed by a French company. 

References:
- https://www.ypareo.com/legacy
- https://www.ymag.fr/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Template was developed and tested against the version **3.7.1** of nuclei.

### Additional Details (leave it blank if not applicable)

The Shodan query is into the template.

### Additional References:

None