### PR TITLE
Add Mage AI detection template

### DIFF
--- a/http/exposed-panels/mageai-panel.yaml
+++ b/http/exposed-panels/mageai-panel.yaml
@@ -1,0 +1,37 @@
+id: mageai-panel
+
+info:
+  name: Mage AI Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Mage AI (mage.ai / github.com/mage-ai/mage-ai) is an open-source data pipeline + orchestration platform with a notebook-style UI. Self-hosted instances default to TCP 6789 and historically have shipped without authentication. Exposed instances may reveal pipeline source, secrets, and provide an authenticated path to arbitrary code execution via custom blocks.
+  reference:
+    - https://github.com/mage-ai/mage-ai
+    - https://docs.mage.ai/
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: mage_ai
+    product: mage-ai
+    shodan-query: http.title:"Mage"
+    fofa-query: title="Mage"
+  tags: panel,mage-ai,mageai,data-pipeline,orchestration,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/api/status"
+
+    host-redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>mage</title>")'
+          - 'status_code == 200 && contains(body, "mage-ai")'
+          - 'status_code == 200 && contains(body, "\"status\":\"OK\"") && contains(body, "\"is_instance_healthy\":true")'
+        condition: or

--- a/http/exposed-panels/mageai-panel.yaml
+++ b/http/exposed-panels/mageai-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: mage-ai
     shodan-query: http.title:"Mage"
     fofa-query: title="Mage"
-  tags: panel,mage-ai,mageai,data-pipeline,orchestration,detect,discovery
+  tags: panel,mageai,detect
 
 http:
   - method: GET
@@ -32,6 +32,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200 && contains(to_lower(body), "<title>mage</title>")'
-          - 'status_code == 200 && contains(body, "mage-ai")'
-          - 'status_code == 200 && contains(body, "\"status\":\"OK\"") && contains(body, "\"is_instance_healthy\":true")'
+          - 'status_code == 200 && contains_all(body, "status\":\"OK", "\"is_instance_healthy\":true")'
         condition: or

--- a/http/exposed-panels/mageai-panel.yaml
+++ b/http/exposed-panels/mageai-panel.yaml
@@ -33,4 +33,5 @@ http:
         dsl:
           - 'status_code == 200 && contains(to_lower(body), "<title>mage</title>")'
           - 'status_code == 200 && contains_all(body, "status\":\"OK", "\"is_instance_healthy\":true")'
+          - 'status_code == 200 && contains_all(body, "statuses\":", "is_instance_manager\":", "scheduler_status\":")'
         condition: or


### PR DESCRIPTION
[Mage AI](https://github.com/mage-ai/mage-ai) is an open-source data pipeline + orchestration platform with a notebook-style UI. Self-hosted instances default to TCP 6789 and historically have shipped without authentication. Exposed instances may reveal pipeline source, secrets, and provide an authenticated path to arbitrary code execution via custom blocks.

No existing `mage-ai` / `mageai` template in the repo (the existing `mage` matches are for unrelated tools).

### Detection signatures
- `<title>Mage</title>` on the root page
- `mage-ai` token in body (covers SPA shells)
- `/api/status` returning `{"status":"OK","is_instance_healthy":true}`

Validated with `nuclei -validate`.