### PR TITLE
Update mongodb-unauth.yml (didn't work for MongoDB 6.0+)

### DIFF
--- a/network/misconfig/mongodb-unauth.yaml
+++ b/network/misconfig/mongodb-unauth.yaml
@@ -14,6 +14,21 @@ info:
     max-request: 1
   tags: network,mongodb,unauth,misconfig,tcp,vuln
 tcp:
+  # Modern: listDatabases via OP_MSG (MongoDB 3.6+, incl. 6.0/7.0/8.0)
+  - inputs:
+      - data: 3c0000000100000000000000dd070000000000000027000000106c697374446174616261736573000100000002246462000600000061646d696e0000
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 27017
+
+    read-size: 4096
+    matchers:
+      - type: word
+        words:
+          - "totalSize"
+  # Legacy: getLog startupWarnings via OP_QUERY (MongoDB <=5.x and <3.6)
   - inputs:
       - data: 480000000200000000000000d40700000000000061646d696e2e24636d6400000000000100000021000000026765744c6f670010000000737461727475705761726e696e67730000
         type: hex
@@ -27,4 +42,3 @@ tcp:
       - type: word
         words:
           - "totalLinesWritten"
-# digest: 490a0046304402204c8b092b54d321bd00931e58c377335e7e5aa70a3b38100639f494a67351424e02204e9a3a9cdd0c0307db7b87ecfe493d8d47cd32c0b54eec1d3f28fefaa8a246dc:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

the old ("legacy") rule only covered MongoDB up to versions 5.x

from 6.0 it is necessary to use a new operation (OP_MSG)

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
