### PR TITLE
Add Redis Exporter metrics exposure template

### DIFF
--- a/http/misconfiguration/redis-exporter-metrics.yaml
+++ b/http/misconfiguration/redis-exporter-metrics.yaml
@@ -1,0 +1,44 @@
+id: redis-exporter-metrics
+
+info:
+  name: Redis Exporter Metrics - Exposure
+  author: koungq
+  severity: low
+  description: Redis Exporter metrics endpoint is exposed.
+  reference:
+    - https://github.com/oliver006/redis_exporter
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+  tags: redis,exporter,metrics,exposure,misconfig,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/metrics"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "# HELP"
+          - "redis_exporter_build_info"
+          - "redis_up"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "redis_connected_clients"
+          - "redis_memory_used_bytes"
+          - "redis_instance_info"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/http/misconfiguration/redis-exporter-metrics.yaml
+++ b/http/misconfiguration/redis-exporter-metrics.yaml
@@ -14,31 +14,18 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: redis,exporter,metrics,exposure,misconfig,vuln
+  tags: redis,exporter,metrics,exposure,misconfig
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/metrics"
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "# HELP"
-          - "redis_exporter_build_info"
-          - "redis_up"
+      - type: dsl
+        dsl:
+          - 'contains_any(body, "redis_connected_clients", "redis_memory_used_bytes", "redis_instance_info")'
+          - 'contains_all(body, "# HELP", "redis_exporter_build_info", "redis_up")'
+          - 'contains(content_type, "text/plain")'
+          - 'status_code == 200'
         condition: and
-
-      - type: word
-        part: body
-        words:
-          - "redis_connected_clients"
-          - "redis_memory_used_bytes"
-          - "redis_instance_info"
-        condition: or
-
-      - type: status
-        status:
-          - 200


### PR DESCRIPTION
  ### PR Information

  - Added Redis Exporter metrics exposure detection template
  - References:
    - https://github.com/oliver006/redis_exporter

  This PR adds a new misconfiguration template to detect exposed Redis Exporter metrics endpoints.

  The template checks:

  - `/metrics`

  It detects Redis Exporter by matching Redis Exporter specific Prometheus metrics, including:

  - `redis_exporter_build_info`
  - `redis_up`
  - `redis_connected_clients`
  - `redis_memory_used_bytes`
  - `redis_instance_info`

  An exposed Redis Exporter endpoint can disclose Redis operational information such as Redis version, role, connected clients, memory usage, keyspace statistics, command
  statistics, and exporter build information.

  ### Template validation

  - [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
  - [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

  #### Additional Details (leave it blank if not applicable)

  Validated locally with:

  - `redis:7-alpine`
  - `oliver006/redis_exporter:v1.82.0`

  Test setup:

  ```bash
  docker run --rm --name nuclei-redis-exporter-redis -p 16379:6379 -d redis:7-alpine

  docker run --rm --name nuclei-redis-exporter \
    -p 19121:9121 \
    -e REDIS_ADDR=redis://host.docker.internal:16379 \
    -d oliver006/redis_exporter:v1.82.0
  ```

  Observed Redis Exporter metrics response:

  ```http
  HTTP/1.1 200 OK
  Content-Type: text/plain; version=0.0.4; charset=utf-8; escaping=underscores

  # HELP redis_exporter_build_info redis exporter build_info
  # TYPE redis_exporter_build_info gauge
  redis_exporter_build_info{version="v1.82.0"} 1

  # HELP redis_up Information about the Redis instance
  # TYPE redis_up gauge
  redis_up 1

  # HELP redis_connected_clients connected_clients metric
  # TYPE redis_connected_clients gauge
  redis_connected_clients 1

  # HELP redis_memory_used_bytes memory_used_bytes metric
  # TYPE redis_memory_used_bytes gauge
  redis_memory_used_bytes 1.046336e+06

  # HELP redis_instance_info instance_info metric
  # TYPE redis_instance_info gauge
  redis_instance_info{redis_mode="standalone",redis_version="7.4.8",role="master"} 1
  ```

  Template syntax validation:

  ```bash
  nuclei -validate -t http/misconfiguration/redis-exporter-metrics.yaml -lfa
  ```

  Result:

  ```text
  All templates validated successfully
  ```

  True Positive scan:

  ```bash
  nuclei -t http/misconfiguration/redis-exporter-metrics.yaml -u http://127.0.0.1:19121 -duc -lfa -silent
  ```

  Result:

  ```text
  [redis-exporter-metrics] [http] [low] http://127.0.0.1:19121/metrics
  ```

  False Positive check against the Redis TCP service directly:

  ```bash
  nuclei -t http/misconfiguration/redis-exporter-metrics.yaml -u http://127.0.0.1:16379 -duc -lfa -silent
  ```

  Result:

  ```text
  No results found.
  ```

  Cleanup:

  ```bash
  docker stop nuclei-redis-exporter nuclei-redis-exporter-redis
  ```

  ### Additional References:

  - [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
  - [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
  - [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
  - [PD-Community Discord server](https://discord.gg/projectdiscovery)