### PR TITLE
Added Avaya Phone Web Interface Default Login Template

### DIFF
--- a/http/default-logins/avaya-phone-default-login.yaml
+++ b/http/default-logins/avaya-phone-default-login.yaml
@@ -1,0 +1,48 @@
+id: avaya-phone-default-login
+info:
+  name: Avaya Phone Web Interface Default Login - Detect
+  author: tpierru
+  severity: high
+  description: |
+    Avaya phone web interface contains a default login vulnerability. An attacker can obtain access to sensitive information, modify data, and/or execute unauthorized operations.
+  reference:
+    - https://documentation.avaya.com/bundle/InstallandadminJ100seriesIPPhone_r4.1.x/page/Logging_into_web_UI.html
+  classification:
+    cwe-id: CWE-1392
+  tags: default-login,avaya
+ 
+# Perform the authentication request only if a nonce has been retrieved in the cookies of the first request
+flow: http(1) && http(2)
+ 
+http:
+  # Get a nonce to use in the authentication request
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/J100WebServer.cgi?Operation=0"
+    extractors:
+      - type: kval
+        name: nonce
+        kval:
+          - j100nonce
+        internal: true
+ 
+  # Perform the authentication request by appending the nonce to the password and calculate a sha256 hash
+    - method: POST
+      path:
+        - "{{BaseURL}}/cgi-bin/J100WebServer.cgi?Operation=1"
+      body: "uname={{username}}&psw={{sha256(concat(password,nonce))}}"
+      attack: pitchfork
+      payloads:
+        username:
+          - admin
+        password:
+          - 27238
+      matchers-condition: and
+      matchers:
+        - type: status
+          status:
+            - 200
+        - type: word
+          part: body
+          words:
+            - "/cgi-bin/J100WebServer.cgi?Operation=211"

--- a/http/default-logins/avaya-phone-default-login.yaml
+++ b/http/default-logins/avaya-phone-default-login.yaml
@@ -1,6 +1,7 @@
 id: avaya-phone-default-login
+
 info:
-  name: Avaya Phone Web Interface Default Login - Detect
+  name: Avaya Phone Web Interface - Default Login
   author: tpierru
   severity: high
   description: |
@@ -9,40 +10,53 @@ info:
     - https://documentation.avaya.com/bundle/InstallandadminJ100seriesIPPhone_r4.1.x/page/Logging_into_web_UI.html
   classification:
     cwe-id: CWE-1392
-  tags: default-login,avaya
- 
-# Perform the authentication request only if a nonce has been retrieved in the cookies of the first request
+  metadata:
+    verified: true
+    max-requests: 1
+    shodan-query: html:"Avaya J179 Phone"
+  tags: default-login,avaya,misconfig
+
+variables:
+  username: "admin"
+  password: "27238"
+
 flow: http(1) && http(2)
- 
+
 http:
-  # Get a nonce to use in the authentication request
   - method: GET
     path:
       - "{{BaseURL}}/cgi-bin/J100WebServer.cgi?Operation=0"
+
     extractors:
       - type: kval
         name: nonce
         kval:
           - j100nonce
         internal: true
- 
-  # Perform the authentication request by appending the nonce to the password and calculate a sha256 hash
-    - method: POST
-      path:
-        - "{{BaseURL}}/cgi-bin/J100WebServer.cgi?Operation=1"
-      body: "uname={{username}}&psw={{sha256(concat(password,nonce))}}"
-      attack: pitchfork
-      payloads:
-        username:
-          - admin
-        password:
-          - 27238
-      matchers-condition: and
-      matchers:
-        - type: status
-          status:
-            - 200
-        - type: word
-          part: body
-          words:
-            - "/cgi-bin/J100WebServer.cgi?Operation=211"
+
+  - raw:
+      - |
+        POST /cgi-bin/J100WebServer.cgi?Operation=1 HTTP/1.1
+        Host: {{Host}}
+        Content-Type: application/x-www-form-urlencoded
+
+        uname={{username}}&psw={{sha256(concat(password,nonce))}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/cgi-bin/J100WebServer.cgi?Operation=211"
+          - "id=\"redirectToDefault"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "Invalid username or password"
+        negative: true
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

Avaya phone web interface contains a default login vulnerability.

The password for the admin user is 27238 as referenced in the documentation :
- https://documentation.avaya.com/bundle/InstallandadminJ100seriesIPPhone_r4.1.x/page/Logging_into_web_UI.html

A first request is needed in order to get a nonce to append to the password before calculating a sha256 hash.
The second request is made only if the nonce has been recovered.

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Output when use on a vulnerable phone :

```
echo https://REDACTED_IP | nuclei -t avaya-phone-default-login.yaml -debug -duc

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

                projectdiscovery.io

[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.4.2 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 121
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [avaya-phone-web-interface-default-login] Dumped HTTP request for https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=0

GET /cgi-bin/J100WebServer.cgi?Operation=0 HTTP/1.1
Host: REDACTED_IP
User-Agent: Mozilla/5.0 (SS; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [avaya-phone-web-interface-default-login] Dumped HTTP response https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=0

HTTP/1.1 200 OK
Connection: close
Content-Length: 10259
Cache-Control: no-cache,no-store,must-revalidate
Content-Type: text/html;charset=utf-8
Date: Thu, 16 Apr 2026 10:54:50 GMT
Server: lighttpd/1.4.53
Set-Cookie: J100sessionId=BF56F03EF7017C7FC2F9EC8132E86F56; SameSite=Strict; Path=/
Set-Cookie: J100nonce=C45ABB4B79793EAF85F7BA1C3D4047F1; SameSite=Strict; Path=/
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

<!--****************************************************************************
* Copyright Avaya Inc., All Rights Reserved.
* THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF Avaya Inc.
* The copyright notice above does not evidence any actual or intended publication of such source code.
* Some third-party source code components may have been modified from their original versions by Avaya Inc.
* The modifications are Copyright Avaya Inc., All Rights Reserved.
* Avaya - Confidential & Restricted. May not be distributed further without written permission of the Avaya owner.
****************************************************************************-->
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html>
<head>
        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
        <link rel="stylesheet" type="text/css" href="/login.css">
        <style type="text/css"></style>
        <script language="javascript" src="/main.js"></script>
        <script>
                var j100cookies = document.cookie;
                var loginNonce = j100cookies.split("J100nonce=")[1].split(";")[0];
                var sDisplay = "";
                window.onload = CheckRequestType();


                function CheckEmpty()
                {
                        var sUname = document.getElementById("uname").value;
                        var sPsw = document.getElementById("psw").value;

                        if ((sUname.length > 0) && (sPsw.length > 0))
                        {
                                document.getElementById("submitBtn").disabled = false;
                        }
                        else
                        {
                                document.getElementById("submitBtn").disabled = true;
                        }
                }

                function GetBrowserDetails()
                {
                        //e.g.
                        //      Chrome:
                        //              sUserAgent = Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
                        //              returns Chrome 70
                        //      Firefox:
                        //              sUserAgent = Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0
                        //              returns Firefox 76
                        //      Edge:
                        //              sUserAgent = Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134
                        //              returns Edge 17
                        //      IE:
                        //              us = Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; rv:11.0) like Gecko
                        //              returns IE 11
                        var sUserAgent = navigator.userAgent;

                        // e.g.
                        //      Chrome:
                        //              sTokenizeUserAgent : Chrome/70,Chrome,70
                        //              sTokenizeUserAgent[0] : Chrome/70, sTokenizeUserAgent[1] : Chrome, sTokenizeUserAgent[2] : 70
                        //      Firefox:
                        //              sTokenizeUserAgent : Firefox/76,Firefox,76
                        //              sTokenizeUserAgent[0] : Firefox/76, sTokenizeUserAgent[1] : Firefox, sTokenizeUserAgent[2] : 76
                        //      Edge:
                        //              Chrome/64,Chrome,64
                        //              sTokenizeUserAgent[0] : Chrome/64, sTokenizeUserAgent[1] : Chrome, sTokenizeUserAgent[2] : 64
                        //      IE:
                        //              sTokenizeUserAgent : Trident/7,Trident,7
                        //              sTokenizeUserAgent[0] : Trident/7, sTokenizeUserAgent[1] : Trident, sTokenizeUserAgent[2] : 7
                        sTokenizeUserAgent = sUserAgent.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []; //

                        // Handling IE
                        if (/trident/i.test(sTokenizeUserAgent[1]))
                        {
                                // Extract 11 from below useragent string (i.e. rc:11.0)
                                // Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; rv:11.0) like Gecko
                                sTemp =  /\brv[ :]+(\d+)/g.exec(sUserAgent) || [];
                                return 'IE '+(sTemp[1] || '');
                        }
                        // Edge and Opera has Chrome details as well
                        // Handling Opera and edge here
                        if (sTokenizeUserAgent[1] === 'Chrome')
                        {
                                sTemp = sUserAgent.match(/\b(OPR|Edge)\/(\d+)/);
                                if (sTemp != null)
                                {
                                        return sTemp.slice(1).join(' ').replace('OPR', 'Opera');
                                }
                        }

                        // e.g.
                        //      Chrome:
                        //              sTokenizeUserAgent = Chrome,70
                        // Firefox
                        //              sTokenizeUserAgent = Firefox,76
                        sTokenizeUserAgent = sTokenizeUserAgent[2]? [sTokenizeUserAgent[1], sTokenizeUserAgent[2]]: [navigator.appName, navigator.appVersion, '-?'];
                        // The match() method searches a string for a match against a regular expression,
                        // and returns the matches, as an Array object.
                        // For any of our case Firefox or Chrome it does not matches,
                        // as sTokenizeUserAgent has Chrome,70 or Firefox,76
                        if ((sTemp = sUserAgent.match(/version\/(\d+)/i)) != null)
                        {
                                // The splice() method adds/removes items to/from an array
                                // and returns the removed item(s).
                                // e.g array.splice(index, howmany, item1, ....., itemX)
                                sTokenizeUserAgent.splice(1, 1, sTemp[1]);
                        }
                        // The join() method returns the array as a string.
                        // The elements will be separated by a specified separator.
                        // So here seperator is space
                        // So return Firefox 76
                        return sTokenizeUserAgent.join(' ');
                }

                function CheckRequestType()
                {
                        // Check HTTP request for all browsers.
                        // Allows http for IE, as IE is deprecated/end of support
                        // and we are not expecting any new update coming for IE.
                        var browserDetails = GetBrowserDetails();
                        if ((location.protocol != 'https:') &&
                            (browserDetails.indexOf("IE") == -1))
                        {
                                sDisplay = "Please use secure (HTTPS) connection.";
                        }
                }

                function SendCredentials(passHash)
                {
                        try
                        {
                                var httpReq = new XMLHttpRequest();
                                var params = encodeURIComponent('uname') + '=' + encodeURIComponent(document.getElementById("uname").value) + '&' + encodeURIComponent('psw') + '=' + encodeURIComponent(passHash);
                                var url = "/cgi-bin/J100WebServer.cgi?Operation=1";
                                httpReq.open("POST", url, true);
                                httpReq.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
                                httpReq.onreadystatechange = function()
                                {
                                        if (this.readyState == 4 && this.status == 200)
                                        {
                                                document.write(this.responseText);
                                        }
                                };
                                httpReq.send(params);
                        }
                        catch(e)
                        {
                                alert("unsupported");
                        }
                }

                function EncodeInUTF8(text)
                {
                        if (window.TextEncoder)
                        {
                                return new TextEncoder('utf-8').encode(text);
                        }
                        var utf8Text = unescape(encodeURIComponent(text));
                        var resultInUTF8 = new Uint8Array(utf8Text.length);
                        for (var i = 0; i < utf8Text.length; i++)
                        {
                                resultInUTF8[i] = utf8Text.charCodeAt(i);
                        }
                        return resultInUTF8;
                }

                function RequestLogin()
                {
                        var passPhrase = document.getElementById("psw").value + loginNonce;
                        var passHash;
                        var buffer = EncodeInUTF8(passPhrase);
                        var cryptoObject = window.crypto || window.msCrypto;    // msCrypto is for IE
                        console.log("Crypto Object is = " + typeof cryptoObject.subtle);
                        if (typeof cryptoObject.subtle === 'undefined' || cryptoObject.subtle === null)
                        {
                                console.log("not supported here");
                                return false;
                        }
                        var textDigest = cryptoObject.subtle.digest("SHA-256", buffer);
                        if (textDigest.then) // textDigest is a promise
                        {
                                textDigest.then(function (hash)
                                        {
                                                passHash = GetHex(hash);
                                                SendCredentials(passHash);
                                        });
                        }
                        else
                        {
                                textDigest.oncomplete = function(evt)
                                {
                                        if (textDigest.result) // for IE textDigest is an event
                                        {
                                                passHash = GetHex(textDigest.result);
                                                SendCredentials(passHash);
                                        }
                                };
                        }
                }
                function GetHex(buffer)
                {
                        var hexCodes = [];
                        var view = new DataView(buffer);
                        for (var i = 0; i < view.byteLength; i += 4)
                        {
                                // getUint32 processes 4 bytes at a time
                                var value = view.getUint32(i)
                                // toString(16) will give the hex representation of the number without padding
                                var stringValue = value.toString(16)
                                // We use concatenation and slice for padding
                                var padding = '00000000'
                                var paddedValue = (padding + stringValue).slice(-padding.length)
                                hexCodes.push(paddedValue);
                        }

                        // Join all the hex strings into one
                        return hexCodes.join("");
                }
        </script>
</head>
<body onLoad="deleteAllCookies();">
<form method="POST" onsubmit="javascript:RequestLogin();return false;">
        <div id="loginPage">
                <div align="center" id="loginheader"></div>
            <div id="container" style="margin-left:50px">
                        <label>Username</label>&nbsp;&nbsp;&nbsp;&nbsp;
                        <input type="text" placeholder="" name="uname" id="uname" oninput="CheckEmpty();" required autofocus>
                <br>
                        <label>Password</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                        <input type="password" placeholder="" name="psw" id="psw" oninput="CheckEmpty();" required>
                        <br>
                </div>
            <div align="center">&nbsp;&nbsp;&nbsp;<button type="submit" id="submitBtn" disabled="disabled" onclick="javascript:RequestLogin();return false;">Login</button><br><br></div>
        </div>
        <div id="httpErrorMsg" >
                <p style="text-align:center;" >
                        <b id="HTTP_ERROR_MESSAGE"></b>
                </p>
        </div>
        <script>
        if (window.sDisplay === "")
        {
                document.getElementById("httpErrorMsg").style.display = 'none';
        }
        else
        {
                document.getElementById("HTTP_ERROR_MESSAGE").innerHTML = sDisplay;
                document.getElementById("loginPage").style.display = 'none';
        }
        </script>
</form>
</body>
</html>
<script>document.title = 'Avaya J179 Phone';</script><script>document.getElementById('loginheader').innerHTML = 'J179 Login';</script>
[INF] [avaya-phone-web-interface-default-login] Dumped HTTP request for https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=1

POST /cgi-bin/J100WebServer.cgi?Operation=1 HTTP/1.1
Host: REDACTED_IP
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0
Content-Length: 80
Accept: */*
Accept-Language: en
Cookie: J100sessionId=BF56F03EF7017C7FC2F9EC8132E86F56; J100nonce=C45ABB4B79793EAF85F7BA1C3D4047F1
Accept-Encoding: gzip

uname=admin&psw=168ccb2c0d60d2a7968ae4123ba1b2a071d334264a40275b505ffcd3c5c1e034
[DBG] [avaya-phone-web-interface-default-login] Dumped HTTP response https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=1

HTTP/1.1 200 OK
Connection: close
Content-Length: 201
Content-Type: text/html
Date: Thu, 16 Apr 2026 10:54:51 GMT
Server: lighttpd/1.4.53
Set-Cookie: J100sessionId=BF56F03EF7017C7FC2F9EC8132E86F56; SameSite=Strict; Path=/
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

<html><TITLE>Avaya J179 Phone</TITLE>
<head><script type="text/javascript" ></script></head><body>
<script>
 window.location.assign("/cgi-bin/J100WebServer.cgi?Operation=211");
</script>
</body></html>
[avaya-phone-web-interface-default-login:status-1] [http] [high] https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=1 [password="27238",username="admin"]
[avaya-phone-web-interface-default-login:word-2] [http] [high] https://REDACTED_IP/cgi-bin/J100WebServer.cgi?Operation=1 [password="27238",username="admin"]
[INF] Scan completed in 2.99146157s. 2 matches found.
```
<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
