### PR TITLE
CVE-2023-2745: Add missing cve-id

### DIFF
--- a/http/cves/2023/CVE-2023-2745.yaml
+++ b/http/cves/2023/CVE-2023-2745.yaml
@@ -16,6 +16,7 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
+    cve-id: CVE-2023-2745
     cwe-id: CWE-22
     epss-score: 0.77175
     epss-percentile: 0.98989


### PR DESCRIPTION
### PR Information

Updates `classification` metadata in CVE-2023-2745 template to add missing `cve-id`.

### Template validation

Untested since core template logic was untouched.