### PR TITLE
Added template for CVE-2025-55150

### DIFF
--- a/http/cves/2025/CVE-2025-55150.yaml
+++ b/http/cves/2025/CVE-2025-55150.yaml
@@ -12,7 +12,10 @@ info:
    Upgrade to version 1.1.0 or later.
   reference:
     - https://github.com/Stirling-Tools/Stirling-PDF/security/advisories/GHSA-xw8v-9mfm-g2pm
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-55150
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2025-55150
     cwe-id: CWE-918
   metadata:
@@ -61,6 +64,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "contains(interactsh_protocol,'dns') || contains(interactsh_protocol,'http')"
+          - "contains(interactsh_protocol,'dns')"
           - "contains(body,'%PDF-1.7')"
         condition: and


### PR DESCRIPTION
PR Information
Added CVE-2025-55150 (Server-Side Request Forgery in Stirling-PDF prior to 1.1.0)

References:
https://nvd.nist.gov/vuln/detail/CVE-2025-55150
https://github.com/Stirling-Tools/Stirling-PDF/security/advisories/GHSA-xw8v-9mfm-g2pm

Template validation
 Pending validation with a confirmed vulnerable instance (True Positive not yet recorded)
 Pending validation with a confirmed patched instance (False Positive resistance not yet recorded)

Additional Details
This template targets the unauthenticated /api/v1/convert/html/pdf endpoint in Stirling-PDF. It submits a minimal HTML file containing an external image reference that points to an Interactsh-controlled domain. If the backend attempts to resolve or fetch that external resource during HTML-to-PDF conversion, the template detects the resulting out-of-band interaction and reports the target as potentially vulnerable.

This approach was chosen because the publicly described issue is a server-side request forgery in the HTML-to-PDF conversion workflow. The template uses a DNS-based OOB check to keep validation lightweight and avoid more invasive verification logic. It does not attempt internal network enumeration, response exfiltration, or arbitrary URL validation beyond observing whether the application makes an outbound lookup during conversion.

Because detection relies on Interactsh, successful matching depends on outbound DNS resolution being allowed from the target environment. In egress-restricted deployments, or where remote resource fetching is disabled during conversion, the template may not trigger even if the target is otherwise affected.

Hunting Dorks:
Shodan: http.title:"Stirling PDF"
FOFA: title="Stirling PDF"