### PR TITLE
Add Linkwarden detection template

### DIFF
--- a/http/exposed-panels/linkwarden-panel.yaml
+++ b/http/exposed-panels/linkwarden-panel.yaml
@@ -29,6 +29,12 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "<title>linkwarden</title>")'
-          - 'status_code == 200 && contains(body, "linkwarden") && contains(body, "_next")'
-        condition: or
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>linkwarden</title>")'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "linkwarden", "_next")'
+        condition: and

--- a/http/exposed-panels/linkwarden-panel.yaml
+++ b/http/exposed-panels/linkwarden-panel.yaml
@@ -1,0 +1,34 @@
+id: linkwarden-panel
+
+info:
+  name: Linkwarden Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Linkwarden (linkwarden.app / github.com/linkwarden/linkwarden) is a popular open-source self-hosted bookmark and link archiving manager. Default Docker port 3000. Exposed instances may reveal users' archived link collections, screenshots, and PDFs.
+  reference:
+    - https://github.com/linkwarden/linkwarden
+    - https://linkwarden.app/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: linkwarden
+    product: linkwarden
+    shodan-query: http.title:"Linkwarden"
+    fofa-query: title="Linkwarden"
+  tags: panel,linkwarden,bookmarks,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>linkwarden</title>")'
+          - 'status_code == 200 && contains(body, "linkwarden") && contains(body, "_next")'
+        condition: or


### PR DESCRIPTION
[Linkwarden](https://github.com/linkwarden/linkwarden) is a popular open-source self-hosted bookmark and link-archiving manager. Default Docker port 3000. Exposed instances may reveal users' archived link collections, screenshots, and PDFs.

No existing `linkwarden` template in the repo.

### Detection signatures
- `<title>Linkwarden</title>` on the root page
- body containing both `linkwarden` and `_next` (the Next.js build marker — this is a Next.js app)

Validated with `nuclei -validate`.