### PR TITLE
Create Google Gemini API Key Check

### DIFF
--- a/http/exposures/tokens/google/google-gemini-key-exposure.yaml
+++ b/http/exposures/tokens/google/google-gemini-key-exposure.yaml
@@ -1,11 +1,11 @@
-id: google-api-key-exposure
+id: google-gemini-key-exposure
 
 info:
-  name: Google API Key - Gemini Files API Exposure
+  name: Google Gemini API Key - Exposure
   author: Mestizo
   severity: high
   description: |
-    Detects exposed Google API keys and verifies access to the Gemini Files API endpoint.Exploitation can result in unauthorized data exposure, quota exhaustion, and potential financial loss.
+    Detects exposed Google API keys and verifies access to the Gemini Files API endpoint. Exploitation can result in unauthorized data exposure, quota exhaustion, and potential financial loss.
   metadata:
     max-request: 2
     verified: true


### PR DESCRIPTION
### PR Information

When the Gemini API (Generative Language API) is enabled on a Google Cloud project, existing API keys in that project can silently gain access to sensitive Gemini endpoints.    When you create a new API key in Google Cloud, it defaults to "Unrestricted," meaning it's immediately valid for every enabled API in the project, including Gemini.

- References: https://trufflesecurity.com/blog/google-api-keys-werent-secrets-but-then-gemini-changed-the-rules

### Template validation


- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
