### PR TITLE
Add CVE-2025-54988: Apache Tika XXE Injection

### DIFF
--- a/http/cves/2025/CVE-2025-54988.yaml
+++ b/http/cves/2025/CVE-2025-54988.yaml
@@ -1,0 +1,110 @@
+id: CVE-2025-54988
+
+info:
+  name: Apache Tika XXE Injection - CVE-2025-54988
+  author: tx1ee
+  severity: critical
+  description: |
+    Apache Tika versions 1.13 through 3.2.1 contain an XML External Entity (XXE) vulnerability
+    in the tika-parser-pdf-module. Attackers can exploit this by embedding malicious XFA
+    (XML Forms Architecture) content within PDF files. This allows attackers to:
+    - Read sensitive files from the server (e.g., /etc/passwd)
+    - Perform SSRF attacks against internal resources
+    - Access data from third-party servers
+
+    The vulnerability is caused by improper restriction of XML external entity references (CWE-611).
+  impact: |
+    An attacker can read sensitive server files or perform SSRF attacks against internal infrastructure.
+  remediation: |
+    Upgrade to Apache Tika 3.2.2 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54988
+    - https://lists.apache.org/thread/8xn3rqy6kz5b3l1t83kcofkw0w4mmj1w
+    - https://lists.debian.org/debian-lts-announce/2025/10/msg00030.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    epss-score: 0.045
+    cwe-id: CWE-611
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: apache
+    product: tika
+    shodan-query: title:"Apache Tika"
+    fofa-query: title="Apache Tika"
+  tags: cve,cve2025,apache,tika,xxe,ssrf,pdf,xml,injection,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/tika"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Apache Tika'
+          - 'This is Tika'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "Apache Tika [0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"
+          - "Apache Tika v?([0-9]+\\.[0-9]+\\.[0-9]+)"
+
+  - method: PUT
+    path:
+      - "{{BaseURL}}/tika"
+
+    headers:
+      Accept: text/plain
+      Content-Type: application/pdf
+      X-Tika-PDFextractInlineImages: "true"
+      X-Tika-PDFextractMarkedContent: "true"
+
+    body: |
+      %PDF-1.4
+      1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+      2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+      3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]
+      /Contents 4 0 R/Resources<<>>>>endobj
+      4 0 obj<</Length 44>>
+      stream
+      BT /F1 12 Tf 100 700 Td (XXE Test) Tj ET
+      endstream
+      endobj
+      xref
+      0 5
+      0000000000 65535 f
+      0000000009 00000 n
+      0000000058 00000 n
+      0000000115 00000 n
+      0000000214 00000 n
+      trailer<</Size 5/Root 1 0 R>>
+      startxref
+      307
+      %%EOF
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - 'XXE Test'
+          - 'XXE'
+          - 'Tika'
+        condition: or
+
+      - type: status
+        status:
+          - 200
+          - 201

--- a/http/cves/2025/CVE-2025-54988.yaml
+++ b/http/cves/2025/CVE-2025-54988.yaml
@@ -1,26 +1,19 @@
 id: CVE-2025-54988
 
 info:
-  name: Apache Tika XXE Injection - CVE-2025-54988
+  name: Apache Tika - XXE Injection
   author: tx1ee
   severity: critical
   description: |
-    Apache Tika versions 1.13 through 3.2.1 contain an XML External Entity (XXE) vulnerability
-    in the tika-parser-pdf-module. Attackers can exploit this by embedding malicious XFA
-    (XML Forms Architecture) content within PDF files. This allows attackers to:
-    - Read sensitive files from the server (e.g., /etc/passwd)
-    - Perform SSRF attacks against internal resources
-    - Access data from third-party servers
-
-    The vulnerability is caused by improper restriction of XML external entity references (CWE-611).
+    Apache Tika versions 1.13 through 3.2.1 are vulnerable to XXE via malicious XFA in PDFs, allowing file read and SSRF attacks.
   impact: |
     An attacker can read sensitive server files or perform SSRF attacks against internal infrastructure.
   remediation: |
     Upgrade to Apache Tika 3.2.2 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-54988
     - https://lists.apache.org/thread/8xn3rqy6kz5b3l1t83kcofkw0w4mmj1w
     - https://lists.debian.org/debian-lts-announce/2025/10/msg00030.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-54988
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -33,7 +26,9 @@ info:
     product: tika
     shodan-query: title:"Apache Tika"
     fofa-query: title="Apache Tika"
-  tags: cve,cve2025,apache,tika,xxe,ssrf,pdf,xml,injection,vuln
+  tags: cve,cve2025,apache,tika,xxe,ssrf,vuln
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
@@ -42,6 +37,7 @@ http:
       - "{{BaseURL}}/tika"
 
     stop-at-first-match: true
+    redirects: true
 
     matchers-condition: and
     matchers:
@@ -50,10 +46,7 @@ http:
           - 'Apache Tika'
           - 'This is Tika'
         condition: or
-
-      - type: status
-        status:
-          - 200
+        internal: true
 
     extractors:
       - type: regex
@@ -80,7 +73,7 @@ http:
       /Contents 4 0 R/Resources<<>>>>endobj
       4 0 obj<</Length 44>>
       stream
-      BT /F1 12 Tf 100 700 Td (XXE Test) Tj ET
+      BT /F1 12 Tf 100 700 Td (CVE-2025-54988 POC File) Tj ET
       endstream
       endobj
       xref
@@ -95,14 +88,16 @@ http:
       307
       %%EOF
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         words:
-          - 'XXE Test'
-          - 'XXE'
-          - 'Tika'
-        condition: or
+          - 'CVE-2025-54988 POC File'
+
+      - type: word
+        part: content_type
+        words:
+          - 'text/plain'
 
       - type: status
         status:

--- a/http/cves/2025/CVE-2025-54988.yaml
+++ b/http/cves/2025/CVE-2025-54988.yaml
@@ -73,7 +73,7 @@ http:
       /Contents 4 0 R/Resources<<>>>>endobj
       4 0 obj<</Length 44>>
       stream
-      BT /F1 12 Tf 100 700 Td (CVE-2025-54988 POC File) Tj ET
+      BT /F1 12 Tf 100 700 Td ({{randstr}}) Tj ET
       endstream
       endobj
       xref
@@ -88,18 +88,10 @@ http:
       307
       %%EOF
 
-    matchers-condition: and
     matchers:
-      - type: word
-        words:
-          - 'CVE-2025-54988 POC File'
-
-      - type: word
-        part: content_type
-        words:
-          - 'text/plain'
-
-      - type: status
-        status:
-          - 200
-          - 201
+      - type: dsl
+        dsl:
+          - status_code == 200 || status_code == 201
+          - contains(body, "{{randstr}}")
+          - contains(header,"text/plain")
+        condition: and


### PR DESCRIPTION
## Summary

Added nuclei template for **CVE-2025-54988** - Apache Tika XXE Injection vulnerability.

### Vulnerability Details

- **Product**: Apache Tika
- **Type**: XXE (XML External Entity Injection)
- **Severity**: Critical (CVSS 9.8)
- **CWE**: CWE-611
- **Affected Versions**: 1.13 through 3.2.1

### Detection Method

The template detects Apache Tika servers and tests the PDF parsing endpoint:
1. GET requests to `/` and `/tika` to detect Apache Tika banner
2. PUT request to `/tika` with PDF content to test parsing functionality
3. Version extraction via regex pattern matching

### Testing

- [x] Tested on vulnerable version (3.2.1) - Detected
- [x] Template validated successfully

### References

- https://nvd.nist.gov/vuln/detail/CVE-2025-54988
- https://lists.apache.org/thread/8xn3rqy6kz5b3l1t83kcofkw0w4mmj1w
- https://lists.debian.org/debian-lts-announce/2025/10/msg00030.html