### PR TITLE
Add CVE-2026-42945 nginx version detection

### DIFF
--- a/http/cves/2026/CVE-2026-42945.yaml
+++ b/http/cves/2026/CVE-2026-42945.yaml
@@ -1,0 +1,71 @@
+id: CVE-2026-42945
+
+info:
+  name: NGINX ngx_http_rewrite_module Heap Buffer Overflow - Version Detection
+  author: KonaN
+  severity: high
+  description: |
+    NGINX Plus and NGINX Open Source contain a heap-based buffer overflow in
+    ngx_http_rewrite_module. The issue is reachable only when a vulnerable
+    rewrite configuration is present: a rewrite directive using unnamed PCRE
+    captures such as $1 or $2 with a replacement string containing a question
+    mark, followed by another rewrite, if, or set directive. This template is
+    intentionally non-intrusive and reports exposed nginx versions in the known
+    affected Open Source range; confirm exploitability by reviewing nginx
+    configuration for the vulnerable rewrite pattern.
+  impact: |
+    An unauthenticated attacker may crash an nginx worker process. Remote code
+    execution may be possible on systems with ASLR disabled and the required
+    vulnerable rewrite configuration.
+  remediation: |
+    Upgrade nginx Open Source to 1.31.0 or later, or apply vendor backports.
+    For NGINX Plus, upgrade to a fixed release after R36. Review rewrite rules
+    and remove unnamed capture replacements containing question marks when they
+    are followed by rewrite, if, or set directives.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42945
+    - https://my.f5.com/manage/s/article/K000161019
+    - https://depthfirst.com/nginx-rift
+    - https://almalinux.org/blog/2026-05-13-nginx-rift-cve-2026-42945/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2026-42945
+    cwe-id: CWE-122
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: f5
+    product: nginx
+    confidence: low
+    shodan-query: 'http.server:"nginx/"'
+    fofa-query: 'server=="nginx"'
+  tags: cve,cve2026,nginx,f5,exposure,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Server:"
+          - "nginx/"
+        condition: and
+        case-insensitive: true
+
+      - type: regex
+        part: header
+        regex:
+          - '(?i)Server:\s*nginx/(?:0\.(?:6\.(?:2[7-9]|[3-9][0-9])|[7-9]\.[0-9]+)|1\.(?:[0-9]|[12][0-9]|30)(?:\.[0-9]+)?)(?:\s|$)'
+
+    extractors:
+      - type: regex
+        name: nginx_version
+        part: header
+        group: 1
+        regex:
+          - '(?i)Server:\s*nginx/([0-9]+\.[0-9]+(?:\.[0-9]+)?)'


### PR DESCRIPTION
### Template / PR Information

This PR adds a non-intrusive detection template for CVE-2026-42945, a heap-based buffer overflow in NGINX ngx_http_rewrite_module.

The vulnerability is configuration-dependent, requiring rewrite directives with unnamed PCRE captures and a replacement containing a question mark followed by another rewrite, if, or set directive. To avoid unsafe worker crashes or RCE-style probing, this template only detects exposed nginx Open Source versions in the reported affected range and asks operators to confirm exploitability by reviewing configuration.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-42945
- https://my.f5.com/manage/s/article/K000161019
- https://depthfirst.com/nginx-rift
- https://almalinux.org/blog/2026-05-13-nginx-rift-cve-2026-42945/

### Template Validation

- YAML syntax validated locally with Python safe_load
- Nuclei CLI was not available in the local environment for nuclei -validate
