### PR TITLE
add exposed-git-commit-msg detection template

### DIFF
--- a/http/exposures/configs/exposed-git-commit-msg.yaml
+++ b/http/exposures/configs/exposed-git-commit-msg.yaml
@@ -1,0 +1,31 @@
+id: exposed-git-commit-msg
+
+info:
+ name: Exposed Git Commit Message
+ author: joel6948
+ severity: medium
+ description: Detects publicly accessible .git/COMMIT_EDITMSG that may expose sensitive commit messages
+ tags: git,exposure,misconfiguration
+
+http:
+ - method: GET
+   path:
+     - "{{BaseURL}}/.git/COMMIT_EDITMSG"
+   matchers-condition: and
+   matchers:
+     - type: status
+       status:
+         - 200
+     - type: word
+       part: body
+       words:
+         - "application/octet-stream"
+         - "text/plain"
+       condition: or
+     - type: dsl
+       dsl:
+         - "len(body) > 0"
+         - "!contains(tolower(body), '<html')"
+         - "!contains(tolower(body), '<body')"
+       condition: and
+      


### PR DESCRIPTION
### PR Information
Added template to detect publicly accessible .git/COMMIT_EDITMSG
files that expose sensitive developer commit messages including
internal server names, credentials or security notes.
This file is created automatically by Git after every commit and
contains the last commit message. When exposed publicly it can
reveal sensitive information about the codebase, security fixes,
or internal infrastructure.
- References:
- https://pentester.land/blog/source-code-disclosure-via-exposed-git-folder/
### Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)
#### Additional Details
Template tested against local Python HTTP server serving
exposed .git directory.
True Positive Test:
- Created local git repository with commit message
- Served via Python HTTP server on localhost:8000
- Template successfully detected exposed COMMIT_EDITMSG file
False Positive Test:
- Tested against targets without exposed .git folders
- No false positives detected
nuclei command used for testing:
nuclei -t exposed-git-commit-msg.yaml -u http://localhost:8000/ -debug
### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
