### PR TITLE
PHPMyFAQ 4.1.2 vulnerability: GHSA-w9xh-5f39-vq89

### DIFF
--- a/http/vulnerabilities/phpmyfaq/phpmyfaq-412-account-takeover.yaml
+++ b/http/vulnerabilities/phpmyfaq/phpmyfaq-412-account-takeover.yaml
@@ -1,0 +1,31 @@
+id: phpmyfaq-412-account-takeover
+
+info:
+  name: PHPMyFAQ 4.1.2 - Account Takeover
+  author: kazet
+  severity: critical
+  description: |
+    An authentication bypass vulnerability in phpMyFAQ allows any unauthenticated attacker to reset the password of any user account, including SuperAdmin accounts. By sending a PUT request with just a valid username and associated email address to /api/user/password/update, an attacker receives a new plaintext password via email without any token verification, rate limiting, or email confirmation. This enables complete account takeover of any user, including full administrative access.
+  reference:
+    - https://github.com/thorsten/phpMyFAQ/security/advisories/GHSA-w9xh-5f39-vq89
+  tags: takeover,vuln
+
+http:
+  - method: GET
+    path:
+    - "{{BaseURL}}"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+        - '<meta content="phpMyFAQ ([0-9.*]*)([^"]*)"\s*name="application-name"'
+        internal: false
+
+    matchers:
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - compare_versions(trim_space(version), '<= 4.1.2')

--- a/http/vulnerabilities/phpmyfaq/phpmyfaq-412-account-takeover.yaml
+++ b/http/vulnerabilities/phpmyfaq/phpmyfaq-412-account-takeover.yaml
@@ -13,7 +13,7 @@ info:
 http:
   - method: GET
     path:
-    - "{{BaseURL}}"
+      - "{{BaseURL}}"
 
     extractors:
       - type: regex
@@ -21,7 +21,7 @@ http:
         part: body
         group: 1
         regex:
-        - '<meta content="phpMyFAQ ([0-9.*]*)([^"]*)"\s*name="application-name"'
+          - '<meta content="phpMyFAQ ([0-9.*]*)([^"]*)"\s*name="application-name"'
         internal: false
 
     matchers:


### PR DESCRIPTION
### PR Information

New vulnerabilities in PHPMyFAQ have been published, e.g. https://github.com/thorsten/phpMyFAQ/security/advisories/GHSA-w9xh-5f39-vq89
### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)
