### PR TITLE
feat(cves): add CVE-2025-5947 - Service Finder Bookings Auth Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-5947.yaml
+++ b/http/cves/2025/CVE-2025-5947.yaml
@@ -36,18 +36,17 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 301
-          - 302
-
       - type: regex
         part: header
         regex:
           - '(?i)Location:.*\/wp-admin\/'
 
-    extractors:
-      - type: kval
+      - type: regex
         part: header
-        kval:
-          - location
+        regex:
+          - '(?i)Set-Cookie:.*wordpress_logged_in_'
+
+      - type: status
+        status:
+          - 301
+          - 302


### PR DESCRIPTION
### PR Information

- Added CVE-2025-5947 — Service Finder Bookings WordPress Plugin <= 6.0 Authentication Bypass via Cookie Spoofing
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2025-5947
  - https://patchstack.com/database/wordpress/plugin/sf-booking/vulnerability/wordpress-service-finder-bookings-plugin-6-0-authentication-bypass-via-user-switch-cookie-vulnerability
  - https://github.com/advisories/GHSA-x2xx-4qhp-2vqx
  - https://github.com/M4rgs/CVE-2025-5947_Exploit

### Vulnerability Summary

The `service_finder_switch_back()` AJAX action in the Service Finder Bookings plugin fails to validate the `original_user_id` cookie before switching user context. An unauthenticated attacker can set `Cookie: original_user_id=1` and call the action to gain admin-level access.

- **CVSS:** 9.8 (Critical)
- **CWE:** CWE-639 (Authorization Bypass Through User-Controlled Key)
- **Affected:** All versions <= 6.0
- **Patched:** Version 6.1 (released July 17, 2025)
- **Actively exploited:** 13,800+ attempts blocked by Wordfence on disclosure day

### Template Logic

1. First request confirms the plugin is installed by checking `readme.txt`
2. Second request attempts the bypass: `GET /wp-admin/admin-ajax.php?action=service_finder_switch_back` with `Cookie: original_user_id=1`
3. Matches on a 301/302 redirect to `wp-admin` (not `wp-login.php`) indicating successful user context switch

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

> Note: I was unable to test against a live vulnerable instance. Happy to refine matchers with feedback from the team or community members who can verify against a real target.

### Additional Details

- **Shodan query:** `http.html:"sf-booking"`
- **PublicWWW query:** `/wp-content/plugins/sf-booking/`