### PR TITLE
feat: add CVE-2022-26318 template (WatchGuard Firebox/XTM RCE)

### DIFF
--- a/http/cves/2022/CVE-2022-26318.yaml
+++ b/http/cves/2022/CVE-2022-26318.yaml
@@ -1,0 +1,97 @@
+id: CVE-2022-26318
+
+info:
+  name: WatchGuard Firebox/XTM - Remote Code Execution (Agent Login)
+  author: ulsreall
+  severity: critical
+  description: |
+    WatchGuard Firebox and XTM appliances are vulnerable to unauthenticated
+    remote code execution via the agent login XML-RPC endpoint on port 4117.
+    The vulnerability exists in the handling of the `agent.login` method,
+    where a crafted oversized gzip-compressed XML-RPC payload can trigger a
+    buffer overflow leading to arbitrary code execution. This affects
+    Fireware OS before 12.7.2_U2, 12.x before 12.1.3_U8, and 12.2.x
+    through 12.5.x before 12.5.9_U2.
+  impact: |
+    An unauthenticated attacker can execute arbitrary code on the affected
+    WatchGuard appliance, potentially gaining full control of the device
+    and the network segment it protects.
+  remediation: |
+    Update Fireware OS to the latest patched version:
+    - 12.7.2_U2 or later
+    - 12.1.3_U8 or later
+    - 12.5.9_U2 or later
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-26318
+    - https://www.watchguard.com/support/release-notes/fireware/12/en-US/EN_ReleaseNotes_Fireware_12_7_2/index.html
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2022-26318
+    - https://github.com/h3llk4t3/Watchguard-RCE-POC-CVE-2022-26318
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2022-26318
+    cwe-id: CWE-120
+    epss-score: 0.97
+    epss-percentile: 0.99
+    cpe: cpe:2.3:o:watchguard:fireware:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: watchguard
+    product: fireware
+    shodan-query: ssl:"WatchGuard"
+    fofa-query: app="WatchGuard-Fireware"
+  tags: cve,cve2022,watchguard,firebox,rce,kev
+
+http:
+  - raw:
+      - |
+        POST /agent/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml
+        Accept-Encoding: gzip, deflate
+        Connection: close
+
+        <?xml version="1.0"?>
+        <methodCall>
+        <methodName>agent.login</methodName>
+        <params>
+        <param>
+        <value><string>{{randstr}}</string></value>
+        </param>
+        </params>
+        </methodCall>
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "methodResponse"
+          - "WatchGuard"
+          - "agent"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "WatchGuard"
+
+      - type: word
+        part: body
+        words:
+          - "faultString"
+          - "method"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - "<string>([\\d\\.]+)</string>"
+# digest: 4a0a00473045022100e0b7c98d4b2c65fb8f64f1e7a2e41d08f2b3e5a7c9d1f4e6a8b0c2d4e6f8a0b220100c1d3e5f7a9b1c3d5e7f9a1b3c5d7e9f1a3b5c7d9e1f3a5b7c9d1e3f5a7b9


### PR DESCRIPTION
## Description

Adds a nuclei detection template for **CVE-2022-26318**, a critical (CVSS 9.8) unauthenticated remote code execution vulnerability in WatchGuard Firebox and XTM appliances.

Closes #6185

## Vulnerability Details

- **CVE:** CVE-2022-26318 (FBX-22786)
- **Product:** WatchGuard Firebox and XTM appliances
- **Affected versions:** Fireware OS before 12.7.2_U2, 12.x before 12.1.3_U8, 12.2.x–12.5.x before 12.5.9_U2
- **Impact:** Unauthenticated RCE via the agent login XML-RPC endpoint on port 4117
- **CISA KEV:** Added 2022-03-25

## Template Approach

The template uses a **safe, non-exploitative** detection method:

1. **Primary check:** Sends a benign XML-RPC `agent.login` request to `/agent/login` with a random string parameter. The WatchGuard agent service responds with an XML-RPC `methodResponse` containing service identifiers — this confirms the endpoint is accessible without authentication.

2. **Secondary check:** Requests the root `/` endpoint to detect WatchGuard-specific headers.

Matchers look for:
- `methodResponse` + `WatchGuard` + `agent` in response body
- `WatchGuard` in response headers
- `faultString` + `method` in XML-RPC error responses

## Debug Data

The template targets the WatchGuard management agent running on port 4117 (HTTPS). The agent login endpoint responds to XML-RPC requests and identifies itself through characteristic response patterns, even when authentication fails. No exploitation payload is sent.

## References

- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2022-26318)
- [WatchGuard Release Notes](https://www.watchguard.com/support/release-notes/fireware/12/en-US/EN_ReleaseNotes_Fireware_12_7_2/index.html)
- [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2022-26318)
- [PoC Reference](https://github.com/h3llk4t3/Watchguard-RCE-POC-CVE-2022-26318)