### PR TITLE
Added template: Exposed Postman Collection and Environments

### DIFF
--- a/http/exposures/configs/postman-leak.yaml
+++ b/http/exposures/configs/postman-leak.yaml
@@ -28,7 +28,7 @@ requests:
           - '"_postman_id":'
           - '"info":'
           - '"item":'
-        condition: or
+        condition: and
 
       - type: status
         status:

--- a/http/exposures/configs/postman-leak.yaml
+++ b/http/exposures/configs/postman-leak.yaml
@@ -1,4 +1,4 @@
-id: hacker-ai-postman-leak
+id: exposed-postman-collection
 
 info:
   name: Exposed Postman Collection & Environments Leak

--- a/http/exposures/configs/postman-leak.yaml
+++ b/http/exposures/configs/postman-leak.yaml
@@ -1,0 +1,43 @@
+id: hacker-ai-postman-leak
+
+info:
+  name: Exposed Postman Collection & Environments Leak
+  author: Umut ÖZEN
+  severity: high
+  description: Testers and developers often leave Postman collections or environment JSON files in the webroot directory by accident during CI/CD deployments. These files usually contain highly sensitive API keys, Bearer tokens, passwords and hidden endpoint paths.
+  tags: config,exposure,postman,secrets,custom
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/postman_collection.json"
+      - "{{BaseURL}}/collection.json"
+      - "{{BaseURL}}/.postman/environment.json"
+      - "{{BaseURL}}/api.postman_collection.json"
+      - "{{BaseURL}}/test.postman_environment.json"
+      - "{{BaseURL}}/dump.json"
+      - "{{BaseURL}}/secrets.postman_environment.json"
+      - "{{BaseURL}}/admin.postman_collection.json"
+      - "{{BaseURL}}/prod.postman_environment.json"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"_postman_id":'
+          - '"info":'
+          - '"item":'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '(?i)bearer\s*[\w\.\-]+'
+          - '(?i)api[_-]?key[\"\'\s:]*[\w\-]+'
+          - '"value":\s*"[^"]+"'


### PR DESCRIPTION
Testers and developers often leave Postman collections or environment files in the webroot directory by accident during CI/CD deployments. These files usually contain highly sensitive API keys, Bearer tokens, passwords, and hidden endpoint paths. I created this customized template to detect these leaks.