### PR TITLE
Add Essential Eight compliance audit templates for Windows

### DIFF
--- a/code/windows/audit/default-admin-account-enabled.yaml
+++ b/code/windows/audit/default-admin-account-enabled.yaml
@@ -1,0 +1,35 @@
+id: default-admin-account-enabled
+
+info:
+  name: Default Administrator Account Enabled
+  author: boonchuan
+  severity: medium
+  description: Detects if the built-in Administrator account is enabled, which is a common target for brute-force and credential stuffing attacks.
+  impact: |
+    The default Administrator account has a well-known SID and is frequently targeted by attackers. Leaving it enabled increases the attack surface.
+  remediation: |
+    Disable the built-in Administrator account and use a separate named admin account for administrative tasks. Run: net user Administrator /active:no
+  reference:
+    - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
+    - https://learn.microsoft.com/en-us/windows/security/identity-protection/access-control/local-accounts
+  tags: windows,admin,privileges,compliance,essential-eight,code,windows-audit
+
+self-contained: true
+
+code:
+  - pre-condition: |
+      IsWindows();
+    engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+    pattern: "*.ps1"
+    source: |
+      $admin = Get-LocalUser -Name 'Administrator' -ErrorAction SilentlyContinue; if ($admin -and $admin.Enabled) { 'True' } else { 'False' }
+
+    matchers:
+      - type: word
+        words:
+          - "True"

--- a/code/windows/audit/default-admin-account-enabled.yaml
+++ b/code/windows/audit/default-admin-account-enabled.yaml
@@ -4,7 +4,8 @@ info:
   name: Default Administrator Account Enabled
   author: boonchuan
   severity: medium
-  description: Detects if the built-in Administrator account is enabled, which is a common target for brute-force and credential stuffing attacks.
+  description: |
+    Detected built-in Administrator account was enabled, which is a common target for brute-force and credential stuffing attacks.
   impact: |
     The default Administrator account has a well-known SID and is frequently targeted by attackers. Leaving it enabled increases the attack surface.
   remediation: |
@@ -12,9 +13,9 @@ info:
   reference:
     - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
     - https://learn.microsoft.com/en-us/windows/security/identity-protection/access-control/local-accounts
+  metadata:
+    verified: false
   tags: windows,admin,privileges,compliance,essential-eight,code,windows-audit
-
-self-contained: true
 
 code:
   - pre-condition: |
@@ -28,7 +29,6 @@ code:
     pattern: "*.ps1"
     source: |
       $admin = Get-LocalUser -Name 'Administrator' -ErrorAction SilentlyContinue; if ($admin -and $admin.Enabled) { 'True' } else { 'False' }
-
     matchers:
       - type: word
         words:

--- a/code/windows/audit/office-macros-not-restricted.yaml
+++ b/code/windows/audit/office-macros-not-restricted.yaml
@@ -1,0 +1,35 @@
+id: office-macros-not-restricted
+
+info:
+  name: Microsoft Office Macros Not Restricted
+  author: boonchuan
+  severity: high
+  description: Detects if Microsoft Office macro settings are not configured to block or restrict macro execution, increasing risk of macro-based malware delivery.
+  impact: |
+    Unrestricted macros allow attackers to deliver malware through Office documents, a common initial access vector.
+  remediation: |
+    Configure Group Policy to disable macros: User Configuration > Administrative Templates > Microsoft Office > Security > VBA Macro Notification Settings > Disable all without notification (VBAWarnings = 4).
+  reference:
+    - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
+    - https://learn.microsoft.com/en-us/deployoffice/security/internet-macros-blocked
+  tags: windows,office,macros,compliance,essential-eight,code,windows-audit
+
+self-contained: true
+
+code:
+  - pre-condition: |
+      IsWindows();
+    engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+    pattern: "*.ps1"
+    source: |
+      $apps = @('Word','Excel','PowerPoint'); $unrestricted = $false; foreach ($app in $apps) { $val = (Get-ItemProperty -Path "HKCU:\Software\Policies\Microsoft\Office\16.0\$app\Security" -Name 'VBAWarnings' -ErrorAction SilentlyContinue).VBAWarnings; if ($null -eq $val -or $val -lt 3) { $unrestricted = $true } }; if ($unrestricted) { 'True' } else { 'False' }
+
+    matchers:
+      - type: word
+        words:
+          - "True"

--- a/code/windows/audit/office-macros-not-restricted.yaml
+++ b/code/windows/audit/office-macros-not-restricted.yaml
@@ -4,7 +4,8 @@ info:
   name: Microsoft Office Macros Not Restricted
   author: boonchuan
   severity: high
-  description: Detects if Microsoft Office macro settings are not configured to block or restrict macro execution, increasing risk of macro-based malware delivery.
+  description: |
+    Detected Microsoft Office macro restrictions were not configured, increasing the risk of macro-based malware delivery through Office documents.
   impact: |
     Unrestricted macros allow attackers to deliver malware through Office documents, a common initial access vector.
   remediation: |
@@ -12,9 +13,9 @@ info:
   reference:
     - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
     - https://learn.microsoft.com/en-us/deployoffice/security/internet-macros-blocked
+  metadata:
+    verified: false
   tags: windows,office,macros,compliance,essential-eight,code,windows-audit
-
-self-contained: true
 
 code:
   - pre-condition: |
@@ -28,7 +29,6 @@ code:
     pattern: "*.ps1"
     source: |
       $apps = @('Word','Excel','PowerPoint'); $unrestricted = $false; foreach ($app in $apps) { $val = (Get-ItemProperty -Path "HKCU:\Software\Policies\Microsoft\Office\16.0\$app\Security" -Name 'VBAWarnings' -ErrorAction SilentlyContinue).VBAWarnings; if ($null -eq $val -or $val -lt 3) { $unrestricted = $true } }; if ($unrestricted) { 'True' } else { 'False' }
-
     matchers:
       - type: word
         words:

--- a/code/windows/audit/windows-auto-update-disabled.yaml
+++ b/code/windows/audit/windows-auto-update-disabled.yaml
@@ -4,7 +4,8 @@ info:
   name: Windows Automatic Updates Disabled
   author: boonchuan
   severity: high
-  description: Detects if Windows automatic updates are explicitly disabled, leaving the system vulnerable to unpatched security flaws.
+  description: |
+    Detected Windows automatic updates were found disabled, leaving the system vulnerable to unpatched security flaws.
   impact: |
     Systems without automatic updates will miss critical security patches, increasing exposure to known vulnerabilities and exploits.
   remediation: |
@@ -12,9 +13,9 @@ info:
   reference:
     - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
     - https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+  metadata:
+    verified: false
   tags: windows,updates,patching,compliance,essential-eight,code,windows-audit
-
-self-contained: true
 
 code:
   - pre-condition: |
@@ -28,7 +29,6 @@ code:
     pattern: "*.ps1"
     source: |
       $au = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -ErrorAction SilentlyContinue; if ($au -and $au.NoAutoUpdate -eq 1) { 'True' } else { 'False' }
-
     matchers:
       - type: word
         words:

--- a/code/windows/audit/windows-auto-update-disabled.yaml
+++ b/code/windows/audit/windows-auto-update-disabled.yaml
@@ -1,0 +1,35 @@
+id: windows-auto-update-disabled
+
+info:
+  name: Windows Automatic Updates Disabled
+  author: boonchuan
+  severity: high
+  description: Detects if Windows automatic updates are explicitly disabled, leaving the system vulnerable to unpatched security flaws.
+  impact: |
+    Systems without automatic updates will miss critical security patches, increasing exposure to known vulnerabilities and exploits.
+  remediation: |
+    Enable automatic updates via Group Policy: Computer Configuration > Administrative Templates > Windows Components > Windows Update > Configure Automatic Updates > set to Auto download and schedule install.
+  reference:
+    - https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model
+    - https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+  tags: windows,updates,patching,compliance,essential-eight,code,windows-audit
+
+self-contained: true
+
+code:
+  - pre-condition: |
+      IsWindows();
+    engine:
+      - powershell
+      - powershell.exe
+    args:
+      - -ExecutionPolicy
+      - Bypass
+    pattern: "*.ps1"
+    source: |
+      $au = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -ErrorAction SilentlyContinue; if ($au -and $au.NoAutoUpdate -eq 1) { 'True' } else { 'False' }
+
+    matchers:
+      - type: word
+        words:
+          - "True"


### PR DESCRIPTION
## Summary

3 new Windows audit templates mapped to Australia's ASD Essential Eight Maturity Model — a mandatory cybersecurity framework for Australian government agencies and increasingly expected across the private sector.

## Templates Added

| Template | E8 Control | Severity | Description |
|----------|-----------|----------|-------------|
| `office-macros-not-restricted.yaml` | Control 3: Configure Microsoft Office Macros | High | Detects unrestricted Office macro settings across Word, Excel, PowerPoint |
| `default-admin-account-enabled.yaml` | Control 5: Restrict Administrative Privileges | Medium | Detects enabled built-in Administrator account |
| `windows-auto-update-disabled.yaml` | Control 6: Patch Operating Systems | High | Detects explicitly disabled Windows automatic updates |

## Why These Matter

- The Essential Eight is mandatory for all Australian Commonwealth entities and increasingly required by cyber insurers and government supply chains
- These checks fill gaps in the existing Windows audit template coverage
- All templates follow the existing `code/windows/audit/` format and conventions
- Tagged with `essential-eight` and `compliance` for easy filtering

## References

- [ASD Essential Eight Maturity Model](https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-maturity-model)
- [E8Mate - Open Source Essential Eight Scanner](https://github.com/boonchuan/e8mate)

## Testing

Tested on Windows 11 Home (10.0.26200) — all templates produce correct results for both compliant and non-compliant configurations.
