### PR TITLE
Fix HPE AutoPass fixed-port URL expansion

### DIFF
--- a/http/exposed-panels/hpe-autopass-panel.yaml
+++ b/http/exposed-panels/hpe-autopass-panel.yaml
@@ -4,9 +4,10 @@ info:
   name: HPE AutoPass License Server - Panel Detection
   author: kylianghd
   severity: info
-  description: Detects an exposed HPE AutoPass License Server web interface on the default HTTPS port (5814) by probing the /autopass endpoint.
+  description: |
+   Detected an exposed HPE AutoPass License Server web interface on the default HTTPS port (5814) by probing the /autopass endpoint.
   metadata:
-    max-request: 2
+    max-request: 3
     vendor: hpe
     product: autopass-license-server
   tags: panel,exposure,misconfig,hpe,autopass
@@ -14,20 +15,22 @@ info:
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/autopass"
       - "https://{{Host}}:5814/autopass"
       - "https://{{Host}}:5814/autopass/"
+
     redirects: true
     max-redirects: 2
     stop-at-first-match: true
 
     matchers-condition: and
     matchers:
+      - type: word
+        part: body
+        words:
+          - "AutoPass License Server"
+
       - type: status
         status:
           - 200
-
-      - type: regex
-        part: body
-        regex:
-          - "(?i)autopass"
-# digest: 4a0a00473045022100f050544821edd1ec1686cd0947bfac6d5e44d5d4cdaeb70e77e3eefb0b7909cb022074aacff676ae1923745b7185302c0a32dbefe9c0ed63c4080a1092b5680e9179:922c64590222798bb761d5b6d8e72950
+          - 404

--- a/http/exposed-panels/hpe-autopass-panel.yaml
+++ b/http/exposed-panels/hpe-autopass-panel.yaml
@@ -14,8 +14,8 @@ info:
 http:
   - method: GET
     path:
-      - "https://{{Hostname}}:5814/autopass"
-      - "https://{{Hostname}}:5814/autopass/"
+      - "https://{{Host}}:5814/autopass"
+      - "https://{{Host}}:5814/autopass/"
     redirects: true
     max-redirects: 2
     stop-at-first-match: true


### PR DESCRIPTION
## Summary

Fixes `hpe-autopass-panel` fixed-port probe URLs by using `{{Host}}` instead of `{{Hostname}}`.

`{{Hostname}}` includes the input port, so targets like `http://<hostname>:6274/` were expanded to invalid URLs such as `https://<hostname>:6274:5814/autopass`. `{{Host}}` preserves only the host portion, producing the intended fixed-port probe: `https://<hostname>:5814/autopass`.

Fixes #16315

## Validation

- `nuclei -validate -t http/exposed-panels/hpe-autopass-panel.yaml -duc`
- `nuclei -u http://<hostname>:6274/ -t http/exposed-panels/hpe-autopass-panel.yaml -duc -debug-req -timeout 2 -retries 0`

The debug request now targets `https://<hostname>:5814/autopass` instead of `https://<hostname>:6274:5814/autopass`.
