### PR TITLE
Create CVE-2026-2993.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-2993.yaml
+++ b/http/cves/2026/CVE-2026-2993.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-2993
+
+info:
+  name: AI Chatbot & Workflow Automation by AIWU <= 1.4.17 - SQL Injection
+  author: moizxsec
+  severity: high
+  description: |
+    AI Chatbot & Workflow Automation by AIWU plugin for WordPress <= 1.4.17 contains a SQL injection in the getListForTbl() function, which fails to properly escape user-supplied parameters and does not adequately prepare the underlying SQL query, letting unauthenticated attackers append additional SQL statements to extract sensitive database information.
+  impact: |
+    Unauthenticated attackers can extract sensitive database information, leading to data disclosure and potential further compromise.
+  remediation: |
+    Update to the latest version beyond 1.4.17.
+  reference:
+    - https://www.sentinelone.com/vulnerability-database/cve-2026-2993/
+    - https://wordpress.org/plugins/ai-copilot-content-generator/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2993
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-2993
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    publicwww-query: "/wp-content/plugins/ai-copilot-content-generator/"
+    product: ai-copilot-content-generator
+    vendor: wupsales
+  tags: cve,cve2026,wordpress,wp-plugin,ai-copilot-content-generator,sqli,unauth,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/ai-copilot-content-generator/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "compare_versions(version, '<= 1.4.17')"
+          - "contains(body, 'AIWU')"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        name: version
+        regex:
+          - 'Stable tag: ([0-9.]+)'
+        internal: true


### PR DESCRIPTION
Adds a template for **CVE-2026-2993** — AI Chatbot & Workflow Automation by AIWU (`ai-copilot-content-generator`) `<= 1.4.17` — unauthenticated SQL injection (CWE-89, CVSS 7.5).

The flaw is in the plugin's `getListForTbl()` function, which fails to properly escape user-supplied parameters, allowing unauthenticated attackers to extract database data.

### Detection
The actual SQLi exploitation is data-extracting/intrusive and the advisory does not document a single fixed injectable parameter, so this uses a **safe, passive version-based detection**: it reads the plugin `readme.txt` and matches `Stable tag <= 1.4.17` plus an `AIWU` body marker to avoid false positives. This mirrors existing passive WP-plugin templates (e.g. `CVE-2025-13773`).

### Validation
- `nuclei -validate -t http/cves/2026/CVE-2026-2993.yaml` → validated successfully.
- Confirmed against the live wp.org `readme.txt` (current `Stable tag: 1.4.21`), so patched instances are correctly **not** matched.

### References
- https://www.sentinelone.com/vulnerability-database/cve-2026-2993/
- https://nvd.nist.gov/vuln/detail/CVE-2026-2993
- https://wordpress.org/plugins/ai-copilot-content-generator/

### Template
- [x] Template validated with `nuclei -validate`
- [x] Follows the existing passive WP-plugin detection pattern