### PR TITLE
Add CVE-2026-23486 information leak details

### DIFF
--- a/http/cves/2026/CVE-2026-23486.yaml
+++ b/http/cves/2026/CVE-2026-23486.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-23486
+
+info:
+  name: Blinko <= 1.8.3 - User Information Leak
+  author: 0x_Akoko
+  severity: low
+  description: |
+    Blinko <= 1.8.4 contains an information disclosure caused by a publicly accessible endpoint exposing user information including usernames, roles, and account creation dates, letting remote attackers access sensitive user data, exploit requires no special privileges.
+  impact: |
+    Remote attackers can access sensitive user information, potentially leading to privacy violations and targeted attacks.
+  remediation: |
+    Update to version 1.8.4 or later.
+  reference:
+    - https://github.com/blinkospace/blinko/security/advisories/GHSA-446p-2xf5-frxf
+    - https://github.com/blinkospace/blinko
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+    cve-id: CVE-2026-23486
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: blinkospace
+    product: blinko
+    fofa-query: title="Blinko" || body="blinko"
+    shodan-query: http.title:"Blinko"
+  tags: cve,cve2026,blinko,exposure,unauth,info-leak
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/user/public-user-list"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"name\"", "\"nickname\"", "\"role\"", "\"loginType\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '"name"\s*:\s*"[^"]+"'
+
+      - type: regex
+        part: body
+        regex:
+          - '"role"\s*:\s*"[^"]+"'

--- a/http/cves/2026/CVE-2026-23486.yaml
+++ b/http/cves/2026/CVE-2026-23486.yaml
@@ -13,6 +13,7 @@ info:
   reference:
     - https://github.com/blinkospace/blinko/security/advisories/GHSA-446p-2xf5-frxf
     - https://github.com/blinkospace/blinko
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23486
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
@@ -23,9 +24,9 @@ info:
     max-request: 1
     vendor: blinkospace
     product: blinko
-    fofa-query: title="Blinko" || body="blinko"
+    fofa-query: title="Blinko"
     shodan-query: http.title:"Blinko"
-  tags: cve,cve2026,blinko,exposure,unauth,info-leak
+  tags: cve,cve2026,blinko,exposure,unauth
 
 flow: http(1) && http(2)
 
@@ -53,10 +54,3 @@ http:
           - 'contains(content_type, "application/json")'
           - 'contains_all(body, "\"name\":", "\"role\":")'
         condition: and
-
-    extractors:
-      - type: json
-        part: body
-        json:
-          - '.[].name'
-          - '.[].role'

--- a/http/cves/2026/CVE-2026-23486.yaml
+++ b/http/cves/2026/CVE-2026-23486.yaml
@@ -27,7 +27,21 @@ info:
     shodan-query: http.title:"Blinko"
   tags: cve,cve2026,blinko,exposure,unauth,info-leak
 
+flow: http(1) && http(2)
+
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "<title>Blinko</title>", "Blinko self-hosted personal note")'
+        condition: and
+        internal: true
+
   - method: GET
     path:
       - "{{BaseURL}}/api/v1/user/public-user-list"
@@ -37,16 +51,12 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"name\"", "\"nickname\"", "\"role\"", "\"loginType\"")'
+          - 'contains_all(body, "\"name\":", "\"role\":")'
         condition: and
 
     extractors:
-      - type: regex
+      - type: json
         part: body
-        regex:
-          - '"name"\s*:\s*"[^"]+"'
-
-      - type: regex
-        part: body
-        regex:
-          - '"role"\s*:\s*"[^"]+"'
+        json:
+          - '.[].name'
+          - '.[].role'


### PR DESCRIPTION
CVE-2026-23486 details an information leak in Blinko <= 1.8.3, allowing remote attackers to access sensitive user data via a public endpoint. The remediation suggests updating to version 1.8.4 or later.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
