### PR TITLE
Add ContrastAPI domain reconnaissance template

### DIFF
--- a/http/http/miscellaneous/contrastapi-domain-recon.yaml
+++ b/http/http/miscellaneous/contrastapi-domain-recon.yaml
@@ -12,7 +12,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: osint,recon,domain,whois,dns,ssl,threat-intel
+  tags: misc,recon,domain,whois,dns,ssl,threat-intel
 
 variables:
   hostname: "{{Host}}"

--- a/http/http/miscellaneous/contrastapi-domain-recon.yaml
+++ b/http/http/miscellaneous/contrastapi-domain-recon.yaml
@@ -64,14 +64,14 @@ http:
       - type: json
         name: mx_records
         json:
-          - '.dns.mx[]'
+          - '.dns.mx[].host'
 
       - type: json
-        name: tech_stack
+        name: waf_vendors
         json:
-          - '.technologies[].name'
+          - '.waf.detected[]'
 
       - type: json
-        name: threat_score
+        name: risk_score
         json:
-          - '.threat.risk_score'
+          - '.risk_score'

--- a/http/osint/contrastapi-domain-recon.yaml
+++ b/http/osint/contrastapi-domain-recon.yaml
@@ -1,0 +1,79 @@
+id: contrastapi-domain-recon
+
+info:
+  name: ContrastAPI Domain Reconnaissance
+  author: UPinar
+  severity: info
+  description: |
+    Performs domain security reconnaissance using ContrastAPI. Retrieves WHOIS data,
+    DNS records, SSL certificate details, security headers, and threat intelligence
+    for the target domain.
+  reference:
+    - https://api.contrastcyber.com/docs
+    - https://github.com/UPinar/contrastapi
+  metadata:
+    verified: true
+    max-request: 1
+  tags: osint,recon,domain,whois,dns,ssl,threat-intel
+
+variables:
+  hostname: "{{Host}}"
+
+http:
+  - method: GET
+    path:
+      - "https://api.contrastcyber.com/v1/report/{{hostname}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "domain"
+          - "dns"
+        condition: and
+
+    extractors:
+      - type: json
+        name: registrar
+        json:
+          - '.whois.registrar'
+
+      - type: json
+        name: nameservers
+        json:
+          - '.dns.ns[]'
+
+      - type: json
+        name: ssl_issuer
+        json:
+          - '.ssl.issuer'
+
+      - type: json
+        name: ssl_expiry
+        json:
+          - '.ssl.not_after'
+
+      - type: json
+        name: ip_address
+        json:
+          - '.dns.a[]'
+
+      - type: json
+        name: mx_records
+        json:
+          - '.dns.mx[]'
+
+      - type: json
+        name: tech_stack
+        json:
+          - '.technologies[].name'
+
+      - type: json
+        name: threat_score
+        json:
+          - '.threat.risk_score'

--- a/http/osint/contrastapi-domain-recon.yaml
+++ b/http/osint/contrastapi-domain-recon.yaml
@@ -5,9 +5,7 @@ info:
   author: UPinar
   severity: info
   description: |
-    Performs domain security reconnaissance using ContrastAPI. Retrieves WHOIS data,
-    DNS records, SSL certificate details, security headers, and threat intelligence
-    for the target domain.
+    Performs domain security reconnaissance using ContrastAPI. Retrieves WHOIS data, DNS records, SSL certificate details, security headers, and threat intelligence for the target domain.
   reference:
     - https://api.contrastcyber.com/docs
     - https://github.com/UPinar/contrastapi
@@ -22,20 +20,20 @@ variables:
 http:
   - method: GET
     path:
-      - "https://api.contrastcyber.com/v1/report/{{hostname}}"
+      - "https://api.contrastcyber.com/v1/domain/{{hostname}}"
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
           - "domain"
           - "dns"
         condition: and
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: json


### PR DESCRIPTION
## What

Adds a domain reconnaissance template that uses [ContrastAPI](https://api.contrastcyber.com) to gather security intelligence about target domains.

## Template Details

- **Category:** `http/osint/`
- **Severity:** info
- **Requests:** 1 (single API call returns comprehensive report)

## Extracted Data

The template extracts:
- WHOIS registrar info
- DNS records (A, NS, MX)
- SSL certificate issuer and expiry
- Technology stack
- Threat risk score

## About ContrastAPI

Free security intelligence API — no API key required (100 req/hr rate limit). 29 endpoints total: CVE/EPSS/KEV lookup, domain recon, IOC enrichment, code security, OSINT.

- GitHub: https://github.com/UPinar/contrastapi
- Live API: https://api.contrastcyber.com
- Privacy: transparency endpoint at `/v1/privacy/my-data`