### PR TITLE
fix(http/vulnerabilities/gradio-image-ssrf): template parsing failed

### DIFF
--- a/http/vulnerabilities/gradio-image-ssrf.yaml
+++ b/http/vulnerabilities/gradio-image-ssrf.yaml
@@ -39,8 +39,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body, '{"event_id":')
-          - contains(interactsh_protocol, 'http')
-          - contains(content_type, 'application/json')
+          - 'contains(body, "{\"event_id\":")'
+          - 'contains(interactsh_protocol, "http")'
+          - 'contains(content_type, "application/json")'
         condition: and
-# digest: 4a0a00473045022100bd4700e0bc99d4983fc71abcf5f7d78a07b421c53c08f889da74ecf6c846ca770220472f497266f16974aec7d4b82be1417678140fb37cc66d54770dca0e976220bc:922c64590222798bb761d5b6d8e72950
+# digest: 490a00463044022055e9a7a2a7cee7cf569792da2d154dc433668e9ac466acfc3c1856660388d1bf0220018ee9ee90eee6d532b8b50688ec10226c2b553c12cbd7ad88a8c0c94f2b7e49:066c0268537398d7afd900ba8237f912


### PR DESCRIPTION
Before this change, the template was unable to be parsed:
```
$ nuclei -lfa -duc -sign -ud http/vulnerabilities/gradio-image-ssrf.yaml -t http/vulnerabilities/gradio-image-ssrf.yaml
  [ERR] could not sign 'http/vulnerabilities/gradio-image-ssrf.yaml': cause="Cannot transition token types from STRING [{] to VARIABLE [event_id]" chain="failed to parse template; failed to get template from disk"
  [INF] All templates signatures were elaborated success=0 failed=1
```

This is a follow-up of this PR: https://github.com/projectdiscovery/nuclei-templates/pull/16210