### PR TITLE
http: convert watchguard credentials disclosure to CVE-2020-10532

### DIFF
--- a/http/cves/2020/CVE-2020-10532.yaml
+++ b/http/cves/2020/CVE-2020-10532.yaml
@@ -1,4 +1,4 @@
-id: watchguard-credentials-disclosure
+id: CVE-2020-10532
 
 info:
   name: WatchGuard Fireware AD Helper Component - Credentials Disclosure
@@ -6,15 +6,17 @@ info:
   severity: critical
   description: WatchGuard Fireware Threat Detection and Response (TDR) service contains a credential-disclosure vulnerability in the AD Helper component that allows unauthenticated attackers to gain Active Directory credentials for a Windows domain in plaintext.
   reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-10532
     - https://www.exploit-db.com/exploits/48203
     - https://www.watchguard.com/wgrd-blog/tdr-ad-helper-credential-disclosure-vulnerability
   classification:
+    cve-id: CVE-2020-10532
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10
     cwe-id: CWE-288
   metadata:
     max-request: 1
-  tags: watchguard,disclosure,edb,vuln
+  tags: cve,cve2020,watchguard,disclosure,edb,vuln
 
 http:
   - method: GET

--- a/http/cves/2021/CVE-2021-4463.yaml
+++ b/http/cves/2021/CVE-2021-4463.yaml
@@ -1,20 +1,24 @@
-id: bems-api-lfi
+id: CVE-2021-4463
 
 info:
-  name: Longjing Technology BEMS API 1.21 - Local File Inclusion
+  name: Longjing Technology BEMS API 1.21 - Unauthenticated Arbitrary File Download
   author: gy741
   severity: high
   description: Longjing Technology BEMS API 1.21 is vulnerable to local file inclusion. Input passed through the fileName parameter through the downloads API endpoint is not properly verified before being used to download files. This can be exploited to disclose the contents of arbitrary and sensitive files through directory traversal attacks.
   reference:
     - https://www.zeroscience.mk/en/vulnerabilities/ZSL-2021-5657.php
     - https://packetstormsecurity.com/files/163702/
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-4463
+    - https://www.cve.org/CVERecord?id=CVE-2021-4463
+    - https://www.exploit-db.com/exploits/50163
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cwe-id: CWE-23,CWE-73
+    cwe-id: CWE-22,CWE-552
+    cve-id: CVE-2021-4463
   metadata:
     max-request: 1
-  tags: lfi,packetstorm,vuln
+  tags: cve,cve2021,lfi,packetstorm,vuln
 
 http:
   - method: GET


### PR DESCRIPTION
## Summary
- convert `http/vulnerabilities/other/watchguard-credentials-disclosure.yaml` to `http/cves/2020/CVE-2020-10532.yaml`
- update template `id` to `CVE-2020-10532`
- add NVD reference and `classification.cve-id`
- preserve existing request and matcher behavior

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("http/cves/2020/CVE-2020-10532.yaml"); puts "YAML OK"'`