### PR TITLE
Add Coveralls Configuration File Exposure

### DIFF
--- a/http/exposures/configs/coveralls-configuration-file-exposure.yaml
+++ b/http/exposures/configs/coveralls-configuration-file-exposure.yaml
@@ -1,0 +1,56 @@
+id: coveralls-configuration-file-exposure
+
+info:
+  name: Coveralls Configuration File Exposure
+  author: 0x_Akoko
+  severity: medium
+  description: |
+   Detected a Coveralls configuration file (.coveralls.yml) on the target. This file could have exposed a sensitive repo_token, allowing an attacker to submit fake data, view private coverage details, or impersonate the project.
+  reference:
+    - https://docs.coveralls.io/ci-services
+    - https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html
+  classification:
+    cwe-id: CWE-538
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: html:".coveralls.yml"
+  tags: exposure,config,coveralls,token,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.coveralls.yml"
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "len(body) > 30"
+          - "contains_any(content_type, 'application/octet-stream', 'text/plain')"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "repo_token"
+          - "service_name"
+        condition: or
+
+      - type: word
+        part: response
+        words:
+          - "MongoDB over HTTP on the native"
+          - "application/javascript"
+          - "application/x-javascript"
+          - "application/json"
+          - "application/xml"
+          - "text/xml"
+          - "<html"
+          - "<!doctype"
+          - "<script"
+          - "<meta"
+          - "image/"
+          - "Response xmlns"
+        negative: true


### PR DESCRIPTION
Added a YAML configuration file for detecting Coveralls configuration file exposure, detailing potential security risks and HTTP request matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
