### PR TITLE
Add CVE-2025-13773 - Print Invoice & Delivery Notes for WooCommerce <= 5.8.0 Unauthenticated RCE

### DIFF
--- a/http/cves/2025/CVE-2025-13773.yaml
+++ b/http/cves/2025/CVE-2025-13773.yaml
@@ -1,0 +1,60 @@
+id: CVE-2025-13773
+
+info:
+  name: Print Invoice & Delivery Notes for WooCommerce <= 5.8.0 - Unauthenticated RCE
+  author: engguga
+  severity: critical
+  description: |
+    O plugin Print Invoice & Delivery Notes for WooCommerce para WordPress
+    é vulnerável a Remote Code Execution em versões até 5.8.0 via função
+    'WooCommerce_Delivery_Notes::update'. A falha combina ausência de
+    verificação de permissão, PHP habilitado no Dompdf e falta de escape
+    no template.php, permitindo execução de código por atacantes não autenticados.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13773
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e52b34fe-2414-4d6f-bf43-9c5b65ebf769
+    - https://plugins.trac.wordpress.org/changeset/3426119/woocommerce-delivery-notes
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-13773
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: tychesoftwares
+    product: woocommerce-delivery-notes
+    fofa-query: body="woocommerce-delivery-notes"
+    shodan-query: http.component:"woocommerce-delivery-notes"
+  tags: cve,cve2025,wordpress,wp-plugin,rce,woocommerce,unauth,critical
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-delivery-notes/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Print Invoice"
+          - "WooCommerce"
+        condition: and
+        part: body
+
+      - type: regex
+        regex:
+          - "Stable tag: ([0-4]\\.[0-9]+\\.[0-9]+|5\\.[0-7]\\.[0-9]+|5\\.8\\.0)"
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "Stable tag: ([0-9.]+)"
+        part: body


### PR DESCRIPTION
### PR Information

- Added CVE-2025-13773 - Print Invoice & Delivery Notes for WooCommerce <= 5.8.0 Unauthenticated RCE

- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2025-13773
  - https://www.wordfence.com/threat-intel/vulnerabilities/id/e52b34fe-2414-4d6f-bf43-9c5b65ebf769
  - https://plugins.trac.wordpress.org/changeset/3426119/woocommerce-delivery-notes

### Template validation

- Template was tested against scanme.sh using nuclei v3.8.0
- Template validated successfully with `nuclei -validate`
- No false positives observed on a non-vulnerable target
- Detection is based on plugin version check via readme.txt (safe, non-destructive)

### About the vulnerability

The plugin is vulnerable to unauthenticated RCE via the `WooCommerce_Delivery_Notes::update` 
function due to: missing capability check, PHP execution enabled in bundled Dompdf, 
and missing output escaping in template.php. Affects all versions up to and including 5.8.0.
Fixed in version 5.8.1.