### PR TITLE
Add Spring Boot 3.x httpexchanges actuator endpoint detection

### DIFF
--- a/http/misconfiguration/springboot/springboot-httpexchanges.yaml
+++ b/http/misconfiguration/springboot/springboot-httpexchanges.yaml
@@ -1,14 +1,11 @@
 id: springboot-httpexchanges
 
 info:
-  name: Spring Boot Actuator - HTTP Exchanges Exposed
+  name: Detects Springboot HTTP Exchanges Actuator
   author: parkyoungdu
   severity: low
   description: |
-    Spring Boot 3.x Actuator httpexchanges endpoint is exposed without authentication.
-    This endpoint records recent HTTP request/response exchanges including URIs, headers,
-    and status codes. It was renamed from httptrace in Spring Boot 2.x to httpexchanges in 3.x,
-    meaning existing springboot-httptrace templates fail to detect this on Spring Boot 3.x applications.
+    The exposed httpexchanges endpoint can leak recent HTTP request/response data, including URIs, headers, and status codes.
   reference:
     - https://docs.spring.io/spring-boot/docs/3.0.0/actuator-api/htmlsingle/\#httpexchanges
     - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide

--- a/http/misconfiguration/springboot/springboot-httpexchanges.yaml
+++ b/http/misconfiguration/springboot/springboot-httpexchanges.yaml
@@ -1,0 +1,47 @@
+id: springboot-httpexchanges
+
+info:
+  name: Spring Boot Actuator - HTTP Exchanges Exposed
+  author: parkyoungdu
+  severity: low
+  description: |
+    Spring Boot 3.x Actuator httpexchanges endpoint is exposed without authentication.
+    This endpoint records recent HTTP request/response exchanges including URIs, headers,
+    and status codes. It was renamed from httptrace in Spring Boot 2.x to httpexchanges in 3.x,
+    meaning existing springboot-httptrace templates fail to detect this on Spring Boot 3.x applications.
+  reference:
+    - https://docs.spring.io/spring-boot/docs/3.0.0/actuator-api/htmlsingle/\#httpexchanges
+    - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide
+  metadata:
+    max-request: 2
+  tags: springboot,exposure,misconfig,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/httpexchanges"
+      - "{{BaseURL}}/actuator/httpexchanges"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"exchanges"'
+          - '"request"'
+          - '"response"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+          - "application/vnd.spring-boot.actuator"
+          - "application/vnd.spring-boot.actuator.v3+json"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
- Added `springboot-httpexchanges.yaml` to detect exposed Spring Boot 3.x `/actuator/httpexchanges` endpoint.
- In Spring Boot 3.0, the `httptrace` endpoint was renamed to `httpexchanges`. The existing [springboot-httptrace.yaml](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/misconfiguration/springboot/springboot-httptrace.yaml) only checks `/httptrace` and `/actuator/httptrace`, both of which return 404 on Spring Boot 3.x — creating a detection gap.
- When exposed without authentication, this endpoint leaks recent HTTP request/response history including URIs, methods, headers (e.g. Authorization), and status codes.

- References:
  - https://docs.spring.io/spring-boot/docs/3.0.0/actuator-api/htmlsingle/#httpexchanges
  - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide
  - https://github.com/projectdiscovery/nuclei-templates/blob/main/http/misconfiguration/springboot/springboot-httptrace.yaml

---

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested against **Spring Boot 3.3.0** (`webgoat/webgoat` v2025.3 and custom test app).


**1. False Negative — existing `springboot-httptrace.yaml` misses Spring Boot 3.x**

    $ nuclei -u http://127.0.0.1:8080 -t springboot-httptrace.yaml -debug

    GET /httptrace HTTP/1.1          → HTTP/1.1 404
    GET /actuator/httptrace HTTP/1.1 → HTTP/1.1 404

    [INF] Scan completed in 23ms. No results found. ❌


**2. True Positive — new `springboot-httpexchanges.yaml` detects Spring Boot 3.x**

    $ nuclei -u http://127.0.0.1:8080 -t springboot-httpexchanges.yaml -debug

    GET /httpexchanges HTTP/1.1          → HTTP/1.1 404
    GET /actuator/httpexchanges HTTP/1.1 → HTTP/1.1 200
      Content-Type: application/vnd.spring-boot.actuator.v3+json
      {"exchanges":[{"timestamp":"...","request":{...},"response":{"status":200}}]}

    [springboot-httpexchanges:word-1] [http] [low] http://127.0.0.1:8080/actuator/httpexchanges
    [springboot-httpexchanges:word-2] [http] [low] http://127.0.0.1:8080/actuator/httpexchanges
    [springboot-httpexchanges:status-3] [http] [low] http://127.0.0.1:8080/actuator/httpexchanges
    [INF] Scan completed in 29ms. 3 matches found. ✅


**3. False Positive prevention — Spring Security enabled (authenticated endpoint)**

    $ nuclei -u http://127.0.0.1:8080 -t springboot-httpexchanges.yaml -debug

    GET /httpexchanges HTTP/1.1          → HTTP/1.1 401 (Www-Authenticate: Basic realm="Realm")
    GET /actuator/httpexchanges HTTP/1.1 → HTTP/1.1 401 (Www-Authenticate: Basic realm="Realm")

    [INF] Scan completed in 69ms. No results found. ✅


- Nuclei version: v3.8.0
- nuclei-templates version: v10.4.2
- Test environment: macOS, Spring Boot 3.3.0, Java 17

---

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
