### PR TITLE
fix(misconfig): restrict public-tomcat-manager matcher to header (False Positive)

### DIFF
--- a/http/exposed-panels/apache/public-tomcat-manager.yaml
+++ b/http/exposed-panels/apache/public-tomcat-manager.yaml
@@ -33,7 +33,7 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: response
+        part: header
         words:
           - "Apache Tomcat"
           - "Tomcat Manager"


### PR DESCRIPTION
## Description
This PR resolves a false positive issue where Plesk control panels and other web applications were being incorrectly flagged as exposed Tomcat Managers. 

The previous template used `part: response`, which caused the word matcher to trigger on harmless HTML footer text (e.g., "Powered by Apache Tomcat"). By restricting the matcher strictly to `part: header`, the template now correctly requires the authoritative `WWW-Authenticate` or server headers to trigger the alert.

Fixes #15561