### PR TITLE
Create apache-casbin-mcp-gateway-detect.yaml and apache-casbin-mcp-gateway-default-login.yaml

### DIFF
--- a/http/default-logins/apache/apache-casbin-mcp-gateway-default-login.yaml
+++ b/http/default-logins/apache/apache-casbin-mcp-gateway-default-login.yaml
@@ -1,0 +1,44 @@
+id: apache-casbin-mcp-gateway-default-login
+
+info:
+  name: Apache Casbin MCP Gateway - Default Login
+  author: icarot
+  severity: high
+  description: |
+    Apache Casbin MCP Gateway server, enables default credentials. An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/apache/casbin-mcp-gateway
+  metadata:
+    max-request: 2
+    vendor: apache
+    product: casbin-mcp-gateway
+  tags: apache,casbin-mcp-gateway,default-login
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"{{username}}","password":"{{password}}"}
+    attack: pitchfork
+    payloads:
+      username:
+        - alice
+        - bob
+      password:
+        - password123
+        - password456
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"token":'
+          - '"user":'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/default-logins/apache/apache-casbin-mcp-gateway-default-login.yaml
+++ b/http/default-logins/apache/apache-casbin-mcp-gateway-default-login.yaml
@@ -5,7 +5,7 @@ info:
   author: icarot
   severity: high
   description: |
-    Apache Casbin MCP Gateway server, enables default credentials. An attacker can execute unauthorized operations.
+    Apache Casbin MCP Gateway server default login credentials were discovered.
   reference:
     - https://github.com/apache/casbin-mcp-gateway
   metadata:
@@ -22,6 +22,7 @@ http:
         Content-Type: application/json
 
         {"username":"{{username}}","password":"{{password}}"}
+
     attack: pitchfork
     payloads:
       username:
@@ -39,6 +40,7 @@ http:
           - '"token":'
           - '"user":'
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/technologies/apache/apache-casbin-mcp-gateway-detect.yaml
+++ b/http/technologies/apache/apache-casbin-mcp-gateway-detect.yaml
@@ -1,0 +1,34 @@
+id: apache-casbin-mcp-gateway-detect
+
+info:
+  name: Apache Casbin MCP Gateway - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects an Apache Casbin MCP Gateway server, a lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
+  reference:
+    - https://github.com/apache/casbin-mcp-gateway
+  metadata:
+    vendor: apache
+    product: casbin-mcp-gateway
+  tags: tech,casbin-mcp-gateway,apache,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/health"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"service": "mcp-gateway"'
+        condition: and
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: version
+        part: body
+        json:
+          - '.version'


### PR DESCRIPTION
These nuclei templates:

* Detects an Apache Casbin MCP Gateway server, a lightweight gateway service that instantly transforms existing MCP Servers and APIs into MCP servers with zero code changes.
* Apache Casbin MCP Gateway server, enables default credentials. An attacker can execute unauthorized operations.

- References:

https://github.com/apache/casbin-mcp-gateway

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Casbin MCP Gateway Docker Compose:**

1. Running container:

`$ git clone https://github.com/casbin/mcp-gateway.git`

`$ cd mcp-gateway`

`$ docker build -t apache-casbin-mcp-gateway .`

`$ docker run -d -p 9000:9000 --name apache-casbin-mcp-gateway-container apache-casbin-mcp-gateway:latest`

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apache-casbin-mcp-gateway-container`

**Nuclei execution:**

`~/go/bin/nuclei -t apache-casbin-mcp-gateway-detect.yaml -t apache-casbin-mcp-gateway-default-login.yaml -u "http://<host_machine_IP_address_or_obtained_Docker_IP_address>:9000" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1589" height="641" alt="image" src="https://github.com/user-attachments/assets/0218a07b-655b-4d30-a1ac-ef8f6b705dc5" />

<img width="1049" height="819" alt="image" src="https://github.com/user-attachments/assets/b16f966a-3f98-43e0-959c-80f7b2d0a9b2" />

<img width="1849" height="372" alt="image" src="https://github.com/user-attachments/assets/72474370-8606-45dd-a9a5-f0e9c093c4bf" />

