### PR TITLE
Add generic Model Context Protocol (MCP) security templates

### DIFF
--- a/http/misconfiguration/mcp/mcp-cors-misconfig.yaml
+++ b/http/misconfiguration/mcp/mcp-cors-misconfig.yaml
@@ -1,0 +1,47 @@
+id: mcp-cors-misconfig
+
+info:
+  name: MCP Server - Permissive CORS Configuration
+  author: razasharif
+  severity: medium
+  description: |
+    Detects Model Context Protocol (MCP) servers with overly permissive CORS
+    headers. A wildcard Access-Control-Allow-Origin combined with
+    Access-Control-Allow-Credentials allows any website to make authenticated
+    requests to the MCP server from the browser, enabling credential theft and
+    unauthorised tool invocation.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cwe-id: CWE-942
+  metadata:
+    max-request: 1
+  tags: mcp,cors,misconfig
+
+http:
+  - method: OPTIONS
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Origin: "https://attacker.example.com"
+      Access-Control-Request-Method: POST
+      Access-Control-Request-Headers: Content-Type
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - 'Access-Control-Allow-Origin: *'
+          - 'Access-Control-Allow-Origin: https://attacker.example.com'
+        condition: or
+      - type: word
+        part: header
+        words:
+          - 'Access-Control-Allow-Credentials: true'

--- a/http/misconfiguration/mcp/mcp-missing-auth-header.yaml
+++ b/http/misconfiguration/mcp/mcp-missing-auth-header.yaml
@@ -1,0 +1,63 @@
+id: mcp-missing-auth-header
+
+info:
+  name: MCP Server - Missing Authorization on Protected Methods
+  author: razasharif
+  severity: high
+  description: |
+    Detects Model Context Protocol (MCP) servers that allow calling
+    tools/call without requiring an Authorization header or session token.
+    MCP servers exposing tools/call to unauthenticated clients may permit
+    attackers to directly invoke backend functions, potentially leading to
+    data exfiltration, remote code execution, or privilege escalation depending
+    on the tool implementations.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://owasp.org/www-project-mcp-top-10/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-306
+  metadata:
+    max-request: 2
+  tags: mcp,auth,unauth,critical
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"tools"'
+          - '"name"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"error"'
+          - 'unauthorized'
+          - 'Unauthorized'
+          - '"code":-32001'
+          - '"code":-32002'
+        condition: or
+        negative: true
+      - type: word
+        part: header
+        words:
+          - 'WWW-Authenticate'
+        negative: true
+      - type: status
+        status:
+          - 200

--- a/http/misconfiguration/mcp/mcp-missing-origin-validation.yaml
+++ b/http/misconfiguration/mcp/mcp-missing-origin-validation.yaml
@@ -1,0 +1,56 @@
+id: mcp-missing-origin-validation
+
+info:
+  name: MCP Server - Missing Origin Header Validation (DNS Rebinding Risk)
+  author: razasharif
+  severity: medium
+  description: |
+    Detects Model Context Protocol (MCP) servers that accept requests with
+    arbitrary Origin headers. The MCP specification recommends validating the
+    Origin header to prevent DNS rebinding attacks where a malicious website
+    can issue requests to an MCP server bound to localhost or an internal
+    network, potentially invoking tools on behalf of the victim.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://en.wikipedia.org/wiki/DNS_rebinding
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N
+    cvss-score: 4.7
+    cwe-id: CWE-346
+  metadata:
+    max-request: 1
+  tags: mcp,misconfig,dns-rebinding,origin
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+      Origin: "http://evil.example.com"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"nuclei-origin-test","version":"1.0"}}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"result"'
+          - '"serverInfo"'
+        condition: and
+      - type: word
+        part: header
+        words:
+          - 'Access-Control-Allow-Origin: *'
+          - 'Access-Control-Allow-Origin: http://evil.example.com'
+        condition: or
+        negative: false
+      - type: status
+        status:
+          - 200

--- a/http/misconfiguration/mcp/mcp-prompts-list-unauth.yaml
+++ b/http/misconfiguration/mcp/mcp-prompts-list-unauth.yaml
@@ -1,0 +1,53 @@
+id: mcp-prompts-list-unauth
+
+info:
+  name: MCP Server - Unauthenticated Prompts List Exposure
+  author: razasharif
+  severity: low
+  description: |
+    Detects Model Context Protocol (MCP) servers that expose their prompts/list
+    method without authentication. Prompt templates can reveal business logic,
+    use cases, and internal workflows. Unauthenticated exposure aids an attacker
+    in understanding the server's intended purpose.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+  tags: mcp,exposure,unauth,misconfig
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"prompts"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"error"'
+          - 'unauthorized'
+          - 'Unauthorized'
+        condition: or
+        negative: true
+      - type: status
+        status:
+          - 200

--- a/http/misconfiguration/mcp/mcp-resources-list-unauth.yaml
+++ b/http/misconfiguration/mcp/mcp-resources-list-unauth.yaml
@@ -1,0 +1,65 @@
+id: mcp-resources-list-unauth
+
+info:
+  name: MCP Server - Unauthenticated Resources List Exposure
+  author: razasharif
+  severity: medium
+  description: |
+    Detects Model Context Protocol (MCP) servers that expose their resources/list
+    method without authentication. Resources represent data accessible to agents
+    (files, databases, APIs). Unauthenticated exposure lets attackers map the
+    available data surface of the server.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+  tags: mcp,exposure,unauth,misconfig
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"resources"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"uri"'
+          - '"name"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"error"'
+          - 'unauthorized'
+          - 'Unauthorized'
+        condition: or
+        negative: true
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: resource_uris
+        part: body
+        json:
+          - ".result.resources[].uri"

--- a/http/misconfiguration/mcp/mcp-server-detection.yaml
+++ b/http/misconfiguration/mcp/mcp-server-detection.yaml
@@ -1,0 +1,67 @@
+id: mcp-server-detection
+
+info:
+  name: Model Context Protocol (MCP) Server Detection
+  author: razasharif
+  severity: info
+  description: |
+    Detects exposed Model Context Protocol (MCP) servers by issuing a JSON-RPC
+    initialize request. MCP is an open protocol for connecting LLMs to external
+    tools and data sources. This template works against any MCP server that
+    implements the streamable HTTP transport (JSON-RPC 2.0 over POST).
+  reference:
+    - https://modelcontextprotocol.io
+    - https://spec.modelcontextprotocol.io
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"MCP"
+  tags: mcp,tech,detect,json-rpc
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"nuclei-mcp-scan","version":"1.0"}}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"protocolVersion"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"result"'
+          - '"serverInfo"'
+        condition: or
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: protocol_version
+        part: body
+        json:
+          - ".result.protocolVersion"
+      - type: json
+        name: server_name
+        part: body
+        json:
+          - ".result.serverInfo.name"
+      - type: json
+        name: server_version
+        part: body
+        json:
+          - ".result.serverInfo.version"

--- a/http/misconfiguration/mcp/mcp-sse-transport-detection.yaml
+++ b/http/misconfiguration/mcp/mcp-sse-transport-detection.yaml
@@ -1,0 +1,66 @@
+id: mcp-sse-transport-detection
+
+info:
+  name: Model Context Protocol (MCP) Server Detection - SSE Transport
+  author: razasharif
+  severity: info
+  description: |
+    Detects exposed Model Context Protocol (MCP) servers that implement the
+    legacy Server-Sent Events (SSE) transport defined in the 2024-11-05
+    specification. These servers expose a /sse GET endpoint for the event
+    stream and a /messages/ POST endpoint for JSON-RPC requests. This
+    template probes both using a method-mismatch approach to force instant
+    responses without holding an SSE stream open, then fingerprints the
+    characteristic error patterns used by FastMCP and other SSE-transport
+    MCP server implementations.
+  reference:
+    - https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/
+    - https://modelcontextprotocol.io
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+  tags: mcp,tech,detect,sse
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/sse"
+      - "{{BaseURL}}/mcp/sse"
+      - "{{BaseURL}}/api/sse"
+    headers:
+      Content-Type: application/json
+    body: "{}"
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 405
+      - type: word
+        part: header
+        words:
+          - 'allow: HEAD, GET'
+          - 'allow: GET, HEAD'
+          - 'Allow: HEAD, GET'
+          - 'Allow: GET, HEAD'
+        condition: or
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/messages/"
+      - "{{BaseURL}}/messages"
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - 'session'
+          - 'Missing session_id'
+          - 'Invalid session'
+        condition: or

--- a/http/misconfiguration/mcp/mcp-tools-list-unauth.yaml
+++ b/http/misconfiguration/mcp/mcp-tools-list-unauth.yaml
@@ -1,0 +1,70 @@
+id: mcp-tools-list-unauth
+
+info:
+  name: MCP Server - Unauthenticated Tools List Exposure
+  author: razasharif
+  severity: medium
+  description: |
+    Detects Model Context Protocol (MCP) servers that expose their tools/list
+    method without authentication. This allows attackers to enumerate all
+    available tools (function handlers) exposed by the server, which can be
+    used to plan further attacks. MCP servers should require authentication
+    before disclosing tool definitions.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://owasp.org/www-project-mcp-top-10/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+  tags: mcp,exposure,unauth,misconfig
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"tools"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"name"'
+          - '"description"'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - '"error"'
+          - '"code":-32600'
+          - '"code":-32001'
+          - '"code":-32002'
+          - 'unauthorized'
+          - 'Unauthorized'
+        condition: or
+        negative: true
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: tool_names
+        part: body
+        json:
+          - ".result.tools[].name"

--- a/http/misconfiguration/mcp/mcp-verbose-error-disclosure.yaml
+++ b/http/misconfiguration/mcp/mcp-verbose-error-disclosure.yaml
@@ -1,0 +1,57 @@
+id: mcp-verbose-error-disclosure
+
+info:
+  name: MCP Server - Verbose Error Message Information Disclosure
+  author: razasharif
+  severity: low
+  description: |
+    Detects Model Context Protocol (MCP) servers that return verbose error
+    messages containing stack traces, file paths, or internal implementation
+    details. This information aids attackers in identifying the technology
+    stack, file system layout, and potential vulnerabilities in the server
+    implementation.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/errors
+    - https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html
+    - https://owasp.org/www-community/Improper_Error_Handling
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-209
+  metadata:
+    max-request: 1
+  tags: mcp,info-disclosure,misconfig
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/mcp/v1"
+      - "{{BaseURL}}/"
+    headers:
+      Content-Type: application/json
+      Accept: "application/json, text/event-stream"
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"__nonexistent_tool_abcxyz__","arguments":{}}}
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Traceback (most recent call last)'
+          - 'at Object.<anonymous>'
+          - '.py", line '
+          - '.js:'
+          - '/home/'
+          - '/usr/local/'
+          - 'C:\\Users\\'
+          - 'node_modules'
+          - 'site-packages'
+          - 'Stack trace:'
+        condition: or
+      - type: regex
+        part: body
+        regex:
+          - 'at [A-Za-z0-9_$]+ \(/[^)]+\)'
+          - 'File "[^"]+\.py", line \d+'


### PR DESCRIPTION
## Summary

This PR adds 9 generic Nuclei templates for detecting security issues in Model Context Protocol (MCP) servers. MCP is an open protocol by Anthropic that connects LLMs to external tools, data sources, and services. Public MCP server deployments are growing rapidly and there are currently no Nuclei templates covering this attack surface.

All templates target the MCP specification directly and work against any MCP server implementation, not a specific vendor or deployment. Both transport variants defined by the spec are covered: streamable HTTP (2025-06-18) and SSE (2024-11-05).

## Context

Previous PR #15708 was closed with feedback that templates were too specific to a single deliberately vulnerable server. This PR replaces that work with spec-driven generic templates, tested against three independent MCP implementations.

## Templates

| Template | Severity | What it detects |
|----------|----------|-----------------|
| mcp-server-detection | info | Streamable HTTP MCP server presence via JSON-RPC initialize |
| mcp-sse-transport-detection | info | SSE transport MCP server (2024-11-05 spec) |
| mcp-tools-list-unauth | medium | Unauthenticated tools/list exposure |
| mcp-resources-list-unauth | medium | Unauthenticated resources/list exposure |
| mcp-prompts-list-unauth | low | Unauthenticated prompts/list exposure |
| mcp-missing-auth-header | high | Missing authentication on protected JSON-RPC methods |
| mcp-cors-misconfig | medium | Permissive CORS with credentials |
| mcp-missing-origin-validation | medium | DNS rebinding risk via missing Origin validation |
| mcp-verbose-error-disclosure | low | Stack traces and file paths in error responses |

## Testing

Validated against three independent MCP implementations:

1. **Local reference implementation** (vulnerable Node.js test server) -- 9/9 templates fire
2. **Local reference implementation** (secure Node.js test server) -- 0/9 templates fire (no false positives)
3. **harishsg993010/damn-vulnerable-MCP-server** (Python FastMCP, SSE transport, 1.2k stars) -- SSE detection fires on all 10 challenge instances
4. **Live public MCP server** (cybersecai-uk/dvmcp, streamable HTTP transport) -- 6/9 templates fire (3 correctly do not fire: server has secure CORS, no verbose errors, not SSE transport)

All templates validate via \`nuclei -validate\`.

## References

- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification/2025-06-18)
- [MCP 2024-11-05 SSE Transport Specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/)
- [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
- [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/)

Source repo with test harness: https://github.com/razashariff/mcp-nuclei-templates