### PR TITLE
Add CVE-2008-2052 template (Bitrix open redirect conversion)

### DIFF
--- a/http/cves/2008/CVE-2008-2052.yaml
+++ b/http/cves/2008/CVE-2008-2052.yaml
@@ -1,20 +1,30 @@
-id: bitrix-open-redirect
+id: CVE-2008-2052
 
 info:
-  name: Bitrix Site Management Russia 2.0 - Open Redirect
-  author: pikpikcu,gtrrnr
+  name: Bitrix Site Management 2.x - Open Redirect
+  author: pikpikcu,gtrrnr,liangtovi-debug
   severity: medium
-  description: Bitrix Site Management Russia 2.0 contains an open redirect vulnerability. An attacker can redirect a user to a malicious site and possibly obtain sensitive information, modify data, and/or execute unauthorized operations.
+  description: |
+    Bitrix Site Management 2.x contains an open redirect vulnerability allowing attackers to redirect users to arbitrary external sites via crafted redirect parameters.
+  impact: |
+    Successful exploitation can facilitate phishing and token theft by redirecting users to attacker-controlled destinations.
+  remediation: |
+    Upgrade Bitrix to a patched version and validate redirect targets against an allowlist.
   reference:
     - https://packetstormsecurity.com/files/151955/1C-Bitrix-Site-Management-Russia-2.0-Open-Redirection.html
+    - https://holisticinfosec.blogspot.com/2008/07/bitrix-open-redirect-vulnerability.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-2052
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
+    cve-id: CVE-2008-2052
     cwe-id: CWE-601
   metadata:
     max-request: 14
+    vendor: bitrix
+    product: site_management
     shodan-query: "html:\"/bitrix/\""
-  tags: redirect,bitrix,packetstorm,vuln
+  tags: cve,cve2008,redirect,bitrix,packetstorm,vuln
 
 http:
   - method: GET
@@ -51,4 +61,3 @@ http:
         status:
           - 302
           - 301
-# digest: 4a0a00473045022100ac224cbd1123e2b4d7b61ff3de3328391e1b979b8bad0b20c12dd1d93e116eda022039cfbffe49bd69832fd3a9e9cb684fa7a739d467ca26c862940fdc7dab45ed22:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- convert `http/vulnerabilities/other/bitrix-open-redirect.yaml` to CVE format as `http/cves/2008/CVE-2008-2052.yaml`
- keep detection logic and payload coverage unchanged
- add CVE classification metadata and extra reference requested in #15275

## Validation
- YAML parse check passed locally
- `nuclei -validate` not run in this environment (`nuclei` CLI not installed)

Part of #15275.
