### PR TITLE
Create Chatwoot - Unfinished Installation

### DIFF
--- a/http/misconfiguration/installer/chatwoot-installer.yaml
+++ b/http/misconfiguration/installer/chatwoot-installer.yaml
@@ -1,7 +1,7 @@
-id: chatwoot-installer-exposed
+id: chatwoot-installer
 
 info:
-  name: Chatwoot - Unfinished Installation
+  name: Chatwoot - Installation
   author: 0x_Akoko
   severity: high
   description: |
@@ -27,6 +27,5 @@ http:
       - type: dsl
         dsl:
           - 'contains_all(body, "SuperAdmin | Chatwoot", "Howdy, Welcome to Chatwoot", "Finish Setup")'
-          - 'contains(content_type, "text/html")'
           - 'status_code == 200'
         condition: and

--- a/http/misconfiguration/installer/hatwoot-installer-exposed.yaml
+++ b/http/misconfiguration/installer/hatwoot-installer-exposed.yaml
@@ -1,0 +1,32 @@
+id: chatwoot-installer-exposed
+
+info:
+  name: Chatwoot - Unfinished Installation
+  author: 0x_Akoko
+  severity: high
+  description: |
+   Detected chatwoot instance with the initial installation onboarding page accessible at /installation/onboarding, enabling unauthenticated users to create the first Super Admin account and gain full platform control.
+  reference:
+    - https://github.com/chatwoot/chatwoot
+    - https://www.chatwoot.com/docs/self-hosted/monitoring/super-admin-sidekiq
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: chatwoot
+    product: chatwoot
+    shodan-query: http.title:"SuperAdmin | Chatwoot"
+    fofa-query: title="SuperAdmin | Chatwoot"
+  tags: misconfig,install,exposure,chatwoot,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/installation/onboarding"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "SuperAdmin | Chatwoot", "Howdy, Welcome to Chatwoot", "Finish Setup")'
+          - 'contains(content_type, "text/html")'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
Added a new YAML configuration for detecting Chatwoot installation exposure.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
