### PR TITLE
add: LiteLLM proxy unauthenticated /model/info exposure

### DIFF
--- a/http/misconfiguration/litellm-unauth-model-exposure.yaml
+++ b/http/misconfiguration/litellm-unauth-model-exposure.yaml
@@ -1,26 +1,15 @@
 id: litellm-unauth-model-exposure
 
 info:
-  name: LiteLLM Proxy - Unauthenticated Model Exposure
+  name: LiteLLM Proxy - Model Exposure
   author: DevamShah
   severity: medium
   description: |
-    LiteLLM proxy was detected with anonymous access to the model listing API.
-    LiteLLM proxies that ship without `general_settings.master_key` (or with the
-    key disabled) expose the configured upstream model catalog via /v1/models
-    and /model/info — revealing which OpenAI / Anthropic / Azure / Bedrock /
-    local-LLM endpoints are wired in, often along with their litellm_params
-    routing config, and frequently leaving /chat/completions and /embeddings
-    reachable without any bearer token.
+    LiteLLM proxy was detected with anonymous access to the model listing API. LiteLLM proxies that ship without `general_settings.master_key` (or with the key disabled) expose the configured upstream model catalog via /v1/models and /model/info — revealing which OpenAI / Anthropic / Azure / Bedrock / local-LLM endpoints are wired in, often along with their litellm_params routing config, and frequently leaving /chat/completions and /embeddings reachable without any bearer token.
   impact: |
-    Attackers can enumerate the proxy's full model catalog and abuse the upstream
-    accounts for free inference (cost amplification), exfiltrate any prompt logs
-    cached locally, or pivot to internal-only model endpoints exposed via the
-    proxy's routing config.
+    Attackers can enumerate the proxy's full model catalog and abuse the upstream accounts for free inference (cost amplification), exfiltrate any prompt logs cached locally, or pivot to internal-only model endpoints exposed via the proxy's routing config.
   remediation: |
-    Set `general_settings.master_key: sk-...` in the LiteLLM config, or pass
-    `--api_key` on startup. Enforce per-user virtual keys via the LiteLLM admin
-    API and place the proxy behind authenticated reverse proxy or service mesh.
+    Set `general_settings.master_key: sk-...` in the LiteLLM config, or pass `--api_key` on startup. Enforce per-user virtual keys via the LiteLLM admin API and place the proxy behind authenticated reverse proxy or service mesh.
   reference:
     - https://docs.litellm.ai/docs/proxy/virtual_keys
     - https://docs.litellm.ai/docs/proxy/configs
@@ -38,7 +27,7 @@ info:
       - 'http.title:"LiteLLM API - Swagger UI"'
       - 'http.html:"LiteLLM"'
     fofa-query: title="LiteLLM API"
-  tags: litellm,llm,ai,misconfig,unauth,exposure
+  tags: litellm,llm,ai,misconfig,exposure
 
 http:
   - method: GET

--- a/http/misconfiguration/litellm-unauth-model-exposure.yaml
+++ b/http/misconfiguration/litellm-unauth-model-exposure.yaml
@@ -1,0 +1,62 @@
+id: litellm-unauth-model-exposure
+
+info:
+  name: LiteLLM Proxy - Unauthenticated Model Exposure
+  author: DevamShah
+  severity: medium
+  description: |
+    LiteLLM proxy was detected with anonymous access to the model listing API.
+    LiteLLM proxies that ship without `general_settings.master_key` (or with the
+    key disabled) expose the configured upstream model catalog via /v1/models
+    and /model/info — revealing which OpenAI / Anthropic / Azure / Bedrock /
+    local-LLM endpoints are wired in, often along with their litellm_params
+    routing config, and frequently leaving /chat/completions and /embeddings
+    reachable without any bearer token.
+  impact: |
+    Attackers can enumerate the proxy's full model catalog and abuse the upstream
+    accounts for free inference (cost amplification), exfiltrate any prompt logs
+    cached locally, or pivot to internal-only model endpoints exposed via the
+    proxy's routing config.
+  remediation: |
+    Set `general_settings.master_key: sk-...` in the LiteLLM config, or pass
+    `--api_key` on startup. Enforce per-user virtual keys via the LiteLLM admin
+    API and place the proxy behind authenticated reverse proxy or service mesh.
+  reference:
+    - https://docs.litellm.ai/docs/proxy/virtual_keys
+    - https://docs.litellm.ai/docs/proxy/configs
+    - https://github.com/BerriAI/litellm
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L
+    cvss-score: 6.5
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: berriai
+    product: litellm
+    shodan-query:
+      - 'http.title:"LiteLLM API - Swagger UI"'
+      - 'http.html:"LiteLLM"'
+    fofa-query: title="LiteLLM API"
+  tags: litellm,llm,ai,misconfig,unauth,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/model/info"
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"data\":", "\"litellm_params\":", "\"model_info\":")'
+        condition: and
+
+    extractors:
+      - type: json
+        name: models
+        part: body
+        json:
+          - '.data[].model_name'


### PR DESCRIPTION
#### Template / PR Information
**Template**: `http/misconfiguration/litellm-unauth-model-exposure.yaml` (new)
**Severity**: medium (CVSS 6.5)
**Type**: new template — emerging surface, previously only swagger-ui detect existed
**References**:
- https://docs.litellm.ai/docs/proxy/virtual_keys
- https://docs.litellm.ai/docs/proxy/configs
- https://github.com/BerriAI/litellm

#### Why this template

LiteLLM proxy without `general_settings.master_key` exposes the upstream model catalog + routing config to anonymous visitors via `/model/info`. The response includes per-model `litellm_params` (provider credentials, base URLs, deployment IDs for Azure / Bedrock / etc.) and `model_info` metadata — directly identifying which OpenAI / Anthropic / Azure / Bedrock / local-LLM endpoints the proxy is fronting.

Same misconfiguration usually leaves `/chat/completions` and `/embeddings` accessible too, enabling cost-amplification attacks against the upstream accounts.

Existing repo coverage:
- `http/technologies/litellm-swagger-detect.yaml` → presence only
- No template checks for the dominant misconfiguration pattern (master_key not set).

#### Why /model/info instead of /v1/models

`/v1/models` returns the OpenAI-compatible shape that vLLM, ollama OpenAI mode, llama.cpp server, and LocalAI all emit identically — matching on it would FP across the entire self-hosted LLM ecosystem.

`/model/info` is LiteLLM-specific; the response shape (`litellm_params` + `model_info` keys) only appears in LiteLLM proxy, keeping the matcher unambiguous.

#### Verification
- `yamllint -c .yamllint http/misconfiguration/litellm-unauth-model-exposure.yaml` → clean
- `nuclei -t ... -validate` → "All templates validated successfully"
- Marked `verified: true` after testing against `docker run -e LITELLM_LOG=DEBUG -p 4000:4000 ghcr.io/berriai/litellm:main-latest --config config.yaml` with no master_key set.