### PR TITLE
Add CVE-2024-32114 - Apache ActiveMQ unauthenticated Jolokia/Message API access

### DIFF
--- a/http/cves/2024/CVE-2024-32114.yaml
+++ b/http/cves/2024/CVE-2024-32114.yaml
@@ -1,0 +1,60 @@
+id: CVE-2024-32114
+
+info:
+  name: Apache ActiveMQ 6.x < 6.1.2 - Unauthenticated Jolokia/Message API Access
+  author: ChrisJr404
+  severity: high
+  description: |
+    Apache ActiveMQ 6.x prior to 6.1.2 ships with a default configuration that does not secure the API web context. The Jolokia JMX REST API and the Message REST API at `/api/jolokia/` and `/api/message/` are exposed without authentication, allowing unauthenticated remote attackers to enumerate MBeans, invoke broker operations, and produce or consume messages. When chained with CVE-2026-34197, this enables pre-auth remote code execution.
+  impact: |
+    An unauthenticated attacker can interact with the message broker, list and read JMX MBeans, manage queues, and invoke arbitrary MBean operations - including chains that lead to remote code execution.
+  remediation: |
+    Upgrade to Apache ActiveMQ 6.1.2 or later, or update `conf/jetty.xml` to require authentication on the `/api/` web context.
+  reference:
+    - https://activemq.apache.org/security-advisories.data/CVE-2024-32114-announcement.txt
+    - https://github.com/advisories/GHSA-gj5m-m88j-v7c3
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-32114
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2024-32114
+    cwe-id: CWE-1188
+    epss-score: 0.01541
+    epss-percentile: 0.81464
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: apache
+    product: activemq
+    shodan-query: http.title:"ActiveMQ"
+    fofa-query: title="ActiveMQ"
+  tags: cve,cve2024,activemq,apache,jolokia,unauth,misconfig
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/jolokia/version"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"agent\"")'
+          - 'contains(body, "\"protocol\"")'
+          - 'contains(body, "\"status\":200")'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/jolokia/search/org.apache.activemq:type=Broker,*"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "org.apache.activemq:brokerName")'
+          - 'contains(body, "type=Broker")'
+        condition: and

--- a/http/cves/2024/CVE-2024-32114.yaml
+++ b/http/cves/2024/CVE-2024-32114.yaml
@@ -1,7 +1,7 @@
 id: CVE-2024-32114
 
 info:
-  name: Apache ActiveMQ 6.x < 6.1.2 - Unauthenticated Jolokia/Message API Access
+  name: Apache ActiveMQ 6.x < 6.1.2 - Broken Access Control
   author: ChrisJr404
   severity: high
   description: |
@@ -12,8 +12,9 @@ info:
     Upgrade to Apache ActiveMQ 6.1.2 or later, or update `conf/jetty.xml` to require authentication on the `/api/` web context.
   reference:
     - https://activemq.apache.org/security-advisories.data/CVE-2024-32114-announcement.txt
-    - https://github.com/advisories/GHSA-gj5m-m88j-v7c3
     - https://github.com/vulhub/vulhub/tree/master/activemq/CVE-2024-32114
+    - https://github.com/advisories/GHSA-gj5m-m88j-v7c3
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-32114
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
     cvss-score: 8.8
@@ -28,25 +29,9 @@ info:
     product: activemq
     shodan-query: http.title:"ActiveMQ"
     fofa-query: title="ActiveMQ"
-  tags: cve,cve2024,activemq,apache,jolokia,unauth,kev,vkev
-
-flow: http(1) && http(2)
+  tags: cve,cve2024,activemq,apache,jolokia,kev,vkev
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/jolokia/version"
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains(body, "\"agent\"")'
-          - 'contains(body, "\"protocol\"")'
-          - 'contains(body, "\"status\":200")'
-        condition: and
-        internal: true
-
   - method: GET
     path:
       - "{{BaseURL}}/api/jolokia/search/org.apache.activemq:type=Broker,*"
@@ -54,7 +39,7 @@ http:
     matchers:
       - type: dsl
         dsl:
+          - 'contains_all(body, "request\":{", "type=Broker", "mbean\":", "org.apache.activemq")'
+          - 'contains(content_type, "text/plain")'
           - 'status_code == 200'
-          - 'contains(body, "org.apache.activemq:brokerName")'
-          - 'contains(body, "type=Broker")'
         condition: and

--- a/http/cves/2024/CVE-2024-32114.yaml
+++ b/http/cves/2024/CVE-2024-32114.yaml
@@ -5,15 +5,15 @@ info:
   author: ChrisJr404
   severity: high
   description: |
-    Apache ActiveMQ 6.x prior to 6.1.2 ships with a default configuration that does not secure the API web context. The Jolokia JMX REST API and the Message REST API at `/api/jolokia/` and `/api/message/` are exposed without authentication, allowing unauthenticated remote attackers to enumerate MBeans, invoke broker operations, and produce or consume messages. When chained with CVE-2026-34197, this enables pre-auth remote code execution.
+    Apache ActiveMQ 6.x contains an unauthenticated API web context caused by default configuration lacking security measures in the Jetty server, letting anyone interact with broker APIs and messaging layers, exploit requires no authentication.
   impact: |
-    An unauthenticated attacker can interact with the message broker, list and read JMX MBeans, manage queues, and invoke arbitrary MBean operations - including chains that lead to remote code execution.
+    Unauthenticated users can interact with the broker, potentially producing, consuming, or deleting messages and accessing sensitive management APIs.
   remediation: |
     Upgrade to Apache ActiveMQ 6.1.2 or later, or update `conf/jetty.xml` to require authentication on the `/api/` web context.
   reference:
     - https://activemq.apache.org/security-advisories.data/CVE-2024-32114-announcement.txt
     - https://github.com/advisories/GHSA-gj5m-m88j-v7c3
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-32114
+    - https://github.com/vulhub/vulhub/tree/master/activemq/CVE-2024-32114
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
     cvss-score: 8.8
@@ -28,7 +28,7 @@ info:
     product: activemq
     shodan-query: http.title:"ActiveMQ"
     fofa-query: title="ActiveMQ"
-  tags: cve,cve2024,activemq,apache,jolokia,unauth,misconfig
+  tags: cve,cve2024,activemq,apache,jolokia,unauth,kev,vkev
 
 flow: http(1) && http(2)
 


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2024-32114** — Apache ActiveMQ 6.x prior to 6.1.2 ships with a default `conf/jetty.xml` that does not protect the `/api/` web context, leaving the Jolokia JMX REST API and the Message REST API exposed without authentication. An unauthenticated attacker can list and read MBeans, manage queues, and invoke arbitrary MBean operations — and chain this with CVE-2026-34197 for pre-auth RCE.

References:
- https://activemq.apache.org/security-advisories.data/CVE-2024-32114-announcement.txt
- https://github.com/advisories/GHSA-gj5m-m88j-v7c3
- https://nvd.nist.gov/vuln/detail/CVE-2024-32114

### Detection logic
Two-step flow that proves both (a) the API context is reachable without credentials and (b) the target is actually ActiveMQ:

1. `GET /api/jolokia/version` must return `200` with a Jolokia version JSON body containing `"agent"`, `"protocol"`, and `"status":200`. On a patched 6.1.2+ default install this returns `401 Unauthorized` instead.
2. `GET /api/jolokia/search/org.apache.activemq:type=Broker,*` must return `200` with the broker MBean enumeration containing `org.apache.activemq:brokerName` and `type=Broker`. This rejects non-ActiveMQ Jolokia agents that happen to live under `/api/`.

### Verification
Tested locally against `vulhub/activemq:6.1.1` (vulnerable) and `apache/activemq-classic:6.1.6` (patched) on a clean Kali host.

**Vulnerable target — match (template behaves as expected):**

```
[VER] [CVE-2024-32114] Sent HTTP request to http://localhost:8161/api/jolokia/version
[VER] [CVE-2024-32114] Sent HTTP request to http://localhost:8161/api/jolokia/search/org.apache.activemq:type=Broker,*
[CVE-2024-32114] [http] [high] http://localhost:8161/api/jolokia/search/org.apache.activemq:type=Broker,*
[INF] Scan completed in 17.898523ms. 1 matches found.
```

`/api/jolokia/version` response (truncated):
```
HTTP/1.1 200 OK
Content-Type: text/plain;charset=utf-8
{"request":{"type":"version"},"value":{"agent":"2.0.0-M4","protocol":"7.2",...,"secured":false,...},"status":200}
```

`/api/jolokia/search/...` response (truncated):
```
HTTP/1.1 200 OK
{"request":{"mbean":"org.apache.activemq:type=Broker,*","type":"search"},"value":["org.apache.activemq:brokerName=localhost,service=Health,type=Broker",...,"org.apache.activemq:brokerName=localhost,connector=clientConnectors,connectorName=openwire,type=Broker",...],"status":200}
```

**Patched target — no match (no false positive):**

```
[VER] [CVE-2024-32114] Sent HTTP request to http://localhost:18161/api/jolokia/version
[INF] Scan completed in 7.657722ms. No results found.
```

`/api/jolokia/version` on the patched 6.1.6 instance returns:
```
HTTP/1.1 401 Unauthorized
HTTP ERROR 401 Unauthorized
URI: /api/jolokia/version
```
The `flow:` short-circuits after the first request fails the matcher, so the broker probe is never sent.

### Reproduction
Both environments are upstream-published images and require no custom build:

```bash
# vulnerable
docker run -d --name amq-vuln    -p 8161:8161  vulhub/activemq:6.1.1
# patched
docker run -d --name amq-patched -p 18161:8161 apache/activemq-classic:6.1.6
nuclei -t http/cves/2024/CVE-2024-32114.yaml -u http://localhost:8161   # match
nuclei -t http/cves/2024/CVE-2024-32114.yaml -u http://localhost:18161  # no match
```

The vulhub environment is also published at `vulhub/vulhub` under `activemq/CVE-2024-32114/`.

### Template Type / Checklist
- [x] CVE template (http/cves/2024/)
- [x] Verified (`metadata.verified: true`)
- [x] Two distinct matchers to reduce false positives
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced