### PR TITLE
Add StackStorm Web UI panel detection

### DIFF
--- a/http/exposed-panels/stackstorm-web-ui-panel.yaml
+++ b/http/exposed-panels/stackstorm-web-ui-panel.yaml
@@ -1,0 +1,28 @@
+id: stackstorm-web-ui-panel
+
+info:
+  name: StackStorm Web UI - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    StackStorm Web UI interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"StackStorm Web UI"
+  tags: panel,stackstorm,webui,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/history"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "stackstorm web ui")'
+        condition: and

--- a/http/exposed-panels/stackstorm-web-ui-panel.yaml
+++ b/http/exposed-panels/stackstorm-web-ui-panel.yaml
@@ -6,23 +6,27 @@ info:
   severity: info
   description: |
     StackStorm Web UI interface was discovered.
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cwe-id: CWE-200
+  reference:
+    - https://stackstorm.com/
   metadata:
     max-request: 1
     verified: true
     shodan-query: html:"StackStorm Web UI"
-  tags: panel,stackstorm,webui,discovery
+    vendor: stackstorm
+    product: stackstorm
+  tags: panel,stackstorm,webui,detect
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/history"
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "stackstorm web ui")'
+          - 'contains(to_lower(body), "<title>stackstorm web ui")'
         condition: and


### PR DESCRIPTION
### PR Information

Template to discover StackStorm Web UI 

### Template validation

I have validated template 

<img width="664" height="320" alt="image" src="https://github.com/user-attachments/assets/85eac310-9cdc-450b-9265-928c3d508b36" />

<img width="711" height="202" alt="image" src="https://github.com/user-attachments/assets/c4dd69b2-c775-4037-b94b-9dc265338528" />

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
