### PR TITLE
fix(gradio-image-ssrf): mismatched quotes in dsl matchers

### DIFF
--- a/http/vulnerabilities/gradio-image-ssrf.yaml
+++ b/http/vulnerabilities/gradio-image-ssrf.yaml
@@ -39,8 +39,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body, "{\"event_id\":')
+          - contains(body, '{"event_id":')
           - contains(interactsh_protocol, 'http')
-          - contains(content_type, "application/json')
+          - contains(content_type, 'application/json')
         condition: and
 # digest: 4a0a00473045022100bd4700e0bc99d4983fc71abcf5f7d78a07b421c53c08f889da74ecf6c846ca770220472f497266f16974aec7d4b82be1417678140fb37cc66d54770dca0e976220bc:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Two dsl matchers opened with ` " ` and closed with ` ' `, causing "Unclosed string literal" once dsl uses the stricter projectdiscovery/govaluate fork.