### PR TITLE
Create android-request-install-packages-permission.yaml 

### DIFF
--- a/file/android/android-request-install-packages-permission.yaml
+++ b/file/android/android-request-install-packages-permission.yaml
@@ -1,0 +1,23 @@
+id: android-request-install-packages-permission
+
+info:
+  name: Android Dangerous Permission - REQUEST_INSTALL_PACKAGES
+  author: Th3l0newolf
+  severity: medium
+  description: |
+    The Android application requests the REQUEST_INSTALL_PACKAGES permission,
+    which allows the app to request installation of packages from unknown sources.
+    This permission may increase the risk of unauthorized APK installation or abuse.
+  reference:
+    - https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES
+  tags: file,android,permission,manifest
+
+file:
+  - extensions:
+      - xml
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '<uses-permission[^>]*android:name\s*=\s*"android\.permission\.REQUEST_INSTALL_PACKAGES"[^>]*/?>'

--- a/file/android/android-request-install-packages-permission.yaml
+++ b/file/android/android-request-install-packages-permission.yaml
@@ -5,9 +5,7 @@ info:
   author: Th3l0newolf
   severity: medium
   description: |
-    The Android application requests the REQUEST_INSTALL_PACKAGES permission,
-    which allows the app to request installation of packages from unknown sources.
-    This permission may increase the risk of unauthorized APK installation or abuse.
+    The Android application requests the REQUEST_INSTALL_PACKAGES permission, which allows the app to request installation of packages from unknown sources. This permission may increase the risk of unauthorized APK installation or abuse.
   reference:
     - https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES
   tags: file,android,permission,manifest
@@ -20,4 +18,4 @@ file:
       - type: regex
         part: body
         regex:
-          - '<uses-permission[^>]*android:name\s*=\s*"android\.permission\.REQUEST_INSTALL_PACKAGES"[^>]*/?>'
+          - '<uses-permission[^>]*\w+:name\s*=\s*["\x27]android\.permission\.REQUEST_INSTALL_PACKAGES["\x27][^>]*/?\s*>'


### PR DESCRIPTION
Added a YAML file to define the REQUEST_INSTALL_PACKAGES permission for Android applications, detailing its risks and usage.

### PR Information

 - The Android application requests the REQUEST_INSTALL_PACKAGES permission,
    which allows the app to request installation of packages from unknown sources.
    This permission may increase the risk of unauthorized APK installation or abuse.

 -  References:  https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES

### Template validation

I have validated template
 
<img width="816" height="324" alt="image" src="https://github.com/user-attachments/assets/3178d3f5-e215-4ce5-9e59-cd1422095599" />

<img width="1050" height="368" alt="image" src="https://github.com/user-attachments/assets/9b3f2760-426b-43c1-8f62-e0d96e318041" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
