### PR TITLE
[FIX & ENHANCEMENT] False Positive AVEVA InTouch Access Anywhere - Panel

### DIFF
--- a/http/exposed-panels/aveva-intouch-access-anywhere-panel.yaml
+++ b/http/exposed-panels/aveva-intouch-access-anywhere-panel.yaml
@@ -5,10 +5,7 @@ info:
   author: rxerium
   severity: info
   description: |
-    AVEVA InTouch Access Anywhere is a secure gateway that provides browser-based
-    remote access to InTouch HMI applications over the internet. It is widely used in
-    industrial process control, utilities, and manufacturing environments. Exposed
-    instances may provide access to industrial HMI displays and SCADA interfaces.
+    Detected AVEVA InTouch Access Anywhere was a secure gateway that provided browser-based remote access to InTouch HMI applications over the internet. It was widely used in industrial process control, utilities, and manufacturing environments. Exposed instances may have provided access to industrial HMI displays and SCADA interfaces.
   reference:
     - https://www.aveva.com/en/products/intouch-hmi/
     - https://www.aveva.com/en/products/intouch-access-anywhere/
@@ -28,17 +25,10 @@ http:
     host-redirects: true
     max-redirects: 2
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - 'InTouch'
-          - 'Access Anywhere'
-          - 'AccessAnywhere'
-        condition: or
-
-      - type: status
-        status:
-          - 200
-# digest: 4a0a0047304502210093bf81e88fad1e5764f3ddc247dacb9b47c6cae56a2dc8d5bdda1ad2c75b0fd602204d033ba8f1e9cb3f79f867be30031f334e59e121abe339608a7b793e34e8b639:922c64590222798bb761d5b6d8e72950
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "AppName", "OnClickConnect", "ericom", "InTouch")'
+          - 'contains_any(body, "Access Anywhere", "AccessAnywhere")'
+        condition: and


### PR DESCRIPTION
Previously it Marked as FP :
[aveva-intouch-access-anywhere-panel] [http] [info] https://comarketing.anywebsite.com/AccessAnywhere/start.html

So add more strict matcher for avoid FP

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
