### PR TITLE
Add LocalStack detection template

### DIFF
--- a/http/exposed-panels/localstack-detect.yaml
+++ b/http/exposed-panels/localstack-detect.yaml
@@ -1,0 +1,41 @@
+id: localstack-detect
+
+info:
+  name: LocalStack - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    LocalStack (localstack.cloud / github.com/localstack/localstack) is a local AWS cloud-service emulator widely used in development and CI. It typically listens on TCP 4566 and exposes an unauthenticated /_localstack/health endpoint that lists every emulated service and its enabled state. An exposed LocalStack on a non-loopback interface gives an attacker a fully-functional fake AWS account, including S3, SQS, IAM, SecretsManager and Lambda execution.
+  reference:
+    - https://github.com/localstack/localstack
+    - https://docs.localstack.cloud/references/internal-endpoints/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: localstack
+    product: localstack
+    shodan-query: '"localstack"'
+    fofa-query: 'body="LocalStack"'
+  tags: localstack,aws,cloud,detect,discovery,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/_localstack/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"services\"")'
+          - 'contains(body, "\"edition\"") || contains(body, "\"version\"")'
+          - 'contains(to_lower(header), "application/json")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'
+          - '"edition"\s*:\s*"([^"]+)"'

--- a/http/technologies/localstack-detect.yaml
+++ b/http/technologies/localstack-detect.yaml
@@ -16,7 +16,7 @@ info:
     product: localstack
     shodan-query: '"localstack"'
     fofa-query: 'body="LocalStack"'
-  tags: localstack,aws,cloud,detect,discovery,exposure
+  tags: localstack,aws,cloud,detect,discovery,tech
 
 http:
   - method: GET


### PR DESCRIPTION
[LocalStack](https://github.com/localstack/localstack) is a local AWS cloud-service emulator widely used in development and CI. It typically listens on TCP 4566 and exposes an unauthenticated `/_localstack/health` endpoint that lists every emulated service and its enabled state. An exposed LocalStack on a non-loopback interface gives an attacker a fully-functional fake AWS account, including S3, SQS, IAM, SecretsManager and Lambda execution.

No existing `localstack` template in the repo.

### Detection signature
- `/_localstack/health` returns 200 with a JSON body containing `"services"` map and either `"edition"` or `"version"` fields

Includes regex extractors for the version and edition values. Validated with `nuclei -validate`.