### PR TITLE
Removing one matcher that triggered FPs

### DIFF
--- a/http/exposed-panels/workspace-one-uem.yaml
+++ b/http/exposed-panels/workspace-one-uem.yaml
@@ -32,7 +32,6 @@ http:
         part: body
         words:
           - "About VMware AirWatch"
-          - 'content="AirWatch'
           - "/AirWatch/Images"
         condition: or
 # digest: 4b0a00483046022100fb7cda67be48a1aeff9ad6bc776fd5851f122a74dae5b43101b5bbf89d2e03ab022100d2c7a6d7b3bbb6412203cbc6cac104ff4be550b3505e77366a4e2866dd9895f8:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information
On one of the sites we scan at CERT PL, we observed a false positive where the path was put in content="" attribute, thus leading to `content="AirWatch` false match. I did not check the template against a real AirWatch instance.

### Template validation
- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)
