### PR TITLE
Add and normalize CWE metadata across HTTP templates

### DIFF
--- a/http/exposures/apis/postman-collection-exposure.yaml
+++ b/http/exposures/apis/postman-collection-exposure.yaml
@@ -8,6 +8,8 @@ info:
     Detected exposed Postman collection JSON files that contained API endpoints and environment details. These files were publicly accessible and disclosed authentication headers and other sensitive information.
   reference:
     - https://medium.com/@utkarshporwal24/exposed-postman-collections-ed6086b96ba5
+  classification:
+    cwe-id: CWE-538
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/backups/batflat-sqlite-exposure.yaml
+++ b/http/exposures/backups/batflat-sqlite-exposure.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://batflat.org/
     - https://github.com/sruupl/batflat
+  classification:
+    cwe-id: CWE-219,CWE-552
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/configs/3cx-config.yaml
+++ b/http/exposures/configs/3cx-config.yaml
@@ -8,6 +8,8 @@ info:
     3CX Configuration file was discovered.
   reference:
     - https://www.3cx.com/docs/configure-pbx-automatically/
+  classification:
+    cwe-id: CWE-219,CWE-552
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/configs/git-config-nginxoffbyslash.yaml
+++ b/http/exposures/configs/git-config-nginxoffbyslash.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
-    cwe-id: CWE-200
+    cwe-id: CWE-23
   metadata:
     max-request: 10
   tags: config,exposure,nginx,vuln

--- a/http/exposures/logs/access-log-file.yaml
+++ b/http/exposures/logs/access-log-file.yaml
@@ -5,6 +5,8 @@ info:
   author: sheikhrishad
   severity: low
   description: Log file was exposed.
+  classification:
+    cwe-id: CWE-219,CWE-552
   metadata:
     max-request: 4
   tags: logs,exposure,vuln

--- a/http/exposures/tokens/adafruit/adafruit-api-key.yaml
+++ b/http/exposures/tokens/adafruit/adafruit-api-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/adafruit-api-key.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/adafruit-api-key.go
     - https://io.adafruit.com/api/docs
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/adobe/adobe-oauth-secret.yaml
+++ b/http/exposures/tokens/adobe/adobe-oauth-secret.yaml
@@ -9,6 +9,8 @@ info:
     - https://developer.adobe.com/developer-console/docs/guides/authentication/
     - https://developer.adobe.com/developer-console/docs/guides/authentication/OAuthIntegration/
     - https://developer.adobe.com/developer-console/docs/guides/authentication/OAuth/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/age/age-secret-key.yaml
+++ b/http/exposures/tokens/age/age-secret-key.yaml
@@ -9,6 +9,8 @@ info:
     - https://github.com/FiloSottile/age/blob/main/doc/age.1.html
     - https://github.com/C2SP/C2SP/blob/8b6a842e0360d35111c46be2a8019b2276295914/age.md#the-x25519-recipient-type
     - https://age-encryption.org
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/airtable/airtable-api-key.yaml
+++ b/http/exposures/tokens/airtable/airtable-api-key.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/airtable-api-key.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/airtable-api-key.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/algolia/algolia-api-key.yaml
+++ b/http/exposures/tokens/algolia/algolia-api-key.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/algolia-api-key.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/algolia-api-key.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/alibaba/alibaba-accesskey-id.yaml
+++ b/http/exposures/tokens/alibaba/alibaba-accesskey-id.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/alibaba-access-key-id.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/alibaba-access-key-id.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/amazon/amazon-mws-auth-token.yaml
+++ b/http/exposures/tokens/amazon/amazon-mws-auth-token.yaml
@@ -4,6 +4,8 @@ info:
   name: Amazon MWS Auth Token
   author: puzzlepeaches
   severity: info
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,aws,amazon,auth,vuln

--- a/http/exposures/tokens/artifactory/artifactory-api-password.yaml
+++ b/http/exposures/tokens/artifactory/artifactory-api-password.yaml
@@ -6,6 +6,8 @@ info:
   severity: info
   reference:
     - https://jfrog.com/help/r/jfrog-rest-apis/introduction-to-the-artifactory-rest-apis
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,artifactory,vuln

--- a/http/exposures/tokens/atlassian/atlassian-token.yaml
+++ b/http/exposures/tokens/atlassian/atlassian-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/atlassian-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/atlassian-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/azure/azure-apim-secretkey.yaml
+++ b/http/exposures/tokens/azure/azure-apim-secretkey.yaml
@@ -5,6 +5,8 @@ info:
   author: israel comazzetto dos reis
   severity: info
   description: Azure APIM Secret Key
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/bittrex/bittrex-accesskey.yaml
+++ b/http/exposures/tokens/bittrex/bittrex-accesskey.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/bittrex-access-key.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/bittrex-access-key.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/clojars/clojars-token.yaml
+++ b/http/exposures/tokens/clojars/clojars-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/clojars-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/clojars-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/cloudinary/cloudinary-credentials.yaml
+++ b/http/exposures/tokens/cloudinary/cloudinary-credentials.yaml
@@ -4,6 +4,8 @@ info:
   name: Cloudinary Credentials Disclosure
   author: Ice3man
   severity: info
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,cloudinary,vuln

--- a/http/exposures/tokens/codeclimate/codeclimate-token.yaml
+++ b/http/exposures/tokens/codeclimate/codeclimate-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/codeclimate.yml
     - https://github.com/codeclimate/ruby-test-reporter/issues/34
     - https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/codecov/codecov-accesstoken.yaml
+++ b/http/exposures/tokens/codecov/codecov-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/codecov-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/codecov-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/coinbase/coinbase-accesstoken.yaml
+++ b/http/exposures/tokens/coinbase/coinbase-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/coinbase-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/coinbase-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/confluent/confluent-accesstoken.yaml
+++ b/http/exposures/tokens/confluent/confluent-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/confluent-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/confluent-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/contentful/contentful-token.yaml
+++ b/http/exposures/tokens/contentful/contentful-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/contentful-delivery-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/contentful-delivery-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/crates/crates-api-key.yaml
+++ b/http/exposures/tokens/crates/crates-api-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/crates.io.yml
     - https://crates.io/data-access
     - https://github.com/rust-lang/crates.io/blob/master/src/util/token.rs
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/databricks/databricks-token.yaml
+++ b/http/exposures/tokens/databricks/databricks-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/databricks-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/databricks-api-token.go
     - https://docs.databricks.com/en/dev-tools/auth/pat.html
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/datadog/datadog-accesstoken.yaml
+++ b/http/exposures/tokens/datadog/datadog-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/datadog-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/datadog-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/dependency/dependency-track-api.yaml
+++ b/http/exposures/tokens/dependency/dependency-track-api.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/dependency_track.yml
     - https://docs.dependencytrack.org/integrations/rest-api/
     - https://docs.dependencytrack.org/getting-started/configuration/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/digitalocean/digital-ocean-personal-token.yaml
+++ b/http/exposures/tokens/digitalocean/digital-ocean-personal-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/rules/digitalocean.yml
     - https://docs.digitalocean.com/reference/api/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/docker/docker-hub-pat.yaml
+++ b/http/exposures/tokens/docker/docker-hub-pat.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/dockerhub.yml
     - https://docs.docker.com/security/for-developers/access-tokens/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/doppler/doppler-audit-token.yaml
+++ b/http/exposures/tokens/doppler/doppler-audit-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/doppler.yml
     - https://docs.doppler.com/reference/api
     - https://docs.doppler.com/reference/auth-token-formats
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/droneci/droneci-accesstoken.yaml
+++ b/http/exposures/tokens/droneci/droneci-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/droneci-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/droneci-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/dropbox/dropbox-access-token.yaml
+++ b/http/exposures/tokens/dropbox/dropbox-access-token.yaml
@@ -9,6 +9,8 @@ info:
     - https://developers.dropbox.com/oauth-guide
     - https://www.dropbox.com/developers/
     - https://www.dropbox.com/developers/documentation/http/documentation
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/duffel/duffel-token.yaml
+++ b/http/exposures/tokens/duffel/duffel-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/duffel-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/duffel-api-token.go
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/dynatrace/dynatrace-api-token.yaml
+++ b/http/exposures/tokens/dynatrace/dynatrace-api-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/dynatrace.yml
     - https://www.dynatrace.com/support/help/dynatrace-api
     - https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/easypost/easypost-token.yaml
+++ b/http/exposures/tokens/easypost/easypost-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/easypost-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/easypost-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/elastic/elastic-cloud-api-key.yaml
+++ b/http/exposures/tokens/elastic/elastic-cloud-api-key.yaml
@@ -8,6 +8,8 @@ info:
     Detects Elastic Cloud API keys used for programmatic access to the Elastic Cloud and serverless APIs.
   reference:
     - https://www.elastic.co/docs/deploy-manage/api-keys/elastic-cloud-api-keys
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/etsy/etsy-accesstoken.yaml
+++ b/http/exposures/tokens/etsy/etsy-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/etsy-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/etsy-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/facebook/facebook-access-token.yaml
+++ b/http/exposures/tokens/facebook/facebook-access-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/facebook.yml
     - https://developers.facebook.com/docs/facebook-login/access-tokens/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/fastly/fastly-token.yaml
+++ b/http/exposures/tokens/fastly/fastly-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/fastly-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/fastly-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/figma/figma-personal-token.yaml
+++ b/http/exposures/tokens/figma/figma-personal-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/rules/figma.yml
     - https://www.figma.com/developers/api
     - https://www.figma.com/developers/api#access-tokens
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/finicity/finicity-token.yaml
+++ b/http/exposures/tokens/finicity/finicity-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/finicity-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/finicity-api-token.go
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/finnhub/finnhub-accesstoken.yaml
+++ b/http/exposures/tokens/finnhub/finnhub-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/finnhub-access-token.go
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/finnhub-access-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/frameio/frameio-token.yaml
+++ b/http/exposures/tokens/frameio/frameio-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/frameio-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/frameio-api-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/freshbooks/freshbooks-accesstoken.yaml
+++ b/http/exposures/tokens/freshbooks/freshbooks-accesstoken.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/freshbooks-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/freshbooks-access-token.go
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/generic/credentials-disclosure.yaml
+++ b/http/exposures/tokens/generic/credentials-disclosure.yaml
@@ -5,6 +5,8 @@ info:
   author: Sy3Omda,forgedhallpass,geeknik
   severity: unknown
   description: Look for keys/tokens/passwords in HTTP responses, exposed keys/tokens/secrets requires manual verification for impact evaluation.
+  classification:
+    cwe-id: CWE-200
   metadata:
     max-request: 1
   tags: exposure,token,key,api,secret,password,generic,vuln

--- a/http/exposures/tokens/github/github-oauth-access.yaml
+++ b/http/exposures/tokens/github/github-oauth-access.yaml
@@ -9,6 +9,8 @@ info:
     - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github
     - https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps
     - https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/gitlab/gitlab-pipeline-token.yaml
+++ b/http/exposures/tokens/gitlab/gitlab-pipeline-token.yaml
@@ -9,6 +9,8 @@ info:
     - https://docs.gitlab.com/ee/ci/triggers/
     - https://gitlab.com/gitlab-org/gitlab/-/issues/371396
     - https://gitlab.com/gitlab-org/gitlab/-/issues/388379
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/gitter/gitter-token.yaml
+++ b/http/exposures/tokens/gitter/gitter-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/gitter-access-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/gitter-access-token.go
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/gocardless/gocardless-token.yaml
+++ b/http/exposures/tokens/gocardless/gocardless-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/gocardless-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/gocardless-api-token.go
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/google/fcm-server-key.yaml
+++ b/http/exposures/tokens/google/fcm-server-key.yaml
@@ -7,6 +7,8 @@ info:
   description: FCM Server Key is leaked.
   reference:
     - https://abss.me/posts/fcm-takeover
+  classification:
+    cwe-id: CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,google,vuln

--- a/http/exposures/tokens/grafana/grafana-cloud-token.yaml
+++ b/http/exposures/tokens/grafana/grafana-cloud-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/grafana-cloud-api-token.yaml
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/grafana-cloud-api-token.go
     - https://grafana.com/docs/grafana-cloud/api-reference/cloud-api/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/hashicorp/hashicorp-token.yaml
+++ b/http/exposures/tokens/hashicorp/hashicorp-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/hashicorp-tf-api-token.go
     - https://github.com/returntocorp/semgrep-rules/blob/develop/generic/secrets/gitleaks/hashicorp-tf-api-token.yaml
     - https://developer.hashicorp.com/vault/docs/concepts/tokens
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/heroku/heroku-api-key.yaml
+++ b/http/exposures/tokens/heroku/heroku-api-key.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/heroku.yml
     - https://devcenter.heroku.com/articles/authentication
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/huggingface/huggingface-user-access-token.yaml
+++ b/http/exposures/tokens/huggingface/huggingface-user-access-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/huggingface.yml
     - https://huggingface.co/docs/hub/security-tokens
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/jenkins/jenkins-crumb-token.yaml
+++ b/http/exposures/tokens/jenkins/jenkins-crumb-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/jenkins.yml
     - https://www.jenkins.io/blog/2018/07/02/new-api-token-system/
     - https://www.jenkins.io/doc/book/security/csrf-protection/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/jwk-json-leak.yaml
+++ b/http/exposures/tokens/jwk-json-leak.yaml
@@ -10,6 +10,7 @@ info:
     - https://portswigger.net/web-security/jwt/algorithm-confusion
   classification:
     cpe: cpe:2.3:a:jwt_project:jwt:*:*:*:*:*:*:*:*
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/loqate/loqate-api-key.yaml
+++ b/http/exposures/tokens/loqate/loqate-api-key.yaml
@@ -7,6 +7,8 @@ info:
   description: Loqate API Key is leaked.
   reference:
     - https://www.loqate.com/en-gb/home/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,loqate,vuln

--- a/http/exposures/tokens/mailgun/mailgun-api-token.yaml
+++ b/http/exposures/tokens/mailgun/mailgun-api-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/mailgun.yml
     - https://documentation.mailgun.com/en/latest/api-intro.html#authentication-1
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/newrelic/newrelic-api-service-key.yaml
+++ b/http/exposures/tokens/newrelic/newrelic-api-service-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/newrelic.yml
     - https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys
     - https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-key
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/nextjs/cipher-secret-key.yaml
+++ b/http/exposures/tokens/nextjs/cipher-secret-key.yaml
@@ -4,6 +4,8 @@ info:
   name: Cipher Secret Key Exposure
   author: israel comazzetto dos reis
   severity: info
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,vuln

--- a/http/exposures/tokens/npm/npm-access-token.yaml
+++ b/http/exposures/tokens/npm/npm-access-token.yaml
@@ -9,6 +9,8 @@ info:
     - https://docs.npmjs.com/about-access-tokens
     - https://github.com/github/roadmap/issues/557
     - https://github.blog/changelog/2022-12-06-limit-scope-of-npm-tokens-with-the-new-granular-access-tokens/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/nuget/nuget-api-key.yaml
+++ b/http/exposures/tokens/nuget/nuget-api-key.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/nuget.yml
     - https://docs.microsoft.com/en-us/nuget/nuget-org/publish-a-package#create-api-keys
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/odbc/odbc-connection-string.yaml
+++ b/http/exposures/tokens/odbc/odbc-connection-string.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/odbc.yml
     - https://docs.aws.amazon.com/redshift/latest/mgmt/configure-odbc-connection.html
     - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/kusto
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/okta/okta-api-token.yaml
+++ b/http/exposures/tokens/okta/okta-api-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/okta.yml
     - https://devforum.okta.com/t/api-token-length/5519
     - https://developer.okta.com/docs/guides/create-an-api-token/main/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/openai/openai-service-account-api-key.yaml
+++ b/http/exposures/tokens/openai/openai-service-account-api-key.yaml
@@ -6,6 +6,8 @@ info:
   severity: info
   reference:
     - https://platform.openai.com/settings/organization/api-keys
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/particle/particle-access-token.yaml
+++ b/http/exposures/tokens/particle/particle-access-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/particle.io.yml
     - https://docs.particle.io/reference/cloud-apis/api/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/paypal/braintree-access-token.yaml
+++ b/http/exposures/tokens/paypal/braintree-access-token.yaml
@@ -4,6 +4,8 @@ info:
   name: PayPal Braintree Access Token Disclosure
   author: Ice3man
   severity: info
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,paypal,vuln

--- a/http/exposures/tokens/picatic/picatic-api-key.yaml
+++ b/http/exposures/tokens/picatic/picatic-api-key.yaml
@@ -4,6 +4,8 @@ info:
   name: Picatic API Key Disclosure
   author: Ice3man
   severity: info
+  classification:
+    cwe-id: CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,vuln

--- a/http/exposures/tokens/pinata/pinata-api-key.yaml
+++ b/http/exposures/tokens/pinata/pinata-api-key.yaml
@@ -4,6 +4,8 @@ info:
   name: Pinata API Key - Expose
   author: 0xpugal
   severity: info
+  classification:
+    cwe-id: CWE-540
   tags: pinata,exposure,api-keys,tokens,vuln
 
 http:

--- a/http/exposures/tokens/postman/postman-key.yaml
+++ b/http/exposures/tokens/postman/postman-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/rules/postman.yml
     - https://learning.postman.com/docs/developer/intro-api/
     - https://learning.postman.com/docs/developer/postman-api/authentication/
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/pypi/pypi-upload-token.yaml
+++ b/http/exposures/tokens/pypi/pypi-upload-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/pypi.yml
     - https://github.com/pypa/warehouse/issues/6051
     - https://pypi.org/project/pypitoken/
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/rapid/rapidapi-access-token.yaml
+++ b/http/exposures/tokens/rapid/rapidapi-access-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/rapidapi-access-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/rapidapi-access-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
     verified: true

--- a/http/exposures/tokens/react/react-app-username.yaml
+++ b/http/exposures/tokens/react/react-app-username.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/react.yml
     - https://create-react-app.dev/docs/adding-custom-environment-variables/
     - https://stackoverflow.com/questions/48699820/how-do-i-hide-an-api-key-in-create-react-app
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/readme/readme-api-token.yaml
+++ b/http/exposures/tokens/readme/readme-api-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/readme-api-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/readme-api-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
     verified: true

--- a/http/exposures/tokens/ruby/rubygems-api-key.yaml
+++ b/http/exposures/tokens/ruby/rubygems-api-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/rubygems.yml
     - https://guides.rubygems.org/rubygems-org-api/
     - https://guides.rubygems.org/api-key-scopes/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/salesforce/salesforce-access-token.yaml
+++ b/http/exposures/tokens/salesforce/salesforce-access-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/salesforce.yml
     - https://help.salesforce.com/s/articleView?id=sf.remoteaccess_access_tokens.htm&type=5
     - https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/quickstart_oauth.htm
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/sauce/sauce-token.yaml
+++ b/http/exposures/tokens/sauce/sauce-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/sauce.yml
     - https://docs.saucelabs.com/dev/api/
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/scalingo/scalingo-api-token.yaml
+++ b/http/exposures/tokens/scalingo/scalingo-api-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/scalingo-api-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/scalingo-api-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
     verified: true

--- a/http/exposures/tokens/segment/segment-public-token.yaml
+++ b/http/exposures/tokens/segment/segment-public-token.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/segment.yml
     - https://segment.com/docs/api/public-api/
     - https://segment.com/blog/how-segment-proactively-protects-customer-api-tokens/
+  classification:
+    cwe-id: CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/sendbird/sendbird-access-token.yaml
+++ b/http/exposures/tokens/sendbird/sendbird-access-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendbird-access-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendbird-access-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
     verified: true

--- a/http/exposures/tokens/sendgrid/sendgrid-api-key.yaml
+++ b/http/exposures/tokens/sendgrid/sendgrid-api-key.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendgrid-api-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendgrid-api-token.yaml
     - https://docs.sendgrid.com/ui/account-and-settings/api-keys
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,sendgrid,vuln

--- a/http/exposures/tokens/sendinblue/sendinblue-api-token.yaml
+++ b/http/exposures/tokens/sendinblue/sendinblue-api-token.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendinblue-api-token.go
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/sendinblue-api-token.yaml
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/shopify/shopify-app-secret.yaml
+++ b/http/exposures/tokens/shopify/shopify-app-secret.yaml
@@ -8,6 +8,8 @@ info:
     - https://github.com/praetorian-inc/noseyparker/blob/main/crates/noseyparker/data/default/builtin/rules/shopify.yml
     - https://shopify.dev/apps/auth
     - https://shopify.dev/changelog/app-secret-key-length-has-increased
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     verified: true
     max-request: 1

--- a/http/exposures/tokens/slack/slack-app-token.yaml
+++ b/http/exposures/tokens/slack/slack-app-token.yaml
@@ -9,6 +9,8 @@ info:
     - https://github.com/semgrep/semgrep-rules/blob/develop/generic/secrets/gitleaks/slack-app-token.yaml
     - https://api.slack.com/authentication
     - https://api.slack.com/authentication/best-practices
+  classification:
+    cwe-id: CWE-522,CWE-540
   metadata:
     max-request: 1
   tags: exposure,token,slack,vuln

--- a/http/miscellaneous/external-service-interaction.yaml
+++ b/http/miscellaneous/external-service-interaction.yaml
@@ -10,7 +10,7 @@ info:
     - https://success.qualys.com/support/s/article/000006843
     - https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
   classification:
-    cwe-id: CWE-918,CWE-406
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: miscellaneous,http,misc,oast,vuln

--- a/http/misconfiguration/aem/aem-querybuilder-internal-path-read.yaml
+++ b/http/misconfiguration/aem/aem-querybuilder-internal-path-read.yaml
@@ -9,6 +9,7 @@ info:
     - https://speakerdeck.com/0ang3el/aem-hacker-approaching-adobe-experience-manager-webapps-in-bug-bounty-programs?slide=91
   classification:
     cpe: cpe:2.3:a:adobe:experience_manager:*:*:*:*:*:*:*:*
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 4
     vendor: adobe

--- a/http/misconfiguration/aem/aem-xss-childlist-selector.yaml
+++ b/http/misconfiguration/aem/aem-xss-childlist-selector.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
     shodan-query:

--- a/http/misconfiguration/akamai/akamai-arl-xss.yaml
+++ b/http/misconfiguration/akamai/akamai-arl-xss.yaml
@@ -14,7 +14,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: akamai,xss,misconfig,vuln

--- a/http/misconfiguration/ibm-websphere-xml.yaml
+++ b/http/misconfiguration/ibm-websphere-xml.yaml
@@ -8,6 +8,8 @@ info:
     Disclose application specific files contained within the war file, including files under the web-inf and meta-inf directories.
   reference:
     - https://www.acunetix.com/vulnerabilities/web/ibm-websphere-weblogic-application-source-file-exposure/
+  classification:
+    cwe-id: CWE-219
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/mapproxy-file-read.yaml
+++ b/http/misconfiguration/mapproxy-file-read.yaml
@@ -14,7 +14,7 @@ info:
     - https://github.com/mapproxy/mapproxy
     - https://mapproxy.org
   classification:
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/mingyu-xmlrpc-sock-adduser.yaml
+++ b/http/misconfiguration/mingyu-xmlrpc-sock-adduser.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/dbappsecurity-mingyu-xmlrpc-sock-adduser.yaml
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/iot/%E5%AE%89%E6%81%92/%E5%AE%89%E6%81%92%20%E6%98%8E%E5%BE%A1%E8%BF%90%E7%BB%B4%E5%AE%A1%E8%AE%A1%E4%B8%8E%E9%A3%8E%E9%99%A9%E6%8E%A7%E5%88%B6%E7%B3%BB%E7%BB%9F%20xmlrpc.sock%20%E4%BB%BB%E6%84%8F%E7%94%A8%E6%88%B7%E6%B7%BB%E5%8A%A0%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/nginx/nginx-api-traversal.yaml
+++ b/http/misconfiguration/nginx/nginx-api-traversal.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://nginx.org/en/docs/http/ngx_http_api_module.html
     - https://x.com/akshaysharma71/status/1825815869953552844
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
   tags: nginx,fuzz,misconfig,lfi,vuln

--- a/http/misconfiguration/nginx/nginx-status-403-bypass.yaml
+++ b/http/misconfiguration/nginx/nginx-status-403-bypass.yaml
@@ -8,6 +8,8 @@ info:
     Detected an NGINX status disclosure and a 403 bypass that allowed unauthorized access to the /nginx_status endpoint.
   reference:
     - https://book.hacktricks.xyz/network-services-pentesting/pentesting-web/nginx
+  classification:
+    cwe-id: CWE-22
   metadata:
     verified: true
     shodan-query: "server:nginx"

--- a/http/misconfiguration/portal-api-ssrf.yaml
+++ b/http/misconfiguration/portal-api-ssrf.yaml
@@ -8,6 +8,8 @@ info:
     A Server-Side Request Forgery (SSRF) vulnerability in the Portal API endpoint by injecting a crafted X-Portal-Context-Origin header.
   reference:
     - https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+  classification:
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/proxy/open-proxy-internal.yaml
+++ b/http/misconfiguration/proxy/open-proxy-internal.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-441
+    cwe-id: CWE-441,CWE-918
   metadata:
     max-request: 25
   tags: exposure,config,proxy,misconfig,fuzz,vuln

--- a/http/misconfiguration/proxy/open-proxy-localhost.yaml
+++ b/http/misconfiguration/proxy/open-proxy-localhost.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-441
+    cwe-id: CWE-441,CWE-918
   metadata:
     max-request: 6
   tags: exposure,config,proxy,misconfig,fuzz,vuln

--- a/http/misconfiguration/proxy/open-proxy-portscan.yaml
+++ b/http/misconfiguration/proxy/open-proxy-portscan.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-441
+    cwe-id: CWE-441,CWE-918
   metadata:
     max-request: 8
   tags: exposure,config,proxy,misconfig,fuzz,vuln

--- a/http/misconfiguration/servicenow-title-injection.yaml
+++ b/http/misconfiguration/servicenow-title-injection.yaml
@@ -8,6 +8,7 @@ info:
     - https://www.assetnote.io/resources/research/chaining-three-bugs-to-access-all-your-servicenow-data
   classification:
     cpe: cpe:2.3:a:servicenow:servicenow:*:*:*:*:*:*:*:*
+    cwe-id: CWE-79
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/sitecore-lfi.yaml
+++ b/http/misconfiguration/sitecore-lfi.yaml
@@ -7,6 +7,8 @@ info:
   description: SiteCore 9.3 is vulnerable to LFI.
   reference:
     - https://blog.assetnote.io/2023/05/10/sitecore-round-two/
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/symfony/symfony-fragment.yaml
+++ b/http/misconfiguration/symfony/symfony-fragment.yaml
@@ -13,6 +13,7 @@ info:
     - https://github.com/ambionics/symfony-exploits
   classification:
     cpe: cpe:2.3:a:sensiolabs:symfony:*:*:*:*:*:*:*:*
+    cwe-id: CWE-15,CWE-94
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/titiler-ssrf.yaml
+++ b/http/misconfiguration/titiler-ssrf.yaml
@@ -8,6 +8,8 @@ info:
     Blind SSRF vulnerability in TiTiler, a dynamic tile server for Cloud Optimized GeoTIFFs (COGs). The flaw lies in how the application handles the url parameter in the /cog/info endpoint, allowing attackers to make arbitrary internal or external HTTP requests.
   reference:
     - https://xbow.com/blog/xbow-titiler-lfi/
+  classification:
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/wildcard-postmessage.yaml
+++ b/http/misconfiguration/wildcard-postmessage.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-346
   metadata:
     max-request: 1
   tags: xss,postmessage,misconfig,vuln

--- a/http/misconfiguration/xss-deprecated-header.yaml
+++ b/http/misconfiguration/xss-deprecated-header.yaml
@@ -11,6 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cvss-score: 0
+    cwe-id: CWE-79
   metadata:
     max-request: 1
   tags: xss,misconfig,generic,vuln

--- a/http/technologies/elfinder-version.yaml
+++ b/http/technologies/elfinder-version.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 2
   tags: tech,elfinder,oss,discovery

--- a/http/vulnerabilities/74cms/74cms-weixin-sqli.yaml
+++ b/http/vulnerabilities/74cms/74cms-weixin-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://cn-sec.com/archives/25900.html
   classification:
     cpe: cpe:2.3:a:74cms:74cms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/acme-challenge-path-xss.yaml
+++ b/http/vulnerabilities/acme-challenge-path-xss.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://labs.detectify.com/security-guidance/xss-using-quirky-implementations-of-acme-http-01/
     - https://www.acunetix.com/vulnerabilities/web/cross-site-scripting-in-http-01-acme-challenge-implementation/
+  classification:
+    cwe-id: CWE-80
   metadata:
     shodan-query: html:"acme-challenge"
   tags: xss,acme,misconfig,vuln

--- a/http/vulnerabilities/amazon/amazon-ec2-ssrf.yaml
+++ b/http/vulnerabilities/amazon/amazon-ec2-ssrf.yaml
@@ -8,7 +8,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
     cvss-score: 9.3
-    cwe-id: CWE-441
+    cwe-id: CWE-441,CWE-918
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/apache/apache-druid-log4j-rce.yaml
+++ b/http/vulnerabilities/apache/apache-druid-log4j-rce.yaml
@@ -9,7 +9,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-502
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:apache:druid:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/apache/apache-flink-unauth-rce.yaml
+++ b/http/vulnerabilities/apache/apache-flink-unauth-rce.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-94,CWE-434
   metadata:
     max-request: 1
   tags: apache,flink,rce,intrusive,unauth,vuln

--- a/http/vulnerabilities/apache/apache-ofbiz-log4j-rce.yaml
+++ b/http/vulnerabilities/apache/apache-ofbiz-log4j-rce.yaml
@@ -16,7 +16,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-95
     cpe: cpe:2.3:a:apache:ofbiz:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/apache/apache-solr-file-read.yaml
+++ b/http/vulnerabilities/apache/apache-solr-file-read.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 3
   tags: apache,solr,lfi,vuln

--- a/http/vulnerabilities/apache/apache-solr-log4j-rce.yaml
+++ b/http/vulnerabilities/apache/apache-solr-log4j-rce.yaml
@@ -17,7 +17,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-94,CWE-917
     cpe: cpe:2.3:a:apache:solr:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/apache/apache-solr-rce.yaml
+++ b/http/vulnerabilities/apache/apache-solr-rce.yaml
@@ -7,6 +7,8 @@ info:
   description: Apache Solr 9.1 is vulnerable to RCE.
   reference:
     - https://web.archive.org/web/20230414152023/https://noahblog.360.cn/apache-solr-rce/
+  classification:
+    cwe-id: CWE-15,CWE-94,CWE-99
   metadata:
     max-request: 2
   tags: solr,apache,rce,oast,intrusive,vuln

--- a/http/vulnerabilities/apache/log4j/jamf-pro-log4j-rce.yaml
+++ b/http/vulnerabilities/apache/log4j/jamf-pro-log4j-rce.yaml
@@ -16,7 +16,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/avtech/avtech-dvr-ssrf.yaml
+++ b/http/vulnerabilities/avtech/avtech-dvr-ssrf.yaml
@@ -6,6 +6,8 @@ info:
   severity: medium
   description: |
     AVTECH DVR device, Search.cgi can be accessed directly. Search.cgi is responsible for searching and accessing cameras in the local network. Search.cgi provides the cgi_query function.
+  classification:
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/backdoor/php-zerodium-backdoor-rce.yaml
+++ b/http/vulnerabilities/backdoor/php-zerodium-backdoor-rce.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-94
   metadata:
     max-request: 1
   tags: php,backdoor,rce,zerodium,vuln

--- a/http/vulnerabilities/churchcrm/churchcrm-xss.yaml
+++ b/http/vulnerabilities/churchcrm/churchcrm-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
     cvss-score: 6.5
-    cwe-id: CWE-79
+    cwe-id: CWE-80
     epss-score: 0.07062
     epss-percentile: 0.94141
     cpe: cpe:2.3:a:churchcrm:churchcrm:*:*:*:*:*:*:*:*

--- a/http/vulnerabilities/cisco/cisco-broadworks-log4j-rce.yaml
+++ b/http/vulnerabilities/cisco/cisco-broadworks-log4j-rce.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
     fofa-query: "Cisco BroadWorks"

--- a/http/vulnerabilities/cisco/cisco-cloudcenter-suite-log4j-rce.yaml
+++ b/http/vulnerabilities/cisco/cisco-cloudcenter-suite-log4j-rce.yaml
@@ -15,7 +15,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
     shodan-query: title:"CloudCenter Suite"

--- a/http/vulnerabilities/cisco/cisco-unified-communications-log4j-rce.yaml
+++ b/http/vulnerabilities/cisco/cisco-unified-communications-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:cisco:unified_communications_domain_manager:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/cisco/cisco-vmanage-log4j-rce.yaml
+++ b/http/vulnerabilities/cisco/cisco-vmanage-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/cisco/cisco-webex-log4j-rce.yaml
+++ b/http/vulnerabilities/cisco/cisco-webex-log4j-rce.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:cisco:webex_meetings_online:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/code42/code42-log4j-rce.yaml
+++ b/http/vulnerabilities/code42/code42-log4j-rce.yaml
@@ -19,7 +19,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: cve,cve2021,jndi,log4j,rce,oast,code42,kev,vuln

--- a/http/vulnerabilities/confluence-xslt-macro-ssrf.yaml
+++ b/http/vulnerabilities/confluence-xslt-macro-ssrf.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 6.5
     cve-id: CVE-2024-29415
-    cwe-id: CWE-918
+    cwe-id: CWE-611,CWE-918
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/copyparty-xss.yaml
+++ b/http/vulnerabilities/copyparty-xss.yaml
@@ -9,6 +9,8 @@ info:
   remediation: Upgrade to the latest version to mitigate this vulnerability.
   reference:
     - https://github.com/9001/copyparty/security/advisories/GHSA-cw7j-v52w-fp5r
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/cross-site-tracing-xss.yaml
+++ b/http/vulnerabilities/cross-site-tracing-xss.yaml
@@ -10,7 +10,7 @@ info:
     - https://medium.com/@tushar_rs_/cross-site-tracing-attack-xst-5aa519658b7a
     - https://www.owasp.org/index.php/Cross_Site_Tracing
   classification:
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,trace,generic

--- a/http/vulnerabilities/dahua/dahua-eims-rce.yaml
+++ b/http/vulnerabilities/dahua/dahua-eims-rce.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%A4%A7%E5%8D%8EEIMS-capture_handle%E6%8E%A5%E5%8F%A3%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
     - https://cn-sec.com/archives/2554372.html
+  classification:
+    cwe-id: CWE-77,CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/dahua/dahua-icc-getclassvalue-rce.yaml
+++ b/http/vulnerabilities/dahua/dahua-icc-getclassvalue-rce.yaml
@@ -8,6 +8,8 @@ info:
     Remote Code Execution Vulnerability in Dahua Intelligent IoT Integrated Management Platform via GetClassValue.jsp.
   reference:
     - https://github.com/zan8in/afrog/blob/main/pocs/afrog-pocs/vulnerability/dahua-icc-getclassvalue-rce.yaml
+  classification:
+    cwe-id: CWE-78,CWE-94,CWE-470
   metadata:
     fofa-query: app="dahua-智能物联综合管理平台"
     max-request: 1

--- a/http/vulnerabilities/dahua/dahua-wpms-lfi.yaml
+++ b/http/vulnerabilities/dahua/dahua-wpms-lfi.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://mp.weixin.qq.com/s/uRhVl2XC5fTNKO8eDFFebA
     - https://github.com/Vme18000yuan/FreePOC/blob/master/poc/pocsuite/dahua_zhyq_attachment_fileread.py
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/dbgate-unauth-rce.yaml
+++ b/http/vulnerabilities/dbgate-unauth-rce.yaml
@@ -12,6 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
+    cwe-id: CWE-78,CWE-94
   metadata:
     max-request: 1
     shodan-query: http.favicon.hash:1198579728

--- a/http/vulnerabilities/dedecms/dedecms-carbuyaction-fileinclude.yaml
+++ b/http/vulnerabilities/dedecms/dedecms-carbuyaction-fileinclude.yaml
@@ -9,6 +9,7 @@ info:
     - https://www.cnblogs.com/milantgh/p/3615986.html
   classification:
     cpe: cpe:2.3:a:dedecms:dedecms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/dedecms/dedecms-config-xss.yaml
+++ b/http/vulnerabilities/dedecms/dedecms-config-xss.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
     cpe: cpe:2.3:a:dedecms:dedecms:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/dedecms/dedecms-rce.yaml
+++ b/http/vulnerabilities/dedecms/dedecms-rce.yaml
@@ -11,6 +11,7 @@ info:
     - https://sectime.top/post/1d114771.html
   classification:
     cpe: cpe:2.3:a:dedecms:dedecms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78,CWE-94
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/dlink/dlink-nas-rce.yaml
+++ b/http/vulnerabilities/dlink/dlink-nas-rce.yaml
@@ -8,6 +8,8 @@ info:
     The D-Link NAS interface sc_mgr.cgi contains a command execution vulnerability that allows attackers to execute arbitrary commands on the device, potentially leading to unauthorized access or control over the system.
   remediation: |
     To remediate this vulnerability, ensure that the device firmware is updated to the latest version provided by the manufacturer. Additionally, consider implementing network segmentation and firewall rules to restrict unauthorized access to the device.
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/dlink/dlink-netgear-xss.yaml
+++ b/http/vulnerabilities/dlink/dlink-netgear-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N
     cvss-score: 4.3
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/drupal/drupal-avatar-xss.yaml
+++ b/http/vulnerabilities/drupal/drupal-avatar-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,drupal,edb,packetstorm,vuln

--- a/http/vulnerabilities/esafenet/esafenet-netsecconfigajax-sqli.yaml
+++ b/http/vulnerabilities/esafenet/esafenet-netsecconfigajax-sqli.yaml
@@ -8,6 +8,7 @@ info:
     The `state` parameter of the `NetSecConfigAjax` interface of the Yisaitong electronic document security management system does not pre-compile and adequately verify the incoming data, resulting in a SQL injection vulnerability in the interface. Malicious attackers may obtain the server through this vulnerability information or directly obtain server permissions.
   classification:
     cpe: cpe:2.3:a:esafenet:cdg:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/esafenet/esafenet-noticeajax-sqli.yaml
+++ b/http/vulnerabilities/esafenet/esafenet-noticeajax-sqli.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   description: |
     CDGServer3 NoticeAjax Interface Sql Injection.
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/fastjson/fastjson-1-2-24-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-24-rce.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 2
   tags: fastjson,rce,deserialization,oast,vulhub,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-41-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-41-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-42-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-42-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-43-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-43-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-62-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-62-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-67-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-67-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 1
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/fastjson/fastjson-1-2-68-rce.yaml
+++ b/http/vulnerabilities/fastjson/fastjson-1-2-68-rce.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     max-request: 3
   tags: fastjson,rce,deserialization,oast,vuln

--- a/http/vulnerabilities/finereport/finereport-path-traversal.yaml
+++ b/http/vulnerabilities/finereport/finereport-path-traversal.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 2
   tags: finereport,lfi,vuln

--- a/http/vulnerabilities/fronsetiav-xss.yaml
+++ b/http/vulnerabilities/fronsetiav-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://seclists.org/fulldisclosure/2024/Nov/10
     - https://packetstormsecurity.com/files/182764/fronsetia-1.1-Cross-Site-Scripting.html
     - https://msecureltd.blogspot.com/2024/11/friday-fun-pentest-series-14-reflected.html
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
     vendor: fronsetiav1.1

--- a/http/vulnerabilities/froxlor-xss.yaml
+++ b/http/vulnerabilities/froxlor-xss.yaml
@@ -9,7 +9,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
-    cwe-id: CWE-80
+    cwe-id: CWE-79
     cpe: cpe:2.3:a:froxlor:froxlor:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/generic/cache-poisoning-xss.yaml
+++ b/http/vulnerabilities/generic/cache-poisoning-xss.yaml
@@ -9,6 +9,8 @@ info:
     - https://blog.melbadry9.xyz/fuzzing/nuclei-cache-poisoning
     - https://portswigger.net/research/practical-web-cache-poisoning
     - https://portswigger.net/web-security/web-cache-poisoning
+  classification:
+    cwe-id: CWE-80
   metadata:
     max-request: 2
   tags: cache,generic,xss,vuln

--- a/http/vulnerabilities/generic/generic-blind-xxe.yaml
+++ b/http/vulnerabilities/generic/generic-blind-xxe.yaml
@@ -5,6 +5,8 @@ info:
   author: geeknik
   severity: high
   description: This template detects Generic Blind XXE.
+  classification:
+    cwe-id: CWE-611
   metadata:
     max-request: 1
   tags: xxe,generic,blind,vuln

--- a/http/vulnerabilities/generic/generic-j2ee-lfi.yaml
+++ b/http/vulnerabilities/generic/generic-j2ee-lfi.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://github.com/ilmila/J2EEScan/blob/master/src/main/java/burp/j2ee/issues/impl/LFIModule.java
     - https://gist.github.com/harisec/519dc6b45c6b594908c37d9ac19edbc3
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 13

--- a/http/vulnerabilities/generic/generic-linux-lfi.yaml
+++ b/http/vulnerabilities/generic/generic-linux-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 32
   tags: linux,lfi,generic,vuln

--- a/http/vulnerabilities/generic/generic-windows-lfi.yaml
+++ b/http/vulnerabilities/generic/generic-windows-lfi.yaml
@@ -9,7 +9,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 22
   tags: azure,windows,lfi,generic,vuln

--- a/http/vulnerabilities/generic/oob-header-based-interaction.yaml
+++ b/http/vulnerabilities/generic/oob-header-based-interaction.yaml
@@ -7,6 +7,8 @@ info:
   description: The remote server fetched a spoofed URL from the request headers.
   reference:
     - https://github.com/PortSwigger/collaborator-everywhere
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: oast,ssrf,generic,vuln

--- a/http/vulnerabilities/generic/oob-param-based-interaction.yaml
+++ b/http/vulnerabilities/generic/oob-param-based-interaction.yaml
@@ -7,6 +7,8 @@ info:
   description: The remote server fetched a spoofed URL from the request parameters.
   reference:
     - https://github.com/PortSwigger/collaborator-everywhere
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: oast,ssrf,generic,vuln

--- a/http/vulnerabilities/generic/request-based-interaction.yaml
+++ b/http/vulnerabilities/generic/request-based-interaction.yaml
@@ -7,6 +7,8 @@ info:
   description: The remote server fetched a spoofed DNS Name from the request.
   reference:
     - https://portswigger.net/research/cracking-the-lens-targeting-https-hidden-attack-surface
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 5
   tags: oast,ssrf,generic,vuln

--- a/http/vulnerabilities/generic/xmlrpc-pingback-ssrf.yaml
+++ b/http/vulnerabilities/generic/xmlrpc-pingback-ssrf.yaml
@@ -7,6 +7,8 @@ info:
   description: XMLRPC Pingback leads to SSRF.
   reference:
     - https://hackerone.com/reports/406387
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: xmlrpc,hackerone,ssrf,generic,vuln

--- a/http/vulnerabilities/generic/xss-uri-reflected.yaml
+++ b/http/vulnerabilities/generic/xss-uri-reflected.yaml
@@ -6,6 +6,8 @@ info:
   severity: low
   description: |
     Reflected cross-site scripting vulnerability was discovered via generic testing. Manual testing is needed to verify exploitation.
+  classification:
+    cwe-id: CWE-79
   metadata:
     max-request: 1
   tags: xss,generic,vuln

--- a/http/vulnerabilities/geovision-geowebserver-lfi-xss.yaml
+++ b/http/vulnerabilities/geovision-geowebserver-lfi-xss.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.geovision.com.tw/cyber_security.php
     - https://www.exploit-db.com/exploits/50211
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 3

--- a/http/vulnerabilities/gitlab/gitlab-rce.yaml
+++ b/http/vulnerabilities/gitlab/gitlab-rce.yaml
@@ -14,7 +14,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-22205
-    cwe-id: CWE-20
+    cwe-id: CWE-77,CWE-78
     cpe: cpe:2.3:a:gitlab:gitlab:*:*:*:*:enterprise:*:*:*
   metadata:
     max-request: 2

--- a/http/vulnerabilities/gnuboard/gnuboard-sms-xss.yaml
+++ b/http/vulnerabilities/gnuboard/gnuboard-sms-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
-    cwe-id: CWE-80
+    cwe-id: CWE-79,CWE-83
     cpe: cpe:2.3:a:gnuboard:gnuboard5:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/gradio-lfi.yaml
+++ b/http/vulnerabilities/gradio-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-20
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
     vendor: gradio_app

--- a/http/vulnerabilities/gradio/gradio-ssrf.yaml
+++ b/http/vulnerabilities/gradio/gradio-ssrf.yaml
@@ -12,6 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
+    cwe-id: CWE-918
     epss-percentile: 0.36659
     cpe: cpe:2.3:a:gradio_project:gradio:*:*:*:*:python:*:*:*
   metadata:

--- a/http/vulnerabilities/hcm/hcm-cloud-lfi.yaml
+++ b/http/vulnerabilities/hcm/hcm-cloud-lfi.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://mp.weixin.qq.com/s/nvV7_ZGDqSUZJ5FNEWDhKw
     - https://github.com/wy876/POC/blob/main/%E6%B5%AA%E6%BD%AE%E4%BA%91/HCM-Cloud%E4%BA%91%E7%AB%AF%E4%B8%93%E4%B8%9A%E4%BA%BA%E5%8A%9B%E8%B5%84%E6%BA%90%E5%B9%B3%E5%8F%B0download%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/hikvision/hikvision-fastjson-rce.yaml
+++ b/http/vulnerabilities/hikvision/hikvision-fastjson-rce.yaml
@@ -10,6 +10,8 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/iot/HIKVISION/HIKVISION%20%E7%BB%BC%E5%90%88%E5%AE%89%E9%98%B2%E7%AE%A1%E7%90%86%E5%B9%B3%E5%8F%B0%20applyCT%20Fastjson%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
     - https://github.com/MrWQ/vulnerability-paper/blob/master/bugs/%E6%B5%B7%E5%BA%B7%E5%A8%81%E8%A7%86%E7%BB%BC%E5%90%88%E5%AE%89%E9%98%B2%20Fastjson%20%E5%86%85%E5%AD%98%E9%A9%AC%E6%89%93%E6%B3%95.md
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/hikvision-fastjson-rce.yaml
+  classification:
+    cwe-id: CWE-94,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/hjsoft/hjsoft-hcm-lfi.yaml
+++ b/http/vulnerabilities/hjsoft/hjsoft-hcm-lfi.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%AE%8F%E6%99%AFeHR%E4%BA%BA%E5%8A%9B%E8%B5%84%E6%BA%90%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%E6%8E%A5%E5%8F%A3DownLoadCourseware%E5%AD%98%E5%9C%A8%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
     - https://blog.csdn.net/qq_41904294/article/details/140180110
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/hjsoft/hjsoft-hcm-tb-sqli.yaml
+++ b/http/vulnerabilities/hjsoft/hjsoft-hcm-tb-sqli.yaml
@@ -8,6 +8,8 @@ info:
     There is a SQL injection vulnerability in the /gz/LoadOtherTreeServlet interface of Hongjing HCM. Unauthenticated remote attackers can use the SQL injection vulnerability with the database xp_cmdshell to execute arbitrary commands and control the server. After analysis and judgment, the vulnerability is easy to exploit and it is recommended to be fixed as soon as possible.
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%AE%8F%E6%99%AFeHR%E4%BA%BA%E5%8A%9B%E8%B5%84%E6%BA%90%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%E6%8E%A5%E5%8F%A3LoadOtherTreeServlet%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/httpbin/httpbin-xss.yaml
+++ b/http/vulnerabilities/httpbin/httpbin-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
     shodan-query:

--- a/http/vulnerabilities/huatian/huatian-oa-sqli.yaml
+++ b/http/vulnerabilities/huatian/huatian-oa-sqli.yaml
@@ -8,6 +8,8 @@ info:
     There is a SQL injection vulnerability in the workFlowService interface of Huatian Power OA 8000. An attacker can exploit this vulnerability to obtain sensitive database information.
   reference:
     - https://blog.csdn.net/qq_41617034/article/details/124305120
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/huawei/huawei-authhttp-lfi.yaml
+++ b/http/vulnerabilities/huawei/huawei-authhttp-lfi.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://mp.weixin.qq.com/s?__biz=MzIxMTg1ODAwNw==&mid=2247498499&idx=1&sn=6850c3e9a3df795e48ba9a10c9772ddd
     - https://github.com/Vme18000yuan/FreePOC/blob/master/poc/pocsuite/huawei-auth-http-readfile.py
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/huawei/huawei-hg255s-lfi.yaml
+++ b/http/vulnerabilities/huawei/huawei-hg255s-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
     cpe: cpe:2.3:h:huawei:hg255s:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/ibm/eclipse-help-system-xss.yaml
+++ b/http/vulnerabilities/ibm/eclipse-help-system-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: ibm,xss,vuln

--- a/http/vulnerabilities/ibm/ibm-infoprint-lfi.yaml
+++ b/http/vulnerabilities/ibm/ibm-infoprint-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: matrix,printer,edb,ibm,lfi,vuln

--- a/http/vulnerabilities/idoc/idocview-lfi.yaml
+++ b/http/vulnerabilities/idoc/idocview-lfi.yaml
@@ -4,6 +4,8 @@ info:
   name: IDoc View - Arbitrary File Read
   author: DhiyaneshDK
   severity: high
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/imo/imo-file-download.yaml
+++ b/http/vulnerabilities/imo/imo-file-download.yaml
@@ -8,6 +8,8 @@ info:
     The imo cloud office can read system sensitive files because the filename parameter of the /file/Placard/upload/Imo_DownLoadUI.php page is not strictly filtered.
   reference:
     - https://forum.butian.net/article/214
+  classification:
+    cwe-id: CWE-200,CWE-552
   metadata:
     max-request: 2
   tags: imo,file-download,vuln

--- a/http/vulnerabilities/imo/imo-rce.yaml
+++ b/http/vulnerabilities/imo/imo-rce.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cwe-id: CWE-89
+    cwe-id: CWE-78
   metadata:
     max-request: 3
   tags: imo,rce,vuln

--- a/http/vulnerabilities/jamf/jamf-blind-xxe.yaml
+++ b/http/vulnerabilities/jamf/jamf-blind-xxe.yaml
@@ -7,6 +7,8 @@ info:
   description: Blind XXE / SSRF exists in JAMF which is a company that provides enterprise-level software solutions for managing and securing Apple devices in organizations.
   reference:
     - https://www.synack.com/blog/a-deep-dive-into-xxe-injection/
+  classification:
+    cwe-id: CWE-611,CWE-918
   metadata:
     max-request: 1
   tags: xxe,ssrf,jamf,vuln

--- a/http/vulnerabilities/jenkins/jenkins-script.yaml
+++ b/http/vulnerabilities/jenkins/jenkins-script.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78,CWE-94
   metadata:
     max-request: 2
   tags: devops,hackerone,jenkins,rce,vuln

--- a/http/vulnerabilities/jinhe/jinhe-jc6-sqli.yaml
+++ b/http/vulnerabilities/jinhe/jinhe-jc6-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/wy876/POC/blob/main/%E9%87%91%E5%92%8COA%20jc6%20clobfield%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
     - https://blog.csdn.net/qq_41904294/article/details/135074649
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/jinhe/jinhe-oa-c6-lfi.yaml
+++ b/http/vulnerabilities/jinhe/jinhe-oa-c6-lfi.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   description: |
     There is an arbitrary file read vulnerability in Jinhe OA C6 download.jsp file, through which an attacker can obtain sensitive information in the server
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/jinhe/jinhe-oa-c6-upload-lfi.yaml
+++ b/http/vulnerabilities/jinhe/jinhe-oa-c6-upload-lfi.yaml
@@ -8,6 +8,8 @@ info:
     There is an arbitrary file reading vulnerability in the UploadFileDownLoadnew.aspx interface of Jinhe OA C6. An unauthenticated attacker can use this vulnerability to read important system files (such as database configuration files, system configuration files), database configuration files, etc., causing the website to be in Extremely unsafe state.
   reference:
     - https://github.com/wy876/POC/blob/main/%E9%87%91%E5%92%8COA_C6_UploadFileDownLoadnew%E5%AD%98%E5%9C%A8%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
     verified: true

--- a/http/vulnerabilities/jolokia/jolokia-createstandardhost-rce.yaml
+++ b/http/vulnerabilities/jolokia/jolokia-createstandardhost-rce.yaml
@@ -7,6 +7,8 @@ info:
   description: File read and file write to RCE by deploying a vhost with MBeanFactory/createStandardHost and DiagnosticCommand/jfrStart
   reference:
     - https://github.com/laluka/jolokia-exploitation-toolkit
+  classification:
+    cwe-id: CWE-15,CWE-94
   tags: jolokia,rce,vuln
 
 http:

--- a/http/vulnerabilities/jolokia/jolokia-file-read-compilerdirectivesadd.yaml
+++ b/http/vulnerabilities/jolokia/jolokia-file-read-compilerdirectivesadd.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
     cvss-score: 8.3
-    cwe-id: CWE-522
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 2
   tags: jolokia,springboot,tomcat,lfi,misconfig,vuln

--- a/http/vulnerabilities/joomla/joomla-department-sqli.yaml
+++ b/http/vulnerabilities/joomla/joomla-department-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/opensec-cn/kunpeng/blob/master/plugin/json/joomla_departments_sqli.json
     - https://github.com/w3bd0gs/cocoworker/blob/master/plugins/beebeeto/poc_2014_0170.py
+  classification:
+    cwe-id: CWE-89
   metadata:
     max-request: 1
     shodan-query: http.component:"Joomla"

--- a/http/vulnerabilities/joomla/joomla-easyshop-lfi.yaml
+++ b/http/vulnerabilities/joomla/joomla-easyshop-lfi.yaml
@@ -8,6 +8,8 @@ info:
     The Joomla! component Easy Shop version 1.2.3 is vulnerable to Local File Inclusion (LFI) attacks.
   reference:
     - https://blog.csdn.net/weixin_42628854/article/details/136036109
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/joomla/joomla-joombri-careers-xss.yaml
+++ b/http/vulnerabilities/joomla/joomla-joombri-careers-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://packetstormsecurity.com/files/168641/Joomla-JoomBri-Careers-3.3.0-Cross-Site-Scripting.html
     - https://cxsecurity.com/issue/WLB-2022100024
     - https://extensions.joomla.org/
+  classification:
+    cwe-id: CWE-79
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/joomla/joomla-jvehicles-lfi.yaml
+++ b/http/vulnerabilities/joomla/joomla-jvehicles-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: joomla,lfi,edb,vuln

--- a/http/vulnerabilities/joomla/joomla-jvtwitter-xss.yaml
+++ b/http/vulnerabilities/joomla/joomla-jvtwitter-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://buaq.net/go-44433.html
     - https://cxsecurity.com/issue/WLB-2020110041
     - https://extensions.joomla.org/
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/joomla/joomla-marvikshop-sqli.yaml
+++ b/http/vulnerabilities/joomla/joomla-marvikshop-sqli.yaml
@@ -10,6 +10,8 @@ info:
     - https://vulners.com/zdt/1337DAY-ID-38020
     - https://cxsecurity.com/issue/WLB-2022100015
     - https://extensions.joomla.org/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/joomla/joomla-marvikshop-xss.yaml
+++ b/http/vulnerabilities/joomla/joomla-marvikshop-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://packetstormsecurity.com/files/168598/Joomla-MarvikShop-ShoppingCart-3.4-Cross-Site-Scripting.html
     - https://cxsecurity.com/issue/WLB-2022100015
     - https://extensions.joomla.org/
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/joomla/joomla-solidres-xss.yaml
+++ b/http/vulnerabilities/joomla/joomla-solidres-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://www.exploit-db.com/exploits/51638
     - https://cxsecurity.com/issue/WLB-2023070080
     - https://cyberlegion.io/joomla-solidres-2-13-3-cross-site-scripting/
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/joomla/rusty-joomla.yaml
+++ b/http/vulnerabilities/joomla/rusty-joomla.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-94,CWE-502
   metadata:
     max-request: 2
   tags: joomla,rce,unauth,php,cms,objectinjection,vuln

--- a/http/vulnerabilities/jorani/jorani-benjamin-xss.yaml
+++ b/http/vulnerabilities/jorani/jorani-benjamin-xss.yaml
@@ -8,6 +8,8 @@ info:
     The value of the `language request` parameter is copied into a JavaScript string which is encapsulated in double quotation marks. The payload 75943";alert(1)//569 was submitted in the language parameter. This input was echoed unmodified in the application's response. The attacker can modify the token session and he can discover sensitive information for the server.
   reference:
     - https://packetstormsecurity.com/files/174341/Jorani-1.0.3-Cross-Site-Scripting.html
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/juniper/junos-xss.yaml
+++ b/http/vulnerabilities/juniper/junos-xss.yaml
@@ -8,6 +8,7 @@ info:
     - https://labs.watchtowr.com/the-second-wednesday-of-the-first-month-of-every-quarter-juniper-0day-revisited/
   classification:
     cpe: cpe:2.3:o:juniper:junos:*:*:*:*:*:*:*:*
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/landray/landray-eis-sqli.yaml
+++ b/http/vulnerabilities/landray/landray-eis-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/wy876/POC/blob/main/%E8%93%9D%E5%87%8CEIS%E6%99%BA%E6%85%A7%E5%8D%8F%E5%90%8C%E5%B9%B3%E5%8F%B0rpt_listreport_definefield.aspx%E6%8E%A5%E5%8F%A3%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md?plain=1
   classification:
     cpe: cpe:2.3:a:landray:landray_office_automation:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/landray/landray-oa-sysSearchMain-editParam-rce.yaml
+++ b/http/vulnerabilities/landray/landray-oa-sysSearchMain-editParam-rce.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/mhaskar/XMLDecoder-payload-generator
   classification:
     cpe: cpe:2.3:a:landray:landray_office_automation:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78,CWE-95,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/landray/landray-oa-treexml-rce.yaml
+++ b/http/vulnerabilities/landray/landray-oa-treexml-rce.yaml
@@ -11,6 +11,7 @@ info:
     - https://vuls.info/PeiQi/wiki/oa/%E8%93%9D%E5%87%8COA/%E8%93%9D%E5%87%8COA%20treexml.tmpl%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E/#_4
   classification:
     cpe: cpe:2.3:a:landray:landray_office_automation:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78,CWE-94
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/laravel/laravel-ignition-xss.yaml
+++ b/http/vulnerabilities/laravel/laravel-ignition-xss.yaml
@@ -14,7 +14,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: laravel,xss,ignition,vuln

--- a/http/vulnerabilities/leantime/leantime-stored-xss.yaml
+++ b/http/vulnerabilities/leantime/leantime-stored-xss.yaml
@@ -8,6 +8,8 @@ info:
     Any low privileged user like manager, or editor, can create an API key with XSS payload. When admin will visit the Company page, the XSS will automatically get triggerred leading to the unauthorized action performed from the ADMIN account. Like, removing any user, or adding someone else as high privilege, and many more.
   reference:
     - https://github.com/advisories/GHSA-c39w-3pjx-qc7m
+  classification:
+    cwe-id: CWE-79,CWE-83
   tags: leantime,xss,stored,authenticated,vuln
 
 flow: http(1) && http(2) && http(3)

--- a/http/vulnerabilities/lucee-rce.yaml
+++ b/http/vulnerabilities/lucee-rce.yaml
@@ -6,6 +6,8 @@ info:
   severity: critical
   reference:
     - https://blog.projectdiscovery.io/hello-lucee-let-us-hack-apple-again
+  classification:
+    cwe-id: CWE-95
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/mamp/mamp-server-xss.yaml
+++ b/http/vulnerabilities/mamp/mamp-server-xss.yaml
@@ -15,7 +15,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/metersphere/metersphere-plugin-rce.yaml
+++ b/http/vulnerabilities/metersphere/metersphere-plugin-rce.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/microsoft/office-webapps-ssrf.yaml
+++ b/http/vulnerabilities/microsoft/office-webapps-ssrf.yaml
@@ -9,6 +9,7 @@ info:
     - https://drive.google.com/file/d/1aeNq_5wVwHRR1np1jIRQM1hocrgcZ6Qu/view (Slide 37,38)
   classification:
     cpe: cpe:2.3:a:microsoft:office_web_apps_server:*:*:*:*:*:*:*:*
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/netmizer/netmizer-cmd-rce.yaml
+++ b/http/vulnerabilities/netmizer/netmizer-cmd-rce.yaml
@@ -8,6 +8,8 @@ info:
     Remote Command Execution vulnerability in the NetMizer log management system cmd.php, and the attacker can execute the command by passing in the cmd parameter.
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/%E7%BD%91%E7%BB%9C%E8%AE%BE%E5%A4%87%E6%BC%8F%E6%B4%9E/NetMizer%20%E6%97%A5%E5%BF%97%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%20cmd.php%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/netsweeper/netsweeper-rxss.yaml
+++ b/http/vulnerabilities/netsweeper/netsweeper-rxss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: edb,xss,packetstorm,netsweeper,vuln

--- a/http/vulnerabilities/nuxt/nuxt-js-lfi.yaml
+++ b/http/vulnerabilities/nuxt/nuxt-js-lfi.yaml
@@ -10,6 +10,8 @@ info:
     - https://huntr.dev/bounties/4849af83-450c-435e-bc0b-71705f5be440/
     - https://bryces.io/blog/nuxt3
     - https://twitter.com/fofabot/status/1669339995780558849
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: "true"
     max-request: 2

--- a/http/vulnerabilities/nuxt/nuxt-js-semi-lfi.yaml
+++ b/http/vulnerabilities/nuxt/nuxt-js-semi-lfi.yaml
@@ -11,6 +11,7 @@ info:
     - https://twitter.com/fofabot/status/1669339995780558849
   classification:
     cpe: cpe:2.3:a:nuxt:framework:*:*:*:*:*:*:*:*
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: "true"
     max-request: 2

--- a/http/vulnerabilities/nuxt/nuxt-js-xss.yaml
+++ b/http/vulnerabilities/nuxt/nuxt-js-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://huntr.dev/bounties/70ac720d-c932-4ed3-98b1-dd2cbcb90185/
     - https://bryces.io/blog/nuxt3
     - https://twitter.com/fofabot/status/1669339995780558849
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/opencpu/opencpu-rce.yaml
+++ b/http/vulnerabilities/opencpu/opencpu-rce.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://pulsesecurity.co.nz/articles/R-Shells
     - https://github.com/opencpu/opencpu/
+  classification:
+    cwe-id: CWE-78,CWE-95
   metadata:
     max-request: 1
   tags: rce,opencpu,oss,vuln

--- a/http/vulnerabilities/oracle/oracle-ebs-xss.yaml
+++ b/http/vulnerabilities/oracle/oracle-ebs-xss.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://www.blackhat.com/docs/us-16/materials/us-16-Litchfield-Hackproofing-Oracle-eBusiness-Suite.pdf
     - http://www.davidlitchfield.com/AssessingOraclee-BusinessSuite11i.pdf
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 3
     shodan-query: html:"OA_HTML"

--- a/http/vulnerabilities/oracle/oracle-siebel-xss.yaml
+++ b/http/vulnerabilities/oracle/oracle-siebel-xss.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,oracle,siebel,packetstorm,edb,vuln

--- a/http/vulnerabilities/other/3cx-management-console.yaml
+++ b/http/vulnerabilities/other/3cx-management-console.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
     cpe: cpe:2.3:a:3cx:3cx:*:*:*:*:*:*:*:*
   metadata:
     max-request: 2

--- a/http/vulnerabilities/other/accent-microcomputers-lfi.yaml
+++ b/http/vulnerabilities/other/accent-microcomputers-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: microcomputers,accent,lfi,vuln

--- a/http/vulnerabilities/other/acme-xss.yaml
+++ b/http/vulnerabilities/other/acme-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,acme,vuln

--- a/http/vulnerabilities/other/acti-video-lfi.yaml
+++ b/http/vulnerabilities/other/acti-video-lfi.yaml
@@ -10,6 +10,7 @@ info:
     - https://www.cnblogs.com/hmesed/p/16292252.html
   classification:
     cpe: cpe:2.3:o:acti:camera_firmware:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/alibaba-anyproxy-lfi.yaml
+++ b/http/vulnerabilities/other/alibaba-anyproxy-lfi.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://github.com/alibaba/anyproxy/issues/391
     - https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/Alibaba%20AnyProxy%20fetchBody%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/applezeed-sqli.yaml
+++ b/http/vulnerabilities/other/applezeed-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Applezeed's 'travel-details.php?id=' URL with possible time-based SQL injection (SQLi) vulnerability allows attackers to manipulate the 'id' parameter, potentially causing delays in SQL queries and unauthorized retrieval of travel information from the database
   reference:
     - https://cxsecurity.com/issue/WLB-2019120057
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/array-vpn-lfi.yaml
+++ b/http/vulnerabilities/other/array-vpn-lfi.yaml
@@ -8,6 +8,8 @@ info:
     Array VPN Arbitrary File Reading Vulnerability
   reference:
     - https://github.com/wy876/POC/blob/main/Array%20VPN%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/asanhamayesh-lfi.yaml
+++ b/http/vulnerabilities/other/asanhamayesh-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: asanhamayesh,lfi,traversal,vuln

--- a/http/vulnerabilities/other/aspcms-commentlist-sqli.yaml
+++ b/http/vulnerabilities/other/aspcms-commentlist-sqli.yaml
@@ -8,6 +8,8 @@ info:
     An SQL injection vulnerability has been identified in the commentList.asp file of AspCMS. Exploiting this vulnerability, an attacker can illicitly acquire the administrator's MD5 password.
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/cms/AspCMS/AspCMS%20commentList.asp%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/avada-xss.yaml
+++ b/http/vulnerabilities/other/avada-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,wp,wordpress,wp-theme,avada,wpscan,vuln

--- a/http/vulnerabilities/other/avcon6-execl-lfi.yaml
+++ b/http/vulnerabilities/other/avcon6-execl-lfi.yaml
@@ -8,6 +8,8 @@ info:
     Arbitrary File Download vulnerability in the org_execl_download.action of the AVCON6 system management platform, through which an attacker can download arbitrary files from the server
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/AVCON6%20%E7%B3%BB%E7%BB%9F%E7%AE%A1%E7%90%86%E5%B9%B3%E5%8F%B0%20org_execl_download.action%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8B%E8%BD%BD%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/avcon6-lfi.yaml
+++ b/http/vulnerabilities/other/avcon6-lfi.yaml
@@ -8,6 +8,8 @@ info:
     File Download vulnerability in the download.action of the AVCON6 system management platform, through which an attacker can download arbitrary files from the server
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/AVCON6%20%E7%B3%BB%E7%BB%9F%E7%AE%A1%E7%90%86%E5%B9%B3%E5%8F%B0%20download.action%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8B%E8%BD%BD%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/azon-dominator-sqli.yaml
+++ b/http/vulnerabilities/other/azon-dominator-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/52059
     - https://www.codester.com/items/12775/azon-dominator-affiliate-marketing-script
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/bagisto-csti.yaml
+++ b/http/vulnerabilities/other/bagisto-csti.yaml
@@ -11,6 +11,7 @@ info:
     - https://demo.bagisto.com/
   classification:
     cpe: cpe:2.3:a:webkul:bagisto:*:*:*:*:*:*:*:*
+    cwe-id: CWE-94
   metadata:
     max-request: 1
     vendor: webkul

--- a/http/vulnerabilities/other/bems-api-lfi.yaml
+++ b/http/vulnerabilities/other/bems-api-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: lfi,packetstorm,vuln

--- a/http/vulnerabilities/other/beward-ipcamera-disclosure.yaml
+++ b/http/vulnerabilities/other/beward-ipcamera-disclosure.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: iot,camera,disclosure,edb,vuln

--- a/http/vulnerabilities/other/beyond-trust-xss.yaml
+++ b/http/vulnerabilities/other/beyond-trust-xss.yaml
@@ -10,6 +10,7 @@ info:
     - https://www.exploit-db.com/exploits/50632
   classification:
     cpe: cpe:2.3:a:beyondtrust:remote_support:*:*:*:*:*:*:*:*
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/blue-ocean-excellence-lfi.yaml
+++ b/http/vulnerabilities/other/blue-ocean-excellence-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: blue-ocean,lfi,vuln

--- a/http/vulnerabilities/other/brightsign-dsdws-ssrf.yaml
+++ b/http/vulnerabilities/other/brightsign-dsdws-ssrf.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://brightsign.zendesk.com/hc/en-us/articles/360056180694-Regarding-Advisory-ID-ZSL-2020-5595
     - https://www.zeroscience.mk/codes/brightsign_ssrf.txt
+  classification:
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/bullwark-momentum-lfi.yaml
+++ b/http/vulnerabilities/other/bullwark-momentum-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
     shodan-query: Bullwark

--- a/http/vulnerabilities/other/caimore-gateway-rce.yaml
+++ b/http/vulnerabilities/other/caimore-gateway-rce.yaml
@@ -8,6 +8,8 @@ info:
     The gateway of Xiamen Caimao Communication Technology Co., Ltd. is designed with open software architecture. It is a metal shell design, with two Ethernet RJ45 interfaces, and an industrial design wireless gateway using 3G/4G/5G wide area network for Internet communication. There is a command execution vulnerability in the formping file of the gateway of Xiamen Caimao Communication Technology Co., Ltd. An attacker can use this vulnerability to arbitrarily execute code on the server side, write to the back door, obtain server permissions, and then control the entire web server.
   reference:
     - https://www.ctfiot.com/126482.html
+  classification:
+    cwe-id: CWE-78
   metadata:
     max-request: 2
     fofa-query: app="CAIMORE-Gateway"

--- a/http/vulnerabilities/other/castel-digital-sqli.yaml
+++ b/http/vulnerabilities/other/castel-digital-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.casteldigital.com.br/
     - https://cxsecurity.com/issue/WLB-2024050032
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/other/cerio-dt-rce.yaml
+++ b/http/vulnerabilities/other/cerio-dt-rce.yaml
@@ -10,6 +10,8 @@ info:
     - https://github.com/20142995/sectool
     - https://github.com/tanjiti/sec_profile
     - https://github.com/wy876/POC/blob/main/D-Link_DAR-8000%E6%93%8D%E4%BD%9C%E7%B3%BB%E7%BB%9F%E5%91%BD%E4%BB%A4%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E(CVE-2023-4542).md
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/chamilo-lms-xss.yaml
+++ b/http/vulnerabilities/other/chamilo-lms-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: xss,chamilo,vuln

--- a/http/vulnerabilities/other/citrix-xenapp-log4j-rce.yaml
+++ b/http/vulnerabilities/other/citrix-xenapp-log4j-rce.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:citrix:xenapp:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/other/clodop-printer-lfi.yaml
+++ b/http/vulnerabilities/other/clodop-printer-lfi.yaml
@@ -8,6 +8,8 @@ info:
     The C-Lodop printer has an arbitrary file reading vulnerability. By constructing a special URL, it can read any file in the system.
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/8e4f0be1f75a71cffe4b2c2c558ad1cd4d03d9a7/%E7%BD%91%E7%BB%9C%E8%AE%BE%E5%A4%87%E6%BC%8F%E6%B4%9E/C-Lodop%E6%89%93%E5%8D%B0%E6%9C%BA%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/cloud-oa-system-sqli.yaml
+++ b/http/vulnerabilities/other/cloud-oa-system-sqli.yaml
@@ -8,6 +8,8 @@ info:
     cloud OA system /OA/PM/svc.asmx page parameters are not properly filtered, resulting in a SQL injection vulnerability, which can be used to obtain sensitive information in the database.
   reference:
     - https://github.com/GREENHAT7/pxplan/blob/e2fc04893ca95e177021ddf61cc2134ecc120a8e/xray_pocs/yaml-poc-eqccd-eqccd_oa-sql_injection-CT-456760.yml#L8
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/cloudlog-system-sqli.yaml
+++ b/http/vulnerabilities/other/cloudlog-system-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Unauthorised SQL injection vulnerability in the Cloudlog system interface request_form. In addition to being able to exploit the SQL injection vulnerability to obtain information from the database, unauthenticated remote attackers can also.
   reference:
     - https://github.com/wy876/POC/blob/main/Cloudlog/Cloudlog%E7%B3%BB%E7%BB%9Frequest_form%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/coldfusion-debug-xss.yaml
+++ b/http/vulnerabilities/other/coldfusion-debug-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
     cpe: cpe:2.3:a:adobe:coldfusion:*:*:*:*:*:*:*:*
   metadata:
     max-request: 2

--- a/http/vulnerabilities/other/core-chuangtian-cloud-rce.yaml
+++ b/http/vulnerabilities/other/core-chuangtian-cloud-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-434
   metadata:
     max-request: 2
   tags: rce,fileupload,intrusive,cloud,chuangtian,vuln

--- a/http/vulnerabilities/other/cpas-managment-lfi.yaml
+++ b/http/vulnerabilities/other/cpas-managment-lfi.yaml
@@ -8,6 +8,8 @@ info:
     The CPAS Audit Management System has been found to contain a vulnerability that allows arbitrary file read. This security flaw can be exploited by attackers to access sensitive files on the server, potentially exposing critical system information. The vulnerability can be triggered by sending a specially crafted HTTP GET request to the endpoint /cpasm4/plugInManController/downPlugs with parameters fileId and fileName, enabling the retrieval of arbitrary files such as /etc/passwd. This issue poses a significant risk to system security and should be addressed immediately to prevent unauthorized access and potential data breaches.
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%8C%97%E4%BA%AC%E5%8F%8B%E6%95%B0%E8%81%9A%E7%A7%91%E6%8A%80/CPAS%E5%AE%A1%E8%AE%A1%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%E5%AD%98%E5%9C%A8%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/cpas-managment-sqli.yaml
+++ b/http/vulnerabilities/other/cpas-managment-sqli.yaml
@@ -8,6 +8,8 @@ info:
     The CPAS Audit Management System V4 has been identified with an SQL injection vulnerability in the getCurserIfAllowLogin endpoint. This flaw allows unauthenticated remote attackers to exploit the system by injecting malicious SQL queries. Through this vulnerability, attackers can retrieve sensitive data from the database and, under high-privilege circumstances, upload malicious payloads such as web shells to the server. This could potentially lead to a full compromise of the server's system. The vulnerability is triggered via a crafted HTTP POST request containing a malicious ygbh parameter, making it a critical issue that requires immediate remediation to protect the integrity of the system.
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%8C%97%E4%BA%AC%E5%8F%8B%E6%95%B0%E8%81%9A%E7%A7%91%E6%8A%80/CPAS%E5%AE%A1%E8%AE%A1%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9FgetCurserIfAllowLogin%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/crawlab-lfi.yaml
+++ b/http/vulnerabilities/other/crawlab-lfi.yaml
@@ -7,6 +7,8 @@ info:
   description: Crawlab is vulnerable to arbitrary file read.
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/Crawlab%20file%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/crocus-lfi.yaml
+++ b/http/vulnerabilities/other/crocus-lfi.yaml
@@ -8,6 +8,8 @@ info:
     There is an arbitrary file reading vulnerability in the Service.do interface of Ruiming Technology's Crocus system. An unauthenticated remote attacker can use this vulnerability to read important system files (such as database configuration files, system configuration files), database configuration files, etc. This leaves the website in an extremely unsafe state.
   reference:
     - https://github.com/wy876/POC/blob/main/%E9%94%90%E6%98%8E%E6%8A%80%E6%9C%AFCrocus%E7%B3%BB%E7%BB%9FService.do%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/crystal-live-server-lfi.yaml
+++ b/http/vulnerabilities/other/crystal-live-server-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: lfi,crystal,vuln

--- a/http/vulnerabilities/other/csz-cms-sqli.yaml
+++ b/http/vulnerabilities/other/csz-cms-sqli.yaml
@@ -8,6 +8,8 @@ info:
     CSZ CMS version 1.3.0 suffers from multiple remote blind SQL injection vulnerabilities.
   reference:
     - https://packetstormsecurity.com/files/167028/CSZ-CMS-1.3.0-SQL-Injection.html
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/digital-ocean-ssrf.yaml
+++ b/http/vulnerabilities/other/digital-ocean-ssrf.yaml
@@ -8,7 +8,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
     cvss-score: 9.3
-    cwe-id: CWE-441
+    cwe-id: CWE-918
   metadata:
     max-request: 2
   tags: digitalocean,ssrf,vuln

--- a/http/vulnerabilities/other/ecology-oa-file-sqli.yaml
+++ b/http/vulnerabilities/other/ecology-oa-file-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/TgHook/Vulnerability-Wiki/blob/master/docs-base/docs/oa/%E6%B3%9B%E5%BE%AEOA%20e-cology%20FileDownloadForOutDoc%E5%89%8D%E5%8F%B0SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/other/ektron-blog-xmlrpc-xxe.yaml
+++ b/http/vulnerabilities/other/ektron-blog-xmlrpc-xxe.yaml
@@ -10,6 +10,8 @@ info:
     - https://www.exploit-db.com/exploits/21085
     - https://packetstormsecurity.com/files/116259/Ektron-CMS-8.5.0-File-Upload-XXE-Injection.html
     - https://www.acunetix.com/vulnerabilities/web/ektron-cms-multiple-vulnerabilities
+  classification:
+    cwe-id: CWE-611,CWE-918
   metadata:
     verified: false
     max-request: 2

--- a/http/vulnerabilities/other/elasticsearch5-log4j-rce.yaml
+++ b/http/vulnerabilities/other/elasticsearch5-log4j-rce.yaml
@@ -14,7 +14,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:elastic:elasticsearch:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/other/elgg-sqli.yaml
+++ b/http/vulnerabilities/other/elgg-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/4rdr/proofs/blob/main/info/Elgg_unauth_SQLi_5.1.4.md
     - https://github.com/Elgg/Elgg
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/enjoyrmis-sqli.yaml
+++ b/http/vulnerabilities/other/enjoyrmis-sqli.yaml
@@ -8,6 +8,8 @@ info:
     EnjoyRMIS GetOAById has a SQL injection vulnerability, through which an attacker can obtain sensitive database information and even control the server.
   reference:
     - https://github.com/wy876/POC/blob/main/EnjoyRMIS-GetOAById%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     fofa-query: body="CheckSilverlightInstalled"
     verified: true

--- a/http/vulnerabilities/other/ep-web-cms-xss.yaml
+++ b/http/vulnerabilities/other/ep-web-cms-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/erensoft-sqli.yaml
+++ b/http/vulnerabilities/other/erensoft-sqli.yaml
@@ -8,6 +8,8 @@ info:
     SQL Injection is a type of SQL injection attack in which an attacker can exploit a vulnerability in a web application's input fields to manipulate the application's SQL queries.
   reference:
     - https://cxsecurity.com/issue/WLB-2023070055
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/flexnet-log4j-rce.yaml
+++ b/http/vulnerabilities/other/flexnet-log4j-rce.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:flexera:flexnet_publisher:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/other/fortiportal-log4j-rce.yaml
+++ b/http/vulnerabilities/other/fortiportal-log4j-rce.yaml
@@ -12,7 +12,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:fortinet:fortiportal:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/other/global-domains-xss.yaml
+++ b/http/vulnerabilities/other/global-domains-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: globaldomains,xss,packetstorm,vuln

--- a/http/vulnerabilities/other/goanywhere-mft-log4j-rce.yaml
+++ b/http/vulnerabilities/other/goanywhere-mft-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/other/graylog-log4j-rce.yaml
+++ b/http/vulnerabilities/other/graylog-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
     cpe: cpe:2.3:a:graylog:graylog:*:*:*:*:*:*:*:*
   metadata:
     verified: true

--- a/http/vulnerabilities/other/groomify-sqli.yaml
+++ b/http/vulnerabilities/other/groomify-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://codecanyon.net/item/groomify-barbershop-salon-spa-booking-and-ecommerce-platform/45808114#
     - https://vulners.com/zdt/1337DAY-ID-38799
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: "true"
     max-request: 1

--- a/http/vulnerabilities/other/gz-forum-script-xss.yaml
+++ b/http/vulnerabilities/other/gz-forum-script-xss.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/51559
     - https://gzscripts.com/gz-forum-script.html
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/h3c-imc-rce.yaml
+++ b/http/vulnerabilities/other/h3c-imc-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 2
     fofa-query: body="/imc/javax.faces.resource/images/login_help.png.jsf?ln=primefaces-imc-new-webui"

--- a/http/vulnerabilities/other/halo-tism-sqli.yaml
+++ b/http/vulnerabilities/other/halo-tism-sqli.yaml
@@ -8,6 +8,8 @@ info:
     A Time-Based SQL Injection vulnerability in Halo ITSM allows unauthenticated attackers to execute malicious SQL queries by leveraging time delays, potentially leading to data exfiltration, privilege escalation, or full system compromise.
   reference:
     - https://slcyber.io/assetnote-security-research-center/loose-types-sink-ships-pre-authentication-sql-injection-in-halo-itsm/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/hanta-rce.yaml
+++ b/http/vulnerabilities/other/hanta-rce.yaml
@@ -5,6 +5,8 @@ info:
   author: momika233
   severity: high
   description: Hanta Internet Behavior Management System is vulnerable to RCE.
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/hashicorp-consul-rce.yaml
+++ b/http/vulnerabilities/other/hashicorp-consul-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 1
   tags: hashicorp,rce,oast,intrusive,edb,vuln

--- a/http/vulnerabilities/other/hasura-graphql-ssrf.yaml
+++ b/http/vulnerabilities/other/hasura-graphql-ssrf.yaml
@@ -7,6 +7,8 @@ info:
   description: Hasura GraphQL Engine is vulnerable to SSRF( Server Side Request Forgery )
   reference:
     - https://cxsecurity.com/issue/WLB-2021040115
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: hasura,ssrf,graphql,vuln

--- a/http/vulnerabilities/other/hongfan-ioffice-sqli.yaml
+++ b/http/vulnerabilities/other/hongfan-ioffice-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/lal0ne/vulnerability/blob/main/%E7%BA%A2%E5%B8%86OA/iOffice_sqlscan/sql.py
     - https://github.com/MrWQ/vulnerability-paper/blob/master/bugs/%E3%80%90%E6%BC%8F%E6%B4%9E%E5%A4%8D%E7%8E%B0%E3%80%91%E7%BA%A2%E5%B8%86%E5%8C%BB%E7%96%97%E4%BA%91%20OA%20udfmr.asmx%20SQL%20%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
+++ b/http/vulnerabilities/other/httpbin-contenttype-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
     shodan-query: html:"httpbingo.org"

--- a/http/vulnerabilities/other/huatian-oa8000-sqli.yaml
+++ b/http/vulnerabilities/other/huatian-oa8000-sqli.yaml
@@ -8,6 +8,8 @@ info:
     There is a SQL injection vulnerability in the workFlowService interface of Huatian Power OA 8000 version, through which an attacker can obtain sensitive database information
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E5%8D%8E%E5%A4%A9OA/%E5%8D%8E%E5%A4%A9%E5%8A%A8%E5%8A%9BOA%208000%E7%89%88%20workFlowService%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/indonasia-toko-cms-sql.yaml
+++ b/http/vulnerabilities/other/indonasia-toko-cms-sql.yaml
@@ -8,6 +8,8 @@ info:
     Indonesia Toko CMS is susceptible to SQL Injection in its login system, enabling attackers to exploit vulnerabilities and bypass authentication by injecting malicious SQL code.
   reference:
     - https://cxsecurity.com/issue/WLB-2019030008
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/java-melody-xss.yaml
+++ b/http/vulnerabilities/other/java-melody-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,javamelody,vuln

--- a/http/vulnerabilities/other/jeeplus-cms-resetpassword-sqli.yaml
+++ b/http/vulnerabilities/other/jeeplus-cms-resetpassword-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/wy876/wiki/blob/main/JeePlus%E4%BD%8E%E4%BB%A3%E7%A0%81%E5%BC%80%E5%8F%91%E5%B9%B3%E5%8F%B0/JeePlus%E4%BD%8E%E4%BB%A3%E7%A0%81%E5%BC%80%E5%8F%91%E5%B9%B3%E5%8F%B0%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
     - http://www.cstam.oyg.cn/detail/429410
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/joomla-jmarket-xss.yaml
+++ b/http/vulnerabilities/other/joomla-jmarket-xss.yaml
@@ -10,6 +10,8 @@ info:
     - https://packetstormsecurity.com/files/168581/Joomla-jMarket-5.15-Cross-Site-Scripting.html
     - https://cxsecurity.com/issue/WLB-2022100002
     - https://extensions.joomla.org/
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/kafdrop-xss.yaml
+++ b/http/vulnerabilities/other/kafdrop-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: kafdrop,xss,vuln

--- a/http/vulnerabilities/other/khodrochi-cms-xss.yaml
+++ b/http/vulnerabilities/other/khodrochi-cms-xss.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploitalert.com/view-details.html?id=38723
     - https://cxsecurity.com/ascii/WLB-2022050087
+  classification:
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/lucee-xss.yaml
+++ b/http/vulnerabilities/other/lucee-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 2
   tags: lucee,xss,unauth,intrusive,vuln

--- a/http/vulnerabilities/other/mcms-search-xss.yaml
+++ b/http/vulnerabilities/other/mcms-search-xss.yaml
@@ -15,7 +15,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
     epss-score: 0.00345
     epss-percentile: 0.6789
     cpe: cpe:2.3:a:mingsoft:mcms:*:*:*:*:*:*:*:*

--- a/http/vulnerabilities/other/microstrategy-ssrf.yaml
+++ b/http/vulnerabilities/other/microstrategy-ssrf.yaml
@@ -7,6 +7,8 @@ info:
   description: Blind server-side (SSRF) request forgery vulnerability on MicroStrategy URL shortener.
   reference:
     - https://medium.com/@win3zz/how-i-made-31500-by-submitting-a-bug-to-facebook-d31bb046e204
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 2
   tags: microstrategy,ssrf,vuln

--- a/http/vulnerabilities/other/mida-eframework-xss.yaml
+++ b/http/vulnerabilities/other/mida-eframework-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: mida,xss,edb,vuln

--- a/http/vulnerabilities/other/news-script-xss.yaml
+++ b/http/vulnerabilities/other/news-script-xss.yaml
@@ -8,6 +8,8 @@ info:
     The attacker can send to victim a link containing a malicious URL in an email or instant message can perform a wide variety of actions, such as stealing the victim's session token or login credentials.
   reference:
     - https://www.exploitalert.com/view-details.html?id=39634
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/nginx-module-vts-xss.yaml
+++ b/http/vulnerabilities/other/nginx-module-vts-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 2
   tags: nginx,xss,status,vuln

--- a/http/vulnerabilities/other/opencart-core-sqli.yaml
+++ b/http/vulnerabilities/other/opencart-core-sqli.yaml
@@ -11,6 +11,7 @@ info:
     - https://cxsecurity.com/issue/WLB-2024040004
   classification:
     cpe: cpe:2.3:a:opencart:opencart:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     max-request: 2
     shodan-query: title:"OpenCart"

--- a/http/vulnerabilities/other/phuket-cms-sqli.yaml
+++ b/http/vulnerabilities/other/phuket-cms-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Phuket Solutions CMS is vulnerable to sql injection in which an attacker is able to manipulate an SQL query through user input, causing the application to execute unintended SQL code.
   reference:
     - https://www.exploitalert.com/view-details.html?id=36234
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/other/pingsheng-electronic-sqli.yaml
+++ b/http/vulnerabilities/other/pingsheng-electronic-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/wy876/POC/blob/main/%E5%B9%B3%E5%8D%87%E7%94%B5%E5%AD%90%E6%B0%B4%E5%BA%93%E7%9B%91%E7%AE%A1%E5%B9%B3%E5%8F%B0GetAllRechargeRecordsBySIMCardId%E6%8E%A5%E5%8F%A3%E5%A4%84%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
     - https://github.com/zan8in/pxplan/blob/main/goby_pocs/10-13-crack/redteam_20230316121609/CVD-2022-5560.go
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: "true"
     max-request: 1

--- a/http/vulnerabilities/other/pmb-sqli.yaml
+++ b/http/vulnerabilities/other/pmb-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/51197
     - https://vulners.com/exploitdb/EDB-ID:51197
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/quick-cms-sqli.yaml
+++ b/http/vulnerabilities/other/quick-cms-sqli.yaml
@@ -11,6 +11,7 @@ info:
     - https://www.exploit-db.com/exploits/51910
   classification:
     cpe: cpe:2.3:a:opensolution:quick.cms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/readymade-unilevel-sqli.yaml
+++ b/http/vulnerabilities/other/readymade-unilevel-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Readymade Unilevel Ecommerce software has sql vulnerability in product-details.php?id
   reference:
     - https://packetstormsecurity.com/files/179886/ReadyMade-Unilevel-Ecommerce-MLM-Blind-SQL-Injection-Cross-Site-Scripting.html
+  classification:
+    cwe-id: CWE-89
   metadata:
     vendor: i-netsolution
     product: readymade-unilevel-ecommerce

--- a/http/vulnerabilities/other/sitemap-sql-injection.yaml
+++ b/http/vulnerabilities/other/sitemap-sql-injection.yaml
@@ -7,6 +7,8 @@ info:
   description: Sitemap is vulnerable to SQL Injection.
   reference:
     - https://twitter.com/GodfatherOrwa/status/1647406811216072705?t=fbn0Eu34euKdrn4fL8UqfQ&s=19
+  classification:
+    cwe-id: CWE-89
   metadata:
     max-request: 2
     google-query: intext:"sitemap" filetype:txt, filetype:xml inurl:sitemap

--- a/http/vulnerabilities/other/sound4-impact-auth-bypass.yaml
+++ b/http/vulnerabilities/other/sound4-impact-auth-bypass.yaml
@@ -8,6 +8,8 @@ info:
     The application suffers from an SQL Injection vulnerability. Input passed through the 'username' POST parameter in 'index.php' is not properly sanitised before being returned to the user or used in SQL queries. This can be exploited to manipulate SQL queries by injecting arbitrary SQL code and bypass the authentication mechanism.
   reference:
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2022-5727.php
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/stackposts-sqli.yaml
+++ b/http/vulnerabilities/other/stackposts-sqli.yaml
@@ -10,6 +10,8 @@ info:
     - https://www.exploit-db.com/exploits/51473
     - https://vulners.com/zdt/1337DAY-ID-38725
     - https://codecanyon.net/item/stackposts-social-marketing-tool/21747459
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/user-management-system-sqli.yaml
+++ b/http/vulnerabilities/other/user-management-system-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/51695
     - https://phpgurukul.com/user-registration-login-and-user-management-system-with-admin-panel/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/other/webpagetest-ssrf.yaml
+++ b/http/vulnerabilities/other/webpagetest-ssrf.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/WPO-Foundation/webpagetest
   classification:
     cpe: cpe:2.3:a:webpagetest:webpagetest:*:*:*:*:*:*:*:*
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/xhibiter-nft-sqli.yaml
+++ b/http/vulnerabilities/other/xhibiter-nft-sqli.yaml
@@ -10,6 +10,8 @@ info:
     - https://www.exploit-db.com/exploits/52060
     - https://blog.securelayer7.net/sql-injection-vulnerability-in-xhibiter-nft-marketplace/
     - https://x.com/ExploitDB/status/1807782485549560196
+  classification:
+    cwe-id: CWE-89
   metadata:
     publicwww-query: "/wp-content/themes/xhibiter/"
     max-request: 2

--- a/http/vulnerabilities/other/zhixiang-oa-msglog-sqli.yaml
+++ b/http/vulnerabilities/other/zhixiang-oa-msglog-sqli.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/%E8%87%B4%E7%BF%94OA/%E8%87%B4%E7%BF%94OA%20msglog.aspx%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.html
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E8%87%B4%E7%BF%94OA/%E8%87%B4%E7%BF%94OA%20msglog.aspx%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/other/zimbra-preauth-ssrf.yaml
+++ b/http/vulnerabilities/other/zimbra-preauth-ssrf.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2020-7796
-    cwe-id: CWE-918
+    cwe-id: CWE-99,CWE-918
   metadata:
     max-request: 1
   tags: zimbra,ssrf,oast,vuln

--- a/http/vulnerabilities/prestashop/prestashop-apmarketplace-sqli.yaml
+++ b/http/vulnerabilities/prestashop/prestashop-apmarketplace-sqli.yaml
@@ -8,6 +8,8 @@ info:
     The AP Marketplace Prestashop module is vulnerable to Blind/Time SQL Injection. An attacker can exploit this vulnerability to execute arbitrary SQL queries on the underlying database.
   reference:
     - https://www.openservis.cz/prestashop-blog/nejcastejsi-utoky-v-roce-2023-seznam-deravych-modulu-nemate-nejaky-z-nich-na-e-shopu-i-vy/#pll_switcher
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     shodan-query: http.component:"Prestashop"

--- a/http/vulnerabilities/prestashop/prestashop-blocktestimonial-file-upload.yaml
+++ b/http/vulnerabilities/prestashop/prestashop-blocktestimonial-file-upload.yaml
@@ -8,6 +8,8 @@ info:
     - https://3xploit7.blogspot.com/2016/12/pretashop-blocktestimonial-upload-shell.html
     - https://github.com/indoxploit-coders/blocktestimonial-file-upload
     - https://exploit.linuxsec.org/prestashop-module-blocktestimonial-file-upload-auto-exploit
+  classification:
+    cwe-id: CWE-434
   metadata:
     max-request: 2
     framework: prestashop

--- a/http/vulnerabilities/prestashop/prestashop-cartabandonmentpro-file-upload.yaml
+++ b/http/vulnerabilities/prestashop/prestashop-cartabandonmentpro-file-upload.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://www.openservis.cz/prestashop-blog/nejcastejsi-utoky-v-roce-2023-seznam-deravych-modulu-nemate-nejaky-z-nich-na-e-shopu-i-vy/
     - https://dh42.com/blog/prestashop-security/
+  classification:
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/qibocms-file-download.yaml
+++ b/http/vulnerabilities/qibocms-file-download.yaml
@@ -5,6 +5,8 @@ info:
   author: theabhinavgaur
   severity: high
   description: Qibocms is vulnerable to arbitrary file download vulnerability.
+  classification:
+    cwe-id: CWE-200,CWE-552
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/rails/rails6-xss.yaml
+++ b/http/vulnerabilities/rails/rails6-xss.yaml
@@ -12,6 +12,8 @@ info:
   description: Ruby on Rails 6.0.0-6.0.3.1 contains a CRLF issue which allows JavaScript to be injected into the response, resulting in cross-site scripting.
   reference:
     - https://hackerone.com/reports/904059
+  classification:
+    cwe-id: CWE-79,CWE-113
   metadata:
     max-request: 1
   tags: rails,xss,crlf,hackerone,vuln

--- a/http/vulnerabilities/realor/realor-gwt-system-sqli.yaml
+++ b/http/vulnerabilities/realor/realor-gwt-system-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Realor GWT System system improperly handles the security of data passed by users, resulting in a SQL injection vulnerability. Remote and unauthorized attackers can use this vulnerability to obtain sensitive information in the database, and can further write webshell backdoors. Access, the attacker can execute arbitrary malicious code on the target server and gain system privileges.
   reference:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/realor-gwt-system-sql-injection.yaml
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: "true"
     max-request: 2

--- a/http/vulnerabilities/retool/retool-svg-xss.yaml
+++ b/http/vulnerabilities/retool/retool-svg-xss.yaml
@@ -8,6 +8,8 @@ info:
     This template checks for SVG Cross-Site Scripting(XSS) vulnerability via the Image Proxy URL parameter in Retool.
   reference:
     - https://docs.retool.com/releases/edge/3.88#:~:text=Fixed%20an%20SVG%20XSS%20vulnerability%20by%20adding%20a%20CSP.%20(%2349381)
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/royalevent/royalevent-management-xss.yaml
+++ b/http/vulnerabilities/royalevent/royalevent-management-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/royalevent/royalevent-stored-xss.yaml
+++ b/http/vulnerabilities/royalevent/royalevent-stored-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/ruijie/ruijie-nbr-fileupload.yaml
+++ b/http/vulnerabilities/ruijie/ruijie-nbr-fileupload.yaml
@@ -8,6 +8,8 @@ info:
     Ruijie NBR router fileupload.php file has an arbitrary file upload vulnerability. An attacker can upload any file to the server through the vulnerability to obtain server permissions.
   reference:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/ruijie-nbr-fileupload.yaml
+  classification:
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/ruijie/ruijie-networks-lfi.yaml
+++ b/http/vulnerabilities/ruijie/ruijie-networks-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: ruijie,lfi,edb,vuln

--- a/http/vulnerabilities/ruijie/ruijie-nmc-sync-rce.yaml
+++ b/http/vulnerabilities/ruijie/ruijie-nmc-sync-rce.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/xinyisleep/pocscan/blob/main/%E9%94%90%E6%8D%B7/%E9%94%90%E6%8D%B7_EG%E6%98%93%E7%BD%91%E5%85%B3_%E4%B8%8A%E7%BD%91%E8%A1%8C%E4%B8%BA%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F_%E5%89%8D%E5%8F%B0RCE.py
   classification:
     cpe: cpe:2.3:h:ruijie:rg-uac:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 3

--- a/http/vulnerabilities/ruijie/ruijie-rg-eg-web-mis-rce.yaml
+++ b/http/vulnerabilities/ruijie/ruijie-rg-eg-web-mis-rce.yaml
@@ -8,6 +8,8 @@ info:
     Ruijie RG-EG easy gateway WEB management system front-end RCE has a command execution vulnerability. An attacker without identity authentication can execute arbitrary commands to control server permissions.
   reference:
     - https://github.com/xinyisleep/pocscan/blob/main/%E9%94%90%E6%8D%B7/%E9%94%90%E6%8D%B7_EG%E6%98%93%E7%BD%91%E5%85%B3_WEB%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F_%E5%89%8D%E5%8F%B0RCE.py
+  classification:
+    cwe-id: CWE-77
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/samsung/samsung-wlan-ap-rce.yaml
+++ b/http/vulnerabilities/samsung/samsung-wlan-ap-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 1
   tags: xss,samsung,rce,vuln

--- a/http/vulnerabilities/samsung/samsung-wlan-ap-xss.yaml
+++ b/http/vulnerabilities/samsung/samsung-wlan-ap-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 1
   tags: xss,samsung,vuln

--- a/http/vulnerabilities/sangfor/sangfor-ba-rce.yaml
+++ b/http/vulnerabilities/sangfor/sangfor-ba-rce.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/sangfor/sangfor-edr-rce.yaml
+++ b/http/vulnerabilities/sangfor/sangfor-edr-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 1
     fofa-query: app="sangfor"

--- a/http/vulnerabilities/sangfor/sangfor-login-rce.yaml
+++ b/http/vulnerabilities/sangfor/sangfor-login-rce.yaml
@@ -8,6 +8,8 @@ info:
     Sangfor application delivery management system login has a remote command execution vulnerability, through which an attacker can obtain server privileges and execute arbitrary commands
   reference:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/sangfor-login-rce.yaml
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/secworld/secgate-3600-file-upload.yaml
+++ b/http/vulnerabilities/secworld/secgate-3600-file-upload.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://peiqi.wgpsec.org/wiki/iot/%E5%A5%87%E5%AE%89%E4%BF%A1/%E7%BD%91%E7%A5%9E%20SecGate%203600%20%E9%98%B2%E7%81%AB%E5%A2%99%20obj_app_upfile%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0%E6%BC%8F%E6%B4%9E.html
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/iot/%E5%A5%87%E5%AE%89%E4%BF%A1/%E7%BD%91%E7%A5%9E%20SecGate%203600%20%E9%98%B2%E7%81%AB%E5%A2%99%20obj_app_upfile%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-434
   metadata:
     verified: "true"
     max-request: 2

--- a/http/vulnerabilities/seeyon/seeyon-oa-fastjson-rce.yaml
+++ b/http/vulnerabilities/seeyon/seeyon-oa-fastjson-rce.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://github.com/achuna33/MYExploit/blob/8ffbf7ee60cbd77ad90b0831b93846aba224ab29/src/main/java/com/achuna33/Controllers/SeeyonController.java
     - https://github.com/hktalent/scan4all/blob/main/pocs_go/seeyon/SeeyonFastjson.go
+  classification:
+    cwe-id: CWE-94,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/seeyon/seeyon-oa-setextno-sqli.yaml
+++ b/http/vulnerabilities/seeyon/seeyon-oa-setextno-sqli.yaml
@@ -10,6 +10,8 @@ info:
     - https://github.com/achuna33/MYExploit/blob/8ffbf7ee60cbd77ad90b0831b93846aba224ab29/src/main/java/com/achuna33/Controllers/SeeyonController.java
     - http://wiki.peiqi.tech/wiki/oa/致远OA/致远OA%20A6%20setextno.jsp%20SQL注入漏洞.html
     - https://github.com/Threekiii/Awesome-POC/blob/master/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E8%87%B4%E8%BF%9COA%20A6%20setextno.jsp%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/seeyon/wooyun-2015-148227.yaml
+++ b/http/vulnerabilities/seeyon/wooyun-2015-148227.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: seeyon,wooyun,lfi,zhiyuan,vuln

--- a/http/vulnerabilities/shiziyu-cms/shiziyu-cms-apicontroller-sqli.yaml
+++ b/http/vulnerabilities/shiziyu-cms/shiziyu-cms-apicontroller-sqli.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   description: |
     Shiziyu CMS ApiController.class.php parameter filtering is not rigorous, resulting in SQL injection vulnerability.
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/smartbi/smartbi-deserialization.yaml
+++ b/http/vulnerabilities/smartbi/smartbi-deserialization.yaml
@@ -10,6 +10,8 @@ info:
     - https://stack.chaitin.com/techblog/detail?id=122
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/smartbi-windowunloading-other.yaml
     - https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/Smartbi%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-94,CWE-502
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/splash/splash-render-ssrf.yaml
+++ b/http/vulnerabilities/splash/splash-render-ssrf.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://github.com/scrapinghub/splash
     - https://b1ngz.github.io/splash-ssrf-to-get-server-root-privilege/
+  classification:
+    cwe-id: CWE-99,CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/springboot/springboot-actuators-jolokia-xxe.yaml
+++ b/http/vulnerabilities/springboot/springboot-actuators-jolokia-xxe.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://www.veracode.com/blog/research/exploiting-spring-boot-actuators
     - https://github.com/mpgn/Spring-Boot-Actuator-Exploit
+  classification:
+    cwe-id: CWE-611
   metadata:
     max-request: 2
   tags: springboot,jolokia,xxe,vuln

--- a/http/vulnerabilities/springboot/springboot-h2-db-rce.yaml
+++ b/http/vulnerabilities/springboot/springboot-h2-db-rce.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78,CWE-94
     cpe: cpe:2.3:a:h2database:h2:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/squirrelmail/squirrelmail-lfi.yaml
+++ b/http/vulnerabilities/squirrelmail/squirrelmail-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 2
   tags: lfi,squirrelmail,edb,vuln

--- a/http/vulnerabilities/squirrelmail/squirrelmail-vkeyboard-xss.yaml
+++ b/http/vulnerabilities/squirrelmail/squirrelmail-vkeyboard-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
-    cwe-id: CWE-80
+    cwe-id: CWE-80,CWE-83
   metadata:
     max-request: 1
   tags: xss,squirrelmail,plugin,edb,vuln

--- a/http/vulnerabilities/thinkcmf/thinkcmf-lfi.yaml
+++ b/http/vulnerabilities/thinkcmf/thinkcmf-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
     win-payload: ../../../../../../../../../../../../../../../../windows/win.ini

--- a/http/vulnerabilities/thinkcmf/thinkcmf-rce.yaml
+++ b/http/vulnerabilities/thinkcmf/thinkcmf-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-94
   metadata:
     max-request: 2
   tags: thinkcmf,rce,intrusive,vuln

--- a/http/vulnerabilities/thinkphp/thinkphp-2-rce.yaml
+++ b/http/vulnerabilities/thinkphp/thinkphp-2-rce.yaml
@@ -7,6 +7,8 @@ info:
   description: ThinkPHP 2.x and 3.0 in Lite mode are susceptible to remote code execution via the s parameter. An attacker can execute malware, obtain sensitive information, modify data, and/or gain full control over a compromised system without entering necessary credentials.
   reference:
     - https://github.com/vulhub/vulhub/tree/0a0bc719f9a9ad5b27854e92bc4dfa17deea25b4/thinkphp/2-rce
+  classification:
+    cwe-id: CWE-95
   metadata:
     max-request: 1
   tags: thinkphp,rce,vuln

--- a/http/vulnerabilities/thinkphp/thinkphp-501-rce.yaml
+++ b/http/vulnerabilities/thinkphp/thinkphp-501-rce.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-78
   metadata:
     max-request: 1
   tags: edb,thinkphp,rce,vuln

--- a/http/vulnerabilities/thinkphp/thinkphp-5023-rce.yaml
+++ b/http/vulnerabilities/thinkphp/thinkphp-5023-rce.yaml
@@ -7,6 +7,8 @@ info:
   description: ThinkPHP 5.0.23 is susceptible to remote code execution. An attacker can execute malware, obtain sensitive information, modify data, and/or gain full control over a compromised system without entering necessary credentials.
   reference:
     - https://github.com/vulhub/vulhub/tree/0a0bc719f9a9ad5b27854e92bc4dfa17deea25b4/thinkphp/5.0.23-rce
+  classification:
+    cwe-id: CWE-95,CWE-470
   metadata:
     max-request: 1
   tags: thinkphp,rce,vuln

--- a/http/vulnerabilities/tongda/tongda-action-uploadfile.yaml
+++ b/http/vulnerabilities/tongda/tongda-action-uploadfile.yaml
@@ -11,6 +11,7 @@ info:
     - https://github.com/shadow1ng/fscan/blob/main/WebScan/pocs/tongda-v2017-uploadfile.yml
   classification:
     cpe: cpe:2.3:a:tongda2000:office_anywhere_2017:*:*:*:*:*:*:*:*
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/tongda/tongda-getdata-rce.yaml
+++ b/http/vulnerabilities/tongda/tongda-getdata-rce.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E9%80%9A%E8%BE%BEOA/%E9%80%9A%E8%BE%BEOA%20v11.9%20getdata%20%E4%BB%BB%E6%84%8F%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:tongda2000:office_anywhere:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78,CWE-95
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/tongda/tongda-getway-rfi.yaml
+++ b/http/vulnerabilities/tongda/tongda-getway-rfi.yaml
@@ -8,6 +8,8 @@ info:
     There is a file inclusion vulnerability in Tongda OA v11.8 getway.php, an attacker sends a malicious request to include a log file, resulting in an arbitrary file writing vulnerability
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E9%80%9A%E8%BE%BEOA%20v11.8%20getway.php%20%E8%BF%9C%E7%A8%8B%E6%96%87%E4%BB%B6%E5%8C%85%E5%90%AB%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-98
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/tongda/tongda-insert-sqli.yaml
+++ b/http/vulnerabilities/tongda/tongda-insert-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E9%80%9A%E8%BE%BEOA/%E9%80%9A%E8%BE%BEOA%20v11.6%20insert%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:tongda2000:office_anywhere:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/tongda/tongda-oa-swfupload-sqli.yaml
+++ b/http/vulnerabilities/tongda/tongda-oa-swfupload-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/通达OA/通达OA%20v11.5%20swfupload_new.php%20SQL注入漏洞.html
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/tongda-swfupload-new-sql-inject.yaml
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/tongda/tongda-path-traversal.yaml
+++ b/http/vulnerabilities/tongda/tongda-path-traversal.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
-    cwe-id: CWE-77
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: tongda,lfi,vuln

--- a/http/vulnerabilities/tongda/tongda-report-func-sqli.yaml
+++ b/http/vulnerabilities/tongda/tongda-report-func-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E9%80%9A%E8%BE%BEOA/%E9%80%9A%E8%BE%BEOA%20v11.6%20report_bi.func.php%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:tongda2000:office_anywhere:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/tongda/tongda-video-file-read.yaml
+++ b/http/vulnerabilities/tongda/tongda-video-file-read.yaml
@@ -10,6 +10,7 @@ info:
     - http://wiki.peiqi.tech/wiki/oa/通达OA/通达OA%20v2017%20video_file.php%20任意文件下载漏洞.html
   classification:
     cpe: cpe:2.3:a:tongda2000:office_anywhere_2017:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/topsec/topsec-topacm-rce.yaml
+++ b/http/vulnerabilities/topsec/topsec-topacm-rce.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/achuna33/MYExploit/blob/8ffbf7ee60cbd77ad90b0831b93846aba224ab29/src/main/java/com/achuna33/Controllers/TRXController.java
     - https://github.com/Phuong39/2022-HW-POC/blob/main/天融信-上网行为管理系统RCE.md
+  classification:
+    cwe-id: CWE-78
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/ueditor/ueditor-ssrf.yaml
+++ b/http/vulnerabilities/ueditor/ueditor-ssrf.yaml
@@ -10,6 +10,7 @@ info:
     - https://www.seebug.org/vuldb/ssvid-97311
   classification:
     cpe: cpe:2.3:a:baidu:ueditor:*:*:*:*:*:*:*:*
+    cwe-id: CWE-99,CWE-918
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/vbulletin/arcade-php-sqli.yaml
+++ b/http/vulnerabilities/vbulletin/arcade-php-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://www.exploit-db.com/exploits/29604
     - https://github.com/OWASP/vbscan/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vbulletin/vbulletin-backdoor.yaml
+++ b/http/vulnerabilities/vbulletin/vbulletin-backdoor.yaml
@@ -7,6 +7,8 @@ info:
   reference:
     - https://github.com/OWASP/vbscan
     - https://blog.sucuri.net/2017/01/vbulletin-malware-hackers-compete-backdoor-control.html
+  classification:
+    cwe-id: CWE-78
   metadata:
     max-request: 21
   tags: backdoor,php,vbulletin,rce,vuln

--- a/http/vulnerabilities/vbulletin/vbulletin-search-sqli.yaml
+++ b/http/vulnerabilities/vbulletin/vbulletin-search-sqli.yaml
@@ -12,6 +12,7 @@ info:
     - https://web.archive.org/web/20181129123620/https://j0hnx3r.org/vbulletin-4-x-sql-injection-vulnerability/
   classification:
     cpe: cpe:2.3:a:vbulletin:vbulletin:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-cloud-xss.yaml
+++ b/http/vulnerabilities/vmware/vmware-cloud-xss.yaml
@@ -7,6 +7,7 @@ info:
   description: VMWare Cloud is vulnerable to Reflected Cross Site Scripting vulnerability.
   classification:
     cpe: cpe:2.3:a:vmware:cloud_foundation:*:*:*:*:*:*:*:*
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-hcx-log4j-rce.yaml
+++ b/http/vulnerabilities/vmware/vmware-hcx-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-horizon-log4j-rce.yaml
+++ b/http/vulnerabilities/vmware/vmware-horizon-log4j-rce.yaml
@@ -15,7 +15,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-nsx-log4j-rce.yaml
+++ b/http/vulnerabilities/vmware/vmware-nsx-log4j-rce.yaml
@@ -13,7 +13,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-77,CWE-502
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-nsx-stream-rce.yaml
+++ b/http/vulnerabilities/vmware/vmware-nsx-stream-rce.yaml
@@ -17,6 +17,8 @@ info:
     - https://srcincite.io/blog/2022/10/25/eat-what-you-kill-pre-authenticated-rce-in-vmware-nsx-manager.html
     - https://attackerkb.com/topics/ngprN6bu76/cve-2021-39144
     - https://github.com/rapid7/metasploit-framework/pull/17222
+  classification:
+    cwe-id: CWE-78,CWE-502
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/vmware/vmware-vcenter-lfi-linux.yaml
+++ b/http/vulnerabilities/vmware/vmware-vcenter-lfi-linux.yaml
@@ -8,7 +8,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: vmware,lfi,vcenter,linux,vuln

--- a/http/vulnerabilities/vmware/vmware-vcenter-lfi.yaml
+++ b/http/vulnerabilities/vmware/vmware-vcenter-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 3
   tags: vmware,lfi,vcenter,vuln

--- a/http/vulnerabilities/vmware/vmware-vcenter-log4j-rce.yaml
+++ b/http/vulnerabilities/vmware/vmware-vcenter-log4j-rce.yaml
@@ -16,7 +16,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cve-id: CVE-2021-44228
-    cwe-id: CWE-77
+    cwe-id: CWE-78,CWE-502
     cpe: cpe:2.3:a:vmware:vcenter_server:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1

--- a/http/vulnerabilities/vmware/vmware-vcenter-ssrf.yaml
+++ b/http/vulnerabilities/vmware/vmware-vcenter-ssrf.yaml
@@ -7,6 +7,8 @@ info:
   description: VMware vCenter 7.0.2.00100 is susceptible to multiple vulnerabilities including server-side request forgery, local file inclusion, and cross-site scripting.
   reference:
     - https://github.com/l0ggg/VMware_vCenter
+  classification:
+    cwe-id: CWE-918
   metadata:
     max-request: 1
   tags: ssrf,lfi,xss,oast,vcenter,vmware,vuln

--- a/http/vulnerabilities/wanhu/wanhu-documentedit-sqli.yaml
+++ b/http/vulnerabilities/wanhu/wanhu-documentedit-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/万户OA/万户OA%20DocumentEdit.jsp%20SQL注入漏洞.html
     - https://github.com/Threekiii/Awesome-POC/blob/master/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E4%B8%87%E6%88%B7OA%20DocumentEdit.jsp%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wanhu/wanhu-download-ftp-file-read.yaml
+++ b/http/vulnerabilities/wanhu/wanhu-download-ftp-file-read.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/万户OA/万户OA%20download_ftp.jsp%20任意文件下载漏洞.html
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/wanhu-oa-download-ftp-file-read.yaml
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wanhu/wanhu-download-old-file-read.yaml
+++ b/http/vulnerabilities/wanhu/wanhu-download-old-file-read.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/万户OA/万户OA%20download_old.jsp%20任意文件下载漏洞.html
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/wanhu-oa-download-old-file-read.yaml
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wanhu/wanhu-teleconferenceservice-xxe.yaml
+++ b/http/vulnerabilities/wanhu/wanhu-teleconferenceservice-xxe.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - http://wiki.peiqi.tech/wiki/oa/万户OA/万户OA%20TeleConferenceService%20XXE注入漏洞.html
     - https://github.com/Threekiii/Awesome-POC/blob/master/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E4%B8%87%E6%88%B7OA%20TeleConferenceService%20XXE%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-611
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wanhu/wanhuoa-downloadservlet-lfi.yaml
+++ b/http/vulnerabilities/wanhu/wanhuoa-downloadservlet-lfi.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/Threekiii/Awesome-POC/blob/master/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E4%B8%87%E6%88%B7OA%20DownloadServlet%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E4%B8%87%E6%88%B7OA/%E4%B8%87%E6%88%B7OA%20DownloadServlet%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/ecology-jqueryfiletree-traversal.yaml
+++ b/http/vulnerabilities/weaver/ecology-jqueryfiletree-traversal.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/90103c248a2c52bb0a060d0ee95d5a67e4579c3d/docs/wiki/oa/%E6%B3%9B%E5%BE%AEOA/%E6%B3%9B%E5%BE%AEOA%20E-Cology%20jqueryFileTree.jsp%20%E7%9B%AE%E5%BD%95%E9%81%8D%E5%8E%86%E6%BC%8F%E6%B4%9E.md?plain=1#L24
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/ecology/ecology-filedownload-directory-traversal.yaml
+++ b/http/vulnerabilities/weaver/ecology/ecology-filedownload-directory-traversal.yaml
@@ -8,7 +8,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
     fofa-query: app="泛微-协同办公OA"

--- a/http/vulnerabilities/weaver/ecology/ecology-oa-byxml-xxe.yaml
+++ b/http/vulnerabilities/weaver/ecology/ecology-oa-byxml-xxe.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   description: |
     EcologyOA deleteUserRequestInfoByXml interface has XXE
+  classification:
+    cwe-id: CWE-611,CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/ecology/ecology-springframework-directory-traversal.yaml
+++ b/http/vulnerabilities/weaver/ecology/ecology-springframework-directory-traversal.yaml
@@ -8,7 +8,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: ecology,springframework,lfi,vuln

--- a/http/vulnerabilities/weaver/oa-v9-uploads-file.yaml
+++ b/http/vulnerabilities/weaver/oa-v9-uploads-file.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
-    cwe-id: CWE-434
+    cwe-id: CWE-94,CWE-434
   metadata:
     max-request: 2
   tags: rce,jsp,fileupload,intrusive,vuln

--- a/http/vulnerabilities/weaver/weaver-checkserver-sqli.yaml
+++ b/http/vulnerabilities/weaver/weaver-checkserver-sqli.yaml
@@ -12,6 +12,7 @@ info:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/weaver-ecology-oa-plugin-checkserver-setting-sqli.yaml
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/weaver-e-cology-validate-sqli.yaml
+++ b/http/vulnerabilities/weaver/weaver-e-cology-validate-sqli.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   description: |
     In the validate.jsp file of the Panwei e-cology OA system, the parameter capitalid is not strictly filtered, which can lead to SQL injection vulnerabilities. An attacker can use this vulnerability to remotely send carefully constructed SQL statements without authorization, thereby obtaining sensitive database information.
+  classification:
+    cwe-id: CWE-89
   metadata:
     max-request: 1
   tags: ecology,weaver,sqli,vuln

--- a/http/vulnerabilities/weaver/weaver-ebridge-lfi.yaml
+++ b/http/vulnerabilities/weaver/weaver-ebridge-lfi.yaml
@@ -8,6 +8,8 @@ info:
     There is an arbitrary file reading vulnerability in the Weaver OA E-Bridge saveYZJFile interface. An attacker can read any file on the server through the vulnerability.
   reference:
     - https://peiqi.wgpsec.org/wiki/oa/%E6%B3%9B%E5%BE%AEOA/%E6%B3%9B%E5%BE%AEOA%20E-Bridge%20saveYZJFile%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.html
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 4

--- a/http/vulnerabilities/weaver/weaver-ecology-bshservlet-rce.yaml
+++ b/http/vulnerabilities/weaver/weaver-ecology-bshservlet-rce.yaml
@@ -8,6 +8,7 @@ info:
     Weaver BeanShell contains a remote command execution vulnerability in the bsh.servlet.BshServlet program.
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-95
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/weaver/weaver-ecology-getsqldata-sqli.yaml
+++ b/http/vulnerabilities/weaver/weaver-ecology-getsqldata-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/Wrin9/weaverOA_sql_RCE/blob/14cca7a6da7a4a81e7c7a7016cb0da75b8b290bc/weaverOA_sql_injection_POC_EXP.py#L46
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/weaver/weaver-ecology-hrmcareer-sqli.yaml
+++ b/http/vulnerabilities/weaver/weaver-ecology-hrmcareer-sqli.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/ibaiw/2023Hvv/blob/556de69ffc370fd9827e2cf5027373543e2513d4/%E6%B3%9B%E5%BE%AE%20HrmCareerApplyPerView%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md?plain=1#L3
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/weaver-jquery-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-jquery-file-upload.yaml
@@ -9,6 +9,7 @@ info:
     - https://github.com/w-digital-scanner/w9scan/blob/master/plugins/weaver_oa/2158.py
   classification:
     cpe: cpe:2.3:a:weaver:e-office:*:*:*:*:*:*:*:*
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 3

--- a/http/vulnerabilities/weaver/weaver-ktreeuploadaction-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-ktreeuploadaction-file-upload.yaml
@@ -10,6 +10,7 @@ info:
     - https://buaq.net/go-117479.html
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/weaver/weaver-lazyuploadify-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-lazyuploadify-file-upload.yaml
@@ -7,6 +7,8 @@ info:
   description: OA E-Office LazyUploadify is vulnerable to arbitrary file upload.
   reference:
     - https://github.com/w-digital-scanner/w9scan/blob/master/plugins/weaver_oa/2158.py
+  classification:
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 3

--- a/http/vulnerabilities/weaver/weaver-officeserver-lfi.yaml
+++ b/http/vulnerabilities/weaver/weaver-officeserver-lfi.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E6%B3%9B%E5%BE%AEOA/%E6%B3%9B%E5%BE%AEOA%20E-Office%20officeserver.php%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:weaver:e-office:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/weaver-sptmforportalthumbnail-lfi.yaml
+++ b/http/vulnerabilities/weaver/weaver-sptmforportalthumbnail-lfi.yaml
@@ -11,6 +11,7 @@ info:
     - https://github.com/GREENHAT7/pxplan/blob/main/xray_pocs/yaml-poc-weaver-weaver_e_cology_oa-readfile-CT-479157.yml
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/weaver/weaver-uploadoperation-file-upload.yaml
+++ b/http/vulnerabilities/weaver/weaver-uploadoperation-file-upload.yaml
@@ -11,6 +11,7 @@ info:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/weaver-oa-workrelate-file-upload.yaml
   classification:
     cpe: cpe:2.3:a:weaver:e-cology:*:*:*:*:*:*:*:*
+    cwe-id: CWE-94,CWE-434
   metadata:
     max-request: 3
     fofa-query: app="泛微-协同办公OA"

--- a/http/vulnerabilities/wordpress/3d-print-lite-xss.yaml
+++ b/http/vulnerabilities/wordpress/3d-print-lite-xss.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/5909e225-5756-472e-a2fc-3ac52c7fb909
     - https://www.acunetix.com/vulnerabilities/web/wordpress-plugin-3dprint-lite-cross-site-scripting-1-9-1-5/
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/ad-widget-lfi.yaml
+++ b/http/vulnerabilities/wordpress/ad-widget-lfi.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,wp,adWidget,wpscan,vuln

--- a/http/vulnerabilities/wordpress/advanced-access-manager-lfi.yaml
+++ b/http/vulnerabilities/wordpress/advanced-access-manager-lfi.yaml
@@ -13,7 +13,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,wp,accessmanager,wpscan,vuln

--- a/http/vulnerabilities/wordpress/advanced-booking-calendar-sqli.yaml
+++ b/http/vulnerabilities/wordpress/advanced-booking-calendar-sqli.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/bac7b590-70de-45b3-bdc2-19f90524ca39
     - https://wordpress.org/plugins/advanced-booking-calendar/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/age-gate-xss.yaml
+++ b/http/vulnerabilities/wordpress/age-gate-xss.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 2
   tags: xss,authenticated,age-gate,wpscan,wordpress,wp-plugin,wp,vuln

--- a/http/vulnerabilities/wordpress/amministrazione-aperta-lfi.yaml
+++ b/http/vulnerabilities/wordpress/amministrazione-aperta-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wp-plugin,lfi,wp,edb,wordpress,vuln

--- a/http/vulnerabilities/wordpress/application-pass-xss.yaml
+++ b/http/vulnerabilities/wordpress/application-pass-xss.yaml
@@ -14,7 +14,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cwe-id: CWE-79
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 3
     vendor: wordpress

--- a/http/vulnerabilities/wordpress/aspose-file-download.yaml
+++ b/http/vulnerabilities/wordpress/aspose-file-download.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: aspose,ebook,wpscan,wordpress,wp-plugin,lfi,vuln

--- a/http/vulnerabilities/wordpress/aspose-ie-file-download.yaml
+++ b/http/vulnerabilities/wordpress/aspose-ie-file-download.yaml
@@ -8,6 +8,8 @@ info:
   reference:
     - https://packetstormsecurity.com/files/131162/
     - https://wordpress.org/plugins/aspose-importer-exporter
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: aspose,packetstorm,wordpress,wp-plugin,lfi,vuln

--- a/http/vulnerabilities/wordpress/aspose-pdf-file-download.yaml
+++ b/http/vulnerabilities/wordpress/aspose-pdf-file-download.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: aspose,packetstorm,wordpress,wp-plugin,lfi,vuln

--- a/http/vulnerabilities/wordpress/aspose-words-file-download.yaml
+++ b/http/vulnerabilities/wordpress/aspose-words-file-download.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,aspose,wpscan,vuln

--- a/http/vulnerabilities/wordpress/brandfolder-lfi.yaml
+++ b/http/vulnerabilities/wordpress/brandfolder-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: lfi,rfi,edb,wordpress,wp-plugin,vuln

--- a/http/vulnerabilities/wordpress/cherry-file-download.yaml
+++ b/http/vulnerabilities/wordpress/cherry-file-download.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,wpscan,vuln

--- a/http/vulnerabilities/wordpress/cherry-lfi.yaml
+++ b/http/vulnerabilities/wordpress/cherry-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wpscan,wordpress,wp-plugin,lfi,wp,vuln

--- a/http/vulnerabilities/wordpress/church-admin-lfi.yaml
+++ b/http/vulnerabilities/wordpress/church-admin-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,wpscan,vuln

--- a/http/vulnerabilities/wordpress/churchope-lfi.yaml
+++ b/http/vulnerabilities/wordpress/churchope-lfi.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://wpscan.com/vulnerability/3c5833bd-1fe0-4eba-97aa-7d3a0c8fda15
   classification:
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 1
   tags: wp,wpscan,wordpress,wp-theme,lfi,vuln

--- a/http/vulnerabilities/wordpress/contus-video-gallery-sqli.yaml
+++ b/http/vulnerabilities/wordpress/contus-video-gallery-sqli.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/b625aee5-8fd1-4f3e-9a9c-d41bdec13243
     - https://wordpress.org/plugins/photo-gallery/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/diarise-theme-lfi.yaml
+++ b/http/vulnerabilities/wordpress/diarise-theme-lfi.yaml
@@ -10,7 +10,7 @@ info:
     - https://cxsecurity.com/issue/WLB-2019050123
     - https://woocommerce.com/?aff=1790
   classification:
-    cwe-id: CWE-98
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: packetstorm,wordpress,wp-theme,lfi,vuln

--- a/http/vulnerabilities/wordpress/elex-woocommerce-xss.yaml
+++ b/http/vulnerabilities/wordpress/elex-woocommerce-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 2
   tags: wp-plugin,xss,authenticated,woocommerce,wpscan,wordpress,vuln

--- a/http/vulnerabilities/wordpress/flow-flow-social-stream-xss.yaml
+++ b/http/vulnerabilities/wordpress/flow-flow-social-stream-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
-    cwe-id: CWE-80
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: xss,wordpress,wpscan,vuln

--- a/http/vulnerabilities/wordpress/hb-audio-lfi.yaml
+++ b/http/vulnerabilities/wordpress/hb-audio-lfi.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
     google-query: inurl:/wp-content/plugins/hb-audio-gallery-lite

--- a/http/vulnerabilities/wordpress/health-check-lfi.yaml
+++ b/http/vulnerabilities/wordpress/health-check-lfi.yaml
@@ -12,7 +12,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23
   metadata:
     max-request: 2
   tags: lfi,wp,wordpress,wp-plugin,authenticated,lfr,wpscan,vuln

--- a/http/vulnerabilities/wordpress/hide-security-enhancer-lfi.yaml
+++ b/http/vulnerabilities/wordpress/hide-security-enhancer-lfi.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: wordpress,wp-plugin,lfi,wp,vuln

--- a/http/vulnerabilities/wordpress/knr-widget-xss.yaml
+++ b/http/vulnerabilities/wordpress/knr-widget-xss.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/ldap-wp-login-xss.yaml
+++ b/http/vulnerabilities/wordpress/ldap-wp-login-xss.yaml
@@ -9,6 +9,8 @@ info:
   remediation: Fixed in version 3.0.2
   reference:
     - https://wpscan.com/vulnerability/1dc2cec8-e3dd-414b-8ccb-d73d51b051ee
+  classification:
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/leaguemanager-sql-injection.yaml
+++ b/http/vulnerabilities/wordpress/leaguemanager-sql-injection.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/f3be48f5-ae2c-4e27-80ca-664829b8fba3
     - https://wordpress.org/plugins/leaguemanager/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/members-list-xss.yaml
+++ b/http/vulnerabilities/wordpress/members-list-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 5.4
-    cwe-id: CWE-80
+    cwe-id: CWE-79,CWE-83
   metadata:
     max-request: 1
   tags: wp,wordpress,wp-plugin,xss,wpscan,vuln

--- a/http/vulnerabilities/wordpress/my-chatbot-xss.yaml
+++ b/http/vulnerabilities/wordpress/my-chatbot-xss.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 7.2
-    cwe-id: CWE-79
+    cwe-id: CWE-80
   metadata:
     max-request: 2
   tags: wordpress,wp-plugin,xss,authenticated,wpscan,vuln

--- a/http/vulnerabilities/wordpress/nativechurch-wp-theme-lfd.yaml
+++ b/http/vulnerabilities/wordpress/nativechurch-wp-theme-lfd.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://packetstormsecurity.com/files/132297/WordPress-NativeChurch-Theme-1.0-1.5-Arbitrary-File-Download.html
     - https://wpscan.com/vulnerability/2e1062ed-0c48-473f-aab2-20ac9d4c72b1
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: wp-theme,lfi,wp,packetstorm,wpscan,wordpress,vuln

--- a/http/vulnerabilities/wordpress/ninja-forms-xss.yaml
+++ b/http/vulnerabilities/wordpress/ninja-forms-xss.yaml
@@ -15,7 +15,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cwe-id: CWE-79
+    cwe-id: CWE-80
     cpe: cpe:2.3:a:ninjaforms:ninja_forms:*:*:*:*:*:wordpress:*:*
   metadata:
     max-request: 5

--- a/http/vulnerabilities/wordpress/notificationx-sqli.yaml
+++ b/http/vulnerabilities/wordpress/notificationx-sqli.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/d1480717-726d-4be2-95cb-1007a3f010bb
     - https://wordpress.org/plugins/notificationx/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/photo-gallery-xss.yaml
+++ b/http/vulnerabilities/wordpress/photo-gallery-xss.yaml
@@ -12,6 +12,7 @@ info:
     - https://wordpress.org/plugins/photo-gallery/advanced/
   classification:
     cpe: cpe:2.3:a:10web:photo_gallery:*:*:*:*:wordpress:*:*:*
+    cwe-id: CWE-80
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/photoblocks-grid-gallery-xss.yaml
+++ b/http/vulnerabilities/wordpress/photoblocks-grid-gallery-xss.yaml
@@ -13,6 +13,7 @@ info:
     - https://wordpress.org/plugins/photoblocks-grid-gallery/
   classification:
     cpe: cpe:2.3:a:wpchill:gallery_photoblocks:*:*:*:*:wordpress:*:*:*
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/wordpress-ssrf-oembed.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-ssrf-oembed.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/incogbyte/quickpress/blob/master/core/req.go
   classification:
     cpe: cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*
+    cwe-id: CWE-918
   metadata:
     max-request: 2
     vendor: wordpress

--- a/http/vulnerabilities/wordpress/wp-adivaha-sqli.yaml
+++ b/http/vulnerabilities/wordpress/wp-adivaha-sqli.yaml
@@ -8,6 +8,8 @@ info:
     An unauthenticated Time-Based SQL injection found in adivaha Travel Plugin 2.3 allows a remote attacker to retrieve the contents of an entire database.
   reference:
     - https://wordpress.org/plugins/adiaha-hotel/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/wp-autosuggest-sql-injection.yaml
+++ b/http/vulnerabilities/wordpress/wp-autosuggest-sql-injection.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/9188
     - https://wordpress.org/plugins/wp-autosuggest/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/wordpress/wp-jetpack-ssrf.yaml
+++ b/http/vulnerabilities/wordpress/wp-jetpack-ssrf.yaml
@@ -6,6 +6,8 @@ info:
   severity: medium
   description: |
     The Jetpack WordPress plugin exposes an endpoint that fetches external URLs provided via the 'urls' parameter to retrieve Twitter (X) card descriptions/metadata. This allows unauthenticated SSRF, enabling attackers to force the server to request attacker-controlled URLs
+  classification:
+    cwe-id: CWE-99,CWE-918
   metadata:
     verified: false
     max-request: 2

--- a/http/vulnerabilities/wordpress/wp-kadence-blocks-rce.yaml
+++ b/http/vulnerabilities/wordpress/wp-kadence-blocks-rce.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wordpress.org/plugins/kadence-blocks/
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/kadence-blocks/kadence-blocks-3110-unauthenticated-arbitrary-file-upload
+  classification:
+    cwe-id: CWE-94,CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/wp-smart-manager-sqli.yaml
+++ b/http/vulnerabilities/wordpress/wp-smart-manager-sqli.yaml
@@ -11,6 +11,8 @@ info:
     - https://wpscan.com/vulnerability/e060fbff-792f-4fb5-baa5-82d80240ec99
     - http://cinu.pl/research/wp-plugins/mail_0666ceeca20683907bf82514e8f93e0f.html
     - https://wordpress.org/plugins/smart-manager-for-wp-e-commerce/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/wp-statistics-sqli.yaml
+++ b/http/vulnerabilities/wordpress/wp-statistics-sqli.yaml
@@ -13,6 +13,7 @@ info:
     - https://wordpress.org/plugins/wp-statistics/
   classification:
     cpe: cpe:2.3:a:veronalabs:wp_statistics:*:*:*:*:wordpress:*:*:*
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/wp-under-construction-ssrf.yaml
+++ b/http/vulnerabilities/wordpress/wp-under-construction-ssrf.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/24784c84-3efd-4166-81c1-e5a266562cfc
     - https://packetstormsecurity.com/files/161576/
+  classification:
+    cwe-id: CWE-99,CWE-918
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/wordpress/zero-spam-sql-injection.yaml
+++ b/http/vulnerabilities/wordpress/zero-spam-sql-injection.yaml
@@ -10,6 +10,8 @@ info:
   reference:
     - https://wpscan.com/vulnerability/44cc8d59-9b45-46b7-afaf-894e4ba62dd5
     - https://wordpress.org/plugins/zero-spam/
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/chanjet-gnremote-sqli.yaml
+++ b/http/vulnerabilities/yonyou/chanjet-gnremote-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Chanjetong has a SQL injection vulnerability, which can be used by attackers to obtain sensitive information in the database.
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/90103c248a2c52bb0a060d0ee95d5a67e4579c3d/docs/wiki/webapp/%E7%94%A8%E5%8F%8B/%E7%94%A8%E5%8F%8B%20%E7%95%85%E6%8D%B7%E9%80%9A%E8%BF%9C%E7%A8%8B%E9%80%9A%20GNRemote.dll%20SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/yonyou/chanjet-tplus-checkmutex-sqli.yaml
+++ b/http/vulnerabilities/yonyou/chanjet-tplus-checkmutex-sqli.yaml
@@ -8,6 +8,8 @@ info:
     There is an SQL injection vulnerability in the Changjetcrm financial crm system under Yonyou.
   reference:
     - https://github.com/MrWQ/vulnerability-paper/blob/7551f7584bd35039028b1d9473a00201ed18e6b2/bugs/%E3%80%90%E6%BC%8F%E6%B4%9E%E5%A4%8D%E7%8E%B0%E3%80%91%E7%94%A8%E5%8F%8B%E7%95%85%E6%8D%B7%E9%80%9A%20T%2B%20SQL%20%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/chanjet-tplus-file-read.yaml
+++ b/http/vulnerabilities/yonyou/chanjet-tplus-file-read.yaml
@@ -8,6 +8,8 @@ info:
     Chanjet TPlus DownloadProxy.aspx file has an arbitrary file reading vulnerability. An attacker can obtain sensitive files on the server through the vulnerability.
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/webapp/%E7%94%A8%E5%8F%8B/%E7%94%A8%E5%8F%8B%20%E7%95%85%E6%8D%B7%E9%80%9AT%2B%20DownloadProxy.aspx%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/chanjet-tplus-ufida-sqli.yaml
+++ b/http/vulnerabilities/yonyou/chanjet-tplus-ufida-sqli.yaml
@@ -8,6 +8,8 @@ info:
     Chanjet TPluse application has a SQL injection vulnerability, which can be used by attackers to obtain sensitive information in the database.
   reference:
     - https://github.com/MrWQ/vulnerability-paper/blob/master/bugs/%E7%95%85%E6%8D%B7%E9%80%9A%20T%2B%20Plus%20%E5%AE%A1%E8%AE%A1%20%EF%BC%88%E8%B6%85%E8%AF%A6%E7%BB%86%EF%BC%89.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/erp-nc-directory-traversal.yaml
+++ b/http/vulnerabilities/yonyou/erp-nc-directory-traversal.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
   tags: lfi,erp-nc,vuln

--- a/http/vulnerabilities/yonyou/wooyun-path-traversal.yaml
+++ b/http/vulnerabilities/yonyou/wooyun-path-traversal.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-22
+    cwe-id: CWE-23,CWE-73
   metadata:
     max-request: 1
   tags: lfi,wooyun,vuln

--- a/http/vulnerabilities/yonyou/yonyou-fe-directory-traversal.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-fe-directory-traversal.yaml
@@ -8,6 +8,8 @@ info:
     There is a directory traversal vulnerability in the templateOfTaohong_manager.jsp file of UFIDA FE collaborative office platform. Through the vulnerability, attackers can obtain directory files and other information, leading to further attacks.
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8B%20FE%E5%8D%8F%E4%BD%9C%E5%8A%9E%E5%85%AC%E5%B9%B3%E5%8F%B0%20templateOfTaohong_manager.jsp%20%E7%9B%AE%E5%BD%95%E9%81%8D%E5%8E%86%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-grp-u8-xxe.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-grp-u8-xxe.yaml
@@ -7,6 +7,8 @@ info:
   description: UFIDA GRP-u8 has an XXE vulnerability. This vulnerability is caused by the application not loading external entities when parsing XML input, resulting in the loading of external SQL statements and command execution.
   reference:
     - http://wiki.peiqi.tech/wiki/oa/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8B%20GRP-U8%20Proxy%20SQL%E6%B3%A8%E5%85%A5%20CNNVD-201610-923.html
+  classification:
+    cwe-id: CWE-89
   metadata:
     max-request: 1
   tags: yonyou,grp,xxe,sqli,vuln

--- a/http/vulnerabilities/yonyou/yonyou-nc-dispatcher-fileupload.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-nc-dispatcher-fileupload.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/lal0ne/vulnerability/blob/c0985107adfd91d85fbd76d9a8acf8fbfa98ed41/YonyouNC/ncDecode/README.md
   classification:
     cpe: cpe:2.3:a:yonyou:ufida-nc:*:*:*:*:*:*:*:*
+    cwe-id: CWE-502
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/yonyou/yonyou-nc-lfi.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-nc-lfi.yaml
@@ -10,6 +10,8 @@ info:
     Successful exploitation allows attackers to access sensitive files and information stored on the server.
   reference:
     - https://github.com/szjr123/Target-practice/blob/05ed667090d8040a09235826f7698ff5347a93cf/%E7%94%A8%E5%8F%8BOA/NC%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96_DocServlet/yongyou_read.py
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-nc-ncmessageservlet-rce.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-nc-ncmessageservlet-rce.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/yonyou-nc-ncmessageservlet-rce.yaml
   classification:
     cpe: cpe:2.3:a:yonyou:ufida-nc:*:*:*:*:*:*:*:*
+    cwe-id: CWE-78,CWE-502
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/yonyou/yonyou-u8-crm-fileupload.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-u8-crm-fileupload.yaml
@@ -6,6 +6,8 @@ info:
   severity: critical
   description: |
     There is an arbitrary file upload vulnerability in the getemaildata.php file of UFIDA U8 CRM customer relationship management system. An attacker can obtain server permissions through the vulnerability and attack the server.
+  classification:
+    cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/yonyou/yonyou-u8-crm-lfi.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-u8-crm-lfi.yaml
@@ -8,6 +8,8 @@ info:
     There is an arbitrary file reading vulnerability in getemaildata.php of UFIDA U8 CRM customer relationship management system. An attacker can obtain sensitive files in the server through the vulnerability.
   reference:
     - https://github.com/PeiQi0/PeiQi-WIKI-Book/blob/main/docs/wiki/oa/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8B%20U8%20CRM%E5%AE%A2%E6%88%B7%E5%85%B3%E7%B3%BB%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%20getemaildata.php%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-22,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-u8-crm-sqli.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-u8-crm-sqli.yaml
@@ -8,6 +8,8 @@ info:
     UFIDA U8-CRM system /config/fillbacksetting.php contains an SQL injection vulnerability, which allows attackers to manipulate the database through maliciously constructed SQL statements, resulting in data leaks, tampering or destruction, and seriously threatening system security.
   reference:
     - https://github.com/wy876/POC/blob/main/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8BU8-CRM%E7%B3%BB%E7%BB%9Ffillbacksetting.php%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-u8-crm-tb-sqli.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-u8-crm-tb-sqli.yaml
@@ -8,6 +8,8 @@ info:
     UFIDA U8-CRM system /config/fillbacksetting.php contains an SQL injection vulnerability, which allows attackers to manipulate the database through maliciously constructed SQL statements, resulting in data leaks, tampering or destruction, and seriously threatening system security.
   reference:
     - https://github.com/wy876/POC/blob/main/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8BU8-CRM%E7%B3%BB%E7%BB%9Ffillbacksetting.php%E5%AD%98%E5%9C%A8SQL%E6%B3%A8%E5%85%A5%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-u8-sqli.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-u8-sqli.yaml
@@ -9,6 +9,8 @@ info:
   reference:
     - https://github.com/zan8in/afrog/blob/main/v2/pocs/afrog-pocs/vulnerability/yonyou-grp-u8-bx_historyDataChecks-sqli.yaml
     - https://github.com/MD-SEC/MDPOCS/blob/main/Yongyou_Grp_U8_bx_historyDataCheck_Sql_Poc.py
+  classification:
+    cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/yonyou/yonyou-ufida-nc-lfi.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-ufida-nc-lfi.yaml
@@ -10,6 +10,7 @@ info:
     - https://github.com/wy876/POC/blob/main/%E7%94%A8%E5%8F%8B%E7%A7%BB%E5%8A%A8%E7%B3%BB%E7%BB%9F%E7%AE%A1%E7%90%86getFileLocal%E6%8E%A5%E5%8F%A3%E5%AD%98%E5%9C%A8%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96.md
   classification:
     cpe: cpe:2.3:a:yonyou:ufida-nc:*:*:*:*:*:*:*:*
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/yonyou/yonyou-yonbip-lfi.yaml
+++ b/http/vulnerabilities/yonyou/yonyou-yonbip-lfi.yaml
@@ -8,6 +8,8 @@ info:
     There is an arbitrary file reading vulnerability in yonbiplogin, the advanced version of YonBIP
   reference:
     - https://github.com/wy876/POC/blob/main/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8BYonBIP%E9%AB%98%E7%BA%A7%E7%89%88yonbiplogin%E5%AD%98%E5%9C%A8%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cwe-id: CWE-23,CWE-73
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/zend/zend-v1-xss.yaml
+++ b/http/vulnerabilities/zend/zend-v1-xss.yaml
@@ -10,6 +10,7 @@ info:
     - https://twitter.com/c3l3si4n/status/1600035722148212737
   classification:
     cpe: cpe:2.3:a:zend:zend_framework:1.12.2:*:*:*:*:*:*:*
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 2

--- a/http/vulnerabilities/zzzcms/zzzcms-ssrf.yaml
+++ b/http/vulnerabilities/zzzcms/zzzcms-ssrf.yaml
@@ -9,6 +9,7 @@ info:
     - https://www.hacking8.com/bug-web/Zzzcms/Zzzcms-1.75-ssrf.html
   classification:
     cpe: cpe:2.3:a:zzzcms:zzzcms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1

--- a/http/vulnerabilities/zzzcms/zzzcms-xss.yaml
+++ b/http/vulnerabilities/zzzcms/zzzcms-xss.yaml
@@ -9,6 +9,7 @@ info:
     - https://github.com/Ares-X/VulWiki/blob/master/Web%E5%AE%89%E5%85%A8/Zzzcms/Zzzcms%201.75%20xss%E6%BC%8F%E6%B4%9E.md
   classification:
     cpe: cpe:2.3:a:zzzcms:zzzcms:*:*:*:*:*:*:*:*
+    cwe-id: CWE-79,CWE-83
   metadata:
     verified: true
     max-request: 1


### PR DESCRIPTION
### PR Information

- Added and normalized `classification.cwe-id` metadata across a broad set of HTTP templates covering common OWASP Top 10 style weakness classes.
- Changes are grouped logically into commits by vulnerability class to make review easier.
- References:
  - MITRE CWE taxonomy
  - existing nuclei-templates metadata conventions

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

This is a metadata-only PR to add and normalize `info.classification.cwe-id` across existing templates.
This PR does not modify detection logic and therefore does not require template revalidation.

CWE assignments were reviewed conservatively against the behaviour evidenced by each template and normalized across templates with the same behaviour for consistency, avoiding CWEs not directly supported by the template.

The update focuses on templates covering common classes such as:

- exposure / secret disclosure
- path traversal / LFI / file read / file download
- SSRF / external interaction
- RCE / deserialization / unsafe execution
- file upload
- XSS
- XXE
- SQL injection
- auth / access-control related cases
- misconfiguration-driven findings

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
