### PR TITLE
Add CVE-2022-41678 - Apache ActiveMQ Jolokia Authenticated RCE

### DIFF
--- a/http/cves/2022/CVE-2022-41678.yaml
+++ b/http/cves/2022/CVE-2022-41678.yaml
@@ -1,14 +1,14 @@
 id: CVE-2022-41678
 
 info:
-  name: Apache ActiveMQ < 5.16.5/5.17.3 - Jolokia Authenticated Remote Code Execution
+  name: Apache ActiveMQ < 5.16.5/5.17.3 - Remote Code Execution
   author: maciejklimek
   severity: high
   description: |
-    Apache ActiveMQ prior to versions 5.16.5 and 5.17.3 exposes the Jolokia REST API at `/api/jolokia` which, when accessed with valid credentials, allows authenticated attackers to achieve remote code execution through the Log4j2 LoggerContextAdminMBean or the JDK FlightRecorderMXBean. These MBeans can be abused to write arbitrary files (such as JSP webshells) to the server.
+    Once an user is authenticated on Jolokia, he can potentially trigger arbitrary code execution.  In details, in ActiveMQ configurations, jetty allows org.jolokia.http.AgentServlet to handler request to /api/jolokia org.jolokia.http.HttpRequestHandler#handlePostRequest is able to create JmxRequest through JSONObject. And calls to org.jolokia.http.HttpRequestHandler#executeRequest. Into deeper calling stacks, org.jolokia.handler.ExecHandler#doHandleRequest can be invoked through refection. This could lead to RCE through via various mbeans. One example is unrestricted deserialization in jdk.management.jfr.FlightRecorderMXBeanImpl which exists on Java version above 11. 1 Call newRecording. 2 Call setConfiguration. And a webshell data hides in it. 3 Call startRecording. 4 Call copyTo method. The webshell will be written to a .jsp file. The mitigation is to restrict (by default) the actions authorized on Jolokia, or disable Jolokia. A more restrictive Jolokia configuration has been defined in default ActiveMQ distribution. We encourage users to upgrade to ActiveMQ distributions version including updated Jolokia configuration: 5.16.6, 5.17.4, 5.18.0, 6.0.0.
   impact: |
-    An authenticated attacker with access to the Jolokia API can write webshells and execute arbitrary commands on the server.
-  remediation: Upgrade Apache ActiveMQ to version 5.16.5, 5.17.3, or later.
+    Authenticated attackers can execute arbitrary code on the server, potentially leading to full system compromise.
+  remediation: Restrict or disable Jolokia, and upgrade to ActiveMQ version 5.16.6, 5.17.4, 5.18.0, or 6.0.0 with updated Jolokia configuration.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2022-41678
     - https://activemq.apache.org/security-advisories.data/CVE-2022-41678-announcement.txt
@@ -31,7 +31,7 @@ http:
         GET /api/jolokia/list/org.apache.logging.log4j2 HTTP/1.1
         Host: {{Hostname}}
         Authorization: Basic YWRtaW46YWRtaW4=
-        Origin: {{BaseURL}}
+        Origin: {{RootURL}}
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
## Summary

Detection template for CVE-2022-41678 — Apache ActiveMQ prior to 5.16.5/5.17.3 exposes the Jolokia REST API which allows authenticated RCE through Log4j2 LoggerContextAdminMBean.

## Verification

Tested against `vulhub/activemq:5.17.3`:
- All 3 matchers hit (status 200, `setConfigText` present, `org.apache.logging.log4j2` in response)
- Jolokia API dump confirms exploitable MBean endpoints

## References

- https://nvd.nist.gov/vuln/detail/CVE-2022-41678
- https://activemq.apache.org/security-advisories.data/CVE-2022-41678-announcement.txt