### PR TITLE
Add ZITADEL detection template

### DIFF
--- a/http/exposed-panels/zitadel-panel.yaml
+++ b/http/exposed-panels/zitadel-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: zitadel
     shodan-query: '"X-Zitadel"'
     fofa-query: title="ZITADEL"
-  tags: panel,zitadel,iam,oidc,auth,detect
+  tags: panel,zitadel,iam,oidc,detect
 
 http:
   - method: GET
@@ -29,6 +29,6 @@ http:
     matchers:
       - type: dsl
         dsl:
+          - 'contains_all(body, "ZITADEL", "<cnsl-root>")'
           - 'status_code == 200'
-          - 'contains_all(body, "ZITADEL", "<cnsl-root>", "www.zitadel.com")'
         condition: and

--- a/http/exposed-panels/zitadel-panel.yaml
+++ b/http/exposed-panels/zitadel-panel.yaml
@@ -1,0 +1,44 @@
+id: zitadel-panel
+
+info:
+  name: ZITADEL Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    ZITADEL (zitadel.com / github.com/zitadel/zitadel) is an open-source identity infrastructure platform — an Auth0/Keycloak alternative providing OIDC, OAuth 2.0, SAML and machine-user IAM. Exposed self-hosted instances may reveal organization/project layout via the unauthenticated discovery and login endpoints, and provide a starting point for credential or token attacks.
+  reference:
+    - https://github.com/zitadel/zitadel
+    - https://zitadel.com/docs
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: zitadel
+    product: zitadel
+    shodan-query: '"X-Zitadel"'
+    fofa-query: 'header="X-Zitadel"'
+  tags: panel,zitadel,iam,oidc,auth,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/openid-configuration"
+      - "{{BaseURL}}/ui/login"
+
+    host-redirects: true
+    max-redirects: 2
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(body, "issuer") && contains(to_lower(header), "x-zitadel-")'
+          - 'status_code == 200 && contains(to_lower(body), "<title>zitadel</title>")'
+          - 'status_code == 200 && contains(body, "zitadel") && contains(body, "oidc")'
+        condition: or
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - 'X-Zitadel-Trace-Id:\s*([a-f0-9]+)'

--- a/http/exposed-panels/zitadel-panel.yaml
+++ b/http/exposed-panels/zitadel-panel.yaml
@@ -5,40 +5,30 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    ZITADEL (zitadel.com / github.com/zitadel/zitadel) is an open-source identity infrastructure platform — an Auth0/Keycloak alternative providing OIDC, OAuth 2.0, SAML and machine-user IAM. Exposed self-hosted instances may reveal organization/project layout via the unauthenticated discovery and login endpoints, and provide a starting point for credential or token attacks.
+    Detected ZITADEL was an open-source identity infrastructure platform providing OIDC, OAuth 2.0, SAML and machine-user IAM.
   reference:
     - https://github.com/zitadel/zitadel
     - https://zitadel.com/docs
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: zitadel
     product: zitadel
     shodan-query: '"X-Zitadel"'
-    fofa-query: 'header="X-Zitadel"'
-  tags: panel,zitadel,iam,oidc,auth,detect,discovery
+    fofa-query: title="ZITADEL"
+  tags: panel,zitadel,iam,oidc,auth,detect
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/.well-known/openid-configuration"
-      - "{{BaseURL}}/ui/login"
+      - "{{BaseURL}}/ui/console/"
 
     host-redirects: true
     max-redirects: 2
-    stop-at-first-match: true
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(body, "issuer") && contains(to_lower(header), "x-zitadel-")'
-          - 'status_code == 200 && contains(to_lower(body), "<title>zitadel</title>")'
-          - 'status_code == 200 && contains(body, "zitadel") && contains(body, "oidc")'
-        condition: or
-
-    extractors:
-      - type: regex
-        part: header
-        group: 1
-        regex:
-          - 'X-Zitadel-Trace-Id:\s*([a-f0-9]+)'
+          - 'status_code == 200'
+          - 'contains_all(body, "ZITADEL", "<cnsl-root>", "www.zitadel.com")'
+        condition: and


### PR DESCRIPTION
[ZITADEL](https://github.com/zitadel/zitadel) is a popular open-source identity infrastructure platform — an Auth0/Keycloak alternative providing OIDC, OAuth 2.0, SAML and machine-user IAM. Exposed self-hosted instances may reveal organization/project layout via the unauthenticated discovery and login endpoints, and provide a starting point for credential or token attacks.

No existing `zitadel` template in the repo.

### Detection signatures
- `/.well-known/openid-configuration` returning JSON with an `issuer` field plus an `X-Zitadel-*` response header (uniquely distinguishes ZITADEL from other OIDC providers)
- `<title>ZITADEL</title>` on the login UI
- body containing both `zitadel` and `oidc`

Includes regex extractor for the `X-Zitadel-Trace-Id` header. Validated with `nuclei -validate`.