### PR TITLE
fix(trendmicro-apexone-panel): tighten matcher to prevent false positives

### DIFF
--- a/http/exposed-panels/trendmicro-apexone-panel.yaml
+++ b/http/exposed-panels/trendmicro-apexone-panel.yaml
@@ -2,7 +2,7 @@ id: trendmicro-apexone-panel
 
 info:
   name: Trend Micro Apex One Login Panel - Detect
-  author: johnk3r
+  author: johnk3r,s4e-io
   severity: info
   description: Trend Micro Apex One login panel was detected.
   classification:
@@ -25,6 +25,7 @@ http:
         words:
           - "officescan"
           - "Trend Micro"
+          - "TMlogonEncrypted"
         condition: and
 
       - type: status

--- a/http/exposed-panels/trendmicro-apexone-panel.yaml
+++ b/http/exposed-panels/trendmicro-apexone-panel.yaml
@@ -17,13 +17,15 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/officescan/console/html/cgi/cgiChkMasterPwd.exe"
+      - "{{BaseURL}}/SMB/console/html/cgi/cgiChkMasterPwd.exe"
+
+    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "officescan"
           - "Trend Micro"
           - "TMlogonEncrypted"
         condition: and
@@ -31,4 +33,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4b0a00483046022100c3044ebe4948997a76134555076172f81004f41f3d286bcf78b963616ce3a1c102210098393ed074826da7bc23fed7521d9e3f1bc16e181aac8e3c6e21b06d311cea11:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

This PR tightens the body matcher of `trendmicro-apexone-panel.yaml` to eliminate a false-positive class on targets that are not running Trend Micro Apex One.

**Background.** The current matcher requires the response body to contain two substrings under an `and` condition:

```yaml
words:
  - "officescan"
  - "Trend Micro"
condition: and
```

Both strings are individually weak indicators:

- `officescan` can appear in the body of any HTTP target that **echoes URL path segments** into the rendered page. In particular, SSR-rendered SPA frameworks with catch-all routes (e.g. Next.js `[...slug]`) embed every requested URL fragment into the page's hydration JSON, so a GET to `…/officescan/console/html/cgi/cgiChkMasterPwd.exe` will produce a 200 OK whose body contains the literal substring `officescan` regardless of the underlying application.
- `Trend Micro` is a vendor name that legitimately appears on a large surface of unrelated pages — IT integrator landing pages, partner programs, MSP service catalogs, comparison articles, and so on (e.g. as `alt="Trend Micro Bronze"` on a partner logo).

When both substrings are present on the same SPA catch-all response — which is common for integrators that publish partner content on a Next.js / similar SSR stack — the existing two-word `AND` matcher fires and produces an `info`-severity finding even though no Apex One panel exists at the target.

**Fix.** A single substring is added to the existing `AND` list — `TMlogonEncrypted` — which is the name of the hidden form input that ships in every real Apex One / OfficeScan `cgiChkMasterPwd.exe` login response:

```html
<form name="form_logon" action="../cgi/cgiChkMasterPwd.exe" method="POST">
    <input type="hidden" name="TMlogonEncrypted" value="">
    <input type="hidden" name="TxtAccount"        value="">
</form>
```

The parameter is part of the `cgiChkMasterPwd.exe` ↔ login HTML API contract: the CGI binary parses an HTTP POST body containing exactly this field name, so the string is effectively frozen across versions. It has been documented under this exact name in advisories spanning OfficeScan 8.0 through current Apex One builds and is hardcoded into upstream exploit tooling.

**References:**
- [CVE-2007-3455](https://www.cvedetails.com/cve/CVE-2007-3455/) — OfficeScan Corporate Edition 8.0 master-password bypass via an empty encrypted-password string; the parameter is `TMlogonEncrypted`.
- [HKCERT advisory](https://www.hkcert.org/security-bulletin/trend-micro-officescan-multiple-remote-buffer-overflow-vulnerabilities) — `TMlogonEncrypted` and `pwd` parameters as buffer-overflow vectors in `cgiChkMasterPwd.exe`.
- [pentest.blog: One ring to rule them all — Same RCE on multiple Trend Micro products](https://pentest.blog/one-ring-to-rule-them-all-same-rce-on-multiple-trend-micro-products/) — references the same parameter in OfficeScan XG widget framework.
- [Metasploit module `exploit/windows/http/trendmicro_officescan`](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/http/trendmicro_officescan.rb) — built around the same parameter.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

##### Diff

```diff
       - type: word
         part: body
         words:
           - "officescan"
           - "Trend Micro"
+          - "TMlogonEncrypted"
         condition: and
```

One line added, no removals. The change is strictly additive: any host the previous matcher correctly identified continues to match, because every real Apex One panel that contained `officescan` + `Trend Micro` also contains `TMlogonEncrypted`.

##### Why `TMlogonEncrypted` is the right discriminator

| Criterion | Evaluation |
|---|---|
| Uniqueness | The `TM` prefix is Trend Micro–specific; the substring does not appear in any URL echo of the template's request path (the slug `["officescan","console","html","cgi","cgiChkMasterPwd.exe"]` does not contain `TMlogonEncrypted`) and is not part of any common vendor/partner content. |
| Stability | Bound by a server-side API contract: `cgiChkMasterPwd.exe` parses this exact parameter name from the POST body, so renaming it would require recompiling the CGI binary and would break every existing client. Documented under the same name in advisories from 2007 onward. |
| Universality | Required by the encrypted logon flow itself — without this hidden field, the JavaScript-driven authentication cannot submit a credential, so any functional Apex One panel must serve it. |
| Backward compatibility | Additive: previous true positives are preserved because real Apex One responses already contain the string twice (once as the hidden input, once as a JavaScript reference). |

##### True positive — confirmed live Apex One panel (target redacted)

A live Apex One panel was located via `port="4343" && (title="OfficeScan" || body="officescan")` on a passive asset discovery engine, then probed with the updated template:

```
[trendmicro-apexone-panel] [http] [info] https://[REDACTED]:4343/officescan/console/html/cgi/cgiChkMasterPwd.exe

HTTP/1.1 200 OK
Strict-Transport-Security: max-age=31536000
X-Content-Security-Policy: default-src 'self'
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
Content-Type: text/html;charset=utf-8

<!DOCTYPE HTML>
<html l10n="LOGON">
...
    <input type="hidden" name="TMlogonEncrypted" value="">
...
    formLogon.TMlogonEncrypted.value = logonEncrypted;
...

[trendmicro-apexone-panel:word-1] [http] [info] https://[REDACTED]:4343/officescan/console/html/cgi/cgiChkMasterPwd.exe
[trendmicro-apexone-panel:status-2] [http] [info] https://[REDACTED]:4343/officescan/console/html/cgi/cgiChkMasterPwd.exe
[INF] Scan completed. 1 matches found.
```

`TMlogonEncrypted` occurs twice in the body (once in the HTML hidden input, once in the JavaScript that populates it). The detection still fires — no regression.

##### False positive — SPA catch-all target (target redacted)

A target running a Next.js / SSR application with a catch-all route, fronted by IIS, previously triggered the template. The catch-all route returns a 200 OK with a ~1.4 MB SPA shell whose hydration JSON embeds the requested URL path:

```json
"page":"/[...slug]","query":{"slug":["officescan","console","html","cgi","cgiChkMasterPwd.exe"]}
```

This places the literal substring `officescan` into the body via URL echo. The same page references `Trend Micro` elsewhere (e.g. partner-program alt text), so the two-word `AND` matcher fired.

After the change, the additional `TMlogonEncrypted` requirement is not satisfied:

```
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Scan completed. No results found.
```

##### Reproducibility for maintainers

Live instances suitable for re-validation can be located through any passive discovery engine using one of the following dorks:

| Engine | Query |
|---|---|
| Fofa | `port="4343" && (title="OfficeScan" || body="officescan")` |
| Shodan | `port:4343 OfficeScan` |

Reachable hits returning a `200 OK` with `Content-Type: text/html;charset=utf-8` and the standard Apex One security header set (`X-Content-Security-Policy`, `X-Frame-Options: SAMEORIGIN`, `Strict-Transport-Security: max-age=31536000`) are real Apex One panels and will continue to be detected by the updated matcher. Targets that return `404`, that lack the security header set, or that respond from a non-IIS / non–Apex One stack are correctly excluded.

All host identifiers in this PR are intentionally redacted to avoid inadvertent third-party disclosure.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
