### PR TITLE
Add Airbyte Panel detection template

### DIFF
--- a/http/exposed-panels/airbyte-panel.yaml
+++ b/http/exposed-panels/airbyte-panel.yaml
@@ -1,0 +1,37 @@
+id: airbyte-panel
+
+info:
+  name: Airbyte Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Airbyte panel was detected. Airbyte (airbyte.com / github.com/airbytehq/airbyte) is a popular open-source data integration platform. Self-hosted Airbyte instances expose an admin UI and a REST/GraphQL API at /api/v1/ that — when reachable without authentication — leak source/destination configurations including credentials.
+  reference:
+    - https://github.com/airbytehq/airbyte
+    - https://airbyte.com/
+    - https://docs.airbyte.com/api-documentation
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: airbyte
+    product: airbyte
+    shodan-query: http.title:"Airbyte"
+    fofa-query: title="Airbyte"
+  tags: panel,airbyte,data-integration,etl,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/api/v1/health"
+
+    host-redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>airbyte</title>")'
+          - 'status_code == 200 && contains(body, "\"available\":true") && contains(to_lower(header), "application/json")'
+        condition: or

--- a/http/exposed-panels/airbyte-panel.yaml
+++ b/http/exposed-panels/airbyte-panel.yaml
@@ -5,7 +5,7 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    Airbyte panel was detected. Airbyte (airbyte.com / github.com/airbytehq/airbyte) is a popular open-source data integration platform. Self-hosted Airbyte instances expose an admin UI and a REST/GraphQL API at /api/v1/ that — when reachable without authentication — leak source/destination configurations including credentials.
+    Airbyte panel was detected. Airbyte is a popular open-source data integration platform.
   reference:
     - https://github.com/airbytehq/airbyte
     - https://airbyte.com/
@@ -17,7 +17,7 @@ info:
     product: airbyte
     shodan-query: http.title:"Airbyte"
     fofa-query: title="Airbyte"
-  tags: panel,airbyte,data-integration,etl,detect,discovery
+  tags: panel,airbyte,login,detect,discovery
 
 http:
   - method: GET
@@ -26,12 +26,11 @@ http:
       - "{{BaseURL}}/api/v1/health"
 
     host-redirects: true
-    max-redirects: 2
     stop-at-first-match: true
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "<title>airbyte</title>")'
-          - 'status_code == 200 && contains(body, "\"available\":true") && contains(to_lower(header), "application/json")'
-        condition: or
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>airbyte</title>") || contains(body, "\"available\":true") && contains(to_lower(header), "application/json")'
+        condition: and

--- a/http/exposed-panels/airbyte-panel.yaml
+++ b/http/exposed-panels/airbyte-panel.yaml
@@ -17,7 +17,7 @@ info:
     product: airbyte
     shodan-query: http.title:"Airbyte"
     fofa-query: title="Airbyte"
-  tags: panel,airbyte,login,detect,discovery
+  tags: panel,airbyte,login,detect
 
 http:
   - method: GET
@@ -26,11 +26,12 @@ http:
       - "{{BaseURL}}/api/v1/health"
 
     host-redirects: true
+    max-redirects: 2
     stop-at-first-match: true
 
     matchers:
       - type: dsl
         dsl:
+          - 'contains_any(to_lower(body), "<title>airbyte", "name=\"airbyte:")'
           - 'status_code == 200'
-          - 'contains(to_lower(body), "<title>airbyte</title>") || contains(body, "\"available\":true") && contains(to_lower(header), "application/json")'
         condition: and


### PR DESCRIPTION
Airbyte ([airbyte.com](https://airbyte.com/) / [github.com/airbytehq/airbyte](https://github.com/airbytehq/airbyte)) is a popular open-source data integration platform. Self-hosted Airbyte instances expose an admin UI and a REST/GraphQL API at `/api/v1/` that — when reachable without authentication — leak source/destination configurations including credentials.

No existing `airbyte` template in the repo.

### Detection signatures
- `<title>Airbyte</title>` on the root page
- `/api/v1/health` returns 200 with `{"available":true}` and a JSON content-type

Validated with `nuclei -validate`.