### PR TITLE
Add CVE-2024-45436: Ollama < 0.1.47 - Zip Slip Path Traversal

### DIFF
--- a/http/cves/2024/CVE-2024-45436.yaml
+++ b/http/cves/2024/CVE-2024-45436.yaml
@@ -1,0 +1,57 @@
+id: CVE-2024-45436
+
+info:
+  name: Ollama < 0.1.47 - Zip Slip Path Traversal
+  author: gugacyber
+  severity: high
+  description: |
+    Ollama before version 0.1.47 is vulnerable to a path traversal vulnerability
+    (Zip Slip) in the extractFromZipFile function in model.go. An attacker can
+    craft a malicious model ZIP archive containing directory traversal sequences
+    to write arbitrary files outside the intended directory, potentially leading
+    to remote code execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-45436
+    - https://github.com/srcx404/CVE-2024-45436
+    - https://github.com/ollama/ollama/security/advisories/GHSA-x8g7-52qv-4wr9
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2024-45436
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ollama
+    product: ollama
+    shodan-query: product:"Ollama"
+    fofa-query: app="Ollama"
+  tags: cve,cve2024,ollama,path-traversal,lfi,ai
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"version"'
+        part: body
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'regex("\"version\":\"0\\.1\\.(([0-9]|[1-3][0-9]|4[0-6]))\"|\"version\":\"0\\.0\\.[0-9]+\"", body)'
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '"version":"([0-9]+\.[0-9]+\.[0-9]+)"'
+        part: body


### PR DESCRIPTION
## Summary

Adds a detection template for CVE-2024-45436, a path traversal (Zip Slip)
vulnerability in Ollama versions prior to 0.1.47.

## Vulnerability Details

The vulnerability exists in the `extractFromZipFile` function in `model.go`.
When pulling a model, Ollama extracts ZIP archives without properly sanitizing
file paths, allowing directory traversal sequences (e.g. `../../`) to write
files outside the intended directory — potentially leading to RCE.

## Detection Method

The template queries `/api/version` to:
1. Confirm the target is an Ollama instance
2. Extract the version number
3. Match only versions below 0.1.47 (vulnerable range)

## References

- https://nvd.nist.gov/vuln/detail/CVE-2024-45436
- https://github.com/srcx404/CVE-2024-45436
- https://github.com/ollama/ollama/security/advisories/GHSA-x8g7-52qv-4wr9

## Closes

Closes #11347