### PR TITLE
http: convert beward-ipcamera-disclosure to CVE-2019-25246 template

### DIFF
--- a/http/cves/2019/CVE-2019-25246.yaml
+++ b/http/cves/2019/CVE-2019-25246.yaml
@@ -5,9 +5,11 @@ info:
   author: geeknik,liangtovi-debug
   severity: high
   description: |
-    The BEWARD N100 compact color IP camera suffers from an authenticated file disclosure vulnerability.
-    Input passed via the READ.filePath parameter in the fileread script is not properly verified before
-    being used to read files.
+    Beward N100 H.264 VGA IP Camera M2.1.6 contains an authenticated file disclosure vulnerability caused by improper validation of the 'READ.filePath' parameter in fileread script and SendCGICMD API, letting authenticated attackers read arbitrary system files.
+  impact: |
+    Authenticated attackers can read sensitive system files, potentially exposing critical information.
+  remediation: |
+    Update to the latest version or apply vendor patches addressing this vulnerability
   reference:
     - https://www.exploit-db.com/exploits/46320
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2019-5511.php

--- a/http/cves/2019/CVE-2019-25246.yaml
+++ b/http/cves/2019/CVE-2019-25246.yaml
@@ -1,20 +1,27 @@
-id: beward-ipcamera-disclosure
+id: CVE-2019-25246
 
 info:
   name: BEWARD N100 H.264 VGA IP Camera M2.1.6 - Arbitrary File Disclosure
-  author: geeknik
+  author: geeknik,liangtovi-debug
   severity: high
-  description: The N100 compact color IP camera suffers from an authenticated file disclosure vulnerability. Input passed via the READ.filePath parameter in fileread script is not properly verified before being used to read files. This can be exploited to disclose the contents of arbitrary files via absolute path or via the SendCGICMD API.
+  description: |
+    The BEWARD N100 compact color IP camera suffers from an authenticated file disclosure vulnerability.
+    Input passed via the READ.filePath parameter in the fileread script is not properly verified before
+    being used to read files.
   reference:
     - https://www.exploit-db.com/exploits/46320
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2019-5511.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-25246
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
     cvss-score: 8.6
+    cve-id: CVE-2019-25246
     cwe-id: CWE-22,CWE-73
   metadata:
     max-request: 1
-  tags: iot,camera,disclosure,edb,vuln
+    vendor: beward
+    product: n100_h.264_vga_ip_camera
+  tags: cve,cve2019,iot,camera,disclosure,edb,vuln
 
 http:
   - method: GET
@@ -33,4 +40,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100a551d5bd4c53f22f804fda72e67417377477507b5a2a7e3fedb7c170a203704202200a4ae7706c061c2963175f26598657441e6a7e8fce25be8b6f473f80039b3233:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- convert `http/vulnerabilities/other/beward-ipcamera-disclosure.yaml` to `http/cves/2019/CVE-2019-25246.yaml`
- keep request/matcher detection logic unchanged
- add CVE classification metadata and NVD reference

## Validation
- `ruby -e "require \'yaml\'; YAML.load_file(\'http/cves/2019/CVE-2019-25246.yaml\'); puts \'YAML_OK\'"`
- `nuclei` CLI validation not run locally (binary not installed)