### PR TITLE
dns: add internal IP address disclosure in DNS A records

### DIFF
--- a/dns/dns-internal-ip-disclosure.yaml
+++ b/dns/dns-internal-ip-disclosure.yaml
@@ -1,0 +1,42 @@
+id: dns-internal-ip-disclosure
+
+info:
+  name: DNS A Record - Internal IP Address Disclosure
+  author: DevamShah
+  severity: info
+  description: |
+    A public DNS A record resolves to an RFC 1918 private or loopback IP address (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8). Exposing internal addressing in authoritative DNS leaks internal network topology and can aid attackers in mapping internal infrastructure or staging DNS rebinding attacks.
+  reference:
+    - https://datatracker.ietf.org/doc/html/rfc1918
+    - https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+    - https://cwe.mitre.org/data/definitions/200.html
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+  tags: dns,a,internal-ip,disclosure,misconfig
+
+dns:
+  - name: "{{FQDN}}"
+    type: A
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        name: a-record-present
+        part: answer
+        regex:
+          - "IN\tA\t(.+)$"
+
+      - type: regex
+        name: rfc1918-or-loopback
+        part: answer
+        regex:
+          - "IN\tA\t(10|127|192\\.168|172\\.(1[6-9]|2[0-9]|3[01]))\\.[0-9]{1,3}\\.[0-9]{1,3}"
+
+    extractors:
+      - type: regex
+        group: 1
+        part: answer
+        regex:
+          - "IN\tA\t((?:10|127|192\\.168|172\\.(?:1[6-9]|2[0-9]|3[01]))\\.[0-9.]+)"

--- a/dns/dns-internal-ip-disclosure.yaml
+++ b/dns/dns-internal-ip-disclosure.yaml
@@ -1,20 +1,20 @@
 id: dns-internal-ip-disclosure
 
 info:
-  name: DNS A Record - Internal IP Address Disclosure
-  author: DevamShah
+  name: Public DNS Resolving to Private IP Addresses
+  author: infosec-asish,DevamShah
   severity: info
   description: |
-    A public DNS A record resolves to an RFC 1918 private or loopback IP address (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8). Exposing internal addressing in authoritative DNS leaks internal network topology and can aid attackers in mapping internal infrastructure or staging DNS rebinding attacks.
+    Detected when a public domain's DNS A records resolved to private or reserved IP addresses, potentially revealing internal network topology to external parties.
   reference:
-    - https://datatracker.ietf.org/doc/html/rfc1918
-    - https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/01-Conduct_Search_Engine_Discovery_Reconnaissance_for_Information_Leakage
+    - https://tools.ietf.org/html/rfc1918
+    - https://tools.ietf.org/html/rfc6598
     - https://cwe.mitre.org/data/definitions/200.html
   classification:
     cwe-id: CWE-200
   metadata:
     max-request: 1
-  tags: dns,a,internal-ip,disclosure,misconfig
+  tags: dns,exposure,misconfig,recon
 
 dns:
   - name: "{{FQDN}}"


### PR DESCRIPTION
## Summary

Adds a DNS-protocol template that detects internal IP address disclosure in authoritative DNS A records. Closes #16279.

The template queries the `A` record for the target and matches when the answer resolves to an RFC 1918 private range or loopback space:

- `10.0.0.0/8`
- `172.16.0.0/12` (correctly bounded to 172.16–172.31)
- `192.168.0.0/16`
- `127.0.0.0/8`

## Problem

Organizations frequently leave internal-only hostnames (e.g. `localhost.example.com`, split-horizon staging entries, forgotten `A` records) in their public authoritative zones pointing at RFC 1918 / loopback addresses. This leaks internal network topology — subnet layout, host counts, naming schemes — to anyone who can resolve the name, and provides primitives for DNS rebinding against internal services. There is currently no template in the `dns/` directory that surfaces this misconfiguration; existing record templates (`aaaa-fingerprint`, `ptr-fingerprint`, etc.) fingerprint record presence but do not evaluate whether the resolved address is internal.

## Change

New template: `dns/dns-internal-ip-disclosure.yaml`

- `dns` protocol, `type: A`, `max-request: 1`, severity `info` (per the issue).
- `matchers-condition: and` with two regex matchers to keep false positives near zero:
  1. `a-record-present` — confirms an `IN A` answer was actually returned.
  2. `rfc1918-or-loopback` — anchored on `IN\tA\t` so the private-range pattern only matches the resolved address field, never the queried name, TTL, or other sections. The `172.x` arm is bounded to the second octet `16–31`, so public `172.x` space (e.g. `172.66.x`, Cloudflare) is excluded.
- Extractor returns the leaked internal IP for triage.

## Security rationale

- **CWE-200** — Exposure of Sensitive Information to an Unauthorized Actor (internal network topology via DNS).
- **OWASP WSTG-INFO** — Information Gathering / leakage reconnaissance.
- Maps to RFC 1918 address allocation. Severity `info`: this is a misconfiguration / recon-value finding, not a direct exploit, consistent with sibling `dns/` discovery templates.

## Testing

`nuclei -t dns/dns-internal-ip-disclosure.yaml -validate` → `All templates validated successfully`.

Live structural validation against `nip.io` (public wildcard resolver where `<ip>.nip.io` resolves to `<ip>`), exercising every RFC 1918 arm plus loopback, with public addresses as negative controls:

```
[dns-internal-ip-disclosure] [dns] [info] 10.0.0.1.nip.io      ["10.0.0.1"]
[dns-internal-ip-disclosure] [dns] [info] 127.0.0.1.nip.io     ["127.0.0.1"]
[dns-internal-ip-disclosure] [dns] [info] 192.168.1.50.nip.io  ["192.168.1.50"]
[dns-internal-ip-disclosure] [dns] [info] 172.20.5.5.nip.io    ["172.20.5.5"]
```

Negative controls (no match — correct):

- `172.66.0.1.nip.io` (public 172.x, outside 172.16–31) → `No results found`
- `8.8.8.8.nip.io` (public) → no match
- `example.com` (public `104.20.x` / `172.66.x`) → no match

`-debug` on the `172.66.0.1.nip.io` case confirms the `A` record is returned (`IN A 172.66.0.1`) yet the template does not fire, demonstrating the second-octet bound and the two-matcher `AND` correctly suppress public-range false positives.
