### PR TITLE
Add CVE-2026-42569 for phpVMS auth bypass vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-42569.yaml
+++ b/http/cves/2026/CVE-2026-42569.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-42569
+
+info:
+  name: phpVMS < 7.0.6 - Legacy Importer Authorization Bypass
+  author: 0x_Akoko
+  severity: critical
+  description: |
+   phpVMS < 7.0.6 contains an authentication bypass caused by unauthenticated access to a legacy import feature, letting unauthenticated attackers access restricted functionality, exploit requires no special privileges.
+  impact: |
+   Unauthenticated attackers can access restricted import functionality, potentially leading to unauthorized data manipulation or system compromise.
+  remediation: |
+   Update to version 7.0.6 or later.
+  reference:
+    - https://github.com/phpvms/phpvms/security/advisories/GHSA-fv26-4939-62fh
+    - https://github.com/phpvms/phpvms/commit/f59ba8e0e8fc25c60c3faf14e526cfd49df3f7dc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42569
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H
+    cvss-score: 9.4
+    cve-id: CVE-2026-42569
+    cwe-id: CWE-284,CWE-306,CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: phpvms
+    product: phpvms
+    shodan-query: http.html:"phpvms"
+    fofa-query: app="phpVMS"
+  tags: cve,cve2026,phpvms,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/importer"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "importer", "phpvms")'
+          - 'contains_any(body, "Import Configuration", "Database Config", "Start Importer", "WIPE OUT YOUR EXISTING DATA", "importer/config")'
+        condition: and


### PR DESCRIPTION
Added CVE-2026-42569 entry detailing a critical authorization bypass in phpVMS versions < 7.0.6. Includes information on impact, remediation, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
