### PR TITLE
Add NGINX rewrite config exposure template related to CVE-2026-42945

### DIFF
--- a/http/exposures/configs/nginx-rewrite-unnamed-capture-config.yaml
+++ b/http/exposures/configs/nginx-rewrite-unnamed-capture-config.yaml
@@ -1,0 +1,71 @@
+id: nginx-rewrite-unnamed-capture-config
+
+info:
+  name: NGINX Rewrite Configuration with Unnamed Capture Exposure
+  author: ydking0911
+  severity: medium
+  description: |
+    Publicly exposed NGINX configuration content was detected containing a rewrite directive with query-string replacement and an unnamed capture reference such as $1 or $2 in a set, rewrite, or if directive. This does not confirm CVE-2026-42945 exploitability; it only identifies exposed configuration patterns that may indicate risk when combined with affected NGINX versions and runtime configuration.
+  impact: |
+    Exposed NGINX configuration files can disclose routing logic, upstream paths, and rewrite behavior. Query-string replacement combined with unnamed capture references may require review for CVE-2026-42945 / NGINX Rift risk conditions on affected NGINX versions.
+  remediation: |
+    Remove NGINX configuration files from public web roots, restrict direct access to backup and editor swap files, and review rewrite directives that combine query-string replacement with unnamed capture references. Confirm risk using the deployed NGINX version and full runtime configuration.
+  reference:
+    - https://depthfirst.com/research/nginx-rift-achieving-nginx-rce-via-an-18-year-old-vulnerability
+    - https://github.com/depthfirstdisclosures/nginx-rift
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    verified: false
+    max-request: 10
+  tags: exposure,config,nginx,rewrite
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/nginx.conf"
+      - "{{BaseURL}}/nginx.conf.bak"
+      - "{{BaseURL}}/default.conf"
+      - "{{BaseURL}}/default.conf.bak"
+      - "{{BaseURL}}/conf/nginx.conf"
+      - "{{BaseURL}}/sites-enabled/default"
+      - "{{BaseURL}}/sites-available/default"
+      - "{{BaseURL}}/nginx.conf.old"
+      - "{{BaseURL}}/default.conf.old"
+      - "{{BaseURL}}/.nginx.conf.swp"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "<html"
+          - "<!DOCTYPE html"
+
+      - type: regex
+        part: body
+        regex:
+          - '(?m)^\s*server\s*\{'
+
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "location"
+          - "rewrite"
+
+      - type: regex
+        part: body
+        regex:
+          - '(?m)^\s*rewrite\s+[^\r\n;]*\?[^\r\n;]*;'
+
+      - type: regex
+        part: body
+        regex:
+          - '(?m)^\s*(?:set|rewrite|if)\b[^\r\n;{}]*\$\d{1,2}\b[^\r\n;{}]*(?:;|\{)'

--- a/http/exposures/configs/nginx-rewrite-unnamed-capture-config.yaml
+++ b/http/exposures/configs/nginx-rewrite-unnamed-capture-config.yaml
@@ -3,7 +3,7 @@ id: nginx-rewrite-unnamed-capture-config
 info:
   name: NGINX Rewrite Configuration with Unnamed Capture Exposure
   author: ydking0911
-  severity: medium
+  severity: low
   description: |
     Publicly exposed NGINX configuration content was detected containing a rewrite directive with query-string replacement and an unnamed capture reference such as $1 or $2 in a set, rewrite, or if directive. This does not confirm CVE-2026-42945 exploitability; it only identifies exposed configuration patterns that may indicate risk when combined with affected NGINX versions and runtime configuration.
   impact: |
@@ -16,8 +16,8 @@ info:
   classification:
     cwe-id: CWE-200
   metadata:
-    verified: false
-    max-request: 10
+    verified: true
+    max-request: 11
   tags: exposure,config,nginx,rewrite
 
 http:
@@ -33,6 +33,7 @@ http:
       - "{{BaseURL}}/nginx.conf.old"
       - "{{BaseURL}}/default.conf.old"
       - "{{BaseURL}}/.nginx.conf.swp"
+      - "{{BaseURL}}/project/nginx.conf"
 
     stop-at-first-match: true
     matchers-condition: and
@@ -47,6 +48,13 @@ http:
         words:
           - "<html"
           - "<!DOCTYPE html"
+          - "<?xml"
+          - "<rss"
+          - "<feed"
+          - "<head>"
+          - "<body"
+          - "<title>"
+          - "<script"
 
       - type: regex
         part: body
@@ -63,9 +71,4 @@ http:
       - type: regex
         part: body
         regex:
-          - '(?m)^\s*rewrite\s+[^\r\n;]*\?[^\r\n;]*;'
-
-      - type: regex
-        part: body
-        regex:
-          - '(?m)^\s*(?:set|rewrite|if)\b[^\r\n;{}]*\$\d{1,2}\b[^\r\n;{}]*(?:;|\{)'
+          - '(?m)^\s*rewrite\s+\S+\s+[^\r\n;]*(?:\?[^\r\n;]*\$\d{1,2}|\$\d{1,2}[^\r\n;]*\?)[^\r\n;]*;'


### PR DESCRIPTION
### PR Information

Added an exposure/config template to detect publicly exposed NGINX configuration files containing rewrite directives with query-string replacement and unnamed capture references such as `$1`, `$2`, or `$10`.

This template is related to CVE-2026-42945 / NGINX Rift risk conditions, but it does not confirm exploitability. It only identifies exposed NGINX configuration patterns that may require review when combined with affected NGINX versions and runtime configuration.

This is not an exploit template. It only performs passive GET requests against common NGINX configuration file paths and does not attempt heap overflow, worker crash, DoS, RCE, or OAST callback validation.

- Added NGINX rewrite unnamed capture config exposure template related to CVE-2026-42945
- References:
  - https://depthfirst.com/research/nginx-rift-achieving-nginx-rce-via-an-18-year-old-vulnerability
  - https://github.com/depthfirstdisclosures/nginx-rift

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)
The validation checkboxes refer to controlled local fixtures representing risky and safe NGINX configurations, not live exploitation against a real vulnerable NGINX instance.

Template validation was performed successfully:

```bash
nuclei -duc -validate -lfa -ud . -t http/exposures/configs/nginx-rewrite-unnamed-capture-config.yaml
```
<img width="714" height="236" alt="스크린샷 2026-05-18 21 22 08" src="https://github.com/user-attachments/assets/35a105e8-6ec2-42fb-ba91-6be0d295c6f3" />

Local matcher behavior was tested using controlled fixtures.

Positive fixture matched:

```nginx
server {
    location ~ ^/api/(.*)$ {
        rewrite ^/api/(.*)$ /internal?migrated=true last;
        set $original_endpoint $1;
    }
}
```
<img width="809" height="96" alt="스크린샷 2026-05-18 21 25 58" src="https://github.com/user-attachments/assets/0378efce-2beb-4e83-9091-eb971d63255d" />

Negative fixtures did not match and were used to reduce false positives:
1. `rewrite` without query-string replacement:
```nginx
server {
    location ~ ^/api/(.*)$ {
        rewrite ^/api/(.*)$ /internal last;
        set $original_endpoint $1;
    }
}
```

2. Named capture usage only:
```nginx
server {
    location ~ ^/api/(?<endpoint>.*)$ {
        rewrite ^/api/(?<endpoint>.*)$ /internal?migrated=true last;
        set $original_endpoint $endpoint;
    }
}
```

3. Non-NGINX text containing similar keywords:
```text
This document mentions rewrite and $1 but is not an NGINX configuration file.
```

Runtime exploitability for CVE-2026-42945 was not tested. No heap overflow, DoS, RCE, worker crash, or OAST validation was performed.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)