### PR TITLE
Improve CVE-2022-3254 matchers to reduce false positives on HTML resp…

### DIFF
--- a/http/cves/2022/CVE-2022-3254.yaml
+++ b/http/cves/2022/CVE-2022-3254.yaml
@@ -30,6 +30,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
+          - 'startswith(trim(body), "{")' # Ensure response is JSON structure
           - 'contains_all(body, "options", "status")'
           - '!contains(body, "\"options\":false")'
           - '!regex(body, "\"options\"\\s*:\\s*\\[\\s*\\]")'


### PR DESCRIPTION
The current rule matches on non-WordPress HTML pages (like Angular apps) if the meta descriptions or CSS contain the words "status" and "options." The `startswith(trim(body), "{")` DSL check was added to ensure structural integrity and avoid matching non-JSON responses.