### PR TITLE
Enrich 4x Perforce templates (now CVE-2026-6043)

### DIFF
--- a/javascript/enumeration/perforce-info-disclosure.yaml
+++ b/javascript/enumeration/perforce-info-disclosure.yaml
@@ -5,14 +5,17 @@ info:
   author: Morgan Robertson
   severity: medium
   description: |
-    Detected Perforce server exposed internal server information without authentication due to dm.info.hide being set to 0 (the default). Disclosed fields included the server version, server root path, internal server address, and license information. SSL-enforcing servers are not affected.
+    Detected Perforce server exposed internal server information without authentication due to dm.info.hide being set to 0 (the default). Disclosed fields included the server version, server root path, internal server address, and license information. This template does not support SSL-enforcing perforce servers. This is one facet of the insecure default configuration tracked as CVE-2026-6043, which affects P4 Server (P4D) versions prior to 2026.1.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+    - https://portal.perforce.com/s/cve/a91Qi000002wRUvIAM/insecure-default-configuration-in-p4-server
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6043
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
+    cve-id: CVE-2026-6043
     cwe-id: CWE-200
     cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
@@ -22,7 +25,7 @@ info:
     product: helix_core
     shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,info-disclosure
+  tags: cve,cve2026,perforce,helixcore,scm,unauth,info-disclosure
 
 flow: tcp(1) && javascript(1)
 

--- a/javascript/enumeration/perforce-user-enum.yaml
+++ b/javascript/enumeration/perforce-user-enum.yaml
@@ -5,14 +5,17 @@ info:
   author: Morgan Robertson
   severity: medium
   description: |
-    Detected Perforce server allowed anonymous user listing due to run.users.authorize being set to 0 (the default). The server returned a full list of users including usernames, email addresses, and full names without authentication. Both ASCII and Unicode server modes were affected. SSL-enforcing servers are not affected.
+    Detected Perforce server allowed anonymous user listing due to run.users.authorize being set to 0 (the default). The server returned a full list of users including usernames, email addresses, and full names without authentication. Both ASCII and Unicode server modes were affected. This template does not support SSL-enforcing perforce servers. This is one facet of the insecure default configuration tracked as CVE-2026-6043, which affects P4 Server (P4D) versions prior to 2026.1.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+    - https://portal.perforce.com/s/cve/a91Qi000002wRUvIAM/insecure-default-configuration-in-p4-server
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6043
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3
+    cve-id: CVE-2026-6043
     cwe-id: CWE-200
     cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
@@ -22,7 +25,7 @@ info:
     product: helix_core
     shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,user-listing,enum
+  tags: cve,cve2026,perforce,helixcore,scm,unauth,user-listing,enum
 
 flow: tcp(1) && javascript(1)
 

--- a/javascript/misconfiguration/perforce-passwordless-users.yaml
+++ b/javascript/misconfiguration/perforce-passwordless-users.yaml
@@ -5,14 +5,17 @@ info:
   author: Morgan Robertson
   severity: critical
   description: |
-    Perforce server contained user accounts with no password set, allowing unauthenticated access as those users. The user-users RPC was issued with the tag parameter to switch the server to tagged (client-FstatInfo) output, which omits the Password field entirely for passwordless accounts. Both ASCII and Unicode server modes were affected. SSL-enforcing servers are not affected.
+    Perforce server contained user accounts with no password set, allowing unauthenticated access as those users. The user-users RPC was issued with the tag parameter to switch the server to tagged (client-FstatInfo) output, which omits the Password field entirely for passwordless accounts. Both ASCII and Unicode server modes were affected. This template does not support SSL-enforcing perforce servers. This is one facet of the insecure default configuration tracked as CVE-2026-6043, which affects P4 Server (P4D) versions prior to 2026.1.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+    - https://portal.perforce.com/s/cve/a91Qi000002wRUvIAM/insecure-default-configuration-in-p4-server
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6043
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
+    cve-id: CVE-2026-6043
     cwe-id: CWE-306
     cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
@@ -22,7 +25,7 @@ info:
     product: helix_core
     shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,passwordless,enum
+  tags: cve,cve2026,perforce,helixcore,scm,unauth,passwordless,enum
 
 flow: tcp(1) && javascript(1)
 

--- a/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
+++ b/javascript/misconfiguration/perforce-remote-depot-unauth.yaml
@@ -5,14 +5,17 @@ info:
   author: Morgan Robertson
   severity: high
   description: |
-    Detected Perforce server allowed unauthenticated remote depot access via the hidden built-in "remote" user. This affected server versions below 2025.1 when the security level was below 4 (default is 0). The depot file listing and change list numbers were retrieved without authentication using the rmt-DbPipe RPC against the db.rev table.
+    Detected Perforce server allowed unauthenticated remote depot access via the hidden built-in "remote" user. This affected server versions below 2025.1 when the security level was below 4 (default is 0). The depot file listing and change list numbers were retrieved without authentication using the rmt-DbPipe RPC against the db.rev table. This template does not support SSL-enforcing perforce servers. This is one facet of the insecure default configuration tracked as CVE-2026-6043; the 'remote' user access vector specifically was addressed in the P4 Server (P4D) 2025.1 release.
   reference:
     - https://morganrobertson.net/p4wned/
     - https://www.keysight.com/blogs/en/tech/nwvs/2022/06/08/a-sneak-peek-into-the-protocol-behind-perforce
     - https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+    - https://portal.perforce.com/s/cve/a91Qi000002wRUvIAM/insecure-default-configuration-in-p4-server
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6043
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
+    cve-id: CVE-2026-6043
     cwe-id: CWE-306
     cpe: cpe:2.3:a:perforce:helix_core:*:*:*:*:*:*:*:*
   metadata:
@@ -22,7 +25,7 @@ info:
     product: helix_core
     shodan-query: port:1666 "P4D"
     fofa-query: port="1666" && protocol="unknown"
-  tags: perforce,helixcore,scm,unauth,rpc,info-disclosure
+  tags: cve,cve2026,perforce,helixcore,scm,unauth,rpc,info-disclosure
 
 flow: tcp(1) && javascript(1)
 


### PR DESCRIPTION
### PR Information

Enrich 4x Perforce templates with CVE metadata. This cluster of exposures and insecure defaults have been designated CVE-2026-6043.

Updated:

```
javascript/enumeration/perforce-info-disclosure.yaml
javascript/enumeration/perforce-user-enum.yaml
javascript/misconfiguration/perforce-passwordless-users.yaml
javascript/misconfiguration/perforce-remote-depot-unauth.yaml
```

- References:
[NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-6043)
[vendor](https://portal.perforce.com/s/cve/a91Qi000002wRUvIAM/insecure-default-configuration-in-p4-server)

### Template validation

- [] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [] Validated with a host running a patched version and/or configuration (avoid False Positive)

N.B. Only metadata update. Did run `-validate` but did not re-run against a live host as only metadata was updated.