### PR TITLE
Add CVE-2024-12537 template for Open WebUI DoS vulnerability

### DIFF
--- a/http/cves/2024/CVE-2024-12537.yaml
+++ b/http/cves/2024/CVE-2024-12537.yaml
@@ -1,0 +1,64 @@
+id: CVE-2024-12537
+
+info:
+  name: Open WebUI < 0.5.14 - Unauthenticated Code Format Denial of Service
+  author: fineman999
+  severity: high
+  description: |
+    Open WebUI exposes the /api/v1/utils/code/format endpoint without
+    authentication in affected versions. An unauthenticated attacker can
+    submit excessively large code formatting requests, causing uncontrolled
+    resource consumption and denial of service. This template detects
+    vulnerable installations via the unauthenticated /api/version fingerprint
+    and does not send a DoS payload.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-12537
+    - https://github.com/advisories/GHSA-chf7-q7m5-fq92
+    - https://huntr.com/bounties/edabd06c-acc0-428c-a481-271f333755bc
+  classification:
+    cve-id: CVE-2024-12537
+    cwe-id: CWE-770
+    cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  metadata:
+    verified: true
+    vendor: openwebui
+    product: open_webui
+    max-request: 2
+  tags: cve,cve2024,openwebui,open-webui,dos,unauth
+
+http:
+  - raw:
+      - |
+        GET /api/version HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /api/v1/utils/code/format HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"code":"x"}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "contains(header_1, 'application/json')"
+          - "contains(body_1, 'version')"
+          - "compare_versions(version, '< 0.5.14')"
+          - "status_code_2 == 200"
+          - "contains(header_2, 'application/json')"
+          - "contains(body_2, 'code')"
+          - "!contains(body_2, 'Not authenticated')"
+          - "!contains(body_2, 'Unauthorized')"
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body_1
+        group: 1
+        regex:
+          - '"version"\s*:\s*"?v?([0-9]+\.[0-9]+\.[0-9]+)'


### PR DESCRIPTION
### PR Information

- Added CVE-2024-12537 — Open WebUI Unauthenticated Code Format Denial of Service
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-12537
  - https://github.com/advisories/GHSA-chf7-q7m5-fq92
  - https://huntr.com/bounties/edabd06c-acc0-428c-a481-271f333755bc

This template detects Open WebUI installations affected by the unauthenticated DoS in `/api/v1/utils/code/format`. To avoid causing service disruption, the template does not send a destructive payload. Instead it performs a two-request check:

1. `GET /api/version` to extract the running Open WebUI version.
2. `POST /api/v1/utils/code/format` with a minimal `{"code":"x"}` body to confirm the endpoint responds without authentication.

The DSL matcher requires (a) the extracted version to satisfy `compare_versions(version, '< 0.5.14')`, (b) the second request to return `200`, and (c) the response body to echo back the `code` key without `Not authenticated` / `Unauthorized` errors. Together these confirm both an affected version and an actually exposed unauthenticated endpoint.

Template path: `http/cves/2024/CVE-2024-12537.yaml`

#### Affected Version Discrepancy

GitHub Advisory `GHSA-chf7-q7m5-fq92` lists affected versions as `<= 0.3.32`, which appears to reflect the latest release at the time of the huntr report on 2024-10-12. Commit tracing in the upstream repository shows the unauthenticated code path persisted until `v0.5.14`:

- `d3d161f72` (2024-12-10, `v0.5.0`–`v0.5.13`): no authentication
- `2f75eef49` (2025-02-17, `v0.5.14`+): adds `get_verified_user`
- `4fe45d443` (2025-06-08, `v0.6.14`+): hardens to `get_admin_user`

The template uses `< 0.5.14` to match the unauthenticated threat model described in the huntr report. Docker reproduction on `v0.5.10` confirms unauthenticated access; Docker `v0.6.14` is used as a patched-version true negative control.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Reproduction is done locally with the public Docker lab:
https://github.com/fineman999/POC_CVE-2024-12537

```bash
# vulnerable
WEBUI_TAG=v0.5.10 docker compose up -d
# patched
WEBUI_TAG=v0.6.14 docker compose up -d
```

#### Additional Details

**Vulnerable: Open WebUI v0.5.10 — matched**

`nuclei -debug` output against the Docker lab on `127.0.0.1:3010`:

```
GET /api/version HTTP/1.1
Host: 127.0.0.1:3010

HTTP/1.1 200 OK
Content-Type: application/json

{"version":"0.5.10"}

POST /api/v1/utils/code/format HTTP/1.1
Host: 127.0.0.1:3010
Content-Type: application/json
Content-Length: 12

{"code":"x"}

HTTP/1.1 200 OK
Content-Type: application/json

{"code":"x\n"}

[CVE-2024-12537:dsl-1] [http] [high] http://127.0.0.1:3010/api/v1/utils/code/format ["0.5.10"]
```

Run command (the `-include-templates` flag is required because the template carries the `dos` tag, which is excluded from default runs):

```bash
nuclei -debug \
  -t http/cves/2024/CVE-2024-12537.yaml \
  -include-templates http/cves/2024/CVE-2024-12537.yaml \
  -u http://127.0.0.1:3010
```

**Patched: Open WebUI v0.6.14 — no match (true negative)**

```
GET /api/version HTTP/1.1
Host: 127.0.0.1:3010

HTTP/1.1 200 OK
Content-Type: application/json

{"version":"0.6.14"}

POST /api/v1/utils/code/format HTTP/1.1
Host: 127.0.0.1:3010
Content-Type: application/json

{"code":"x"}

HTTP/1.1 403 Forbidden
Content-Type: application/json

{"detail":"Not authenticated"}
```

nuclei output: `No results found`

The `status_code_2 == 200` and `!contains(body_2, 'Not authenticated')` matcher conditions both fail on the patched version, so the template correctly produces no result.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)