### PR TITLE
Add CVE-2024-34069 - Werkzeug Debugger Console RCE

### DIFF
--- a/http/cves/2024/CVE-2024-34069.yaml
+++ b/http/cves/2024/CVE-2024-34069.yaml
@@ -1,0 +1,58 @@
+id: CVE-2024-34069
+
+info:
+  name: Werkzeug < 3.0.3 - Debugger Console Remote Code Execution
+  author: maciejklimek
+  severity: critical
+  description: |
+    Werkzeug before 3.0.3 is vulnerable to remote code execution through the interactive debugger console endpoint. The debugger did not validate the Host header, allowing cross-origin requests to execute arbitrary Python code when the debugger is exposed. The /console endpoint provides a full interactive Python shell.
+  impact: |
+    Successful exploitation allows remote code execution on the server through the exposed debugger console.
+  remediation: |
+    Upgrade Werkzeug to version 3.0.3 or later. Never expose the debugger in production (debug=False).
+  reference:
+    - https://github.com/pallets/werkzeug/security/advisories/GHSA-2g68-c3qc-8985
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-34069
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-34069
+    cwe-id: CWE-352
+  metadata:
+    max-request: 2
+    vendor: palletsprojects
+    product: werkzeug
+    framework: flask
+    shodan-query: http.component:"Werkzeug"
+  tags: cve,cve2024,werkzeug,flask,rce,debugger,palletsprojects,nuclei
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/console"
+      - "{{BaseURL}}/__debugger__"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Werkzeug Debugger"
+          - "Interactive Console"
+          - "werkzeug.debug"
+          - "debugger console"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "console"
+          - "python"
+          - "interpreter"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2024-34069 — Werkzeug < 3.0.3 Debugger Console RCE
- References: https://nvd.nist.gov/vuln/detail/CVE-2024-34069, https://github.com/pallets/werkzeug/security/advisories/GHSA-2g68-c3qc-8985

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested with `nuclei -debug`:
```
docker run -d -p 5000:5000 python:3.11-slim bash -c \
  'pip install werkzeug==2.3.0 flask==2.3.0 && python -c "from flask import Flask; app = Flask(__name__); app.run(host=\"0.0.0.0\", port=5000, debug=True)"'

# Wait ~15s, then:
nuclei -t CVE-2024-34069.yaml -u http://localhost:5000
# Result: 3 matches (word-1, word-2, status-3)
```

Matchers: "Werkzeug Debugger" / "Interactive Console" in body + HTTP 200.