### PR TITLE
Updated roundcube-log-disclosure.yaml (remove duplicate line)

### DIFF
--- a/http/exposures/logs/roundcube-log-disclosure.yaml
+++ b/http/exposures/logs/roundcube-log-disclosure.yaml
@@ -44,7 +44,6 @@ http:
           - "IMAP Error:"
           - "Message for"
           - "DB Error:"
-          - "IMAP Error:"
           - "PHP Error:"
           - "PHP Warning:"
         condition: or


### PR DESCRIPTION
Removes duplicate 'IMAP Error:' from match conditions