### PR TITLE
Create Owncast - Default Credentials

### DIFF
--- a/http/default-logins/owncast-default-login.yaml
+++ b/http/default-logins/owncast-default-login.yaml
@@ -1,0 +1,52 @@
+id: owncast-default-login
+
+info:
+  name: Owncast - Default Credentials
+  author: 0x_Akoko
+  severity: high
+  description: |
+    Detected Owncast using default admin credentials admin:abc123. The admin API was accessible via HTTP Basic authentication, allowing full server configuration access.
+  reference:
+    - https://owncast.online/docs/configuration/
+    - https://owncast.online/quickstart/configure/
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: http.title:"Owncast"
+    fofa-query: app="Owncast"
+  tags: default-login,owncast,streaming,admin,vuln
+
+variables:
+  username: admin
+  password: abc123
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /api/status HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "versionNumber", "online")'
+          - 'contains(content_type, "application/json")'
+        condition: and
+
+  - raw:
+      - |
+        GET /api/admin/serverconfig HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ":" + password)}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "instanceDetails", "ffmpegPath")'
+          - 'contains(content_type, "application/json")'
+        condition: and


### PR DESCRIPTION
Added default login credentials for Owncast with HTTP API access details.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
