### PR TITLE
Add Langfuse Panel detection template

### DIFF
--- a/http/exposed-panels/langfuse-panel.yaml
+++ b/http/exposed-panels/langfuse-panel.yaml
@@ -33,5 +33,5 @@ http:
         dsl:
           - 'status_code == 200 && contains(to_lower(body), "<title>langfuse")'
           - 'status_code == 200 && contains(to_lower(header), "x-langfuse-")'
-          - 'status_code == 200 && contains(body, "\"status\":\"OK\"", "version") && contains(to_lower(header), "application/json") && contains(path, "/api/public/health")'
+          - 'status_code == 200 && contains_all(body, "\"status\":\"OK\"", "version") && contains(to_lower(content_type), "application/json") && contains(path, "/api/public/health")'
         condition: or

--- a/http/exposed-panels/langfuse-panel.yaml
+++ b/http/exposed-panels/langfuse-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: langfuse
     shodan-query: http.title:"Langfuse"
     fofa-query: title="Langfuse"
-  tags: panel,langfuse,llm,ai,detect
+  tags: panel,langfuse,llm,ai,detect,login
 
 http:
   - method: GET

--- a/http/exposed-panels/langfuse-panel.yaml
+++ b/http/exposed-panels/langfuse-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: langfuse
     shodan-query: http.title:"Langfuse"
     fofa-query: title="Langfuse"
-  tags: panel,langfuse,llm,ai,observability,detect,discovery
+  tags: panel,langfuse,llm,ai,detect
 
 http:
   - method: GET
@@ -31,7 +31,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "<title>langfuse</title>")'
+          - 'status_code == 200 && contains(to_lower(body), "<title>langfuse")'
           - 'status_code == 200 && contains(to_lower(header), "x-langfuse-")'
-          - 'status_code == 200 && contains(body, "\"status\":\"OK\"") && contains(body, "version") && contains(to_lower(header), "application/json") && contains(path, "/api/public/health")'
+          - 'status_code == 200 && contains(body, "\"status\":\"OK\"", "version") && contains(to_lower(header), "application/json") && contains(path, "/api/public/health")'
         condition: or

--- a/http/exposed-panels/langfuse-panel.yaml
+++ b/http/exposed-panels/langfuse-panel.yaml
@@ -1,0 +1,37 @@
+id: langfuse-panel
+
+info:
+  name: Langfuse Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Langfuse panel was detected. Langfuse is an open-source LLM engineering platform for observability, evaluations, prompt management and analytics. Exposed instances may reveal LLM prompts, traces, evaluations, and connected API keys.
+  reference:
+    - https://github.com/langfuse/langfuse
+    - https://langfuse.com/
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: langfuse
+    product: langfuse
+    shodan-query: http.title:"Langfuse"
+    fofa-query: title="Langfuse"
+  tags: panel,langfuse,llm,ai,observability,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/api/public/health"
+
+    host-redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>langfuse</title>")'
+          - 'status_code == 200 && contains(to_lower(header), "x-langfuse-")'
+          - 'status_code == 200 && contains(body, "\"status\":\"OK\"") && contains(body, "version") && contains(to_lower(header), "application/json") && contains(path, "/api/public/health")'
+        condition: or


### PR DESCRIPTION
Langfuse is a popular open-source LLM observability + evaluations platform ([github.com/langfuse/langfuse](https://github.com/langfuse/langfuse), [langfuse.com](https://langfuse.com/)). Exposed self-hosted instances may reveal LLM prompts, traces, evaluations, and connected API keys.

No existing `langfuse` template in the repo (`find . -iname '*langfuse*'` → 0 hits).

### Detection signatures
- `<title>Langfuse</title>` on the root page
- `x-langfuse-*` response header (the API server emits these)
- `/api/public/health` returning a JSON object with `"status":"OK"` and a `version` field

Three OR'd matchers cover both the marketing landing page and a stripped-down API-only deployment. Validated with `nuclei -validate`.
