### PR TITLE
Add Spring Cloud Config Server - Path Traversal via Profile Parameter

### DIFF
--- a/http/cves/2026/CVE-2026-22739.yaml
+++ b/http/cves/2026/CVE-2026-22739.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-22739
 
 info:
-  name: Spring Cloud Config Server - Path Traversal via Profile Parameter
+  name: Spring Cloud Config Server - Path Traversal
   author: 0x_Akoko,vulnh0lic
   severity: high
   description: |
@@ -27,7 +27,7 @@ info:
     product: spring_cloud_config
     shodan-query: http.html:"propertySources"
     fofa-query: body="propertySources" && body="profiles" && body="label"
-  tags: cve,cve2026,spring,spring-cloud,config-server,lfi,path-traversal
+  tags: cve,cve2026,spring,spring-cloud,config-server,lfi,traversal
 
 flow: http(1) && http(2)
 
@@ -57,17 +57,17 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - application/json
-
       - type: regex
         part: body
         regex:
           - "\"root\":\"x:0:0:"
           - "root:.*:0:0"
         condition: or
+
+      - type: word
+        part: header
+        words:
+          - application/json
 
       - type: status
         status:


### PR DESCRIPTION
This YAML file describes CVE-2026-22739, detailing a path traversal vulnerability in Spring Cloud Config Server, including its impact, remediation steps, and relevant metadata.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
