### PR TITLE
Add CVE-2026-6433 - WordPress Custom CSS-JS-PHP RCE

### DIFF
--- a/http/cves/2026/CVE-2026-6433.yaml
+++ b/http/cves/2026/CVE-2026-6433.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-6433
+
+info:
+  name: WordPress Custom CSS-JS-PHP <= 2.0.7 - Remote Code Execution
+  author: PikaJuna-ops
+  severity: high
+  description: |
+    The Custom CSS-JS-PHP plugin for WordPress is vulnerable to Remote Code Execution in all versions up to, and including, 2.0.7. The plugin passes unsanitized user input into SQL queries via the custom_css_search_query() function, and query results are subsequently passed to eval() in the wce_call_php_script() function. This makes it possible for unauthenticated attackers to execute arbitrary PHP code on the server. The plugin has been abandoned since version 2.0.7 with no patched release available.
+  impact: |
+    Unauthenticated attackers can achieve remote code execution by exploiting the SQL injection to eval() code execution chain.
+  remediation: |
+    Remove the Custom CSS-JS-PHP plugin immediately, as it is abandoned and contains this critical vulnerability.
+  reference:
+    - https://wpscan.com/vulnerability/a0b1c059-e156-4402-ac8d-67f8ad7386cc/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6433
+    - https://www.sentinelone.com/vulnerability-database/cve-2026-6433/
+    - https://cve.imfht.com/detail/CVE-2026-6433
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-6433
+    cwe-id: CWE-89
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: flippercode
+    product: custom-css-js-php
+    fofa-query: body="wp-content/plugins/custom-css-js-php/"
+  tags: cve,cve2026,wordpress,wp-plugin,rce,eval,sqli,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/custom-css-js-php/readme.txt"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Custom CSS-JS-PHP"
+          - "flippercode"
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/custom-css-js-php/assets/css/flippercode-ui.css"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "flippercode"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-6433.yaml
+++ b/http/cves/2026/CVE-2026-6433.yaml
@@ -17,7 +17,7 @@ info:
     - https://cve.imfht.com/detail/CVE-2026-6433
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
-    cvss-score: 7.1
+    cvss-score: 7.3
     cve-id: CVE-2026-6433
     cwe-id: CWE-89
   metadata:


### PR DESCRIPTION
### Template / Add CVE-2026-6433

Adds nuclei template for **CVE-2026-6433** — Remote Code Execution in the
Custom CSS-JS-PHP WordPress plugin (FlipperCode).

**Vulnerability Details:**
- **Plugin:** Custom CSS-JS-PHP by FlipperCode
- **Affected Versions:** ≤ 2.0.7 (plugin abandoned, no fix available)
- **Root Cause:** Unsanitized `$_POST['s']` is concatenated into SQL queries
  in `custom_css_search_query()`. Results are passed to `eval()` in
  `wce_call_php_script()`.
- **Impact:** Unauthenticated SQL injection → remote code execution via PHP eval()
- **CVSS:** 7.3 (High)

**Detection Strategy:**
This is **presence-based passive detection**, not runtime RCE verification.
Since the plugin was abandoned at v2.0.7 with no patched release,
confirming plugin installation is sufficient to flag vulnerability.

Detection uses two passive fingerprints:
1. `readme.txt` — checks for "Custom CSS-JS-PHP" and "flippercode"
2. `assets/css/flippercode-ui.css` — confirms via plugin-specific static asset

**Template Details:**
- Severity: High
- Max Requests: 2
- **verified: false** — not tested against live instance
- Detection-only — no exploit payload
- Tags: `cve,cve2026,wordpress,wp-plugin,rce,eval,sqli,unauth`

**References:**
- https://wpscan.com/vulnerability/a0b1c059-e156-4402-ac8d-67f8ad7386cc/
- https://nvd.nist.gov/vuln/detail/CVE-2026-6433
- https://www.sentinelone.com/vulnerability-database/cve-2026-6433/

**References #16188**