### PR TITLE
http/misconfiguration: add GraphiQL exposure template

### DIFF
--- a/http/misconfiguration/graphql/graphiql-exposure.yaml
+++ b/http/misconfiguration/graphql/graphiql-exposure.yaml
@@ -4,12 +4,13 @@ info:
   name: GraphiQL - Exposure
   author: Vincent Olagbemide
   severity: low
-  description: Detects publicly exposed GraphiQL consoles.
+  description: |
+    Detected publicly exposed GraphiQL consoles.
   reference:
     - https://github.com/graphql/graphiql
   metadata:
     verified: true
-    max-request: 5
+    max-request: 6
     shodan-query: html:"GraphiQL"
   tags: misconfig,graphql,graphiql,exposure
 
@@ -25,6 +26,7 @@ http:
 
     redirects: true
     max-redirects: 2
+
     stop-at-first-match: true
 
     matchers-condition: and


### PR DESCRIPTION
Fixes #15614

### PR Information

- Added GraphiQL exposure template
- References:
  - https://github.com/graphql/graphiql

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

- Template path:
  - `http/misconfiguration/graphql/graphql-graphiql-exposure.yaml`
- Validation:
  - `nuclei -validate -t http/misconfiguration/graphql/graphql-graphiql-exposure.yaml`
- Checked repository before contribution:
  - Existing technology detection found at `http/technologies/graphiql-detect.yaml`
  - No dedicated misconfiguration / exposure template for GraphiQL was found
- Detection is low-noise and GET-only
- Matchers require:
  - HTTP 200
  - `text/html` content
  - GraphiQL-specific markers such as:
    - `graphiql.createFetcher`
    - `GraphiQL`
    - `id="graphiql"`
    - `id='graphiql'`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)