### PR TITLE
Convert geovision-geowebserver-lfi-xss to CVE-2021-47795

### DIFF
--- a/http/cves/2021/CVE-2021-47795.yaml
+++ b/http/cves/2021/CVE-2021-47795.yaml
@@ -1,21 +1,31 @@
-id: geovision-geowebserver-lfi-xss
+id: CVE-2021-47795
 
 info:
-  name: GeoVision Geowebserver <= 5.3.3 - Local File Inclusion / Cross-Site Scripting
+  name: GeoVision GeoWebServer <= 5.3.3 - Local File Inclusion / Cross-Site Scripting
   author: shamo0
   severity: high
   description: |
-    GEOVISION GEOWEBSERVER <= 5.3.3 is vulnerable to several XSS, HTML Injection, and Local File Include (LFI) vectors. The application fails to properly sanitize user requests, allowing injection of HTML code and XSS, as well as client-side exploitation, including session theft.
+    GeoVision GeoWebServer 5.3.3 and prior is vulnerable to local file inclusion and cross-site scripting due to improper sanitization of user-supplied input in the WebStrings.srf endpoint. An unauthenticated attacker can read arbitrary files from the server or inject malicious scripts.
+  impact: |
+    Unauthenticated attackers can read arbitrary files from the server via path traversal, or execute arbitrary JavaScript in the victim's browser via reflected XSS.
+  remediation: |
+    Contact GeoVision support for a patched firmware version that addresses the input sanitization issues.
   reference:
-    - https://www.geovision.com.tw/cyber_security.php
     - https://www.exploit-db.com/exploits/50211
+    - https://www.geovision.com.tw/cyber_security.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-47795
   classification:
-    cwe-id: CWE-80
+    cvss-metrics: CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.2
+    cve-id: CVE-2021-47795
+    cwe-id: CWE-22
   metadata:
     verified: true
     max-request: 3
+    vendor: geovision
+    product: geowebserver
     shodan-query: title:"Geowebserver"
-  tags: geovision,geowebserver,lfi,xss,vuln
+  tags: cve,cve2021,geovision,geowebserver,lfi,xss,vuln
 
 http:
   - raw:
@@ -49,4 +59,3 @@ http:
           - 'contains(content_type, "text/html")'
           - 'status_code == 200'
         condition: and
-# digest: 4a0a00473045022100a16b53a625d9b169c6e33b0753fd23872f7577fe7c2541bf3a7599a897ccf27f02207b3b070c513af9c34b0c8e6b720b03434a4a6e2007433f8dc8749dfa905ea47e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Converted `http/vulnerabilities/geovision-geowebserver-lfi-xss.yaml` to `http/cves/2021/CVE-2021-47795.yaml`
- Closes #15275 (partially)
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2021-47795
  - https://www.exploit-db.com/exploits/50211

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
