### PR TITLE
fix(exposures): add negative html matcher to laravel-env (False Positive)

### DIFF
--- a/http/exposures/configs/laravel-env.yaml
+++ b/http/exposures/configs/laravel-env.yaml
@@ -55,11 +55,9 @@ http:
           - "(?mi)^DB_(HOST|PASSWORD|DATABASE)="
         condition: or
 
-      - type: word
-        part: header
-        words:
-          - "text/html"
-        negative: true
+      - type: dsl
+        dsl:
+          - "!contains(tolower(content_type), 'text/html')"
 
       - type: status
         status:


### PR DESCRIPTION
## Description
This PR resolves a false positive in the `laravel-env.yaml` template. The previous logic was vulnerable to soft 404s and developer blogs where `.env` configurations were discussed in the HTML body. 

Added a negative matcher for `text/html` in the header to ensure the template only triggers on actual raw environment files.