### PR TITLE
Create rustfs-detect.yaml

### DIFF
--- a/http/technologies/rustfs-detect.yaml
+++ b/http/technologies/rustfs-detect.yaml
@@ -13,21 +13,22 @@ info:
   metadata:
     vendor: rustfs
     product: rustfs
-    shodan-query:
-      - title:"RustFS"
+    shodan-query: title:"RustFS"
   tags: tech,rustfs,rustfs,detect
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/rustfs/console/auth/login"
+
     matchers-condition: and
     matchers:
       - type: word
         words:
           - '<title>RustFS</title>'
-          - 'rustfs'
-        condition: and
+          - 'title":"RustFS'
+          - '/rustfs/console/_nuxt'
+        condition: or
 
       - type: status
         status:


### PR DESCRIPTION
This nuclei templates:

* Detects a Rustfs server, a high-performance, distributed object storage system built in Rust.

- References:

 https://github.com/rustfs/rustfs

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Rustfs Docker Container:**

1. Running the docker container:

`$ mkdir -p data logs`

`$ sudo chown -R 10001:10001 data logs`

`$ docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs --name rustfs_container rustfs/rustfs:latest`

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' rustfs_container`

**Nuclei execution:**

`~/go/bin/nuclei -t rustfs-detect.yaml -u "http://<obtained_IP_Address>:9001/" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="700" height="534" alt="image" src="https://github.com/user-attachments/assets/4ab94118-1ab9-4162-922c-d045a76d174d" />

<img width="1433" height="285" alt="image" src="https://github.com/user-attachments/assets/785a1790-2a50-4013-a979-060b1928255f" />
