### PR TITLE
fix(mercurial-hgignore): add text/xml and <?xml to negative matchers to prevent false positive detection

### DIFF
--- a/http/exposures/configs/mercurial-hgignore.yaml
+++ b/http/exposures/configs/mercurial-hgignore.yaml
@@ -2,7 +2,7 @@ id: mercurial-hgignore
 
 info:
   name: Mercurial Ignore - File Disclosure
-  author: DhiyaneshDK
+  author: DhiyaneshDK,s4e-io
   severity: info
   description: Mercurial Ignore file disclosure was detected.
   reference:
@@ -46,7 +46,8 @@ http:
           - "<meta"
           - "image/"
           - "Response xmlns="
+          - "text/xml"
+          - "<?xml"
         part: response
         negative: true
         condition: or
-# digest: 4a0a00473045022100fe9447d2915fd8ad78ef764fb01d09f4777ce327d1f1356ff2d672b23d79fee302207eecf39654a377a040815c0ebd40fc23775edd5ab7506b523eaf1e7973a54a46:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Fixed `mercurial-hgignore` — Template produces false positives on hosts that return `HTTP 200` with an XML response body for all requests, including non-existent paths like `/.hgignore`

**What changed and why:**

The negative word matcher was designed to exclude responses that clearly do not represent a real `.hgignore` file — HTML pages, JavaScript, JSON, images, etc. However, the exclusion list did not account for **XML responses**, which are commonly returned by non-Mercurial applications as generic error or session-expiry messages.

As a result, any host that:

1. Returns `HTTP 200` at `/.hgignore` (status check passes via DSL matcher), AND
2. Returns a response body longer than 50 bytes (length check passes via DSL matcher), AND
3. Does **not** contain any of the existing exclusion strings in its response

...would incorrectly trigger the finding — regardless of whether the response contains actual `.hgignore` content.

**Root cause:**

The affected hosts return a generic XML error response for **all** requests, including paths that do not exist on the server. The existing negative matcher did not include `text/xml` or `<?xml`, which are the two reliable indicators of an XML response:

| Indicator | Location in Response | Present in FP Case |
|---|---|---|
| `text/xml` | `Content-Type` header | ✅ `Content-Type: text/xml;charset=utf-8` |
| `<?xml` | Response body | ✅ Body starts with `<?xml version="1.0"` |

Neither of these strings will ever appear in a legitimate `.hgignore` file:

- **`<?xml`** — XML declaration syntax. `.hgignore` is a plain-text pattern file; it never contains XML.
- **`text/xml`** — A MIME type string containing a forward slash (`/`), which is a path separator and cannot appear as a valid filename pattern in a Mercurial ignore file.

**Fix applied:**

Added `text/xml` and `<?xml` to the existing negative word matcher list.

```yaml
# Before
- "Response xmlns="

# After
- "Response xmlns="
- "text/xml"
- "<?xml"
```

- References:
  - https://swcarpentry.github.io/hg-novice/08-ignore/
  - https://www.mercurial-scm.org/wiki/TutorialIgnore

---

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**False Positive — `nuclei -debug` output before fix (host info redacted per contribution guidelines)**

The targets below are **not running Mercurial**. They are different applications that return `HTTP 200` with a generic XML error body for all requests, including `/.hgignore`. Both the DSL matcher and the negative word matcher passed incorrectly because `text/xml` and `<?xml` were absent from the exclusion list.

The finding IDs `[mercurial-hgignore:dsl-1]` and `[mercurial-hgignore:word-2]` confirm both matchers fired.

```
GET /.hgignore HTTP/1.1
Host: [REDACTED]

HTTP/1.1 200 OK
Content-Type: text/xml;charset=utf-8
Content-Length: 183

<?xml version="1.0" encoding="UTF-8" ?>
<Response>
  <retcode>-2</retcode>
  <desc>[REDACTED]</desc>
  <errorCode>[REDACTED]</errorCode>
</Response>

[mercurial-hgignore:dsl-1] [http] [info] https://[REDACTED]/.hgignore
[mercurial-hgignore:word-2] [http] [info] https://[REDACTED]/.hgignore
[INF] Scan completed in 849ms. 2 matches found.
```

**After fix — same host, false positive eliminated:**

```
[INF] Scan completed in 826ms. 0 matches found.
```

**Summary:**

| Scenario | Before Fix | After Fix |
|---|---|---|
| Non-Mercurial host returning `HTTP 200 + text/xml` at `/.hgignore` | ❌ False Positive | ✅ No finding |
| Host serving a real `.hgignore` file | ✅ True Positive | ✅ True Positive |

**Real `.hgignore` content example (confirmed true positive — public Shodan result):**

```
syntax: glob
.DS_Store
.htaccess
._*
*.orig
syntax: regexp
^assets\/components$
^core$
```

A real `.hgignore` file contains only plain-text glob/regexp patterns. It will never contain `text/xml` or `<?xml`.

**nuclei version:** v3.7.0

---

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
