### PR TITLE
Add LobeChat detection template

### DIFF
--- a/http/exposed-panels/lobechat-panel.yaml
+++ b/http/exposed-panels/lobechat-panel.yaml
@@ -1,0 +1,34 @@
+id: lobechat-panel
+
+info:
+  name: LobeChat Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    LobeChat (lobehub.com / github.com/lobehub/lobe-chat) is a popular open-source ChatGPT/Claude-style AI chat UI, frequently self-hosted via Docker on TCP 3210. Exposed instances without an ACCESS_CODE may reveal conversation history and let any caller burn the operator's API credits via the proxied LLM endpoints.
+  reference:
+    - https://github.com/lobehub/lobe-chat
+    - https://lobehub.com/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: lobehub
+    product: lobe-chat
+    shodan-query: http.title:"LobeChat"
+    fofa-query: title="LobeChat"
+  tags: panel,lobechat,llm,ai,chat,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>lobechat</title>")'
+          - 'status_code == 200 && contains(body, "lobehub") && contains(body, "lobe-chat")'
+        condition: or


### PR DESCRIPTION
[LobeChat](https://github.com/lobehub/lobe-chat) is a popular open-source ChatGPT/Claude-style AI chat UI, frequently self-hosted via Docker on TCP 3210. Exposed instances without an `ACCESS_CODE` may reveal conversation history and let any caller burn the operator's API credits via the proxied LLM endpoints.

No existing `lobechat` / `lobe-chat` template in the repo.

### Detection signatures
- `<title>LobeChat</title>` on the root page
- body containing both `lobehub` and `lobe-chat` (covers SPA shells)

Validated with `nuclei -validate`.