### PR TITLE
Create postiz-registration-enabled.yaml for public account creation

### DIFF
--- a/http/misconfiguration/postiz-registration-enabled.yaml
+++ b/http/misconfiguration/postiz-registration-enabled.yaml
@@ -1,20 +1,18 @@
 id: postiz-registration-enabled
 
 info:
-  name: Postiz Registration Enabled
+  name: Postiz - User Registration Enabled
   author: Th3l0newolf
-  severity: medium
+  severity: info
   description: |
-    Postiz registration page is exposed and allows public account creation.
-    Unrestricted registration may allow unauthorized users to create accounts.
+    Postiz registration page is exposed and allows public account creation. Unrestricted registration may allow unauthorized users to create accounts.
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
-    cwe-id: CWE-284
+    cpe: cpe:2.3:a:postiz:postiz:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
     verified: true
     shodan-query: html:"Postiz Register"
-  tags: postiz,registration,panel,exposure,misconfig
+  tags: postiz,misconfig,exposure
 
 http:
   - method: GET
@@ -25,11 +23,11 @@ http:
     matchers:
       - type: word
         part: body
-        condition: and
         words:
           - "<title>Postiz Register</title>"
           - "Create Account</div></button>"
           - "Sign Up</h1>"
+        condition: and
 
       - type: status
         status:

--- a/http/misconfiguration/postiz-registration-enabled.yaml
+++ b/http/misconfiguration/postiz-registration-enabled.yaml
@@ -1,0 +1,36 @@
+id: postiz-registration-enabled
+
+info:
+  name: Postiz Registration Enabled
+  author: Th3l0newolf
+  severity: medium
+  description: |
+    Postiz registration page is exposed and allows public account creation.
+    Unrestricted registration may allow unauthorized users to create accounts.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
+    cwe-id: CWE-284
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"Postiz Register"
+  tags: postiz,registration,panel,exposure,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "<title>Postiz Register</title>"
+          - "Create Account</div></button>"
+          - "Sign Up</h1>"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Added a new YAML file for Postiz registration misconfiguration detection.

### PR Information

If exposed registration page is left open to wider internet without any restriction anyone can create an account on your instance. Although this is common optional settings, registration should be disabled  

<img width="650" height="544" alt="image" src="https://github.com/user-attachments/assets/7d86acba-c8f0-4964-bc14-974c0952cc7e" />


<img width="805" height="295" alt="image" src="https://github.com/user-attachments/assets/74dadff0-5945-4d89-bec1-a548205eb148" />

- References:
- https://docs.postiz.com/configuration/reference#disable_registration
- https://raw.githubusercontent.com/gitroomhq/postiz-app/main/.env.example


### Template validation
I have validated this template

<img width="758" height="327" alt="image" src="https://github.com/user-attachments/assets/749cae3e-6679-45b0-a00f-2c0d80f2836c" />

<img width="743" height="73" alt="image" src="https://github.com/user-attachments/assets/f0673240-d135-4f20-bfd4-2075f3afb5b0" />

 

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
