### PR TITLE
Add ContrastAPI IP reconnaissance template

### DIFF
--- a/http/miscellaneous/contrastapi-ip-recon.yaml
+++ b/http/miscellaneous/contrastapi-ip-recon.yaml
@@ -73,6 +73,16 @@ http:
           - '.cloud_provider'
 
       - type: json
+        name: is_datacenter
+        json:
+          - '.is_datacenter'
+
+      - type: json
+        name: firehol_listed
+        json:
+          - '.reputation.firehol.listed'
+
+      - type: json
         name: tor_exit
         json:
           - '.tor_exit'

--- a/http/miscellaneous/contrastapi-ip-recon.yaml
+++ b/http/miscellaneous/contrastapi-ip-recon.yaml
@@ -12,7 +12,6 @@ info:
   metadata:
     verified: true
     max-request: 1
-    rate-limit: "100 req/hr keyless, 1000 req/hr with API key"
   tags: misc,recon,ip,asn,osint,threat-intel
 
 variables:

--- a/http/miscellaneous/contrastapi-ip-recon.yaml
+++ b/http/miscellaneous/contrastapi-ip-recon.yaml
@@ -12,6 +12,7 @@ info:
   metadata:
     verified: true
     max-request: 1
+    rate-limit: "100 req/hr keyless, 1000 req/hr with API key"
   tags: misc,recon,ip,asn,osint,threat-intel
 
 variables:

--- a/http/miscellaneous/contrastapi-ip-recon.yaml
+++ b/http/miscellaneous/contrastapi-ip-recon.yaml
@@ -1,0 +1,97 @@
+id: contrastapi-ip-recon
+
+info:
+  name: ContrastAPI IP Reconnaissance
+  author: UPinar
+  severity: info
+  description: |
+    Performs IP address reconnaissance using ContrastAPI. Retrieves ASN, country, PTR, open ports, hostnames, CPEs, vulnerabilities (CVE list with severity), cloud provider attribution, Tor exit status, and a calibrated risk score (0-100) with a coarse severity label.
+  reference:
+    - https://api.contrastcyber.com/docs
+    - https://github.com/UPinar/contrastapi
+  metadata:
+    verified: true
+    max-request: 1
+  tags: misc,recon,ip,asn,osint,threat-intel
+
+variables:
+  hostname: "{{Host}}"
+
+http:
+  - method: GET
+    path:
+      - "https://api.contrastcyber.com/v1/ip/{{hostname}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"ip"'
+          - '"asn"'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        name: asn
+        json:
+          - '.asn'
+
+      - type: json
+        name: asn_name
+        json:
+          - '.asn_name'
+
+      - type: json
+        name: country
+        json:
+          - '.country'
+
+      - type: json
+        name: ptr
+        json:
+          - '.ptr'
+
+      - type: json
+        name: ports
+        json:
+          - '.ports[]'
+
+      - type: json
+        name: hostnames
+        json:
+          - '.hostnames[]'
+
+      - type: json
+        name: cloud_provider
+        json:
+          - '.cloud_provider'
+
+      - type: json
+        name: tor_exit
+        json:
+          - '.tor_exit'
+
+      - type: json
+        name: risk_score
+        json:
+          - '.risk_score'
+
+      - type: json
+        name: severity_label
+        json:
+          - '.severity_label'
+
+      - type: json
+        name: vuln_ids
+        json:
+          - '.vulns[].cve_id'
+
+      - type: json
+        name: vuln_severities
+        json:
+          - '.vulns[].severity'


### PR DESCRIPTION
## What

Adds an IP reconnaissance template that uses [ContrastAPI](https://api.contrastcyber.com) to gather security intelligence about target IP addresses. Companion to the previously merged domain recon template (#15832).

## Template Details

- **Path:** `http/miscellaneous/contrastapi-ip-recon.yaml`
- **Severity:** info
- **Requests:** 1 (single API call returns full IP intel report)

## Extracted Data

- ASN + ASN name
- Country
- PTR record
- Open ports
- Hostnames
- Cloud provider attribution (AWS / GCP / Azure / Cloudflare / Google / null)
- Tor exit status
- Risk score (0-100, calibrated)
- Severity label (low / medium / high / critical)
- Per-IP CVE list — `cve_id` + `severity` for each entry

## About ContrastAPI

Free security intelligence API — no API key required (100 req/hr keyless rate limit). 33 MCP tools / 40+ endpoints: CVE/EPSS/KEV lookup, IP/domain recon, IOC enrichment, code security, OSINT.

- GitHub: https://github.com/UPinar/contrastapi
- Live API: https://api.contrastcyber.com
- Privacy: transparency endpoint at `/v1/privacy/my-data`