### PR TITLE
fix: cpe formats

### DIFF
--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -102,4 +102,3 @@ http:
         part: interactsh_request
         words:
           - "/{{replace(vendor_name, '.', '/')}}/{{app_name}}/1/{{app_name}}-1.pom"
-# digest: 4a0a0047304502207d95a30a30943bb780132d5481398c4a8d30eb67e5fbe881ce5867c9eb167b0f022100b68b4e0755996d52a2697f0324eb5d3bc03c50b361dcc0a73c31e05cb05d9d85:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2019/CVE-2019-1003000.yaml
+++ b/http/cves/2019/CVE-2019-1003000.yaml
@@ -16,7 +16,7 @@ info:
     cve-id: CVE-2019-1003000
     epss-score: 0.94343
     epss-percentile: 0.99956
-    cpe: cpe:2.3:a:jenkins:script_security::::::jenkins::*
+    cpe: cpe:2.3:a:jenkins:script_security:*:*:*:*:*:jenkins:*:*
   reference:
     - https://jenkins.io/security/advisory/2019-01-08/#SECURITY-1266
     - http://www.rapid7.com/db/modules/exploit/multi/http/jenkins_metaprogramming

--- a/http/cves/2023/CVE-2023-50094.yaml
+++ b/http/cves/2023/CVE-2023-50094.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-50094
+id: CVE-2023-50094       
 
 info:
   name: reNgine 2.2.0 - Command Injection
@@ -12,12 +12,12 @@ info:
     Upgrade reNgine to version 2.1.2 or later which includes proper input validation.
   reference:
     - https://github.com/yogeshojha/rengine
-    - https://github.com/Zierax/CVE-2023-50094_POC
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-50094
+    - https://github.com/Zierax/CVE-2023-50094       _POC
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-50094       
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
-    cve-id: CVE-2023-50094
+    cve-id: CVE-2023-50094       
     cwe-id: CWE-78
     epss-score: 0.88564
     epss-percentile: 0.99509
@@ -65,4 +65,3 @@ http:
           - 'contains(interactsh_protocol_2, "dns")'
           - 'status_code_2 == 200'
         condition: and
-# digest: 490a0046304402206210fc4abacd58d4af4ea53f303f1ecaa8f408222c16455089d4fe962ec0516602205e616e786a86e1a63faaf5cf329e76d01fa07bfec78e642f46d9562340a95a15:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2023/CVE-2023-50094.yaml
+++ b/http/cves/2023/CVE-2023-50094.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-50094       
+id: CVE-2023-50094
 
 info:
   name: reNgine 2.2.0 - Command Injection
@@ -12,12 +12,12 @@ info:
     Upgrade reNgine to version 2.1.2 or later which includes proper input validation.
   reference:
     - https://github.com/yogeshojha/rengine
-    - https://github.com/Zierax/CVE-2023-50094       _POC
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-50094       
+    - https://github.com/Zierax/CVE-2023-50094_POC
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-50094
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
-    cve-id: CVE-2023-50094       
+    cve-id: CVE-2023-50094
     cwe-id: CWE-78
     epss-score: 0.88564
     epss-percentile: 0.99509

--- a/http/cves/2023/CVE-2023-50094.yaml
+++ b/http/cves/2023/CVE-2023-50094.yaml
@@ -21,7 +21,7 @@ info:
     cwe-id: CWE-78
     epss-score: 0.88564
     epss-percentile: 0.99509
-    cpe: cpe:2.3:a:yogeshojha::*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:yogeshojha:rengine:*:*:*:*:*:*:*:*
   metadata:
     max-request: 2
     vendor: yogeshojha


### PR DESCRIPTION
### PR Information

Follow-up of this PR: https://github.com/projectdiscovery/nuclei-templates/pull/15828

The initial PR included fix for all CPE formats: https://github.com/projectdiscovery/nuclei-templates/pull/15828/changes/909fe5ed191201940de9d632cf4a1975e2c7f33c
However, the changes on those two templates was lost during the merge: https://github.com/projectdiscovery/nuclei-templates/pull/15828/changes/d2fe045dceb7f2490e9e658051ed24d94c7672c2

This PR fix it.

- `http/cves/2019/CVE-2019-1003000.yaml`: Replaced empty `::` fields with `:*:`
- `http/cves/2023/CVE-2023-50094.yaml`: Filled empty product field with rengine

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
