### PR TITLE
Add 5 CVE-2025 detection templates

### DIFF
--- a/http/cves/2025/CVE-2025-22167.yaml
+++ b/http/cves/2025/CVE-2025-22167.yaml
@@ -1,0 +1,68 @@
+id: CVE-2025-22167
+
+info:
+  name: Atlassian Jira Software Data Center and Server - Path Traversal
+  author: CelebrityPunks
+  severity: high
+  description: |
+    Atlassian Jira Software Data Center and Server contain a path traversal vulnerability that allows an authenticated attacker with low privileges to write to any filesystem path writable by the Jira JVM process. The vulnerability was introduced in versions 9.12.0, 10.3.0, and persists in 11.0.0.
+  impact: |
+    Authenticated attackers with low privileges can perform arbitrary file writes on vulnerable Jira instances, potentially leading to data corruption, webshell implantation, or remote code execution when chained with other vulnerabilities.
+  remediation: |
+    Upgrade Jira Software Data Center and Server to versions 9.12.28, 10.3.12, or 11.1.0 or later.
+  reference:
+    - https://jira.atlassian.com/browse/JSWSERVER-26552
+    - https://securityonline.info/jira-path-traversal-flaw-cve-2025-22167-allows-arbitrary-file-write-on-server-data-center/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-22167
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 8.7
+    cve-id: CVE-2025-22167
+    cwe-id: CWE-22
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: atlassian
+    product: jira
+    shodan-query: http.component:"Atlassian Jira"
+    fofa-query: app="JIRA"
+  tags: cve,cve2025,jira,atlassian,path-traversal,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/secure/Dashboard.jspa"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Jira"
+          - "atlassian"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, ">= 9.12.0", "<= 9.12.27") || compare_versions(version, ">= 10.3.0", "<= 10.3.11") || compare_versions(version, ">= 11.0.0", "<= 11.0.0")'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)data-version="([0-9.]+)"'
+          - '(?i)"version":"([0-9.]+)"'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)data-version="([0-9.]+)"'
+          - '(?i)"version":"([0-9.]+)"'

--- a/http/cves/2025/CVE-2025-23921.yaml
+++ b/http/cves/2025/CVE-2025-23921.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-23921
+
+info:
+  name: WordPress Multi Uploader for Gravity Forms <= 1.1.3 - Unauthenticated Arbitrary File Upload
+  author: CelebrityPunks
+  severity: critical
+  description: |
+    The Multi Uploader for Gravity Forms plugin for WordPress is vulnerable to arbitrary file uploads due to missing file type validation in all versions up to and including 1.1.3. This makes it possible for unauthenticated attackers to upload arbitrary files including web shells on the affected site's server which may make remote code execution possible.
+  impact: |
+    Unauthenticated attackers can upload malicious web shells to the WordPress server using path traversal sequences, potentially leading to full remote code execution and complete site compromise.
+  remediation: |
+    Update Multi Uploader for Gravity Forms plugin to version 1.1.5 or later.
+  reference:
+    - https://www.txone.com/blog/wordpress-multi-uploader-plugin-exploitation/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/gf-multi-uploader/multi-uploader-for-gravity-forms-113-unauthenticated-arbitrary-file-upload
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-23921
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.0
+    cve-id: CVE-2025-23921
+    cwe-id: CWE-434
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: flavor
+    product: multi_uploader_for_gravity_forms
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/gf-multi-uploader/"
+    fofa-query: body="/wp-content/plugins/gf-multi-uploader/"
+  tags: cve,cve2025,wordpress,wp-plugin,file-upload,gf-multi-uploader,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/gf-multi-uploader/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Multi Uploader for Gravity Forms"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 1.1.3")'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'

--- a/http/cves/2025/CVE-2025-39601.yaml
+++ b/http/cves/2025/CVE-2025-39601.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-39601
+
+info:
+  name: WordPress Custom CSS, JS & PHP <= 2.4.1 - CSRF to Remote Code Execution
+  author: CelebrityPunks
+  severity: critical
+  description: |
+    The WPFactory Custom CSS, JS & PHP plugin for WordPress is vulnerable to Cross-Site Request Forgery in all versions up to and including 2.4.1. This is due to missing nonce validation on the settings form. This makes it possible for unauthenticated attackers to inject arbitrary PHP code via a forged request granted they can trick an administrator into performing an action such as clicking a link, leading to remote code execution.
+  impact: |
+    Attackers can inject arbitrary PHP code into the WordPress site that executes automatically on every page load via the plugins_loaded hook, achieving persistent remote code execution and complete site compromise.
+  remediation: |
+    Update the Custom CSS, JS & PHP plugin to version 2.4.2 or later.
+  reference:
+    - https://github.com/Nxploited/CVE-2025-39601
+    - https://patchstack.com/database/wordpress/plugin/custom-css/vulnerability/wordpress-custom-css-js-php-plugin-2-4-1-csrf-to-rce-vulnerability
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-39601
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+    cvss-score: 9.6
+    cve-id: CVE-2025-39601
+    cwe-id: CWE-352
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: wpfactory
+    product: custom_css_js_php
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/custom-css/"
+    fofa-query: body="/wp-content/plugins/custom-css/"
+  tags: cve,cve2025,wordpress,wp-plugin,csrf,rce,custom-css,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/custom-css/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Custom CSS, JS & PHP"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 2.4.1")'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'

--- a/http/cves/2025/CVE-2025-66039.yaml
+++ b/http/cves/2025/CVE-2025-66039.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-66039
+
+info:
+  name: FreePBX - Authentication Bypass via Forged Authorization Header
+  author: CelebrityPunks
+  severity: critical
+  description: |
+    FreePBX contains an authentication bypass vulnerability when the Authorization Type is set to webserver. An attacker can send a request with a valid username in the Authorization header, and FreePBX initializes a session for that user without verifying the password, allowing complete bypass of the authentication mechanism.
+  impact: |
+    Unauthenticated attackers can bypass authentication to gain full administrator access to the FreePBX management interface, potentially leading to complete PBX system compromise when chained with SQL injection and file upload vulnerabilities.
+  remediation: |
+    Upgrade to FreePBX versions 16.0.42, 16.0.92, 17.0.6, or 17.0.22 or later.
+  reference:
+    - https://horizon3.ai/attack-research/the-freepbx-rabbit-hole-cve-2025-66039-and-others/
+    - https://thehackernews.com/2025/12/freepbx-authentication-bypass-exposed.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-66039
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.3
+    cve-id: CVE-2025-66039
+    cwe-id: CWE-287
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: sangoma
+    product: freepbx
+    shodan-query: http.title:"FreePBX"
+    fofa-query: app="FreePBX"
+  tags: cve,cve2025,freepbx,auth-bypass,vuln
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /admin/config.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - 'status_code == 401 || contains(body, "PHP_AUTH_USER") || contains(body, "Authorization")'
+
+  - raw:
+      - |
+        GET /admin/config.php HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46YWRtaW4=
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "FreePBX"
+          - "freepbx"
+          - "config.php"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "PHPSESSID") || contains(header, "Set-Cookie")'
+        condition: and

--- a/http/cves/2025/CVE-2025-7384.yaml
+++ b/http/cves/2025/CVE-2025-7384.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-7384
+
+info:
+  name: WordPress Database for Contact Form 7 <= 1.4.3 - Unauthenticated PHP Object Injection
+  author: CelebrityPunks
+  severity: critical
+  description: |
+    The Database for Contact Form 7, WPforms, Elementor forms plugin for WordPress is vulnerable to PHP Object Injection in all versions up to and including 1.4.3 via deserialization of untrusted input in the get_lead_detail function. This makes it possible for unauthenticated attackers to inject a PHP Object. The additional presence of a POP chain in the Contact Form 7 plugin allows attackers to delete arbitrary files on the server including wp-config.php, which can lead to remote code execution via site re-installation.
+  impact: |
+    Unauthenticated attackers can exploit unsafe deserialization to delete critical files like wp-config.php, enabling WordPress reinstallation under attacker control and leading to full site compromise and remote code execution.
+  remediation: |
+    Update Database for Contact Form 7 plugin to version 1.4.4 or later and audit the database for any previously injected malicious serialized objects.
+  reference:
+    - https://hadrian.io/blog/cve-2025-7384-critical-wordpress-plugin-unauthenticated-rce
+    - https://zeropath.com/blog/cve-2025-7384-wordpress-contact-form-entries-php-object-injection
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-7384
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-7384
+    cwe-id: CWE-502
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: flavor
+    product: contact_form_entries
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/contact-form-entries/"
+    fofa-query: body="/wp-content/plugins/contact-form-entries/"
+  tags: cve,cve2025,wordpress,wp-plugin,php-object-injection,deserialization,contact-form-entries,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/contact-form-entries/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Contact Form Entries"
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 1.4.3")'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+        internal: true
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'


### PR DESCRIPTION
## Summary

Adding detection templates for 5 recent CVE-2025 vulnerabilities that are currently missing from the repository:

- **CVE-2025-23921** (Critical, CVSS 9.0): WordPress Multi Uploader for Gravity Forms <= 1.1.3 - Unauthenticated arbitrary file upload via missing file type validation. Actively exploited in the wild.
- **CVE-2025-66039** (Critical, CVSS 9.3): FreePBX authentication bypass via forged Basic Authorization header when webserver auth type is configured. Chains to RCE.
- **CVE-2025-22167** (High, CVSS 8.7): Atlassian Jira Software Data Center and Server path traversal allowing authenticated users to write arbitrary files via the JVM process.
- **CVE-2025-39601** (Critical, CVSS 9.6): WordPress Custom CSS, JS & PHP plugin <= 2.4.1 - CSRF to RCE via missing nonce validation on PHP code settings form.
- **CVE-2025-7384** (Critical, CVSS 9.8): WordPress Database for Contact Form 7 <= 1.4.3 - Unauthenticated PHP object injection via unsafe deserialization in get_lead_detail. 70,000+ sites affected.

## Detection approach

- WordPress plugins: Version-based detection via readme.txt with `compare_versions` to avoid false positives
- FreePBX: Two-step flow checking for auth requirement then testing bypass with forged Authorization header
- Jira: Version extraction from Dashboard page with range-based version comparison for affected versions

## References

Each template includes references to NVD, vendor advisories, and security research writeups.

## Test plan

- [ ] Validate YAML syntax with `nuclei -validate`
- [ ] Test against known vulnerable instances or docker environments
- [ ] Verify no false positives on patched versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)