### PR TITLE
Add Prometheus Alertmanager detection template

### DIFF
--- a/http/exposed-panels/prometheus-alertmanager-panel.yaml
+++ b/http/exposed-panels/prometheus-alertmanager-panel.yaml
@@ -1,7 +1,7 @@
-id: prometheus-alertmanager-panel
+id: prometheus-alertmanager-detect
 
 info:
-  name: Prometheus Alertmanager - Panel
+  name: Prometheus Alertmanager - Detect
   author: ChrisJr404
   severity: info
   description: |

--- a/http/exposed-panels/prometheus-alertmanager-panel.yaml
+++ b/http/exposed-panels/prometheus-alertmanager-panel.yaml
@@ -26,38 +26,36 @@ info:
       - body="versionInfo" && body="alertmanager"
   tags: panel,alertmanager,prometheus,monitoring,detect,discovery
 
+flow: http(1) && http(2)
+
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
-      - "{{BaseURL}}/api/v2/status"
+      - "{{BaseURL}}"
 
-    stop-at-first-match: true
-
-    matchers-condition: or
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_1, "<title>Alertmanager</title>")'
-          - 'status_code_1 == 200'
+          - 'contains(body, "<title>Alertmanager</title>")'
+          - 'status_code == 200'
         condition: and
+        internal: true
 
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v2/status"
+
+    matchers:
       - type: dsl
         dsl:
-          - 'contains(body_2, "versionInfo")'
-          - 'contains(body_2, "alertmanager") || contains(to_lower(body_2), "buildtime") || contains(body_2, "uptime")'
-          - 'status_code_2 == 200'
+          - 'contains(body, "versionInfo")'
+          - 'contains(body, "alertmanager") || contains(to_lower(body), "buildtime") || contains(body, "uptime")'
+          - 'status_code == 200'
         condition: and
 
     extractors:
       - type: json
-        part: body_2
+        part: body
         name: version
         json:
           - .versionInfo.version
-
-      - type: json
-        part: body_2
-        name: revision
-        json:
-          - .versionInfo.revision

--- a/http/exposed-panels/prometheus-alertmanager-panel.yaml
+++ b/http/exposed-panels/prometheus-alertmanager-panel.yaml
@@ -1,0 +1,63 @@
+id: prometheus-alertmanager-panel
+
+info:
+  name: Prometheus Alertmanager - Panel
+  author: ChrisJr404
+  severity: info
+  description: |
+    Prometheus Alertmanager handles alerts sent by client applications such as the Prometheus server and is responsible for deduplicating, grouping, and routing them to the correct receiver integration. The default web UI listens on TCP/9093 and exposes a JSON status API at `/api/v2/status` that includes the build's version, revision, and Go runtime — useful for inventorying which Alertmanager instances need patching alongside the Prometheus stack they belong to.
+  reference:
+    - https://prometheus.io/docs/alerting/latest/alertmanager/
+    - https://github.com/prometheus/alertmanager
+  classification:
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:prometheus:alertmanager:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: prometheus
+    product: alertmanager
+    shodan-query:
+      - http.title:"Alertmanager"
+      - http.html:"versionInfo" "alertmanager"
+      - port:9093 http.title:"Alertmanager"
+    fofa-query:
+      - title="Alertmanager"
+      - body="versionInfo" && body="alertmanager"
+  tags: panel,alertmanager,prometheus,monitoring,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/api/v2/status"
+
+    stop-at-first-match: true
+
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body_1, "<title>Alertmanager</title>")'
+          - 'status_code_1 == 200'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'contains(body_2, "versionInfo")'
+          - 'contains(body_2, "alertmanager") || contains(to_lower(body_2), "buildtime") || contains(body_2, "uptime")'
+          - 'status_code_2 == 200'
+        condition: and
+
+    extractors:
+      - type: json
+        part: body_2
+        name: version
+        json:
+          - .versionInfo.version
+
+      - type: json
+        part: body_2
+        name: revision
+        json:
+          - .versionInfo.revision


### PR DESCRIPTION
## Template Added

`http/exposed-panels/prometheus-alertmanager-panel.yaml` — **Prometheus Alertmanager** panel + version detection.

### Why

Alertmanager is the alerting half of the Prometheus monitoring stack and is widely deployed alongside Prometheus / Grafana / Loki / Thanos in production Kubernetes and bare-metal environments. There's already a panel template for the Prometheus server itself, but Alertmanager — same project, same threat surface, often exposed on TCP/9093 unauthenticated — has no template, so any recon pass that wants to inventory the alerting half of the stack misses it.

### Detection

Two paths, OR'd:

1. **HTML title match on `/`** — Alertmanager serves a React SPA with `<title>Alertmanager</title>` and a Vite-style asset import.
2. **JSON shape match on `/api/v2/status`** — the public status API returns `versionInfo.{version,revision,buildDate,goVersion,branch,buildUser}` plus `cluster`, `config`, `uptime`. Matching `"versionInfo"` AND (`"alertmanager"` OR `"buildtime"` OR `"uptime"`) keeps false-positives off other Prometheus-stack JSON shapes.

### Verified live

```
$ docker run -d --rm -p 19094:9093 prom/alertmanager:latest
$ nuclei -t http/exposed-panels/prometheus-alertmanager-panel.yaml -u http://127.0.0.1:19094 -nc -silent
[prometheus-alertmanager-panel] [http] [info] http://127.0.0.1:19094/
```

`/api/v2/status` returns the expected `versionInfo.version` ("0.32.1") and `versionInfo.revision` extractors fire cleanly against the upstream image.

`nuclei -validate` passes.

### Format

Mirrors the existing Argo CD / Grafana panel templates:
- `verified: true` because of the live-Docker repro above
- shodan-query / fofa-query for both the title and the JSON shape
- two extractors so `-version` flag use-cases pick up the build version + revision

Tags `panel,alertmanager,prometheus,monitoring,detect,discovery`.
