### PR TITLE
Convert ozeki-10-sms-gateway to CVE-2023-7327 template

### DIFF
--- a/http/cves/2023/CVE-2023-7327.yaml
+++ b/http/cves/2023/CVE-2023-7327.yaml
@@ -1,4 +1,4 @@
-id: ozeki-10-sms-gateway
+id: CVE-2023-7327
 
 info:
   name: Ozeki 10 SMS Gateway 10.3.208 - Arbitrary File Read
@@ -7,12 +7,15 @@ info:
   description: |
     An arbitrary file read vulnerability, also known as a "path traversal" or "directory traversal" vulnerability, occurs when an attacker is able to access files on a system that they shouldn't have access to. This vulnerability arises from improper input validation or insufficient access controls in an application.
   reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-7327
     - https://www.exploit-db.com/exploits/51646
     - https://ozeki-sms-gateway.com/attachments/702/installwindows_1689352737_OzekiSMSGateway_10.3.208.zip
+  classification:
+    cve-id: CVE-2023-7327
   metadata:
     verified: true
     max-request: 1
-  tags: ozeki,lfi,unauth,vuln
+  tags: cve,cve2023,ozeki,lfi,unauth,vuln
 
 http:
   - method: GET


### PR DESCRIPTION
This PR converts `http/vulnerabilities/other/ozeki-10-sms-gateway.yaml` into `http/cves/2023/CVE-2023-7327.yaml` for issue #15275.

Changes:
- moved template to CVE path
- set `id` to `CVE-2023-7327`
- added NVD reference and `classification.cve-id`
- preserved request and matcher logic

Closes #15275 (checklist conversion item).