### PR TITLE
Tighten Janitza UMG panel matcher

### DIFF
--- a/http/exposed-panels/janitza-umg-panel.yaml
+++ b/http/exposed-panels/janitza-umg-panel.yaml
@@ -24,20 +24,10 @@ http:
     host-redirects: true
     max-redirects: 2
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - 'Janitza electronics'
-
-      - type: word
-        part: body
-        words:
-          - 'UMG'
-          - 'janitza.de'
-        condition: or
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Janitza electronics")'
+          - 'contains_any(body, "UMG", "janitza.de")'
+        condition: and

--- a/http/exposed-panels/janitza-umg-panel.yaml
+++ b/http/exposed-panels/janitza-umg-panel.yaml
@@ -30,6 +30,10 @@ http:
         part: body
         words:
           - 'Janitza electronics'
+
+      - type: word
+        part: body
+        words:
           - 'UMG'
           - 'janitza.de'
         condition: or
@@ -37,4 +41,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4b0a00483046022100e8f09d960cf6d4ec5f3fd68ea1f1afb21706bb259c6b654da3658660c1568c7f022100830e8ed91ea836d6fed7d483fe29d305733b90cd807e39f957c79a9209f6655f:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Template
- http/exposed-panels/janitza-umg-panel.yaml

## Details
Tightens the Janitza UMG panel matcher so the template no longer matches on the generic string UMG alone.

The updated matcher requires Janitza electronics and then either UMG or janitza.de, while still requiring HTTP 200.

## Validation
- Parsed the updated template YAML successfully
- Confirmed matcher structure requires the Janitza vendor string plus a secondary product/vendor signal

Closes #16330