### PR TITLE
Added Axios SSRF / NO_PROXY bypass Template (CVE-2025-62718)

### DIFF
--- a/http/cves/2025/CVE-2025-62718.yaml
+++ b/http/cves/2025/CVE-2025-62718.yaml
@@ -1,0 +1,60 @@
+id: CVE-2025-62718
+
+info:
+  name: Axios < 0.31.0 / < 1.15.0 - Server-Side Request Forgery
+  author: Umut ÖZEN
+  severity: medium
+  description: |
+    Axios versions before 0.31.0 and before 1.15.0 are vulnerable to SSRF. 
+    Axios fails to correctly normalize hostnames when checking NO_PROXY environment variables.
+    An attacker can bypass these proxy restrictions by using specific loopback addresses.
+    This template attempts to detect vulnerable versions via exposed package.json files.
+  remediation: |
+    Update Axios to version 0.31.0 or 1.15.0 or later.
+  reference:
+    - https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-62718
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2025-62718
+    cwe-id: CWE-918
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: axios
+    product: axios
+  tags: cve,cve2025,axios,ssrf,npm,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/package.json"
+      - "{{BaseURL}}/package-lock.json"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"axios":'
+
+      - type: regex
+        part: body
+        # Matches axios: "version", vulnerable versions are < 0.31.0 and < 1.15.0
+        regex:
+          - '(?i)"axios"\s*:\s*"\^?(?:0\.(?:[0-2][0-9]?|30)(?:\.[0-9]+)?|1\.(?:[0-9]|1[0-4])(?:\.[0-9]+)?)"'
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        name: version
+        regex:
+          - '(?i)"axios"\s*:\s*"(\^?[0-9]+(?:\.[0-9x*]+)*)"'


### PR DESCRIPTION
## PR Information
Added CVE-2025-62718 (Axios SSRF / NO_PROXY normalizaton bypass)

## References:
- https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5
- https://nvd.nist.gov/vuln/detail/CVE-2025-62718

## Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

## Additional Details
This template provides dependency/version-based detection for the Axios HTTP Client Server-Side Request Forgery vulnerability (CVE-2025-62718). It does this by checking any exposed `package.json` file for vulnerable Axios versions (`< 0.31.0` and `< 1.15.0`) which bypass NO_PROXY constraints via hostname normalization issues.
