### PR TITLE
fix(CVE-2021-40438): support custom interactsh server hostnames (FN)

### DIFF
--- a/http/cves/2021/CVE-2021-40438.yaml
+++ b/http/cves/2021/CVE-2021-40438.yaml
@@ -43,7 +43,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(header, "X-Interactsh-Version", "Server: oast")'
+          - 'contains(header, "X-Interactsh-Version")'
           - "!contains(body, '<h1> Interactsh Server </h1>')"
         condition: and
 # digest: 4b0a00483046022100e3782623b7ca68ca3f543744e64c4db8943b6029e1ec7aa74c7ec8e2b6b2d796022100b384e2d5e54b3da9dfbb26fd4f5fed1901add32b0e95831a1b987f8e57d1f701:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
#### Template / PR Information
**Template**: `http/cves/2021/CVE-2021-40438.yaml`
**CVE**: CVE-2021-40438 (Apache mod_proxy SSRF, CVSS 9.0, KEV)
**Type**: bug-fix (false negative)

#### Problem
Detection matcher required `Server: oast` in the response header:
```
contains_all(header, "X-Interactsh-Version", "Server: oast")
```
This only matches the **default** interactsh deployment (oast.fun, oast.pro). Users running self-hosted or custom interactsh servers hit guaranteed false negatives — the SSRF fires, mod_proxy forwards the request, the upstream interactsh response comes back with the user's custom Server header, and the matcher silently rejects it.

#### Fix
`X-Interactsh-Version` is the universal interactsh signal — emitted by every interactsh server regardless of hostname. Dropping the `Server:` literal portion makes the template work with any deployment.

```diff
- 'contains_all(header, "X-Interactsh-Version", "Server: oast")'
+ 'contains(header, "X-Interactsh-Version")'
```

The `<h1> Interactsh Server </h1>` body-negation guard is retained — it still rejects responses where the user accidentally browsed the interactsh landing page directly.

#### Verification
- `yamllint -c .yamllint http/cves/2021/CVE-2021-40438.yaml` → clean
- `nuclei -t http/cves/2021/CVE-2021-40438.yaml -validate` → "All templates validated successfully"

Closes #12074