### PR TITLE
Added LearnPress Missing Auth bypass Template (CVE-2026-4365)

### DIFF
--- a/http/cves/2026/CVE-2026-4365.yaml
+++ b/http/cves/2026/CVE-2026-4365.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-4365
+
+info:
+  name: LearnPress <= 4.3.2.8 - Missing Authorization (Exposed Nonce)
+  author: Umut ÖZEN
+  severity: critical
+  description: |
+    The LearnPress plugin for WordPress is vulnerable to Missing Authorization in versions up to and including 4.3.2.8.
+    This is due to a missing capability check on the `delete_question_answer` action.
+    This allows unauthenticated attackers to perform unauthorized data deletion. This template leverages partial 
+    Proof-of-Concept detection by validating that the wp_rest nonce is improperly exposed within the lpData object.
+  remediation: |
+    Update the LearnPress plugin to a version newer than 4.3.2.8.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/021bd566-1663-46ba-a616-ab554b691cbb?source=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4365
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2026-4365
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: thimpress
+    product: learnpress
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/learnpress"
+  tags: cve,cve2026,wordpress,wp-plugin,learnpress,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'lpData'
+          - 'wp_rest'
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - '(?i)lpData\s*=\s*\{.*?("|\x27)wp_rest("|\x27)\s*:\s*("|\x27)[a-fA-F0-9]+("|\x27)'
+
+    extractors:
+      - type: regex
+        name: exposed_nonce
+        part: body
+        group: 3
+        regex:
+          - '(?i)lpData\s*=\s*\{.*?("|\x27)wp_rest("|\x27)\s*:\s*("|\x27)([a-fA-F0-9]+)("|\x27)'


### PR DESCRIPTION
## PR Information
Updated CVE-2026-4365 (LearnPress Missing Authorization)

## References:
- https://nvd.nist.gov/vuln/detail/CVE-2026-4365
- https://www.wordfence.com/threat-intel/vulnerabilities/id/021bd566-1663-46ba-a616-ab554b691cbb

## Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

## Additional Details
This template utilizes Partial POC detection for the LearnPress Missing Authorization vulnerability (CVE-2026-4365). Addressing earlier feedback, instead of version-based detection, it actively verifies that the `wp_rest` nonce is improperly exposed within the `lpData` object in the frontend HTML. This securely confirms the attack surface exists without executing destructive unauthorized data deletion.
