### PR TITLE
Add nMon login panel detection configuration

### DIFF
--- a/http/exposed-panels/nmon-login-panel.yaml
+++ b/http/exposed-panels/nmon-login-panel.yaml
@@ -1,0 +1,32 @@
+id: nmon-login-panel
+
+info:
+  name: nMon Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    nMon login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"nMon"
+  tags: panel,login,nmon,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?route=signin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>nMon</title>"
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/nmon-login-panel.yaml
+++ b/http/exposed-panels/nmon-login-panel.yaml
@@ -1,7 +1,7 @@
 id: nmon-login-panel
 
 info:
-  name: nMon Login - Panel Detect
+  name: nMon Panel - Detect
   author: Th3l0newolf
   severity: info
   description: |
@@ -12,8 +12,8 @@ info:
   metadata:
     max-request: 1
     verified: true
-    shodan-query: html:"nMon"
-  tags: panel,login,nmon,discovery
+    shodan-query: title:"nMon"
+  tags: panel,login,nmon,detect
 
 http:
   - method: GET


### PR DESCRIPTION
### PR Information

Template to discover nMon Panel 

### Template validation

- I have validated template.

<img width="782" height="317" alt="image" src="https://github.com/user-attachments/assets/0c21bed0-dd5a-4121-bc0f-6ee819138922" />

<img width="836" height="264" alt="image" src="https://github.com/user-attachments/assets/2e4f89b2-6f0d-4c80-8680-6cc6cb94d2bc" />

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
