### PR TITLE
Add Rallly Login Panel detection

### DIFF
--- a/http/exposed-panels/rallly-login-panel.yaml
+++ b/http/exposed-panels/rallly-login-panel.yaml
@@ -1,0 +1,32 @@
+id: rallly-login-panel
+
+info:
+  name: Rallly Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    Rallly login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"Login | Rallly"
+  tags: panel,login,rallly,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Login | Rallly</title>"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Template to discover Rallly login portal  
- References: https://rallly.co/en-GB

### Template validation
 I have validated this template

<img width="793" height="331" alt="image" src="https://github.com/user-attachments/assets/9a40e937-d5b4-4fd9-a1df-a2f2ce6f1be4" />

<img width="1263" height="130" alt="image" src="https://github.com/user-attachments/assets/2b45c8af-f3fe-4d4c-a0dd-b3824505d41c" />



#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
