### PR TITLE
fix(sentry-panel): add title check to prevent false positives

### DIFF
--- a/http/exposed-panels/sentry-panel.yaml
+++ b/http/exposed-panels/sentry-panel.yaml
@@ -35,6 +35,7 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(body, "/sentry/") && contains(body, "Login")'
+          - 'regex("(?i)<title>[^<]*sentry[^<]*</title>", body)'
         condition: and
 
     extractors:


### PR DESCRIPTION
### PR Information

- Fixed `sentry-panel` exposed panel detection template to reduce false positives
- The current template matches any page containing `/sentry/` and `Login` in the body with a 200 status code. This can match non-Sentry login pages that happen to reference `/sentry/` paths.
- Added an additional DSL matcher that checks the HTML `<title>` tag contains "sentry" (case-insensitive): `regex("(?i)<title>[^<]*sentry[^<]*</title>", body)`
- This aligns with the template's own `shodan-query` and `fofa-query` metadata which already filter by title containing "sentry"

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

The fix adds a single matcher line that requires "sentry" to appear in the page `<title>` tag. This is consistent with the template's existing Shodan/FOFA queries (`http.title:"Login | Sentry"`), which already expect "sentry" in the title. Pages that contain `/sentry/` in the body but are not actual Sentry panels (e.g. documentation pages, other login pages referencing Sentry SDKs) will no longer match.
