### PR TITLE
Update apache-activemq-artemis-detect.yaml

### DIFF
--- a/http/technologies/apache/apache-activemq-artemis-detect.yaml
+++ b/http/technologies/apache/apache-activemq-artemis-detect.yaml
@@ -26,7 +26,8 @@ http:
         words:
           - 'img/activemq.png'
           - 'ActiveMQ Artemis'
-        condition: and
+          - 'Apache Artemis'
+        condition: or
 
     extractors:
       - type: regex


### PR DESCRIPTION
Adaptation for version 2.53.0

<img width="1673" height="702" alt="image" src="https://github.com/user-attachments/assets/0e25b386-c8fe-4715-9710-7c4c51ac2d3a" />

**Steps to test:**

**Apache ActiveMQ Artemis Console Docker:**

1. Running container:

`docker run --detach --name apache-activemq-artemis -p 61616:61616 -p 8161:8161 --rm apache/artemis:latest-alpine`

`docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-activemq-artemis`

And the access URL will be http://<obteined_inspect_IP_Address>:8161/

