### PR TITLE
Create librechat-configexposed.yaml

### DIFF
--- a/http/exposures/configs/librechat-config-exposure.yaml
+++ b/http/exposures/configs/librechat-config-exposure.yaml
@@ -5,7 +5,7 @@ info:
   author: icarot
   severity: low
   description: |
-    Detects if path /api/config of Librechat web application is exposed, getting internal information.
+    Detected the `/api/config` endpoint of the LibreChat web application was publicly accessible, potentially exposing internal configuration details.
   classification:
     cpe: cpe:2.3:a:librechat:librechat:-:*:*:*:*:*:*:*
   metadata:
@@ -30,6 +30,7 @@ http:
           - 'registrationEnabled'
           - 'passwordResetEnabled'
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/exposures/configs/librechat-config-exposure.yaml
+++ b/http/exposures/configs/librechat-config-exposure.yaml
@@ -1,4 +1,4 @@
-id: librechat-configexposed
+id: librechat-config-exposure
 
 info:
   name: librechat - Config Exposure
@@ -9,6 +9,7 @@ info:
   classification:
     cpe: cpe:2.3:a:librechat:librechat:-:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
     vendor: librechat
     product: librechat

--- a/http/exposures/configs/librechat-configexposed.yaml
+++ b/http/exposures/configs/librechat-configexposed.yaml
@@ -1,0 +1,34 @@
+id: librechat-configexposed
+
+info:
+  name: librechat - User Enumeration
+  author: icarot
+  severity: low
+  description: |
+    Detects if path /api/config of Librechat web application is exposed, getting internal information.
+  classification:
+    cpe: cpe:2.3:a:librechat:librechat:-:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: librechat
+    product: librechat
+    shodan-query: title:"librechat"
+  tags: librechat,config,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/config"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'LibreChat'
+          - 'serverDomain'
+          - 'registrationEnabled'
+          - 'passwordResetEnabled'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/exposures/configs/librechat-configexposed.yaml
+++ b/http/exposures/configs/librechat-configexposed.yaml
@@ -1,7 +1,7 @@
 id: librechat-configexposed
 
 info:
-  name: librechat - User Enumeration
+  name: librechat - Config Exposure
   author: icarot
   severity: low
   description: |


### PR DESCRIPTION
This nuclei template:

* Detects if path /api/config of Librechat web application is exposed, getting internal information.

- References:

https://github.com/danny-avila/LibreChat

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**LibreChat Docker Compose:**

1. Running container:

`$ git clone https://github.com/danny-avila/LibreChat.git`

`$ cd LibreChat`

`$ cp .env.example .env`

`$ docker compose up -d`

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' LibreChat`

`Access the URL: http://<host_machine_IP_address_or_obtained_Docker_IP_address>:3080`

**Nuclei execution:**

`~/go/bin/nuclei -t librechat-configexposed.yaml -u "http://<host_machine_IP_address_or_obtained_Docker_IP_address>:3080" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1055" height="797" alt="image" src="https://github.com/user-attachments/assets/619ae398-6aca-4520-b700-958d07432e0e" />

<img width="1843" height="431" alt="image" src="https://github.com/user-attachments/assets/a382b1a4-9074-48f0-9ceb-4f13027b2fc4" />
