### PR TITLE
Fix cve-id mismatch in CVE-2024-38856 template

### DIFF
--- a/http/cves/2024/CVE-2024-38856.yaml
+++ b/http/cves/2024/CVE-2024-38856.yaml
@@ -17,7 +17,7 @@ info:
     - https://ofbiz.apache.org/download.html
     - https://ofbiz.apache.org/security.html
   classification:
-    cve-id: CVE-2024-32113
+    cve-id: CVE-2024-38856
     cvss-score: 9.8
     cwe-id: CWE-22
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H


### PR DESCRIPTION
Template `id`, `name`, `description`, and `references` all identify CVE-2024-38856, but `classification.cve-id` incorrectly read CVE-2024-32113 (a related Apache OFBiz vulnerability with the same root cause). Aligned the field to match. No detection logic was changed.

### PR Information
- Fixed CVE-2024-38856 - corrected the `classification.cve-id` field, which read `CVE-2024-32113` while every other identifier in the template (id, name, description, references, tags) points to `CVE-2024-38856`.
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-38856
  - https://ofbiz.apache.org/security.html
  - https://lists.apache.org/thread/olxxjk6b13sl3wh9cmp0k2dscvp24l7w

### Template validation
- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details
This is a metadata-only correction - it does not touch the request, matchers, or any detection logic, so host-based True/False Positive validation is not applicable. The fix is verifiable from the template itself: the filename (`CVE-2024-38856.yaml`), `id`, `name` ("Apache OFBiz - Improper Authorization & Remote Code Execution"), `description` (affects ≤ 18.12.14, fixed in 18.12.15), and reference URLs all correspond to CVE-2024-38856, whereas `classification.cve-id` alone read CVE-2024-32113.

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)