### PR TITLE
Correct formatting in Retool postMessage XSS YAML

### DIFF
--- a/http/vulnerabilities/retool/retool-postmessage-xss.yaml
+++ b/http/vulnerabilities/retool/retool-postmessage-xss.yaml
@@ -5,7 +5,7 @@ info:
   author: DhiyaneshDk
   severity: high
   description: |
-    Retool Self-Hosted versions 3.284.0 through 3.284.11 contain a cross-site scripting (XSS) vulnerability in the custom component collections iframe handler. The postMessage event listener in custom-component-collections.html accepts messages from any origin without validation and dynamically imports the received code via data:text/javascript URLs,allowing arbitrary JavaScript execution in the Retool instance's origin context.
+    Retool Self-Hosted versions 3.284.0 through 3.284.11 contain a cross-site scripting (XSS) vulnerability in the custom component collections iframe handler. The postMessage event listener in custom-component-collections.html accepts messages from any origin without validation and dynamically imports the received code via data:text/javascript URLs, allowing arbitrary JavaScript execution in the Retool instance origin context.
   reference:
     - https://docs.retool.com/releases
     - https://docs.retool.com/changelog/disclosures/custom-component-xss
@@ -26,7 +26,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_all(body, "Custom Component","custom-component-collections")'
+          - 'contains_all(body, "Custom Component", "custom-component-collections")'
         condition: and
         internal: true
 
@@ -34,18 +34,18 @@ http:
       - type: regex
         name: js-bundle
         part: body
+        group: 1
         regex:
-          - 'custom\-component\-collections([.A-Za-z_]+)'
+          - '["'']/?(libs/custom-component-collections[^"'']+\.js)["'']'
         internal: true
 
   - method: GET
     path:
-      - "{{BaseURL}}/libs/{{js-bundle}}"
+      - "{{BaseURL}}/{{js-bundle}}"
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
           - 'contains_all(body, "customComponentCode", "data:text/javascript", "addEventListener(\"message\"")'
-          - '!contains(body, "unverified origin")'
         condition: and


### PR DESCRIPTION
Fixed formatting issues in the Retool XSS vulnerability description and matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
