### PR TITLE
RabbitMQ AMQP - Default Login

### DIFF
--- a/javascript/default-logins/rabbitmq-amqp-default-login.yaml
+++ b/javascript/default-logins/rabbitmq-amqp-default-login.yaml
@@ -1,0 +1,152 @@
+id: rabbitmq-amqp-default-login
+
+info:
+  name: RabbitMQ AMQP - Default Login
+  author: DhiyaneshDK
+  severity: high
+  description: |
+    RabbitMQ server accepts connections with weak or default credentials over the AMQP 0-9-1 protocol (port 5672).Default credentials (guest/guest) or commonly used weak passwords were found, allowing unauthorized access to the message broker, its queues, exchanges, and all data flowing through them.
+  impact: |
+    An attacker with valid AMQP credentials can connect to the broker, consume or publish messages,create/delete queues and exchanges, and potentially access sensitive application data.
+  remediation: |
+    Change default credentials immediately. Enforce strong password policies. Restrict the guest account to localhost connections only (RabbitMQ default behavior). Enable TLS for AMQP connections. Use vhosts for access isolation.
+  reference:
+    - https://www.rabbitmq.com/docs/access-control
+    - https://www.rabbitmq.com/docs/passwords
+    - https://www.rabbitmq.com/docs/amqp-0-9-1-reference
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-521
+  metadata:
+    verified: true
+    max-request: 6
+    shodan-query: product:"RabbitMQ" port:5672
+    fofa-query: protocol="amqp"
+  tags: js,network,rabbitmq,amqp,default-login
+
+javascript:
+  - pre-condition: |
+      isPortOpen(Host, Port);
+    code: |
+      let m = require("nuclei/net");
+      let conn = m.Open('tcp', `${Host}:${Port}`);
+
+      conn.SendHex("414d515000000901");
+      let serverStart = conn.RecvString(4096);
+
+      if (serverStart.indexOf("RabbitMQ") === -1) {
+        conn.Close();
+        throw "Not a RabbitMQ server";
+      }
+
+      function strToHex(s) {
+        let h = '';
+        for (let i = 0; i < s.length; i++) {
+          let c = s.charCodeAt(i).toString(16);
+          if (c.length < 2) c = '0' + c;
+          h += c;
+        }
+        return h;
+      }
+      function numToHex4(n) {
+        let h = n.toString(16);
+        while (h.length < 8) h = '0' + h;
+        return h;
+      }
+
+      let saslLen = 1 + Username.length + 1 + Password.length;
+
+      let methodPayload = "";
+      methodPayload += "000a000b";
+      methodPayload += "00000000";
+      methodPayload += "05504c41494e";
+      methodPayload += numToHex4(saslLen);
+      methodPayload += "00" + strToHex(Username) + "00" + strToHex(Password);
+      methodPayload += "05656e5f5553";
+
+      let payloadBytes = methodPayload.length / 2;
+
+      let frame = "01" + "0000" + numToHex4(payloadBytes) + methodPayload + "ce";
+
+      conn.SendHex(frame);
+      let authResponse = conn.RecvString(4096);
+      conn.Close();
+
+      // Negative checks — known failure indicators
+      if (authResponse.indexOf("ACCESS_REFUSED") !== -1 || authResponse.indexOf("access_refused") !== -1 || authResponse.indexOf("NOT_ALLOWED") !== -1 || authResponse.length < 8) {
+        throw "Authentication failed for " + Username;
+      }
+
+      // Positive check — verify Connection.Tune frame (class=10, method=30)
+      // Convert response to hex to check for specific AMQP frame bytes
+      function respToHex(s) {
+        let h = '';
+        for (let i = 0; i < s.length; i++) {
+          let c = s.charCodeAt(i).toString(16);
+          if (c.length < 2) c = '0' + c;
+          h += c;
+        }
+        return h;
+      }
+
+      let responseHex = respToHex(authResponse);
+
+      // Connection.Tune frame MUST contain class=10(0x000a) method=30(0x001e)
+      if (responseHex.indexOf("000a001e") === -1) {
+        throw "No Connection.Tune frame in response - not a confirmed auth success";
+      }
+
+      // Verify first byte is 0x01 (method frame type)
+      if (authResponse.charCodeAt(0) !== 1) {
+        throw "Unexpected AMQP frame type: " + authResponse.charCodeAt(0);
+      }
+
+      // Auth confirmed — export credentials and verification data
+      Export("username", Username);
+      Export("password", Password);
+      Export("amqp_frame", "connection.tune");
+
+    args:
+      Host: "{{Host}}"
+      Port: "5672"
+      Username: "{{username}}"
+      Password: "{{password}}"
+
+    payloads:
+      username:
+        - guest
+        - admin
+        - rabbitmq
+        - user
+        - test
+        - amqp
+
+      password:
+        - guest
+        - admin
+        - rabbitmq
+        - user
+        - test
+        - amqp
+
+    attack: pitchfork
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "success == true"
+
+      - type: word
+        part: response
+        words:
+          - "connection.tune"
+
+    extractors:
+      - type: kval
+        kval:
+          - username
+          - password


### PR DESCRIPTION
Add RabbitMQ AMQP default login detection script with payloads and matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
