### PR TITLE
Add CVE-2026-24423 SmarterMail ConnectToHub RCE template

### DIFF
--- a/http/cves/2026/CVE-2026-24423.yaml
+++ b/http/cves/2026/CVE-2026-24423.yaml
@@ -1,15 +1,15 @@
 id: CVE-2026-24423
 
 info:
-  name: SmarterMail < Build 9511 - ConnectToHub Unauthenticated RCE
+  name: SmarterMail - Remote Code Execution
   author: jyoti369
   severity: critical
   description: |
-    SmarterMail before build 9511 has an unauthenticated connect-to-hub API endpoint that accepts a user-supplied hubAddress and makes an outbound HTTP POST to the given address, ultimately allowing remote code execution through attacker-controlled mount configuration commands.
+    SmarterTools SmarterMail < build 9511 contains an unauthenticated remote code execution caused by malicious OS command execution via ConnectToHub API method, letting remote attackers execute arbitrary commands, exploit requires no authentication.
   impact: |
-    Full remote code execution as the SmarterMail service account without any authentication.
+    Remote attackers can execute arbitrary OS commands, potentially leading to full system compromise.
   remediation: |
-    Upgrade SmarterMail to build 9511 or later.
+    Update to build 9511 or later.
   reference:
     - https://www.vulncheck.com/blog/smartermail-connecttohub-rce-cve-2026-24423
     - https://code-white.com/public-vulnerability-list/
@@ -33,7 +33,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"hubAddress":"http://{{interactsh-url}}","oneTimePassword":"test","nodeName":"check"}
+        {"hubAddress":"http://{{interactsh-url}}","oneTimePassword":"{{randstr}}","nodeName":"{{randstr}}"}
 
     matchers-condition: and
     matchers:

--- a/http/cves/2026/CVE-2026-24423.yaml
+++ b/http/cves/2026/CVE-2026-24423.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-24423
+
+info:
+  name: SmarterMail < Build 9511 - ConnectToHub Unauthenticated RCE
+  author: jyoti369
+  severity: critical
+  description: |
+    SmarterMail before build 9511 has an unauthenticated connect-to-hub API endpoint that accepts a user-supplied hubAddress and makes an outbound HTTP POST to the given address, ultimately allowing remote code execution through attacker-controlled mount configuration commands.
+  impact: |
+    Full remote code execution as the SmarterMail service account without any authentication.
+  remediation: |
+    Upgrade SmarterMail to build 9511 or later.
+  reference:
+    - https://www.vulncheck.com/blog/smartermail-connecttohub-rce-cve-2026-24423
+    - https://code-white.com/public-vulnerability-list/
+    - https://www.smartertools.com/smartermail/release-notes/current
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24423
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24423
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: html:"SmarterMail"
+  tags: cve,cve2026,smartermail,rce,oast,kev,vkev
+
+http:
+  - raw:
+      - |
+        POST /api/v1/settings/sysadmin/connect-to-hub HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"hubAddress":"http://{{interactsh-url}}","oneTimePassword":"test","nodeName":"check"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: interactsh_request
+        words:
+          - "setup-initial-connection"


### PR DESCRIPTION
Adds a template for CVE-2026-24423, the unauthenticated RCE in SmarterMail via the ConnectToHub API.

The vulnerable endpoint at `/api/v1/settings/sysadmin/connect-to-hub` accepts a `hubAddress` parameter without authentication. The server then makes an outbound HTTP POST to `{hubAddress}/web/api/node-management/setup-initial-connection` with the supplied parameters. An attacker-controlled server can respond with mount configuration that includes arbitrary commands.

Detection uses interactsh to catch the outbound HTTP callback and confirms the request path contains `setup-initial-connection`, which is specific to the ConnectToHub flow.

References:
- VulnCheck writeup with full root cause: https://www.vulncheck.com/blog/smartermail-connecttohub-rce-cve-2026-24423
- CODE WHITE discovery: https://code-white.com/public-vulnerability-list/

In CISA KEV (added Feb 5, 2026). Affects SmarterMail < Build 9511.

Template validated with `nuclei -validate`.
