### PR TITLE
fix: drop clear-site-data matcher from http-missing-security-headers (FP)

### DIFF
--- a/http/misconfiguration/http-missing-security-headers.yaml
+++ b/http/misconfiguration/http-missing-security-headers.yaml
@@ -70,13 +70,6 @@ http:
         condition: and
 
       - type: dsl
-        name: clear-site-data
-        dsl:
-          - "!regex('(?i)clear-site-data', header)"
-          - "status_code != 301 && status_code != 302"
-        condition: and
-
-      - type: dsl
         name: cross-origin-embedder-policy
         dsl:
           - "!regex('(?i)cross-origin-embedder-policy', header)"


### PR DESCRIPTION
#### Template / PR Information
**Template Name**: `http/misconfiguration/http-missing-security-headers.yaml`
**Severity**: info
**Type**: bug-fix (false positive)
**References**:
- Closes #12008
- W3C Clear-Site-Data spec — https://www.w3.org/TR/clear-site-data/

#### Description
The `clear-site-data` matcher was checking for the header on `BaseURL` (`/`). Per the W3C spec, `Clear-Site-Data` is a **logout/sign-out flow header** — it's emitted in response to logout requests so the UA evicts cookies, storage, cache, and execution contexts. Sending it on a base URL would actively harm the user (it would clear their session on every page load).

That makes the matcher a **guaranteed false positive on every site that implements the header correctly**. There is no defensible "best practice" interpretation under which this header should appear on `/`.

#### Change
Removed the `clear-site-data` matcher block (7 lines). All other matchers untouched.

#### Verification
- `yamllint -c .yamllint http/misconfiguration/http-missing-security-headers.yaml` → clean
- `nuclei -t http/misconfiguration/http-missing-security-headers.yaml -validate` → "All templates validated successfully"