### PR TITLE
Add CVE-2026-32596 for Glances Unauthenticated API exposure

### DIFF
--- a/code/cves/2026/CVE-2026-32596.yaml
+++ b/code/cves/2026/CVE-2026-32596.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-32596
+
+info:
+  name: Glances REST API Exposure - Unauthenticated Access
+  author: Th3l0newolf
+  severity: high
+  description: |
+    Glances web server started with `glances -w` exposes the REST API without authentication,
+    allowing remote attackers to access sensitive system information including process command-lines,
+    credentials, API keys, and tokens. Fixed in Glances version 4.5.2.
+  reference:
+    - https://github.com/nicolargo/glances
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: html:"Glances"
+  tags: cve,cve2026,glances,exposure,unauth,api,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Glances</title>"
+          - "window.__GLANCES__"
+
+      - type: status
+        status:
+          - 200
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/4/system"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"os_name":'
+          - '"hostname":'
+          - '"platform":'
+          - '"os_version":'
+          - '"hr_name":'
+          - '"linux_distro":'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Template For CVE-2026-32596  Detection - Unauthenticated access to Glances REST API.

### PR Information

Glances is an open-source system cross-platform monitoring tool. Prior to 4.5.2, Glances web server runs without authentication by default when started with `glances -w`, exposing REST API with sensitive system information including process command-lines containing credentials (passwords, API keys, tokens) to any network client. Version 4.5.2 fixes the issue.

### How to fix?
Upgrade Glances to version 4.5.2 or higher.

###  References: 
- https://github.com/advisories/GHSA-wvxv-4j8q-4wjq
- https://nvd.nist.gov/vuln/detail/CVE-2026-32596
- https://github.com/nicolargo/glances/releases/tag/v4.5.2

### Template validation
 
I have validated template 

<img width="737" height="348" alt="image" src="https://github.com/user-attachments/assets/06e85c40-f2be-48c9-a40b-5202e2413652" />

<img width="2063" height="893" alt="image" src="https://github.com/user-attachments/assets/b36ea4c4-bc29-470c-8537-90c3ff4e4961" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
