### PR TITLE
fix: correct invalid cve-id field values in classification

### DIFF
--- a/http/cves/2014/CVE-2014-6287.yaml
+++ b/http/cves/2014/CVE-2014-6287.yaml
@@ -19,7 +19,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: 'CVE-2014-6287'
+    cve-id: CVE-2014-6287
     cwe-id: CWE-94
     epss-score: 0.94363
     epss-percentile: 0.99964

--- a/http/cves/2017/CVE-2017-12617.yaml
+++ b/http/cves/2017/CVE-2017-12617.yaml
@@ -19,7 +19,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.1
-    cve-id: "CVE-2017-12617"
+    cve-id: CVE-2017-12617
     cwe-id: CWE-434
     epss-score: 0.94356
     epss-percentile: 0.9996

--- a/http/cves/2019/CVE-2019-17574.yaml
+++ b/http/cves/2019/CVE-2019-17574.yaml
@@ -19,7 +19,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
-    cve-id: 'CVE-2019-17574'
+    cve-id: CVE-2019-17574
     cwe-id: CWE-639
     epss-score: 0.86894
     epss-percentile: 0.99435

--- a/http/cves/2021/CVE-2021-24236.yaml
+++ b/http/cves/2021/CVE-2021-24236.yaml
@@ -18,7 +18,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: "CVE-2021-24236"
+    cve-id: CVE-2021-24236
     cwe-id: CWE-434
     epss-score: 0.74128
     epss-percentile: 0.98849

--- a/http/cves/2021/CVE-2021-42013.yaml
+++ b/http/cves/2021/CVE-2021-42013.yaml
@@ -18,7 +18,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: "CVE-2021-42013"
+    cve-id: CVE-2021-42013
     cwe-id: CWE-22
     epss-score: 0.9441
     epss-percentile: 0.99977

--- a/http/cves/2024/CVE-2024-8852.yaml
+++ b/http/cves/2024/CVE-2024-8852.yaml
@@ -16,7 +16,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
-    cve-id: cve-2024-8852
+    cve-id: CVE-2024-8852
     cwe-id: CWE-532
   metadata:
     verified: true

--- a/http/exposed-panels/veeam-backup-manager-login.yaml
+++ b/http/exposed-panels/veeam-backup-manager-login.yaml
@@ -8,7 +8,7 @@ info:
     Veeam Backup Enterprise Manager Login
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cve-id: CWE-200
+    cwe-id: CWE-200
   metadata:
     max-request: 1
     verified: true


### PR DESCRIPTION
### PR Information

- veeam-backup-manager-login.yaml: replace cve-id: CWE-200 with cwe-id: CWE-200
- CVE-2024-8852.yaml: fix lowercase cve-id to uppercase CVE-2024-8852
- CVE-2017-12617.yaml, CVE-2021-42013.yaml, CVE-2021-24236.yaml: remove double quotes
- CVE-2014-6287.yaml, CVE-2019-17574.yaml: remove single quotes

### Template validation

#### Additional Details (leave it blank if not applicable)

### Additional References:

