### PR TITLE
Add CVE-2026-44338 - PraisonAI Authentication Bypass

### DIFF
--- a/http/cves/2026/cve-2026-44338.yaml
+++ b/http/cves/2026/cve-2026-44338.yaml
@@ -1,0 +1,46 @@
+id: cve-2026-44338
+
+info:
+  name: PraisonAI - Authentication Bypass
+  author: jnoza
+  severity: high
+  description: |
+    PraisonAI 2.5.6 to < 4.6.34 contains a broken authentication vulnerability caused by disabled 
+    default authentication in the legacy Flask API server. Remote attackers can access `/agents` 
+    and enumerate configured agent metadata or trigger workflows without a token.
+  remediation: Upgrade to PraisonAI version 4.6.34 or later.
+  reference:
+    - https://github.com/MervinPraison/PraisonAI/security/advisories/GHSA-6rmh-7xcm-cpxj
+    - https://webflow.sysdig.com/blog/cve-2026-44338-praisonai-authentication-bypass-in-under-4-hours-and-the-growing-trend-of-rapid-exploitation
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.3
+    cve-id: CVE-2026-44338
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,praisonai,auth-bypass,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/agents"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"agent_file"'
+          - '"agents"'
+        condition: and

--- a/http/cves/2026/cve-2026-44338.yaml
+++ b/http/cves/2026/cve-2026-44338.yaml
@@ -1,14 +1,14 @@
-id: cve-2026-44338
+id: CVE-2026-44338
 
 info:
   name: PraisonAI - Authentication Bypass
   author: jnoza
   severity: high
   description: |
-    PraisonAI 2.5.6 to < 4.6.34 contains a broken authentication vulnerability caused by disabled 
-    default authentication in the legacy Flask API server. Remote attackers can access `/agents` 
-    and enumerate configured agent metadata or trigger workflows without a token.
-  remediation: Upgrade to PraisonAI version 4.6.34 or later.
+    PraisonAI 2.5.6 to < 4.6.34 contains a broken authentication caused by disabled default authentication in legacy Flask API server, letting remote attackers access /agents and trigger workflows without token, exploit requires network access to API server.
+  impact: |
+    Remote attackers can access and trigger agent workflows without authentication, potentially leading to unauthorized actions or data exposure.
+  remediation: Upgrade to version 4.6.34 or later.
   reference:
     - https://github.com/MervinPraison/PraisonAI/security/advisories/GHSA-6rmh-7xcm-cpxj
     - https://webflow.sysdig.com/blog/cve-2026-44338-praisonai-authentication-bypass-in-under-4-hours-and-the-growing-trend-of-rapid-exploitation
@@ -20,6 +20,7 @@ info:
   metadata:
     verified: true
     max-request: 1
+    shodan-query: html:"PraisonAI"
   tags: cve,cve2026,praisonai,auth-bypass,kev
 
 http:
@@ -27,20 +28,10 @@ http:
     path:
       - "{{BaseURL}}/agents"
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: header
-        words:
-          - "application/json"
-
-      - type: word
-        part: body
-        words:
-          - '"agent_file"'
-          - '"agents"'
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains_all(body, 'agent_file', 'agents')"
+          - "contains(header, 'application/json')"
         condition: and


### PR DESCRIPTION
## Type of Change
- [x] New Template

## Template Information
- **Vulnerability Name:** PraisonAI Authentication Bypass
- **CVE ID:** CVE-2026-44338
- **Severity:** High (CVSS 7.3)
- **Description:** 
  PraisonAI versions 2.5.6 to < 4.6.34 ship with authentication disabled by default in the legacy Flask API server (`AUTH_ENABLED = False`). Unauthenticated remote attackers can query the `/agents` endpoint to enumerate configured agent metadata or invoke agent workflows via the `/chat` endpoint without a token.

## References
- https://github.com/MervinPraison/PraisonAI/security/advisories/GHSA-6rmh-7xcm-cpxj
- https://webflow.sysdig.com/blog/cve-2026-44338-praisonai-authentication-bypass-in-under-4-hours-and-the-growing-trend-of-rapid-exploitation
- https://nvd.nist.gov/vuln/detail/CVE-2026-44338

---

## Template Validation & Test Telemetry

### 1. Syntactical Validation
Passed local template syntax checks:
<img width="1634" height="454" alt="image" src="https://github.com/user-attachments/assets/6faa0b0e-fc39-41c2-8a98-98f8add7c197" />

### 2. True Positive (Vulnerable Target)
Tested against a local mock server running in vulnerable mode (no authentication required).
<img width="1802" height="628" alt="image" src="https://github.com/user-attachments/assets/da1c2c5a-89eb-44d5-b3f4-5d7b353419dc" />

### 3. True Negative / Patched Target (False Positive Prevention)
Tested against a local mock server running in patched mode (authentication required).
<img width="1764" height="592" alt="image" src="https://github.com/user-attachments/assets/a15b3781-3c25-4f28-8a42-c038bf3391b7" />
