### PR TITLE
Identify OutSystems panels using SSO by cookie names

### DIFF
--- a/http/exposed-panels/outsystems-servicecenter-panel.yaml
+++ b/http/exposed-panels/outsystems-servicecenter-panel.yaml
@@ -33,7 +33,12 @@ http:
           - 'status_code == 200'
           - 'contains(body, "Enter your OutSystems credentials")'
         condition: and
-
+      - type: word
+        words:
+          - "Set-Cookie: osVisitor="
+          - "Set-Cookie: osVisit="
+        condition: and
+        part: header
     extractors:
       - type: regex
         part: body

--- a/http/exposed-panels/outsystems-servicecenter-panel.yaml
+++ b/http/exposed-panels/outsystems-servicecenter-panel.yaml
@@ -15,7 +15,7 @@ info:
     max-request: 2
     vendor: outsystems
     product: platform_server
-    shodan-query: "http.html:\"outsystems\""
+    shodan-query: http.html:"outsystems"
   tags: panel,outsystems,login,detect,discovery
 
 http:
@@ -37,10 +37,10 @@ http:
         condition: and
 
       - type: word
-        part: header
+        part: set_cookie
         words:
-          - "Set-Cookie: osVisitor="
-          - "Set-Cookie: osVisit="
+          - "osVisitor="
+          - "osVisit="
         condition: or
 
     extractors:

--- a/http/exposed-panels/outsystems-servicecenter-panel.yaml
+++ b/http/exposed-panels/outsystems-servicecenter-panel.yaml
@@ -26,23 +26,26 @@ http:
 
     host-redirects: true
     max-redirects: 2
+
     stop-at-first-match: true
+
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
           - 'contains(body, "Enter your OutSystems credentials")'
         condition: and
+
       - type: word
+        part: header
         words:
           - "Set-Cookie: osVisitor="
           - "Set-Cookie: osVisit="
-        condition: and
-        part: header
+        condition: or
+
     extractors:
       - type: regex
         part: body
         group: 1
         regex:
           - 'environmentName:.?([a-z0-9A-Z\s]+).?'
-# digest: 4b0a004830460221008ef369b89386db83179edfa60774288c11c17640256b033e21f6d70529b16643022100d0a8bf02d461b14a2b54fbc5c428263fba40d3505177db0f9bc9fa6e755ac322:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

Existing template only works for sites that are using OutSystems built-in auth and not for systems integrated with SSO providers

### Template validation

Validated against a live system that is integrated with Entra for SSO.

