### PR TITLE
fix: resolve duplicate id for fortisandbox-panel

### DIFF
--- a/http/exposed-panels/fortinet/fortisandbox-panel.yaml
+++ b/http/exposed-panels/fortinet/fortisandbox-panel.yaml
@@ -1,4 +1,4 @@
-id: fortisandbox-panel
+id: fortinet-fortisandbox-panel
 
 info:
   name: Fortinet FortiSandbox Panel - Detect


### PR DESCRIPTION
## Description
Fix duplicate template `id` conflict. Both `exposed-panels/fortisandbox-panel.yaml` 
and `exposed-panels/fortinet/fortisandbox-panel.yaml` share the same id 
`fortisandbox-panel`, which causes issues when importing templates into databases 
that enforce unique ids.

## Change
Rename `id` in `http/exposed-panels/fortinet/fortisandbox-panel.yaml`:
- `fortisandbox-panel` → `fortinet-fortisandbox-panel`

This aligns the id with its file path under the `fortinet/` subdirectory.

## Before
```
http/exposed-panels/
├── fortisandbox-panel.yaml          # id: fortisandbox-panel
└── fortinet/
    └── fortisandbox-panel.yaml      # id: fortisandbox-panel  ← DUPLICATE
```

## After
```
http/exposed-panels/
├── fortisandbox-panel.yaml          # id: fortisandbox-panel
└── fortinet/
    └── fortisandbox-panel.yaml      # id: fortinet-fortisandbox-panel  ✓
```

## Verification
- [x] No other template uses id `fortinet-fortisandbox-panel`
- [x] YAML structure unchanged (only id field modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)