### PR TITLE
Fix: False Positives in CVE-2002-1131 (SquirrelMail Fingerprint)

### DIFF
--- a/http/cves/2002/CVE-2002-1131.yaml
+++ b/http/cves/2002/CVE-2002-1131.yaml
@@ -1,4 +1,4 @@
-id: CVE-2002-1131 
+id: CVE-2002-1131
 
 info:
   name: SquirrelMail 1.2.6/1.2.7 - Cross-Site Scripting
@@ -14,11 +14,10 @@ info:
     - http://www.debian.org/security/2002/dsa-191
     - http://sourceforge.net/project/shownotes.php?group_id=311&release_id=110774
     - https://www.exploit-db.com/exploits/21811
-    - https://nvd.nist.gov/vuln/detail/CVE-2002-1131 
   classification:
     cvss-metrics: CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P
     cvss-score: 7.5
-    cve-id: CVE-2002-1131 
+    cve-id: CVE-2002-1131
     cwe-id: CWE-80
     epss-score: 0.03877
     epss-percentile: 0.88083


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
This PR updates the `CVE-2002-1131` (SquirrelMail 1.2.6/1.2.7 Cross-Site Scripting) nuclei template to address a significant False Positive issue. 

**Motivation:**
During our routine vulnerability scanning, we noticed that this template triggers False Positives against actual corporate assets or poorly-configured web endpoints (e.g., misconfigured proxies, custom SSO login portals, error default pages) that blindly echo back any user input appended to the URL as raw HTML content. Because the previous template solely relied on detecting the payload string (`</script><script>alert(document.domain)</script>`) alongside a `200 OK` status and a `text/html` header, these generic responses incorrectly triggered high-severity XSS alerts, even when the asset was completely unrelated to SquirrelMail.

**Solution Introduced:**
To improve the fidelity of the template and align with ProjectDiscovery best practices, a **Product Fingerprinting** matcher has been introduced.

```yaml
      - type: word
        part: body
        words:
          - "SquirrelMail"
        case-insensitive: true
```

By ensuring the underlying technology is explicitly identified within the response body footprint, this change completely eliminates false positives caused by generic reflection, while ensuring there are zero false negatives against legitimate vulnerable targets.

- Updated `http/cves/2002/CVE-2002-1131.yaml`
- References:
  - [NVD - CVE-2002-1131](https://nvd.nist.gov/vuln/detail/CVE-2002-1131)
  - [Exploit-DB 21811](https://www.exploit-db.com/exploits/21811)

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Prior to this update, a typical reflection scenario causing a False Positive looked like this:

| Request Payload Sent | Server Response Header | Server Response Body (RAW) |
| :--- | :--- | :--- |
| `GET /src/addressbook.php?%3C%... HTTP/1.1`<br>`Host: [REDACTED_CORPORATE_ASSET]` | `HTTP/1.1 200 OK`<br>`Server: nginx`<br>`Content-Type: text/html` | `...`<br>`<input value="/SIPManagement/servlet?</script><script>alert(document.domain)</script>=" name="lastUrl" type="hidden">`<br>`...` |

As observed above, the payload is blindly reflected back inside a hidden input field of a completely different application. Since the word **"SquirrelMail"** is missing, the new template successfully skips this junk endpoint.

**Debugging & Validation Flow:**

```bash
# 1. Validation against a known false positive endpoint
$ nuclei -t http/cves/2002/CVE-2002-1131.yaml -u https://[REDACTED_FALSE_POSITIVE] -fhr

[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 1.450s. No results found.  ✅ (False Positive Eliminated)

# 2. Validation against a real SquirrelMail environment (True Positive Target)
$ nuclei -t http/cves/2002/CVE-2002-1131.yaml -u https://[REDACTED_SQUIRRELMAIL_HOST] -fhr

[CVE-2002-1131] [http] [high] https://[REDACTED_SQUIRRELMAIL_HOST]/src/addressbook.php?...
[INF] Scan completed in 1.890s. 1 matches found.   ✅ (No False Negatives)
```

None of the prerequisites are obligatory; they are merely intended to speed the review process.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)