### PR TITLE
Add CVE-2026-6456 - Account Switcher <= 1.0.2 Authentication Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-6456.yaml
+++ b/http/cves/2026/CVE-2026-6456.yaml
@@ -1,0 +1,84 @@
+id: CVE-2026-6456
+
+info:
+  name: Account Switcher <= 1.0.2 - Authentication Bypass to Privilege Escalation
+  author: Menashi-Admin
+  severity: high
+  description: |
+    The Account Switcher plugin for WordPress is vulnerable to Privilege Escalation
+    in all versions up to, and including, 1.0.2. This is due to the `rememberLogin`
+    REST API endpoint using a loose comparison (`!=` instead of `!==`) for secret
+    validation at `app/RestAPI.php:111`, combined with no validation that the secret
+    is non-empty. When a target user has never used the "Remember me" feature, their
+    `asSecret` user meta does not exist, causing `get_user_meta()` to return an empty
+    string. An attacker can send an empty `secret` parameter, which passes the
+    comparison (`'' != ''` is `false`), and the endpoint then calls
+    `wp_set_auth_cookie()` for the target user. Additionally, all REST routes use
+    `permission_callback => '__return_true'` making it possible for authenticated
+    attackers with Subscriber-level access and above to switch to any user account.
+  impact: |
+    Authenticated attackers with Subscriber-level access can escalate privileges to
+    Administrator by exploiting the loose comparison in the rememberLogin endpoint.
+    This allows complete takeover of the WordPress site.
+  remediation: |
+    Update the Account Switcher plugin to version 1.0.3 or later which implements
+    strict comparison (`!==`) for secret validation and proper nonce checks on REST
+    endpoints.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/9e9cfb9b-6951-4246-9cd6-dd64fee3a1bc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6456
+    - https://plugins.trac.wordpress.org/browser/account-switcher/tags/1.0.2/app/RestAPI.php#L111
+    - https://wordpress.org/plugins/account-switcher/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-6456
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: beycanpress
+    product: account-switcher
+    shodan-query: http.component:"WordPress"
+    fofa-query: body="/wp-content/plugins/account-switcher/"
+  tags: cve,cve2026,wordpress,wp-plugin,account-switcher,woocommerce,privesc,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-content/plugins/account-switcher/readme.txt'
+      - '{{BaseURL}}/wp-content/plugins/account-switcher/account-switcher.php'
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(tolower(body), 'account switcher')"
+          - "contains(tolower(body), 'stable tag: 1.0.2') || contains(tolower(body), 'version: 1.0.2')"
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - '(?:Stable Tag:|Version:)\s*([0-9.]+)'
+        internal: true
+
+  - method: GET
+    path:
+      - '{{BaseURL}}/?rest_route=/as-api/rememberLogin'
+      - '{{BaseURL}}/wp-json/as-api/rememberLogin'
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 401 || status_code == 400"
+          - "contains_all(body, 'rest_cookie_invalid_nonce', 'data') || contains(tolower(body), 'invalid request') || contains(tolower(body), 'rest')"
+          - "compare_versions(version, '<= 1.0.2')"
+        condition: and
+# digest: 4a0a00473045022068e2109e1be936db3557d30f9bdc98b4b1ab55ecebf63281b15a14a2f9b5f0cc02210086ddd9e7e68a9b2ff6e94375023e7e7665a04239481ce39ef28ce6d83ebc0ac3:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Details
CVE-2026-6456 is a Privilege Escalation vulnerability in the Account Switcher WordPress plugin (<= 1.0.2).

### Vulnerability
The `rememberLogin` REST API endpoint uses a loose comparison (`!=`) for secret validation at `app/RestAPI.php:111`. When a target user has never used the "Remember me" feature, `get_user_meta()` returns `false` (empty string). An attacker can send `secret=` (empty), making `"" != ""` evaluate to `false`, bypassing the check and gaining the target user\'s auth cookie.

### Detection
- Checks for the plugin readme.txt or main PHP file to detect version <= 1.0.2
- Verifies the REST endpoint `/wp-json/as-api/rememberLogin` is exposed
- Scans via `?rest_route=` and standard REST path

### References
- https://www.wordfence.com/threat-intel/vulnerabilities/id/9e9cfb9b-6951-4246-9cd6-dd64fee3a1bc
- https://nvd.nist.gov/vuln/detail/CVE-2026-6456
- https://plugins.trac.wordpress.org/browser/account-switcher/tags/1.0.2/app/RestAPI.php#L111