### PR TITLE
Update exposed-dockerd.yaml

### DIFF
--- a/network/exposures/exposed-dockerd.yaml
+++ b/network/exposures/exposed-dockerd.yaml
@@ -13,14 +13,17 @@ info:
   tags: network,docker,exposure,tcp,discovery
 tcp:
   - inputs:
-      - data: "Docker:\nVersion:\n"
+      - data: "GET /_ping HTTP/1.0\r\n\r\n"
 
     host:
       - "{{Hostname}}"
     port: 2375
 
+    matchers-condition: and
     matchers:
       - type: word
         words:
           - "Server: Docker"
-# digest: 490a00463044022061fd5ab7766f85ac7d69b636e92787c9e974d9845964f9ab843b4b1e3719a53f02207ba219a6c72250ac9052d089adcbf6704ca90d82e0858230122ed83155b43ad4:922c64590222798bb761d5b6d8e72950
+      - type: word
+        words:
+          - "Api-Version:"


### PR DESCRIPTION
### PR Information

My confidence level is strong that `exposed-dockerd.yaml` was never able to detect anything. This is because you need to hit an actual valid endpoint in order for the response to have the `Server: Docker/...` response header. A GET on an unexisting endpoint returns a 404 *without* any `Server:` header at all. Same when using some malformed HTTP request as the rule used to do.


### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

On a vulnerable host:
```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.8.0

		projectdiscovery.io

[INF] Current nuclei version: v3.8.0 (latest)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [exposed-dockerd] Dumped Network request for 10.209.48.247:2375
00000000  47 45 54 20 2f 5f 70 69  6e 67 20 48 54 54 50 2f  |GET /_ping HTTP/|
00000010  31 2e 30 0d 0a 0d 0a                              |1.0....| address=10.209.48.247:2375
[exposed-dockerd:word-1] [tcp] [critical] 10.209.48.247:2375
[exposed-dockerd:word-2] [tcp] [critical] 10.209.48.247:2375
[DBG] [exposed-dockerd] Dumped Network response for 10.209.48.247:2375

00000000  48 54 54 50 2f 31 2e 30  20 32 30 30 20 4f 4b 0d  |HTTP/1.0 200 OK.|
00000010  0a 41 70 69 2d 56 65 72  73 69 6f 6e 3a 20 31 2e  |.Api-Version: 1.|
00000020  35 34 0d 0a 42 75 69 6c  64 65 72 2d 56 65 72 73  |54..Builder-Vers|
00000030  69 6f 6e 3a 20 32 0d 0a  43 61 63 68 65 2d 43 6f  |ion: 2..Cache-Co|
00000040  6e 74 72 6f 6c 3a 20 6e  6f 2d 63 61 63 68 65 2c  |ntrol: no-cache,|
00000050  20 6e 6f 2d 73 74 6f 72  65 2c 20 6d 75 73 74 2d  | no-store, must-|
00000060  72 65 76 61 6c 69 64 61  74 65 0d 0a 44 6f 63 6b  |revalidate..Dock|
00000070  65 72 2d 45 78 70 65 72  69 6d 65 6e 74 61 6c 3a  |er-Experimental:|
00000080  20 66 61 6c 73 65 0d 0a  4f 73 74 79 70 65 3a 20  | false..Ostype: |
00000090  6c 69 6e 75 78 0d 0a 50  72 61 67 6d 61 3a 20 6e  |linux..Pragma: n|
000000a0  6f 2d 63 61 63 68 65 0d  0a 53 65 72 76 65 72 3a  |o-cache..Server:|
000000b0  20 44 6f 63 6b 65 72 2f  32 39 2e 35 2e 32 20 28  | Docker/29.5.2 (|
000000c0  6c 69 6e 75 78 29 0d 0a  53 77 61 72 6d 3a 20 69  |linux)..Swarm: i|
000000d0  6e 61 63 74 69 76 65 0d  0a 44 61 74 65 3a 20 57  |nactive..Date: W|
000000e0  65 64 2c 20 30 33 20 4a  75 6e 20 32 30 32 36 20  |ed, 03 Jun 2026 |
000000f0  31 39 3a 32 31 3a 35 35  20 47 4d 54 0d 0a 43 6f  |19:21:55 GMT..Co|
00000100  6e 74 65 6e 74 2d 4c 65  6e 67 74 68 3a 20 32 0d  |ntent-Length: 2.|
00000110  0a 43 6f 6e 74 65 6e 74  2d 54 79 70 65 3a 20 74  |.Content-Type: t|
00000120  65 78 74 2f 70 6c 61 69  6e 3b 20 63 68 61 72 73  |ext/plain; chars|
00000130  65 74 3d 75 74 66 2d 38  0d 0a 0d 0a 4f 4b        |et=utf-8....OK|
[INF] Scan completed in 2.081398ms. 2 matches found.
```
### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
