### PR TITLE
Add panel detection templates for Langflow and LiteLLM

### DIFF
--- a/http/exposed-panels/langflow-panel.yaml
+++ b/http/exposed-panels/langflow-panel.yaml
@@ -1,0 +1,37 @@
+id: langflow-panel
+
+info:
+  name: Langflow Panel - Detect
+  author: 0xBassia
+  severity: info
+  description: |
+    Langflow is an open-source visual editor for building LLM workflows. Exposed instances are common on ports 7860 and 3000, and frequently run without authentication.
+  reference:
+    - https://github.com/langflow-ai/langflow
+    - https://www.langflow.org/
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Langflow"
+    fofa-query: title="Langflow"
+    product: langflow
+    vendor: langflow
+  tags: panel,langflow,llm,ai,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Langflow</title>"
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/litellm-dashboard.yaml
+++ b/http/exposed-panels/litellm-dashboard.yaml
@@ -1,0 +1,42 @@
+id: litellm-dashboard
+
+info:
+  name: LiteLLM Admin Dashboard - Detect
+  author: 0xBassia
+  severity: info
+  description: |
+    LiteLLM is a proxy server and SDK that exposes a unified OpenAI-compatible interface for many LLM providers. The admin dashboard at /ui often ends up exposed on public infrastructure and, when paired with a weak master key or no key at all, can give an attacker control over downstream model access and associated provider credentials.
+  reference:
+    - https://github.com/BerriAI/litellm
+    - https://docs.litellm.ai/docs/proxy/ui
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+    shodan-query: http.title:"LiteLLM"
+    fofa-query: title="LiteLLM"
+    product: litellm
+    vendor: berriai
+  tags: panel,litellm,llm,ai,proxy,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui"
+      - "{{BaseURL}}/ui/"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>LiteLLM Dashboard</title>"
+          - "LiteLLM Proxy Admin UI"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds `exposed-panels` detection templates for two self-hosted AI tools that are commonly reachable on the public internet, often without authentication:

- **Langflow** (`langflow-panel.yaml`) — open-source visual editor for building LLM workflows (https://github.com/langflow-ai/langflow). Default ports 7860 and 3000 are frequently exposed on VPS deployments.
- **LiteLLM admin dashboard** (`litellm-dashboard.yaml`) — OpenAI-compatible proxy for multiple LLM providers (https://github.com/BerriAI/litellm). The admin UI at `/ui` is often exposed with a weak or default master key, which gives an attacker control over downstream provider credentials and model access.

### Fingerprints

Both fingerprints are taken directly from the upstream project source code, so they'll be stable across self-hosted deployments that haven't been customised.

- Langflow: `<title>Langflow</title>` on the root path, as set in [`src/frontend/index.html`](https://github.com/langflow-ai/langflow/blob/main/src/frontend/index.html).
- LiteLLM: `<title>LiteLLM Dashboard</title>` plus `LiteLLM Proxy Admin UI` meta description on `/ui`, as built by the LiteLLM Next.js admin frontend (`litellm-asset-prefix` paths are a characteristic marker).

### Context

AnythingLLM already has a panel template (`anythingllm-panel.yaml`), so that one isn't duplicated here. Chroma DB, MLflow, Ollama, Qdrant, Weaviate, Ray Dashboard, Jupyter Notebook, Dify and n8n also already have coverage. Langflow and LiteLLM stood out as widely deployed AI tools without existing panel detection.

### Validation

- Both templates pass `nuclei -validate` cleanly.
- Severity is `info` since these are discovery/fingerprint templates rather than vulnerabilities. The descriptions note the security context (frequent unauthenticated exposure, provider credential risk) so that downstream users understand why the signal matters.