### PR TITLE
Add CVE-2026-3569: Liaison Site Prober Information Exposure

### DIFF
--- a/http/cves/2026/CVE-2026-3569.yaml
+++ b/http/cves/2026/CVE-2026-3569.yaml
@@ -6,12 +6,12 @@ info:
   author: shrimp
   severity: medium
   description: |
-    The Liaison Site Prober plugin for WordPress is vulnerable to Information Exposure
-    in all versions up to and including 1.2.1 via the /wp-json/site-prober/v1/logs REST API
-    endpoint. The permissions_read() permission callback unconditionally returns true instead
-    of checking for appropriate capabilities. This makes it possible for unauthenticated
-    attackers to retrieve sensitive audit log data including IP addresses, user IDs, usernames,
-    login/logout events, failed login attempts, and detailed activity descriptions.
+    Unauthenticated Information Exposure vulnerability in Liaison Site Prober plugin
+    versions 1.2.1 and below. The `/wp-json/site-prober/v1/logs` REST API endpoint
+    has a `permissions_read()` callback that unconditionally returns `true` instead
+    of checking for appropriate capabilities. This allows unauthenticated attackers
+    to retrieve sensitive audit log data including IP addresses, user IDs, usernames,
+    login/logout events, and failed login attempts.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/liaison-site-prober/liaison-site-prober-121-missing-authorization-to-unauthenticated-information-exposure-in-logs-rest-api-endpoint
     - https://plugins.trac.wordpress.org/browser/liaison-site-prober/trunk/includes/class-liaison-rest-controller.php#L50

--- a/http/cves/2026/CVE-2026-3569.yaml
+++ b/http/cves/2026/CVE-2026-3569.yaml
@@ -1,7 +1,6 @@
 id: CVE-2026-3569-liaison-site-prober-info-exposure
 
 info:
-  id: CVE-2026-3569
   name: Liaison Site Prober <= 1.2.1 - Unauthenticated Information Exposure
   author: shrimp
   severity: medium
@@ -38,17 +37,10 @@ http:
         words:
           - "application/json"
 
-      - type: word
-        words:
-          - '"ip"'
-          - '"user_id"'
-          - '"action"'
-        condition: and
-        part: body
-
       - type: regex
         regex:
-          - '"ip"\s*:\s*"[0-9.]+"'
+          - '"ip"\s*:\s*"(\d{1,3}\.){3}\d{1,3}"'
           - '"user_id"\s*:\s*\d+'
-        condition: or
+          - '"action"\s*:\s*"\w+"'
+        condition: and
         part: body

--- a/http/cves/2026/CVE-2026-3569.yaml
+++ b/http/cves/2026/CVE-2026-3569.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-3569-liaison-site-prober-info-exposure
+
+info:
+  id: CVE-2026-3569
+  name: Liaison Site Prober <= 1.2.1 - Unauthenticated Information Exposure
+  author: shrimp
+  severity: medium
+  description: |
+    The Liaison Site Prober plugin for WordPress is vulnerable to Information Exposure
+    in all versions up to and including 1.2.1 via the /wp-json/site-prober/v1/logs REST API
+    endpoint. The permissions_read() permission callback unconditionally returns true instead
+    of checking for appropriate capabilities. This makes it possible for unauthenticated
+    attackers to retrieve sensitive audit log data including IP addresses, user IDs, usernames,
+    login/logout events, failed login attempts, and detailed activity descriptions.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/liaison-site-prober/liaison-site-prober-121-missing-authorization-to-unauthenticated-information-exposure-in-logs-rest-api-endpoint
+    - https://plugins.trac.wordpress.org/browser/liaison-site-prober/trunk/includes/class-liaison-rest-controller.php#L50
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-3569
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-862
+  tags: wordpress,wp-plugin,liaison-site-prober,info-exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/site-prober/v1/logs"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        words:
+          - '"ip"'
+          - '"user_id"'
+          - '"action"'
+        condition: and
+        part: body
+
+      - type: regex
+        regex:
+          - '"ip"\s*:\s*"[0-9.]+"'
+          - '"user_id"\s*:\s*\d+'
+        condition: or
+        part: body


### PR DESCRIPTION
## Description

This template detects CVE-2026-3569, an unauthenticated information exposure vulnerability in the Liaison Site Prober WordPress plugin.

### Vulnerability Details
- **CVE**: CVE-2026-3569
- **Plugin**: Liaison Site Prober
- **Affected Versions**: <= 1.2.1
- **CVSS**: 5.3 (Medium)
- **CWE**: CWE-862 (Missing Authorization)

### Technical Details
The `/wp-json/site-prober/v1/logs` REST API endpoint has a `permissions_read()` callback that unconditionally returns `true`, allowing unauthenticated attackers to retrieve sensitive audit log data including:
- IP addresses
- User IDs
- Usernames
- Login/logout events
- Failed login attempts

### Detection Method
The template sends a GET request to the vulnerable endpoint and verifies the response contains sensitive log data by checking for JSON structure with `ip`, `user_id`, and `action` fields.

### References
- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/liaison-site-prober/liaison-site-prober-121-missing-authorization-to-unauthenticated-information-exposure-in-logs-rest-api-endpoint
- https://plugins.trac.wordpress.org/browser/liaison-site-prober/trunk/includes/class-liaison-rest-controller.php#L50
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-3569