### PR TITLE
add: Qdrant vector database - unauthenticated collections exposure

### DIFF
--- a/http/misconfiguration/qdrant-collections-exposure.yaml
+++ b/http/misconfiguration/qdrant-collections-exposure.yaml
@@ -1,7 +1,7 @@
 id: qdrant-collections-exposure
 
 info:
-  name: Qdrant Vector Database - Collections Exposure
+  name: Qdrant Vector Database - Information Exposure
   author: DevamShah
   severity: medium
   description: |

--- a/http/misconfiguration/qdrant-unauth-collections-exposure.yaml
+++ b/http/misconfiguration/qdrant-unauth-collections-exposure.yaml
@@ -1,0 +1,55 @@
+id: qdrant-unauth-collections-exposure
+
+info:
+  name: Qdrant Vector Database - Unauthenticated Collections Exposure
+  author: DevamShah
+  severity: medium
+  description: |
+    A Qdrant vector database was detected exposing its collections listing over the unauthenticated REST API. Qdrant enforces no API key by default; when reachable without the service.api_key set, a bare GET /collections returns the names of all collections. Vector stores back RAG and AI applications and hold embedded private corpora, so an exposed instance permits enumeration, retrieval and poisoning of that data.
+  impact: |
+    An open /collections response confirms the data plane (/collections/{name}/points, scroll, search) is reachable without credentials, enabling silent exfiltration of the embedded source corpus, index poisoning of downstream retrieval, and deletion of collections.
+  remediation: |
+    Set service.api_key (and read-only key where applicable) and require it on every request, enable TLS, and place Qdrant behind an authenticated network boundary. Never bind TCP 6333 to a public interface unauthenticated.
+  reference:
+    - https://qdrant.tech/documentation/guides/security/
+    - https://api.qdrant.tech/api-reference/collections/get-collections
+    - https://cwe.mitre.org/data/definitions/200.html
+  classification:
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:qdrant:qdrant:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: qdrant
+    product: qdrant
+    shodan-query: 'title:"Qdrant"'
+    fofa-query: 'body="\"collections\""'
+  tags: qdrant,vectordb,ai,ml,misconfig,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/collections"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"result":'
+          - '"collections":'
+          - '"status":"ok"'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+        condition: and
+
+    extractors:
+      - type: json
+        name: exposed_collections
+        part: body
+        json:
+          - '.result.collections[].name'

--- a/http/misconfiguration/qdrant-unauth-collections-exposure.yaml
+++ b/http/misconfiguration/qdrant-unauth-collections-exposure.yaml
@@ -1,7 +1,7 @@
-id: qdrant-unauth-collections-exposure
+id: qdrant-collections-exposure
 
 info:
-  name: Qdrant Vector Database - Unauthenticated Collections Exposure
+  name: Qdrant Vector Database - Collections Exposure
   author: DevamShah
   severity: medium
   description: |
@@ -22,9 +22,9 @@ info:
     max-request: 1
     vendor: qdrant
     product: qdrant
-    shodan-query: 'title:"Qdrant"'
+    shodan-query: title:"Qdrant"
     fofa-query: 'body="\"collections\""'
-  tags: qdrant,vectordb,ai,ml,misconfig,exposure,unauth
+  tags: qdrant,vectordb,ai,ml,misconfig,exposure
 
 http:
   - method: GET
@@ -46,10 +46,3 @@ http:
           - 'status_code == 200'
           - 'contains(content_type, "application/json")'
         condition: and
-
-    extractors:
-      - type: json
-        name: exposed_collections
-        part: body
-        json:
-          - '.result.collections[].name'


### PR DESCRIPTION
## Summary
Adds a template detecting an unauthenticated **Qdrant** vector database via `GET /collections`, confirming an exposed RAG/AI data store and extracting the collection names.

## Problem / motivation
Qdrant enforces **no API key by default**. When `service.api_key` is unset and the instance is reachable, `GET /collections` returns every collection name with no credential. Vector databases hold the embedded private corpora behind RAG and AI applications, so an exposed Qdrant is a high-value finding: the data plane (`/collections/{name}/points`, `scroll`, `search`) is reachable for retrieval, poisoning, or deletion. nuclei has no Qdrant exposure template today; this extends the same author's merged ChromaDB unauthenticated-collections template to the Qdrant ecosystem.

## Change
New `http/misconfiguration/qdrant-unauth-collections-exposure.yaml`:
- `GET {{BaseURL}}/collections`, `matchers-condition: and`, **3 matchers**: body words `"result":` + `"collections":` + `"status":"ok"` (Qdrant's response envelope), plus a `dsl` check on `200` + `application/json`.
- JSON extractor `.result.collections[].name`. `severity: medium` (data-store exposure, higher impact than a model-listing).

## Security rationale
- **CWE-200** — Exposure of Sensitive Information to an Unauthorized Actor.
- **OWASP LLM Top 10 — LLM02 Sensitive Information Disclosure / LLM03 Supply Chain:** the vector store concentrates an application's embedded private data; unauthenticated access enables corpus exfiltration and retrieval-poisoning.
- **OWASP API Top 10 (2023) API2 Broken Authentication.**

## Testing / validation
- Authored to current `http/misconfiguration` exposure-template conventions (mirrors the merged ChromaDB unauth-collections template by the same author).
- Matchers + `.result.collections[].name` extractor designed against Qdrant's documented `GET /collections` response (`{"result":{"collections":[…]},"status":"ok","time":…}`).
- **Verified** against a local `qdrant/qdrant` docker instance (no `api_key`): `nuclei -validate` passed, and a live `-debug` run fired all matchers and extracted the seeded collection name (`{"result":{"collections":[{"name":"…"}]},"status":"ok"}`). `metadata.verified: true` reflects this author-confirmed test.
