### PR TITLE
Add 5 KEV CVE templates (WebLogic, Plex, Nagios XI, Pi-hole, Roundcube)

### DIFF
--- a/http/cves/2015/CVE-2015-4852.yaml
+++ b/http/cves/2015/CVE-2015-4852.yaml
@@ -27,7 +27,9 @@ info:
     vendor: oracle
     product: weblogic_server
     shodan-query: http.title:"WebLogic" || http.html:"WebLogic Server"
-  tags: cve,cve2015,oracle,weblogic,deserialization,rce,kev,vkev,vuln
+  tags: cve,cve2015,oracle,weblogic,deserialization,rce,kev,vkev
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -35,6 +37,25 @@ http:
         GET /console/login/LoginForm.jsp HTTP/1.1
         Host: {{Hostname}}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "WebLogic")'
+          - 'compare_versions(version, "<= 10.3.6.0") || compare_versions(version, ">= 12.1.2.0", "<= 12.1.3.0") || compare_versions(version, ">= 12.2.1.0", "<= 12.2.1.0")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'WebLogic Server[^<]*?(\d+\.\d+\.\d+\.\d+)'
+
+  - raw:
       - |
         POST /wls-wsat/CoordinatorPortType HTTP/1.1
         Host: {{Hostname}}
@@ -57,21 +78,11 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - 'compare_versions(version, "<= 10.3.6.0") || compare_versions(version, ">= 12.1.2.0", "<= 12.1.2.0") || compare_versions(version, ">= 12.1.3.0", "<= 12.1.3.0") || compare_versions(version, ">= 12.2.1.0", "<= 12.2.1.0")'
+      - type: word
+        part: body
+        words:
+          - "soapenv:Fault"
 
-      - type: dsl
-        dsl:
-          - 'status_code_2 == 500 && contains(body_2, "soapenv:Fault")'
-
-    extractors:
-      - type: regex
-        name: version
-        part: body_1
-        group: 1
-        internal: true
-        regex:
-          - 'WebLogic Server[^<]*?Version:\s*(\d+\.\d+\.\d+\.\d+)'
-          - '<td[^>]*>\s*(\d{2}\.\d+\.\d+\.\d+)\s*</td>'
-          - 'class="copyright">[^<]*?(\d+\.\d+\.\d+\.\d+)'
+      - type: status
+        status:
+          - 500

--- a/http/cves/2017/CVE-2017-16651.yaml
+++ b/http/cves/2017/CVE-2017-16651.yaml
@@ -13,6 +13,7 @@ info:
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2017-16651
     - https://roundcube.net/news/2017/11/08/security-updates-1.3.3-1.2.7-and-1.1.10
+    - https://github.com/roundcube/roundcubemail/issues/6026
     - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
   classification:
     cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
@@ -22,17 +23,19 @@ info:
     cpe: cpe:2.3:a:roundcube:webmail:*:*:*:*:*:*:*:*
   metadata:
     verified: false
-    max-request: 1
+    max-request: 2
     vendor: roundcube
     product: webmail
     shodan-query: http.title:"Roundcube Webmail"
-  tags: cve,cve2017,roundcube,webmail,file-disclosure,kev,vkev,vuln
+  tags: cve,cve2017,roundcube,webmail,file-disclosure,kev,vkev
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/CHANGELOG"
       - "{{BaseURL}}/roundcube/CHANGELOG"
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
@@ -59,4 +62,3 @@ http:
         internal: true
         regex:
           - 'RELEASE\s+(\d+\.\d+\.\d+)'
-          - 'Version\s+(\d+\.\d+\.\d+)'

--- a/http/cves/2019/CVE-2019-15949.yaml
+++ b/http/cves/2019/CVE-2019-15949.yaml
@@ -1,7 +1,7 @@
 id: CVE-2019-15949
 
 info:
-  name: Nagios XI - Authenticated Command Injection
+  name: Nagios XI < 5.6.6 - Authenticated Command Injection
   author: ElromEvedElElyon
   severity: high
   description: |
@@ -26,7 +26,7 @@ info:
     vendor: nagios
     product: nagios_xi
     shodan-query: http.title:"Nagios XI"
-  tags: cve,cve2019,nagios,command-injection,rce,kev,vkev,vuln
+  tags: cve,cve2019,nagios,command-injection,rce,kev,vkev
 
 http:
   - method: GET
@@ -39,6 +39,8 @@ http:
         part: body
         words:
           - "Nagios XI"
+          - "nagiosxi"
+        condition: and
 
       - type: dsl
         dsl:
@@ -55,7 +57,6 @@ http:
         group: 1
         internal: true
         regex:
-          - 'Nagios XI\s+(?:Version\s+)?(\d+\.\d+\.\d+)'
-          - 'nagiosxi[/ -]v?(\d+\.\d+\.\d+)'
-          - '"nagiosxi_version":\s*"(\d+\.\d+\.\d+)"'
+          - '(?i)Nagios\s+XI\s+(?:Version\s+|v)?(\d+\.\d+\.\d+)'
           - 'product_version["\s]*[:=]["\s]*(\d+\.\d+\.\d+)'
+          - 'name="version"\s+value="(\d+\.\d+\.\d+)"'

--- a/http/cves/2020/CVE-2020-5741.yaml
+++ b/http/cves/2020/CVE-2020-5741.yaml
@@ -1,11 +1,11 @@
 id: CVE-2020-5741
 
 info:
-  name: Plex Media Server - Deserialization RCE
+  name: Plex Media Server < 1.19.3 - Deserialization RCE
   author: ElromEvedElElyon
   severity: high
   description: |
-    Plex Media Server before version 1.19.3 on Windows is vulnerable to deserialization of untrusted data. A remote authenticated attacker with server admin access can exploit this to execute arbitrary Python code on the server, leading to complete system compromise.
+    Plex Media Server before version 1.19.3 on Windows is vulnerable to deserialization of untrusted data. A remote authenticated attacker with server admin access can exploit this to execute arbitrary Python code on the server, leading to complete system compromise. Note: This vulnerability only affects Plex Media Server running on Windows.
   impact: |
     An authenticated attacker with Plex admin access can execute arbitrary code on the server, potentially compromising the host system, accessing stored media and metadata, and pivoting to other systems on the network.
   remediation: |
@@ -26,7 +26,7 @@ info:
     vendor: plex
     product: media_server
     shodan-query: http.title:"Plex" || X-Plex-Protocol
-  tags: cve,cve2020,plex,deserialization,rce,kev,vkev,vuln
+  tags: cve,cve2020,plex,deserialization,rce,kev,vkev
 
 http:
   - method: GET

--- a/http/cves/2020/CVE-2020-8816.yaml
+++ b/http/cves/2020/CVE-2020-8816.yaml
@@ -1,7 +1,7 @@
 id: CVE-2020-8816
 
 info:
-  name: Pi-hole Web - Authenticated Remote Code Execution
+  name: Pi-hole Web <= 4.3.2 - Authenticated Remote Code Execution
   author: ElromEvedElElyon
   severity: high
   description: |
@@ -26,7 +26,7 @@ info:
     vendor: pi-hole
     product: web
     shodan-query: http.title:"Pi-hole" || http.html:"Pi-hole"
-  tags: cve,cve2020,pihole,command-injection,rce,kev,vkev,vuln
+  tags: cve,cve2020,pihole,command-injection,rce,kev,vkev
 
 http:
   - method: GET


### PR DESCRIPTION
## Summary

Add nuclei templates for 5 CISA Known Exploited Vulnerabilities from the KEV catalog (ref #7549):

- **CVE-2015-4852**: Oracle WebLogic Server Java Deserialization RCE (CVSS 9.8)
- **CVE-2020-5741**: Plex Media Server Deserialization RCE (CVSS 7.2)
- **CVE-2019-15949**: Nagios XI Authenticated Command Injection (CVSS 8.8)
- **CVE-2020-8816**: Pi-hole Web Authenticated Command Injection RCE (CVSS 7.2)
- **CVE-2017-16651**: Roundcube Webmail Arbitrary File Disclosure (CVSS 7.8)

All templates use **detection-only matchers** (no exploitation payloads). Covers widely-deployed infrastructure (WebLogic, Nagios, Roundcube) and popular self-hosted software (Plex, Pi-hole).

## References

- CISA KEV Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
- Tracking issue: #7549

## Checklist
- [x] Templates follow the naming convention
- [x] Templates have proper metadata (id, info, classification, CPE, CWE)
- [x] Templates use detection-only approach (no exploitation)
- [x] All 5 CVEs confirmed absent from repository
- [x] YAML validated successfully