### PR TITLE
fix: prevent false positives in app-manager-default-login template

### DIFF
--- a/http/default-logins/zoho/app-manager-default-login.yaml
+++ b/http/default-logins/zoho/app-manager-default-login.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     shodan-query: title:"Applications Manager Login Screen"
     verified: true
-    max-request: 1
+    max-request: 3
   tags: default-login,manageengine,zoho,vuln
 
 variables:
@@ -42,10 +42,23 @@ http:
 
     matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
+
       - type: word
         part: body
         words:
           - "Super Administrator"
           - "Add Application"
         condition: and
-# digest: 4b0a00483046022100c5ef3b42fb05c2bc2285ab3ba0a6d4657e3fff12400e5dd910d828c36cbd1654022100835f6b452949619e29a86742ebb8ff6684c531d1af5b50495f2774c946b3a1fb:922c64590222798bb761d5b6d8e72950
+
+      - type: word
+        part: body
+        words:
+          - "j_username"
+          - "j_password"
+          - "clienttype=html"
+        condition: or
+        negative: true
+# digest: 4a0a00473045022100ad94c13e2cf7ac0f2e0bd9e0fd5ba1a62d2f1e4e1df5dd5e03d65bb6b5ac17b8022031af08fb1f5b4d4c0c95f7fe58e82a6c4b7bd66eaf2b8c6e7a2c2b9e3a0e8c1a:922c64590222798bb761d5b6d8e72950

--- a/http/default-logins/zoho/app-manager-default-login.yaml
+++ b/http/default-logins/zoho/app-manager-default-login.yaml
@@ -61,4 +61,3 @@ http:
           - "clienttype=html"
         condition: or
         negative: true
-# digest: 4a0a00473045022100ad94c13e2cf7ac0f2e0bd9e0fd5ba1a62d2f1e4e1df5dd5e03d65bb6b5ac17b8022031af08fb1f5b4d4c0c95f7fe58e82a6c4b7bd66eaf2b8c6e7a2c2b9e3a0e8c1a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary

Fixes #12959

### Problem
The `app-manager-default-login` template was producing false positives on ManageEngine Applications Manager instances where **the strings `Super Administrator` and `Add Application` are present on the unauthenticated login page**. When default credentials fail, the server redirects back to the login page (which already contains those strings), so the template would still fire.

Additionally, `max-request` was set to `1` despite the template making 3 HTTP requests.

### Changes
- **Fix `max-request: 1` → `max-request: 3`** — reflects the actual number of requests
- **Add `status: 200` matcher** — confirm the admin resource page actually loaded
- **Add negative matcher on login-form fields** — rejects any response that still contains `j_username`, `j_password`, or `clienttype=html` (i.e., the login form). After successful auth these fields are absent in the resource view; if auth fails they remain in the redirect/error page.

### Why the negative matcher approach
Authentication state can be tricky to probe with a single positive match. The login page in some deployments includes admin-facing UI elements in the page markup even before auth. The cleanest signal that auth succeeded is the **absence** of the login form in the subsequent admin page response — the authenticated `/showresource.do` view does not render the login inputs.