### PR TITLE
Add generic debug parameters fuzzing configuration

### DIFF
--- a/http/fuzzing/generic-debug-fuzz.yaml
+++ b/http/fuzzing/generic-debug-fuzz.yaml
@@ -1,0 +1,64 @@
+id: generic-debug-parameters-fuzz
+
+info:
+  name: Generic Hidden Debug Parameters Fuzzing
+  author: mohamedfekry # اكتب اسمك هنا
+  severity: medium
+  description: |
+    Fuzzing for hidden debug and development parameters across endpoints. 
+    Enabling these parameters can lead to sensitive information disclosure, stack traces, or bypassing access controls.
+  reference:
+    - https://twitter.com/ # 
+  tags: fuzzing, misconfig, debug, exposure, generic
+
+http:
+  - method: GET
+    path:
+      
+      - "{{BaseURL}}?{{parameter}}={{value}}"
+      - "{{BaseURL}}/api/?{{parameter}}={{value}}"
+      - "{{BaseURL}}/api/ConfigurationReport?{{parameter}}={{value}}"
+
+    payloads:
+      parameter:
+        - debug
+        - _debug
+        - debug_mode
+        - dev
+        - test
+        - trace
+        - verbose
+        - env
+        - show_errors
+      value:
+        - "true"
+        - "1"
+        - "yes"
+        - "on"
+        - "enable"
+
+    attack: clusterbomb 
+    stop-at-first-match: true
+
+    matchers-condition: or
+    matchers:
+     
+      - type: word
+        words:
+          - "Stack Trace:"
+          - "Application Trace:"
+          - "Environment Variables:"
+          - "Exception in thread"
+          - "java.lang.NullPointerException"
+          - "Fatal error:"
+          - "SQL syntax"
+          - "werkzeug.debug"
+          - "Whoops, looks like something went wrong."
+          - "Symfony Exception"
+        part: body
+        condition: or
+        
+      - type: word
+        words:
+          - "application/json"
+        part: header


### PR DESCRIPTION
This YAML file defines a fuzzing configuration for detecting hidden debug parameters across various endpoints, including payloads and matchers for identifying sensitive information disclosure.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
