### PR TITLE
Add crypto address detection template

### DIFF
--- a/http/miscellaneous/crypto-address-detect.yaml
+++ b/http/miscellaneous/crypto-address-detect.yaml
@@ -1,0 +1,52 @@
+id: crypto-address-detect
+
+info:
+  name: Exposed Cryptocurrency Wallet Address
+  author: rxerium
+  severity: info
+  description: |
+    Detected Bitcoin, Monero, Ethereum, or XRP wallet addresses were identified in webpage content.
+  reference:
+    - https://bitcoin.org/
+    - https://xrpl.org/
+    - https://www.getmonero.org/
+    - https://en.wikipedia.org/wiki/Ethereum
+  metadata:
+    max-request: 1
+    verified: true
+  tags: crypto,bitcoin,monero,ethereum,xrp,ripple,osint,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - name: bitcoin-address
+        type: dsl
+        dsl:
+          - 'regex("([13][a-km-zA-HJ-NP-Z1-9]{25,34})", body)'
+          - 'status_code == 200'
+        condition: and
+
+      - name: monero-address
+        type: dsl
+        dsl:
+          - 'regex("(4[0-9AB][1-9A-HJ-NP-Za-km-z]{93})", body)'
+          - 'status_code == 200'
+        condition: and
+
+      - name: ethereum-address
+        type: dsl
+        dsl:
+          - 'regex("(0x[a-fA-F0-9]{40})", body)'
+          - 'status_code == 200'
+        condition: and
+
+      - name: xrp-address
+        type: dsl
+        dsl:
+          - 'regex("(r[0-9a-zA-Z]{24,34})", body)'
+          - 'status_code == 200'
+        condition: and
+# digest: 490a00463044022013fdbdf21e5aaf997aba8c3891e55ea4e44be301df54c942ccd94a3612b37f3002201f761ec2e754855042b417f9b229f1d3a468274b1814a61bb054177dcd8244e5:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Hey team,

I have restored the crypto address detection template under http/miscellaneous. This template detects exposed Bitcoin, Monero, Ethereum, and XRP wallet addresses in webpage content using DSL regex matchers with a 200 status check.

Many thanks,

Rishi