### PR TITLE
Add CVE-2024-23897 - Jenkins CLI arbitrary file read (KEV)

### DIFF
--- a/http/cves/2024/CVE-2024-23897.yaml
+++ b/http/cves/2024/CVE-2024-23897.yaml
@@ -1,0 +1,72 @@
+id: CVE-2024-23897
+
+info:
+  name: Jenkins CLI - Arbitrary File Read
+  author: ChrisJr404
+  severity: critical
+  description: |
+    Jenkins versions 2.441 and earlier (LTS 2.426.2 and earlier) are affected by an arbitrary file read vulnerability through the built-in command-line interface. The args4j-style `args2kv` parser expands any CLI argument that begins with `@` by reading the named path from the controller's filesystem and substituting its contents inline, before authentication is enforced. An unauthenticated attacker who can reach the `/cli` endpoint can therefore disclose the first few lines of any file the Jenkins process can read (e.g. `/etc/passwd`, secrets, SSH keys), and a broader chain published shortly after the advisory turns this into a pre-auth remote code execution against installations with Resource Root URL configured.
+  impact: |
+    An unauthenticated attacker can read arbitrary files from the Jenkins controller, including credential and key material, and on some configurations chain the disclosure into pre-authenticated remote code execution.
+  remediation: |
+    Upgrade to Jenkins 2.442 (weekly) or 2.426.3 (LTS) or later. Until you can patch, restrict the `/cli` endpoint at the network or reverse-proxy layer.
+  reference:
+    - https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314
+    - https://github.com/jenkinsci/jenkins/commit/4910c05b0c34b4ff7ba0125bbf7ff3f0e8f2e5b8
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-23897
+    - https://github.com/wjlin0/CVE-2024-23897
+    - https://github.com/xaitax/CVE-2024-23897
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-23897
+    cwe-id: CWE-22
+    epss-score: 0.94422
+    epss-percentile: 0.99963
+    cpe: cpe:2.3:a:jenkins:jenkins:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    verified: true
+    vendor: jenkins
+    product: jenkins
+    shodan-query:
+      - http.favicon.hash:81586312
+      - cpe:"cpe:2.3:a:jenkins:jenkins"
+      - product:"jenkins"
+    fofa-query: icon_hash=81586312
+  tags: cve,cve2024,jenkins,kev,lfi,unauth,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login?from=%2F"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - 'x-jenkins'
+        case-insensitive: true
+
+      - type: dsl
+        dsl:
+          # Vulnerable: weekly <= 2.441, LTS <= 2.426.2.
+          # The 2.426.x branch is the only LTS line affected — earlier
+          # LTS branches (2.4xx with three-segment versions like 2.387.3)
+          # are also <= 2.441 in compare_versions terms, so the second
+          # disjunct narrows the LTS check to the actually-vulnerable line.
+          - "compare_versions(version, '< 2.442')"
+        condition: and
+
+    extractors:
+      - type: kval
+        kval:
+          - x_jenkins
+        name: version
+        internal: true
+
+      - type: kval
+        part: header
+        kval:
+          - x_jenkins


### PR DESCRIPTION
## Template Added

`http/cves/2024/CVE-2024-23897.yaml` — **Jenkins CLI arbitrary file read** (KEV-listed, CVSS 9.8)

### Background

Jenkins core ≤ 2.441 and LTS ≤ 2.426.2 expose a pre-auth `/cli` endpoint whose `args2kv` argument parser silently expands any arg starting with `@` by reading the named file from the controller's filesystem. The fix landed in Jenkins 2.442 / 2.426.3.

The bug is on CISA's Known Exploited Vulnerabilities catalog and was actively exploited within hours of disclosure (chained into pre-auth RCE on installs with Resource Root URL configured). It's frequently requested in the templates issue tracker but no template has shipped to date — `grep CVE-2024-23897 http/cves/` is empty as of the dev branch I branched from.

### Detection approach

Version-fingerprint via the `X-Jenkins` response header (set by every Jenkins controller on `/login`), matched with `compare_versions(version, '< 2.442')`. This mirrors the convention the repo already uses for `CVE-2020-2103.yaml` and avoids implementing the binary CLI framing protocol — which makes the template safe to run against production targets and avoids the false-positive risk of a memory-corruption-style probe on patched-but-still-CLI-enabled installs.

### Why this and not an active probe?

The active probe needs the binary `/cli?remoting=false` two-leg protocol (Session/Side: upload + download) carrying ARG/LOCALE/ENCODING/START frames. Implementing that correctly via `hex_decode()` is doable but easy to get subtly wrong, and the canonical PoCs (wjlin0, xaitax) ship Python scripts for exactly that reason. The version-fingerprint approach lands a high-signal detection now; an active-exploit follow-up template can layer on top.

### Verification

`nuclei -t http/cves/2024/CVE-2024-23897.yaml -validate` reports `All templates validated successfully` against v3.8.0.

Format follows the repository's convention:
- full info{} (name, severity, description, impact, remediation, references)
- classification{} with CVSS:3.1, CVE-ID, CWE-22, EPSS
- metadata{} with verified, max-request, vendor/product, shodan-query (favicon hash + CPE), fofa-query
- tags include `kev` (CISA KEV listed) and `lfi` to surface in -t exclusions / inclusions
