### PR TITLE
CVE-2025-49001 - DataEase - Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-49001.yaml
+++ b/http/cves/2025/CVE-2025-49001.yaml
@@ -1,8 +1,8 @@
 id: CVE-2025-49001
 
 info:
-  name: DataEase <=2.10.8 - JWT Authentication Bypass
-  author: YunSeoJo
+  name: DataEase < 2.10.10 - JWT Authentication Bypass
+  author: YunSeoJo,aryu-ru
   severity: critical
   description: |
     DataEase < 2.10.10 contains a broken authentication caused by ineffective secret verification, letting users forge JWT tokens, exploit requires no special privileges.
@@ -19,6 +19,8 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2025-49001
     cwe-id: CWE-287
+    epss-score: 0.0017
+    epss-percentile: 0.37881
   metadata:
     verified: true
     max-request: 2
@@ -56,7 +58,20 @@ http:
           - 400
 
       - type: word
+        part: header
+        words:
+          - "de-gateway-flag"
+          - "hmacsha256"
+        condition: and
+        case-insensitive: true
+
+      - type: word
         part: body
         words:
           - "getWriter() has already been called"
-# digest: 4b0a00483046022100a4575045370da5093501278d9e70baf8e9a88a0b95ff6b985e07447aabcf59ab022100b6472b978b75415cc3ae0a837d98fd6fa2b832e03e6ca48b9a90c19cf2a6d92f:922c64590222798bb761d5b6d8e72950
+
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - x_de_execute_version


### PR DESCRIPTION
### PR Information

- Added **CVE-2025-49001** — DataEase < 2.10.10 Authentication Bypass

  `CommunityTokenFilter` decodes the `X-DE-TOKEN` JWT but does not enforce HMAC signature verification: when the signature check throws, the filter logs the error and still continues the filter chain, so the request reaches the controller carrying the attacker-supplied `uid`/`oid` claims and is processed as the administrator (`uid=1`). An unauthenticated attacker can therefore forge an admin token signed with any secret, which can be chained with CVE-2025-32966 for unauthenticated RCE.

  The template forges an `HS256` token (`{"uid":1,"oid":1}`) with an arbitrary key and sends it to `/de2api/user/info`. On a vulnerable instance the forged token is accepted past the signature layer, producing an `HTTP 400` whose `DE-GATEWAY-FLAG` header reports the swallowed `SignatureVerificationException` (`...HmacSHA256`) and whose body contains `getWriter() has already been called`. A patched/unaffected host rejects the request earlier with a clean `401`, so the matcher combines the status code, the flag header and the body marker with `condition: and` to avoid false positives.

  No existing template covers this CVE — the sibling DataEase templates (`CVE-2025-32966`, `CVE-2025-49002`) detect the authenticated H2 JDBC RCE via command output, not this auth-bypass primitive.

- References:
  - https://github.com/dataease/dataease/security/advisories/GHSA-xx2m-gmwg-mf3r
  - https://nvd.nist.gov/vuln/detail/CVE-2025-49001
  - https://github.com/vulhub/vulhub/tree/master/dataease/CVE-2025-49001

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Validated and runtime-tested against the official Vulhub environment (`vulhub/dataease:2.10.7`).

- `nuclei -validate` → `All templates validated successfully`
- Positive (vulnerable instance):
  ```
  [CVE-2025-49001] [http] [critical] http://127.0.0.1:8100/de2api/user/info
  ```
- Negative (benign HTTP targets `example.com`, `scanme.nmap.org`): no match.

Observed `nuclei -debug-resp` response from the vulnerable instance:
```
HTTP/1.1 400
X-De-Execute-Version: 2.10.7
De-Gateway-Flag: The%20Token%27s%20Signature%20resulted%20invalid%20when%20verified%20using%20the%20Algorithm%3A%20HmacSHA256
Content-Type: application/json;charset=ISO-8859-1

{"code":400,"msg":"Request processing failed: java.lang.IllegalStateException: getWriter() has already been called for this response","data":null}
```

Shodan: `http.html:"DataEase"` · Fofa: `app="FIT2CLOUD-DataEase"`
