### PR TITLE
Create CVE-2026-5032.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-5032.yaml
+++ b/http/cves/2026/CVE-2026-5032.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-5032
+
+info:
+  name: W3 Total Cache <= 2.9.3 - Unauthenticated W3TC_DYNAMIC_SECURITY Token Disclosure
+  author: VISHVAJITH-REDDY
+  severity: high
+  description: |
+    W3 Total Cache plugin for WordPress <= 2.9.3 is vulnerable to information
+    disclosure. Sending a request with a User-Agent containing "W3 Total Cache"
+    bypasses output buffering, exposing the W3TC_DYNAMIC_SECURITY token in the
+    page source to unauthenticated attackers when fragment caching is enabled.
+  impact: |
+    An unauthenticated attacker can retrieve the W3TC_DYNAMIC_SECURITY token,
+    which may be leveraged for further attacks against the WordPress installation.
+  remediation: |
+    Update W3 Total Cache to version 2.9.4 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-5032
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a65eb62d-847b-4f3a-848b-1290e3118c01
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-5032
+    cwe-id: CWE-200
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: boldgrid
+    product: w3-total-cache
+    shodan-query: 'http.component:"W3 Total Cache"'
+  tags: cve,cve2026,wordpress,wp-plugin,w3-total-cache,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    headers:
+      User-Agent: "W3 Total Cache"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "W3TC_DYNAMIC_SECURITY"
+
+      - type: word
+        part: body
+        words:
+          - "wordpress"
+          - "wp-content"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information
- Added CVE-2026-5032 - W3 Total Cache <= 2.9.3 Unauthenticated Information Disclosure
- References: https://www.wordfence.com/threat-intel/vulnerabilities/id/a65eb62d-847b-4f3a-848b-1290e3118c01

### Template validation
- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details
W3 Total Cache plugin for WordPress <= 2.9.3 exposes the W3TC_DYNAMIC_SECURITY 
token when a request is sent with User-Agent: "W3 Total Cache". This bypasses 
output buffering and leaks the token in page source to unauthenticated attackers 
when fragment caching is enabled.

CVSS: 7.5 (High) | CWE-200 | Unauthenticated

Shodan query: http.component:"W3 Total Cache"