### PR TITLE
Add Homarr Dashboard exposed-panel detection template

### DIFF
--- a/http/exposed-panels/homarr-panel.yaml
+++ b/http/exposed-panels/homarr-panel.yaml
@@ -16,10 +16,10 @@ info:
   metadata:
     verified: true
     max-request: 1
-    shodan-query: http.title:"Homarr"
-    fofa-query: title="Homarr"
     product: homarr
     vendor: homarr
+    fofa-query: title="Homarr"
+    shodan-query: http.title:"Homarr"
   tags: panel,homarr,dashboard,oss,discovery
 
 http:
@@ -33,16 +33,13 @@ http:
     matchers-condition: and
     matchers:
       - type: word
-        part: body
+        part: response
         words:
           - '<title>Homarr</title>'
-          - 'Homarr Dashboard'
-        condition: or
-
-      - type: word
-        part: header
-        words:
+          - 'content="Homarr'
           - 'homarr.locale'
+          - 'alt="Homarr'
+        condition: or
 
       - type: status
         status:

--- a/http/exposed-panels/homarr-panel.yaml
+++ b/http/exposed-panels/homarr-panel.yaml
@@ -1,0 +1,49 @@
+id: homarr-panel
+
+info:
+  name: Homarr Dashboard - Detect
+  author: potato-20
+  severity: info
+  description: |
+    Homarr dashboard panel was detected. Homarr is a self-hosted dashboard for managing homelab and *arr-stack services.
+  reference:
+    - https://github.com/homarr-labs/homarr
+    - https://homarr.dev
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:homarr:homarr:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"Homarr"
+    fofa-query: title="Homarr"
+    product: homarr
+    vendor: homarr
+  tags: panel,homarr,dashboard,oss,discovery
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}'
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>Homarr</title>'
+          - 'Homarr Dashboard'
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - 'homarr.locale'
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

Adds an exposed-panel detection template for **Homarr** — a popular self-hosted dashboard for homelab / *arr-stack services ([~20k★](https://github.com/homarr-labs/homarr)). No existing template detects Homarr.

The template requires a body signature **and** an app-specific response header **and** a 200 status (`matchers-condition: and`) to keep false positives near zero:
- body: `<title>Homarr</title>` **or** og:title `Homarr Dashboard`
- header: `homarr.locale` (a `Set-Cookie` the app injects on every response, middleware-level)
- status: `200`

- Added: `http/exposed-panels/homarr-panel.yaml`
- References: https://github.com/homarr-labs/homarr , https://homarr.dev

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated locally with **nuclei v3.8.0** against **Homarr v1.x** (`ghcr.io/homarr-labs/homarr:latest`) running in Docker:

- **True positive** — fires on both a **fresh** instance (`/` → 307 → `/init` → 200) and a **fully-configured/onboarded** instance (`/` → 200 with inline login). The `homarr.locale` cookie and og:title `Homarr Dashboard` are present on every page (middleware/layout level), so detection holds regardless of configuration state.
- **False positive** — no match against a plain `nginx` host.
- `nuclei -validate` passes.

```
$ nuclei -t http/exposed-panels/homarr-panel.yaml -u http://<homarr> -ms
[homarr-panel] [matched] [http] [info] http://<homarr>/init

$ nuclei -t http/exposed-panels/homarr-panel.yaml -u http://<nginx>
(no output)
```

Shodan: `http.title:"Homarr"`

> Note: matchers target Homarr **v1.x+**. The legacy `ajnart/homarr` v0.x uses different signals (`color-scheme` cookie, no og:title) and is intentionally out of scope.