### PR TITLE
Add Baserow login panel detection

### DIFF
--- a/http/exposed-panels/baserow-login-panel.yaml
+++ b/http/exposed-panels/baserow-login-panel.yaml
@@ -1,0 +1,34 @@
+id: baserow-login-panel
+
+info:
+  name: Baserow Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    Baserow login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"Login // Baserow"
+  tags: panel,login,baserow,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "<title>Login // Baserow</title>"
+          - "BASEROW_DISABLE_PUBLIC_URL_CHECK"
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/baserow-login-panel.yaml
+++ b/http/exposed-panels/baserow-login-panel.yaml
@@ -10,7 +10,7 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-    verified: true  
+    verified: true
     max-request: 1
     shodan-query: html:"Login // Baserow"
   tags: panel,login,baserow,discovery

--- a/http/exposed-panels/baserow-login-panel.yaml
+++ b/http/exposed-panels/baserow-login-panel.yaml
@@ -10,8 +10,8 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
+    verified: true  
     max-request: 1
-    verified: true
     shodan-query: html:"Login // Baserow"
   tags: panel,login,baserow,discovery
 
@@ -24,10 +24,10 @@ http:
     matchers:
       - type: word
         part: body
-        condition: and
         words:
           - "<title>Login // Baserow</title>"
           - "BASEROW_DISABLE_PUBLIC_URL_CHECK"
+        condition: and
 
       - type: status
         status:


### PR DESCRIPTION
### PR Information

Template to detect  Baserow login pane

### Template validation

I have validated the template 

<img width="728" height="330" alt="image" src="https://github.com/user-attachments/assets/6eb2c09a-271d-47ce-8f7d-7c7a64a12864" />

<img width="1260" height="252" alt="image" src="https://github.com/user-attachments/assets/a222832e-f951-4f57-8888-68a48e48038b" />




#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
