### PR TITLE
fix: webpack-config - false positive detection for SPA catch-all routing

### DIFF
--- a/http/exposures/configs/webpack-config.yaml
+++ b/http/exposures/configs/webpack-config.yaml
@@ -2,9 +2,11 @@ id: webpack-config
 
 info:
   name: Webpack Configuration File - Detect
-  author: ambassify
+  author: ambassify,s4e-io
   severity: info
   description: Webpack configuration file was detected.
+  reference:
+    - https://webpack.js.org/configuration/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cvss-score: 0
@@ -37,7 +39,14 @@ http:
           - "text/javascript"
         condition: or
 
+      - type: word
+        part: body
+        words:
+          - "<html"
+          - "<!doctype"
+        case-insensitive: true
+        negative: true
+
       - type: status
         status:
           - 200
-# digest: 4a0a004730450220550a5959380152a051bfac2ff5f8110b346623504fa445d82cd754fdaffedd69022100abe5feca8b824a6d0b70190d9aada52cb7210ada9cd4520bbd17a54ac5508ad7:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Fixed `webpack-config` template — false positive triggered by Angular/React/Vue SPA catch-all routing
- References:
  - https://webpack.js.org/configuration/

---

### Problem Description

The `webpack-config` template was producing **false positive** results on Single Page Application (SPA) targets built with Angular, React, or Vue. These frameworks use a **catch-all routing strategy**: any unmatched URL path (including `/webpack.config.js`) returns the application's `index.html` shell with HTTP `200 OK`.

#### Root Cause Analysis

The previous matchers had three weaknesses that aligned perfectly on SPA targets:

| Matcher | Issue |
|---|---|
| `module.exports` OR `const` (body) | `const` appears in any inline `<script>` block inside the HTML shell page |
| `application/javascript` OR `text/javascript` (header) | SPA servers assign `application/javascript` to any `.js` path regardless of actual body content |
| `status: 200` | Always true for SPA catch-all routes |

All three `AND` conditions were satisfied simultaneously — resulting in a false positive.

#### Reproduction

On an Angular SPA, every `.js` path returns the same HTML shell:

```
GET /test.js           → 200, Content-Type: application/javascript, body: index.html
GET /webpack.config.js → 200, Content-Type: application/javascript, body: index.html  ← FALSE POSITIVE
```

The response body that triggered the old matcher:

```
HTTP/1.1 200 OK
Content-Type: application/javascript

<!doctype html>
<html lang="en">
  <script>
    function logoLoaded() {
      const img = document.getElementById('loading-image');  ← 'const' matched here
    }
  </script>
  <app-root>...</app-root>
</html>
```

---

### What a Real `webpack.config.js` Looks Like

A genuine exposed webpack config always contains `module.exports` as the export mechanism. Older configs use `var` (no `const`), newer ones use `const` — both must be detected:

```javascript
// Legacy style — has module.exports but NO const
var path = require('path');

module.exports = {
  entry: path.resolve(__dirname, 'src/index.js'),
  output: { filename: 'bundle.js', path: path.resolve(__dirname, 'dist') },
  resolve: { modules: [path.resolve(__dirname, 'node_modules')] },
  devServer: { contentBase: path.join(__dirname, 'dist'), port: 9000 }
};

// Modern style — has both module.exports AND const
const path = require('path');
const HtmlWebpackPlugin = require('html-webpack-plugin');

module.exports = {
  entry: './src/index.js',
  output: { path: path.resolve(__dirname, 'dist'), filename: 'bundle.js' },
  plugins: [new HtmlWebpackPlugin()],
  devServer: { port: 3000 }
};
```

This is why `condition: or` must be kept — switching to `and` would cause false negatives on legacy configs.

---

### Fix

The core fix is a **case-insensitive negative matcher** on the response body. Any SPA catch-all response contains `<html` or `<!doctype` — this single addition eliminates the entire class of SPA false positives:

```yaml
- type: word
  part: body
  words:
    - "<html"
    - "<!doctype"
  case-insensitive: true
  negative: true
```

Additional metadata improvements: added `reference` field and co-author attribution.

#### Before / After

```yaml
# BEFORE
matchers:
  - type: word
    words:
      - "module.exports"
      - "const"
    condition: or          # ← 'const' alone matches SPA inline scripts → FP

  - type: word
    part: header
    words:
      - "application/javascript"
      - "text/javascript"
    condition: or          # ← SPA servers return this for any .js path → FP

  - type: status
    status:
      - 200                # ← always true for SPA catch-all → FP

# AFTER
matchers:
  - type: word
    words:
      - "module.exports"
      - "const"
    condition: or          # kept: covers both var-style and const-style configs

  - type: word
    part: header
    words:
      - "application/javascript"
      - "text/javascript"
    condition: or

  - type: word             # NEW: primary fix
    part: body
    words:
      - "<html"
      - "<!doctype"
    case-insensitive: true
    negative: true         # rejects HTML catch-all responses

  - type: status
    status:
      - 200
```

---

### Template Validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### False Positive — Angular SPA Catch-All (REDACTED)

**Before fix:**
```
nuclei -t webpack-config.yaml -u https://[REDACTED]

[webpack-config] [http] [info] https://[REDACTED]/webpack.config.js
Scan completed. 1 matches found.   ← FALSE POSITIVE
```

**After fix:**
```
nuclei -t webpack-config.yaml -u https://[REDACTED]

Scan completed. No results found.   ← CORRECT
```

---

### Additional References

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
