### PR TITLE
Add Paperless-ngx detection template

### DIFF
--- a/http/exposed-panels/paperless-ngx-panel.yaml
+++ b/http/exposed-panels/paperless-ngx-panel.yaml
@@ -1,0 +1,34 @@
+id: paperless-ngx-panel
+
+info:
+  name: Paperless-ngx Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Paperless-ngx (paperless-ngx.com / github.com/paperless-ngx/paperless-ngx) is a hugely popular self-hosted document-management platform for scanning, OCR-ing and tagging paper documents. Default Docker port 8000. Exposed instances may reveal personal/business documents and provide a path to the upload endpoint.
+  reference:
+    - https://github.com/paperless-ngx/paperless-ngx
+    - https://docs.paperless-ngx.com/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: paperless-ngx
+    product: paperless-ngx
+    shodan-query: http.title:"Paperless-ngx"
+    fofa-query: title="Paperless-ngx"
+  tags: panel,paperless-ngx,paperless,document-management,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>paperless-ngx</title>")'
+          - 'status_code == 200 && contains(body, "paperless-ngx") && contains(body, "<base href=")'
+        condition: or

--- a/http/exposed-panels/paperless-ngx-panel.yaml
+++ b/http/exposed-panels/paperless-ngx-panel.yaml
@@ -5,7 +5,7 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    Paperless-ngx (paperless-ngx.com / github.com/paperless-ngx/paperless-ngx) is a hugely popular self-hosted document-management platform for scanning, OCR-ing and tagging paper documents. Default Docker port 8000. Exposed instances may reveal personal/business documents and provide a path to the upload endpoint.
+    Detected Paperless-ngx was a self-hosted document management platform for scanning, OCR-ing and tagging paper documents.
   reference:
     - https://github.com/paperless-ngx/paperless-ngx
     - https://docs.paperless-ngx.com/
@@ -16,19 +16,16 @@ info:
     product: paperless-ngx
     shodan-query: http.title:"Paperless-ngx"
     fofa-query: title="Paperless-ngx"
-  tags: panel,paperless-ngx,paperless,document-management,selfhosted,detect,discovery
+  tags: panel,paperless-ngx,paperless,discovery,detect
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}"
-
-    host-redirects: true
-    max-redirects: 2
+      - "{{BaseURL}}/accounts/login/"
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "<title>paperless-ngx</title>")'
-          - 'status_code == 200 && contains(body, "paperless-ngx") && contains(body, "<base href=")'
-        condition: or
+          - 'status_code == 200'
+          - 'contains_all(body, "Paperless-ngx", "Paperless-ngx project and contributors")'
+        condition: and


### PR DESCRIPTION
[Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) is a hugely popular self-hosted document-management platform for scanning, OCR-ing and tagging paper documents. Default Docker port 8000. Exposed instances may reveal personal/business documents and provide a path to the upload endpoint.

No existing `paperless-ngx` / `paperless` template in the repo.

### Detection signatures
- `<title>Paperless-ngx</title>` on the root page
- body containing both `paperless-ngx` and a `<base href=` tag (the SPA marker)

Validated with `nuclei -validate`.