### PR TITLE
Added CVE-2025-23048 Template (Apache Access Control Bypass) - Update

### DIFF
--- a/http/cves/2025/CVE-2025-23048.yaml
+++ b/http/cves/2025/CVE-2025-23048.yaml
@@ -1,0 +1,55 @@
+id: CVE-2025-23048
+
+info:
+  name: Apache HTTP Server 2.4.35 - 2.4.63 - Access Control Bypass
+  author: Umut ÖZEN
+  severity: medium
+  description: |
+    Apache HTTP Server versions 2.4.35 through 2.4.63 are vulnerable to an access control bypass.
+    In certain mod_ssl configurations using TLS 1.3 session resumption, a client trusted by one 
+    virtual host might be able to resume a session and access another virtual host, effectively 
+    bypassing intended access controls.
+  remediation: |
+    Upgrade Apache HTTP Server to version 2.4.64 or later, or ensure that SSLStrictSNIVHostCheck 
+    is enabled for the affected virtual hosts.
+  reference:
+    - https://httpd.apache.org/security/vulnerabilities_24.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-23048
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-23048
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N
+    cvss-score: 5.4
+    cve-id: CVE-2025-23048
+    cwe-id: CWE-287
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: apache
+    product: http_server
+    shodan-query:
+      - 'Server: Apache'
+  tags: cve,cve2025,apache,bypass,ssl
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Server: Apache"
+
+      - type: regex
+        part: header
+        regex:
+          - '(?i)Server: Apache/2\.4\.(3[5-9]|[4-5][0-9]|6[0-3])\b'
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - '(?i)Server: (Apache/2\.4\.[0-9]+)'


### PR DESCRIPTION
## PR Information
Added CVE-2025-23048

## References:
- https://httpd.apache.org/security/vulnerabilities_24.html
- https://nvd.nist.gov/vuln/detail/CVE-2025-23048

## Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

## Additional Details
This template provides version-based detection for CVE-2025-23048 (Access Control Bypass in Apache mod_ssl via TLS 1.3 Session Resumption). It checks the `Server` header for vulnerable versions 2.4.35 through 2.4.63.
