### PR TITLE
Add registrar extractors to rdap-whois template

### DIFF
--- a/http/miscellaneous/rdap-whois.yaml
+++ b/http/miscellaneous/rdap-whois.yaml
@@ -93,6 +93,42 @@ http:
 
       - type: json
         part: body
+        name: registrarIANAId
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .publicIds[] | select(.type == "IANA Registrar ID") | .identifier'
+
+      - type: json
+        part: body
+        name: registrarName
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .vcardArray[1].[] | select(.[0] == "fn") | .[-1]'
+
+      - type: json
+        part: body
+        name: registrarOrg
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .vcardArray[1].[] | select(.[0] == "org") | .[-1]'
+
+      - type: json
+        part: body
+        name: registrarUrl
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .links[] | select(.rel == "about") | .href'
+
+      - type: json
+        part: body
+        name: registrarEmail
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .entities[] | select(.roles[] | contains("abuse")) | .vcardArray[1].[] | select(.[0] == "email") | .[-1]'
+
+      - type: json
+        part: body
+        name: registrarPhone
+        json:
+          - '.entities[] | select(.roles[] | contains("registrar")) | .entities[] | select(.roles[] | contains("abuse")) | .vcardArray[1].[] | select(.[0] == "tel") | .[-1]'
+
+      - type: json
+        part: body
         name: nameServers
         json:
           - '.nameservers[] | .ldhName'
@@ -102,4 +138,3 @@ http:
         name: secureDNS
         json:
           - '.secureDNS.delegationSigned // false'
-# digest: 4a0a0047304502210089f0a9e2881e1bdf0fd908267bae0c4091674aab999d12ce7d5f89e0fef5eddd02203622c149d38037f8fda4750b070762b7b3e3339fa73296c79fbac5255373e096:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- extend the existing `rdap-whois` template with registrar enrichment extracted from the RDAP `registrar` entity
- add optional registrar outputs for IANA ID, name, org, about URL, and nested abuse contact email/phone
- remove the stale signed digest footer so upstream signing automation can regenerate it after merge

## Validation
- `nuclei -duc -validate -lfa -ud $PWD -t http/miscellaneous/rdap-whois.yaml`
- `nuclei -duc -lfa -ud $PWD -t http/miscellaneous/rdap-whois.yaml -u example.com -jsonl -silent`