### PR TITLE
Convert bems-api-lfi template to CVE-2021-4463

### DIFF
--- a/http/cves/2021/CVE-2021-4463.yaml
+++ b/http/cves/2021/CVE-2021-4463.yaml
@@ -1,20 +1,24 @@
-id: bems-api-lfi
+id: CVE-2021-4463
 
 info:
-  name: Longjing Technology BEMS API 1.21 - Local File Inclusion
+  name: Longjing Technology BEMS API 1.21 - Unauthenticated Arbitrary File Download
   author: gy741
   severity: high
   description: Longjing Technology BEMS API 1.21 is vulnerable to local file inclusion. Input passed through the fileName parameter through the downloads API endpoint is not properly verified before being used to download files. This can be exploited to disclose the contents of arbitrary and sensitive files through directory traversal attacks.
   reference:
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5657.php
     - https://packetstormsecurity.com/files/163702/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-4463
+    - https://www.cve.org/CVERecord?id=CVE-2021-4463
+    - https://www.exploit-db.com/exploits/50163
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-23,CWE-73
+    cwe-id: CWE-22,CWE-552
+    cve-id: CVE-2021-4463
   metadata:
     max-request: 1
-  tags: lfi,packetstorm,vuln
+  tags: cve,cve2021,lfi,packetstorm,vuln
 
 http:
   - method: GET


### PR DESCRIPTION
## Summary
- convert `http/vulnerabilities/other/bems-api-lfi.yaml` to a CVE template
- move it to `http/cves/2021/CVE-2021-4463.yaml`
- add CVE references and classification metadata (`cve-id`)
- preserve request path and matcher behavior

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("http/cves/2021/CVE-2021-4463.yaml"); puts "YAML OK"'`
