### PR TITLE
Create generic-gambling-defacement http template

### DIFF
--- a/http/miscellaneous/generic-gambling-defacement.yaml
+++ b/http/miscellaneous/generic-gambling-defacement.yaml
@@ -1,0 +1,59 @@
+id: generic-gambling-defacement
+
+info:
+  name: Generic Indonesian Gambling Defacement Detection
+  author: jakxx
+  severity: critical
+  description: Detects Indonesian slot/toto/LARISWD gambling defacement with clean output.
+  tags: defacement,hijack,gambling,slot-gacor,toto,lariswd,indonesian-spam
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+
+    matchers:
+      # Primary detection: Strong gambling terms
+      - type: word
+        name: strong-gambling-terms
+        words:
+          - "slot gacor"
+          - "toto slot"
+          - "situs toto"
+          - "LARISWD"
+          - "gacor maxwin"
+          - "rtp live"
+          - "bandar slot"
+          - "slot gacor hari ini"
+        condition: or
+        part: body
+        case-insensitive: true
+
+      # Filter out small legitimate pages
+      - type: dsl
+        dsl:
+          - "len(body) > 1200"
+
+    # Extractors
+    extractors:
+      - type: regex
+        name: page-title
+        regex:
+          - "(?i)<title>(.*?)</title>"
+        part: body
+
+      - type: regex
+        name: suspicious-domain
+        regex:
+          - "(?i)(https?://[^\"'\\s]*lariswd[^\"'\\s]*)"
+        part: body
+
+      - type: regex
+        name: matched-term
+        regex:
+          - "(?i)(slot gacor|LARISWD|toto slot|gacor maxwin|rtp live)"
+        part: body


### PR DESCRIPTION
### PR Information

Recently have detected a number of websites that have been compromised and replaced with Indonesian gambling content. Wanted a way to check at scale, so developed a template for nuclei. Cannot provide sample sites in this case for obvious reasons.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
