### PR TITLE
Add Supabase Studio detection template

### DIFF
--- a/http/exposed-panels/supabase-studio-panel.yaml
+++ b/http/exposed-panels/supabase-studio-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: supabase
     shodan-query: http.title:"Supabase Studio"
     fofa-query: title="Supabase Studio"
-  tags: panel,supabase,studio,detect,discovery
+  tags: panel,supabase,studio,detect,discovery,login
 
 http:
   - method: GET

--- a/http/exposed-panels/supabase-studio-panel.yaml
+++ b/http/exposed-panels/supabase-studio-panel.yaml
@@ -5,31 +5,29 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    Supabase Studio (supabase.com / github.com/supabase/supabase) is the admin dashboard shipped with Supabase, the popular open-source Firebase alternative (Postgres + auth + realtime + storage + edge functions). Self-hosted Studio defaults to TCP 3000 inside the supabase/postgres-meta stack and historically has shipped with no auth — exposed instances grant browser-driven full DB read/write access.
+    Supabase Studio login panel was detected. The admin dashboard shipped with Supabase, the popular open-source Firebase alternative (Postgres + auth + realtime + storage + edge functions).
   reference:
     - https://github.com/supabase/supabase
     - https://supabase.com/docs/guides/self-hosting
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: supabase
     product: supabase
     shodan-query: http.title:"Supabase Studio"
     fofa-query: title="Supabase Studio"
-  tags: panel,supabase,studio,postgres,baas,detect,discovery
+  tags: panel,supabase,studio,detect,discovery
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
+      - "{{BaseURL}}/_login"
 
-    host-redirects: true
-    max-redirects: 2
-
+    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "<title>supabase studio</title>")'
-          - 'status_code == 200 && contains(body, "supabase-studio") && contains(body, "_next")'
-          - 'status_code == 200 && contains(body, "Supabase Studio") && contains(body, "/_next/static/")'
-        condition: or
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>supabase studio")'
+        condition: and

--- a/http/exposed-panels/supabase-studio-panel.yaml
+++ b/http/exposed-panels/supabase-studio-panel.yaml
@@ -1,0 +1,35 @@
+id: supabase-studio-panel
+
+info:
+  name: Supabase Studio Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Supabase Studio (supabase.com / github.com/supabase/supabase) is the admin dashboard shipped with Supabase, the popular open-source Firebase alternative (Postgres + auth + realtime + storage + edge functions). Self-hosted Studio defaults to TCP 3000 inside the supabase/postgres-meta stack and historically has shipped with no auth — exposed instances grant browser-driven full DB read/write access.
+  reference:
+    - https://github.com/supabase/supabase
+    - https://supabase.com/docs/guides/self-hosting
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: supabase
+    product: supabase
+    shodan-query: http.title:"Supabase Studio"
+    fofa-query: title="Supabase Studio"
+  tags: panel,supabase,studio,postgres,baas,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "<title>supabase studio</title>")'
+          - 'status_code == 200 && contains(body, "supabase-studio") && contains(body, "_next")'
+          - 'status_code == 200 && contains(body, "Supabase Studio") && contains(body, "/_next/static/")'
+        condition: or


### PR DESCRIPTION
[Supabase Studio](https://github.com/supabase/supabase) is the admin dashboard shipped with Supabase, the popular open-source Firebase alternative (Postgres + auth + realtime + storage + edge functions). Self-hosted Studio defaults to TCP 3000 inside the `supabase/postgres-meta` stack and historically has shipped with **no auth** — exposed instances grant browser-driven full DB read/write access.

No existing `supabase` template in the repo.

### Detection signatures
- `<title>Supabase Studio</title>` on the root page
- body containing `supabase-studio` and `_next` (Next.js marker)
- body containing `Supabase Studio` and `/_next/static/` (covers SPA shells where the title isn't server-rendered)

Validated with `nuclei -validate`.