### PR TITLE
Add Vigilix Engine templates for Indonesian internet recon

### DIFF
--- a/osint/vigilix/vigilix-favicon-pivot.yaml
+++ b/osint/vigilix/vigilix-favicon-pivot.yaml
@@ -4,7 +4,7 @@ info:
   name: Favicon Hash Pivot via Vigilix Engine
   author: darkknight
   severity: info
-  description: Finds all Indonesian hosts sharing the same favicon hash. MMH3-compatible with Shodan.
+  description: Finds all hosts sharing the same favicon hash across Vigilix Engine global index. MMH3-compatible with Shodan.
   tags: vigilix,recon,favicon,fingerprint,indonesia
   reference:
     - https://engine.vigilix.id

--- a/osint/vigilix/vigilix-favicon-pivot.yaml
+++ b/osint/vigilix/vigilix-favicon-pivot.yaml
@@ -1,0 +1,47 @@
+id: vigilix-favicon-pivot
+
+info:
+  name: Favicon Hash Pivot via Vigilix Engine
+  author: darkknight
+  severity: info
+  description: Finds all Indonesian hosts sharing the same favicon hash. MMH3-compatible with Shodan.
+  tags: vigilix,recon,favicon,fingerprint,indonesia
+  reference:
+    - https://engine.vigilix.id
+
+self-contained: true
+
+variables:
+  vigilix_api_key: "{{ENV_VIGILIX_API_KEY}}"
+  favicon_hash: "{{FAVICON_HASH}}"
+
+requests:
+  - raw:
+      - |
+        GET /api/v1/search?q=favicon:{{favicon_hash}}&size=100 HTTP/1.1
+        Host: engine.vigilix.id
+        X-API-Key: {{vigilix_api_key}}
+        Accept: application/json
+
+    matchers:
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        name: ip
+        json:
+          - '.results[].ip'
+      - type: json
+        name: port
+        json:
+          - '.results[].port'
+      - type: json
+        name: org
+        json:
+          - '.results[].org'
+      - type: json
+        name: favicon_hash
+        json:
+          - '.results[].favicon_hash'

--- a/osint/vigilix/vigilix-government-exposure.yaml
+++ b/osint/vigilix/vigilix-government-exposure.yaml
@@ -4,7 +4,7 @@ info:
   name: Indonesian Government Exposed Services via Vigilix
   author: darkknight
   severity: info
-  description: Uses Vigilix Engine to find exposed services belonging to Indonesian government sector.
+  description: Uses Vigilix Engine passive global IPv4 index to find exposed government services, currently focused on Indonesian networks.
   tags: vigilix,recon,indonesia,government,osint
   reference:
     - https://engine.vigilix.id

--- a/osint/vigilix/vigilix-government-exposure.yaml
+++ b/osint/vigilix/vigilix-government-exposure.yaml
@@ -1,0 +1,54 @@
+id: vigilix-government-exposure
+
+info:
+  name: Indonesian Government Exposed Services via Vigilix
+  author: darkknight
+  severity: info
+  description: Uses Vigilix Engine to find exposed services belonging to Indonesian government sector.
+  tags: vigilix,recon,indonesia,government,osint
+  reference:
+    - https://engine.vigilix.id
+  metadata:
+    verified: true
+
+self-contained: true
+
+variables:
+  vigilix_api_key: "{{ENV_VIGILIX_API_KEY}}"
+
+requests:
+  - raw:
+      - |
+        GET /api/v1/search?q=sector:Pemerintah+status:200&size=100 HTTP/1.1
+        Host: engine.vigilix.id
+        X-API-Key: {{vigilix_api_key}}
+        Accept: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - '"sector"'
+          - '"Pemerintah"'
+        condition: and
+
+    extractors:
+      - type: json
+        name: ip
+        json:
+          - '.results[].ip'
+      - type: json
+        name: port
+        json:
+          - '.results[].port'
+      - type: json
+        name: title
+        json:
+          - '.results[].title'
+      - type: json
+        name: org
+        json:
+          - '.results[].org'

--- a/osint/vigilix/vigilix-login-panel-discovery.yaml
+++ b/osint/vigilix/vigilix-login-panel-discovery.yaml
@@ -1,0 +1,48 @@
+id: vigilix-login-panel-discovery
+
+info:
+  name: Login Panel Discovery via Vigilix Engine
+  author: darkknight
+  severity: info
+  description: Discovers exposed login panels in Indonesian internet infrastructure using Vigilix Engine passive index.
+  tags: vigilix,recon,indonesia,login,panel
+  reference:
+    - https://engine.vigilix.id
+
+self-contained: true
+
+variables:
+  vigilix_api_key: "{{ENV_VIGILIX_API_KEY}}"
+
+requests:
+  - raw:
+      - |
+        GET /api/v1/search?q=title:login+country:ID&size=100 HTTP/1.1
+        Host: engine.vigilix.id
+        X-API-Key: {{vigilix_api_key}}
+        Accept: application/json
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - '"results"'
+          - '"ip"'
+        condition: and
+
+    extractors:
+      - type: json
+        name: hosts
+        json:
+          - '.results[].ip'
+      - type: json
+        name: titles
+        json:
+          - '.results[].title'
+      - type: json
+        name: ports
+        json:
+          - '.results[].port'

--- a/osint/vigilix/vigilix-login-panel-discovery.yaml
+++ b/osint/vigilix/vigilix-login-panel-discovery.yaml
@@ -4,7 +4,7 @@ info:
   name: Login Panel Discovery via Vigilix Engine
   author: darkknight
   severity: info
-  description: Discovers exposed login panels in Indonesian internet infrastructure using Vigilix Engine passive index.
+  description: Discovers exposed login panels across Vigilix Engine global IPv4 index, currently focused on Indonesian networks.
   tags: vigilix,recon,indonesia,login,panel
   reference:
     - https://engine.vigilix.id


### PR DESCRIPTION
## Summary
Adds 3 new OSINT templates using Vigilix Engine (engine.vigilix.id) 
— a passive IPv4 index for Indonesian internet infrastructure.

## Templates Added
- `vigilix-login-panel-discovery.yaml` — discovers exposed login panels in Indonesia
- `vigilix-government-exposure.yaml` — finds exposed services in Indonesian government sector
- `vigilix-favicon-pivot.yaml` — pivot by favicon hash (MMH3-compatible with Shodan)

## Usage
```bash
nuclei -t osint/vigilix/vigilix-login-panel-discovery.yaml \
  -var vigilix_api_key=YOUR_VIGILIX_API_KEY
```

## Notes
- Requires free Vigilix Engine account at engine.vigilix.id
- API key available after registration
- Favicon hashes are MMH3-compatible with Shodan