### PR TITLE
Enhance Inertia.js detection (proximity-bound matchers, more adapters)

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1519,5 +1519,15 @@
             "website": "https://halilkirazkaya.com",
             "email": "kirazkayahalil@gmail.com"
         }
+    },
+    {
+        "author": "marcialpaulg",
+        "links": {
+            "github": "https://github.com/marcialpaulg",
+            "twitter": "",
+            "linkedin": "https://www.linkedin.com/in/marcialpaulg/",
+            "website": "https://marcialpaulg.com",
+            "email": "im.codename@gmail.com"
+        }
     }
 ]

--- a/http/technologies/inertiajs-detect.yaml
+++ b/http/technologies/inertiajs-detect.yaml
@@ -5,7 +5,7 @@ info:
   author: antonkulyk,marcialpaulg
   severity: info
   description: |
-    Detects Inertia.js, a protocol layer for building single-page apps over classic server-side routing. Detection is fully passive: a single plain GET with no special request headers, matching four independent, server-emitted, Inertia-specific signals on the first-load document. Three proximity-bound body signals cover the on-the-wire forms of the embedded page object, each requiring the component/props/url keys to sit inside the data-page carrier itself (so unrelated pagination data-page attributes or embedded JSON config blocks cannot trigger it): the entity-encoded double-quoted div form (inertia-laravel, inertia-rails, inertia-django, inertia-phoenix), the raw-JSON single-quoted div form (flask-inertia), and the raw-JSON script-element form bound to the script data-page tag (canonical Inertia v2/v3 and Rails script-mode, the v3 default). The header signal is the line-anchored "Vary: X-Inertia" response header set unconditionally by middleware-based adapters such as inertia-laravel, gonertia, and AdonisJS.
+    Detected Inertia.js passively using a single plain GET request with no special headers. It matched four server-emitted Inertia-specific signals on the initial document: three proximity-bound body patterns covering the embedded page object formats and one `Vary: X-Inertia` response header signal set by supported middleware adapters.
   reference:
     - https://inertiajs.com/
     - https://inertiajs.com/the-protocol

--- a/http/technologies/inertiajs-detect.yaml
+++ b/http/technologies/inertiajs-detect.yaml
@@ -2,12 +2,13 @@ id: inertiajs-detect
 
 info:
   name: Inertia.js - Detect
-  author: antonkulyk
+  author: antonkulyk,marcialpaulg
   severity: info
   description: |
-    Detects Inertia.js, a stack for building single-page apps using classic server-side routing. Matching targets the server-rendered page payload embedded in the root element's data-page attribute (JSON with component, props, and url keys), which is the default integration pattern for adapters such as Laravel's inertia-laravel.
+    Detects Inertia.js, a protocol layer for building single-page apps over classic server-side routing. Detection is fully passive: a single plain GET with no special request headers, matching four independent, server-emitted, Inertia-specific signals on the first-load document. Three proximity-bound body signals cover the on-the-wire forms of the embedded page object, each requiring the component/props/url keys to sit inside the data-page carrier itself (so unrelated pagination data-page attributes or embedded JSON config blocks cannot trigger it): the entity-encoded double-quoted div form (inertia-laravel, inertia-rails, inertia-django, inertia-phoenix), the raw-JSON single-quoted div form (flask-inertia), and the raw-JSON script-element form bound to the script data-page tag (canonical Inertia v2/v3 and Rails script-mode, the v3 default). The header signal is the line-anchored "Vary: X-Inertia" response header set unconditionally by middleware-based adapters such as inertia-laravel, gonertia, and AdonisJS.
   reference:
     - https://inertiajs.com/
+    - https://inertiajs.com/the-protocol
     - https://github.com/inertiajs/inertia
     - https://github.com/inertiajs/inertia-laravel
   metadata:
@@ -27,17 +28,22 @@ http:
 
     matchers-condition: or
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - 'data-page="'
-          - '&quot;component&quot;'
-          - '&quot;props&quot;'
-          - '&quot;url&quot;'
-        condition: and
+        regex:
+          - 'data-page="[^"]*&quot;component&quot;[^"]*&quot;props&quot;[^"]*&quot;url&quot;'
 
       - type: regex
         part: body
         regex:
-          - "(?is)data-page\\s*=\\s*\"(?:[^\"\\\\]|\\\\.)*\\\\\"component\\\\\"(?:[^\"\\\\]|\\\\.)*\\\\\"props\\\\\"(?:[^\"\\\\]|\\\\.)*\\\\\"url\\\\\""
-# digest: 490a00463044022005bb2a6b3783297e7f6d9cdf10e9899892a88549ec28211af6be1c83e0bc282c02201da00a9d22f8c045a0685cbcd021172c1fb9f1af90a6ff339dc390254efe2dd9:922c64590222798bb761d5b6d8e72950
+          - 'data-page=''[^'']*"component":[^'']*"props":[^'']*"url":'
+
+      - type: regex
+        part: body
+        regex:
+          - '<script[^>]*data-page=["''][^>]*>[^<]*"component":[^<]*"props":[^<]*"url":'
+
+      - type: regex
+        part: header
+        regex:
+          - '(?im)^vary:[^\r\n]*x-inertia'


### PR DESCRIPTION
## What

Reworks `http/technologies/inertiajs-detect.yaml` from loose `word` matchers into four **proximity-bound regex** signals, so the `component`/`props`/`url` keys must appear *inside* the `data-page` carrier:

- entity-encoded double-quoted `<div data-page="...&quot;component&quot;...">` form (inertia-laravel, inertia-rails, inertia-django, inertia-phoenix)
- raw-JSON single-quoted `<div data-page='..."component":...'>` form (flask-inertia)
- raw-JSON `<script ... data-page=...>..."component":...</script>` script-element form (canonical Inertia v2/v3, Rails script-mode — the v3 default)
- line-anchored `Vary: X-Inertia` response header

## Why

The previous `word` + `condition: and` matchers had no proximity binding and missed several adapters. This fixes three concrete issues:

- **False positive** — a non-Inertia page with a pagination `data-page="N"` plus an unrelated `<script type="application/json">` config block matched.
- **False negative** — flask-inertia's single-quote `data-page='...'` form (no `Vary` header) went undetected.
- **False positive** — the unanchored `vary:` regex matched the substring inside unrelated headers (e.g. `Link:`).

## Validation

- `nuclei -validate` and `yamllint -c .yamllint` both pass.
- **True positives** (match): live Laravel+Inertia site, entity div form, single-quote (flask) div form, script-element form, real `Vary: X-Inertia` header.
- **Negatives** (no match): pagination FP, single-quote pagination FP, Next.js `__NEXT_DATA__`, plain page, `Link:`-header FP, `Vary: Cookie`, and the `honey.scanme.sh` honeypot gate.

Single passive `GET`, `max-request: 1`. Also adds `marcialpaulg` to `contributors.json` and co-authors the template.
