### PR TITLE
Added template: Exposed AI IDE Rules and Copilot Instructions (.cursorrules)

### DIFF
--- a/http/exposures/configs/ai-ide-rules-leak.yaml
+++ b/http/exposures/configs/ai-ide-rules-leak.yaml
@@ -1,0 +1,52 @@
+id: exposed-ai-ide-rules
+
+info:
+  name: Exposed AI IDE Rules & Copilot Instructions (.cursorrules)
+  author: Umut ÖZEN
+  severity: high
+  description: |
+    As the adoption of AI-assisted IDEs like Cursor and GitHub Copilot surges, developers often create hidden instructions files in the root of their projects (e.g., .cursorrules, copilot-instructions.md, .github/copilot-instructions.md). These files supply context to the LLM agent about the project.
+    Often, developers inadvertently hardcode sensitive database connection strings, architecture flow details, internal IP addresses, API secrets, or intellectual property into these files so the AI can "understand" how to write the code. 
+    This template checks for the exposure of such highly sensitive AI configuration files in production environments.
+  tags: exposure,config,ai,cursor,copilot,leak,secrets,custom
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.cursorrules"
+      - "{{BaseURL}}/.cursor/rules/project.md"
+      - "{{BaseURL}}/.github/copilot-instructions.md"
+      - "{{BaseURL}}/copilot-instructions.md"
+      - "{{BaseURL}}/.windsurfrules"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "you are an ai"
+          - "you are a coding assistant"
+          - "cursor"
+          - "copilot"
+          - "always"
+          - "never"
+          - "database"
+          - "secret"
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        name: potential_secrets_in_rules
+        regex:
+          - '(?i)(?:password|secret|api[_-]?key|token|credentials)[\s:=]+["'']?([A-Za-z0-9_\-\.]{10,})["'']?'
+          
+      - type: regex
+        part: body
+        name: database_connection_string
+        regex:
+          - '(?i)(?:mysql|postgresql|postgres|mongodb|redis):\/\/[a-zA-Z0-9_\-\.]+:[^@]+@[a-zA-Z0-9_\-\.]+:[0-9]+\/[a-zA-Z0-9_]+'

--- a/http/exposures/configs/ai-ide-rules-leak.yaml
+++ b/http/exposures/configs/ai-ide-rules-leak.yaml
@@ -2,13 +2,13 @@ id: exposed-ai-ide-rules
 
 info:
   name: Exposed AI IDE Rules & Copilot Instructions (.cursorrules)
-  author: Umut ÖZEN
+  author: Umut OZEN
   severity: high
   description: |
     As the adoption of AI-assisted IDEs like Cursor and GitHub Copilot surges, developers often create hidden instructions files in the root of their projects (e.g., .cursorrules, copilot-instructions.md, .github/copilot-instructions.md). These files supply context to the LLM agent about the project.
     Often, developers inadvertently hardcode sensitive database connection strings, architecture flow details, internal IP addresses, API secrets, or intellectual property into these files so the AI can "understand" how to write the code.
     This template checks for the exposure of such highly sensitive AI configuration files in production environments.
-  tags: exposure,config,ai,cursor,copilot,leak,secrets,custom
+  tags: exposure,config,ai,cursor,copilot
 
 http:
   - method: GET
@@ -18,6 +18,7 @@ http:
       - "{{BaseURL}}/.github/copilot-instructions.md"
       - "{{BaseURL}}/copilot-instructions.md"
       - "{{BaseURL}}/.windsurfrules"
+    max-redirects: 0
 
     matchers-condition: and
     matchers:
@@ -26,16 +27,21 @@ http:
           - 200
 
       - type: word
+        words:
+          - "<!DOCTYPE html>"
+          - "<html"
+        condition: and
+        negative: true
+
+      - type: word
         part: body
         words:
           - "you are an ai"
           - "you are a coding assistant"
-          - "cursor"
+          - "you are an expert"
+          - "@cursor"
           - "copilot"
-          - "always"
-          - "never"
-          - "database"
-          - "secret"
+          - "system prompt"
         condition: or
 
     extractors:

--- a/http/exposures/configs/ai-ide-rules-leak.yaml
+++ b/http/exposures/configs/ai-ide-rules-leak.yaml
@@ -6,7 +6,7 @@ info:
   severity: high
   description: |
     As the adoption of AI-assisted IDEs like Cursor and GitHub Copilot surges, developers often create hidden instructions files in the root of their projects (e.g., .cursorrules, copilot-instructions.md, .github/copilot-instructions.md). These files supply context to the LLM agent about the project.
-    Often, developers inadvertently hardcode sensitive database connection strings, architecture flow details, internal IP addresses, API secrets, or intellectual property into these files so the AI can "understand" how to write the code. 
+    Often, developers inadvertently hardcode sensitive database connection strings, architecture flow details, internal IP addresses, API secrets, or intellectual property into these files so the AI can "understand" how to write the code.
     This template checks for the exposure of such highly sensitive AI configuration files in production environments.
   tags: exposure,config,ai,cursor,copilot,leak,secrets,custom
 
@@ -44,7 +44,7 @@ http:
         name: potential_secrets_in_rules
         regex:
           - '(?i)(?:password|secret|api[_-]?key|token|credentials)[\s:=]+["'']?([A-Za-z0-9_\-\.]{10,})["'']?'
-          
+
       - type: regex
         part: body
         name: database_connection_string


### PR DESCRIPTION
As the adoption of AI-assisted IDEs like Cursor and GitHub Copilot surges, developers often create hidden instructions files in the root of their projects (e.g., .cursorrules, copilot-instructions.md). These files supply context to the LLM agent about the project. Often, developers inadvertently hardcode sensitive database connection strings, architecture flow details, internal IP addresses, or API secrets into these files so the AI can understand how to write the code. This template checks for the exposure of such highly sensitive AI configuration files in production environments.