### PR TITLE
Add UISP Fiber Login panel detection configuration

### DIFF
--- a/http/exposed-panels/uisp-fiber-login-panel.yaml
+++ b/http/exposed-panels/uisp-fiber-login-panel.yaml
@@ -1,0 +1,33 @@
+id: uisp-fiber-login-panel
+
+info:
+  name: UISP Fiber Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    UISP Fiber login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"UISP Fiber - Login"
+  tags: panel,login,uisp,fiber,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login.html"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>UISP Fiber - Login</title>"
+          - '<h2 id="errmsg">Please login to manage your device.</h2>'
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/uisp-fiber-panel.yaml
+++ b/http/exposed-panels/uisp-fiber-panel.yaml
@@ -1,7 +1,7 @@
-id: uisp-fiber-login-panel
+id: uisp-fiber-panel
 
 info:
-  name: UISP Fiber Login - Panel Detect
+  name: UISP Fiber Panel - Detect
   author: Th3l0newolf
   severity: info
   description: |
@@ -26,7 +26,6 @@ http:
         part: body
         words:
           - "<title>UISP Fiber - Login</title>"
-          - '<h2 id="errmsg">Please login to manage your device.</h2>'
 
       - type: status
         status:


### PR DESCRIPTION
### PR Information

- This template is for UISP Fiber login


### Template validation

I have validated this template

<img width="745" height="322" alt="image" src="https://github.com/user-attachments/assets/dbeb08d5-5042-438d-b14f-99170908a8f7" />

<img width="854" height="158" alt="image" src="https://github.com/user-attachments/assets/5815f5e4-d857-4c2f-b174-d17a5131b819" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
