### PR TITLE
Add Splunk MCP Server IDE login detection rule

### DIFF
--- a/http/exposed-panels/splunk-mcp-server-ide-login.yaml
+++ b/http/exposed-panels/splunk-mcp-server-ide-login.yaml
@@ -1,0 +1,34 @@
+id: splunk-mcp-server-ide-login
+
+info:
+  name: Splunk MCP Server IDE - Login Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    Splunk MCP Server IDE login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"Splunk MCP Server"
+  tags: panel,login,splunk,mcp,ide,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "<title>Splunk MCP Server - IDE</title>"
+          - '<h1 class="main">Splunk MCP Server</h1>'
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/splunk-mcp-server-ide-login.yaml
+++ b/http/exposed-panels/splunk-mcp-server-ide-login.yaml
@@ -1,7 +1,7 @@
 id: splunk-mcp-server-ide-login
 
 info:
-  name: Splunk MCP Server IDE - Login Detect
+  name: Splunk MCP Server IDE Login - Detect
   author: Th3l0newolf
   severity: info
   description: |


### PR DESCRIPTION
### PR Information

- Template to detect Splunk MCP Server IDE login


### Template validation

I have validated template 

<img width="727" height="317" alt="image" src="https://github.com/user-attachments/assets/bd610cf9-8c59-4b65-9b6e-0a3b4cfb6d20" />

<img width="825" height="188" alt="image" src="https://github.com/user-attachments/assets/89ff7130-312f-40ad-89a7-2ecde7592a2f" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
