### PR TITLE
Fixed BIG-IP ASM TS cookie matcher in waf-detect template

### DIFF
--- a/http/technologies/waf-detect.yaml
+++ b/http/technologies/waf-detect.yaml
@@ -2,7 +2,7 @@ id: waf-detect
 
 info:
   name: WAF Detection
-  author: dwisiswant0,lu4nx
+  author: dwisiswant0,lu4nx,s4e-io
   severity: info
   description: A web application firewall was detected.
   reference:
@@ -112,7 +112,7 @@ http:
         regex:
           - '(?i)\ATS\w{4,}='
           - '(?i)bigipserver(.i)?|bigipserverinternal'
-          - '(?i)^TS[a-zA-Z0-9]{3,8}='
+          - '(?i)Set-Cookie:\s*TS[a-f0-9]{6,}='
           - '(?i)BigIP|BIG-IP|BIGIP'
           - '(?i)bigipserver'
         condition: or
@@ -806,4 +806,3 @@ http:
         part: header
         words:
           - "X-Protected-By: shieldon.io"
-# digest: 4a0a004730450221008fd5c1d17f4e820d61d09d1fd3b6323c62df87944b57d3f65aac0451a0f578be02201fcfa22d9bf4c1f761c96fcd3c512f606b1ab9c2376f2d215a1786f3b7c9fb11:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
# Fixed BIG-IP ASM TS cookie matcher in waf-detect template

## Summary

The `bigip` matcher in `http/technologies/waf-detect.yaml` is meant to detect **F5 BIG-IP** via its `TS...` session cookie, but the two cookie regexes are anchored in a way that **can never match a real response**. As a result, BIG-IP ASM hosts are reported as "no WAF" (false negative) unless some other text matcher happens to catch them.

This PR replaces the broken regex with a single, correctly scoped one.

## Problem

The matcher runs against `part: response`, which is the **whole raw response as one string** that always begins with the HTTP status line (`HTTP/1.1 ...`). Both TS-cookie patterns are anchored to the **start of that string**:

| Existing regex | Anchor | Why it never matches |
| --- | --- | --- |
| `(?i)\ATS\w{4,}=` | `\A` = start of response | The response starts with `HTTP/1.1 ...`, never with `TS` |
| `(?i)^TS[a-zA-Z0-9]{3,8}=` | `^` = start of text (RE2, no multiline) | Same anchor problem, plus `{3,8}` caps the cookie-name length |

Visually, the anchors point at the status line while the cookie lives further down, inside a `Set-Cookie` header:

```
part: response  (one blob the regex is matched against)
+------------------------------------------------------------+
| HTTP/1.1 200 OK                <-- ^ and \A anchor HERE     |
| Content-Type: text/html                                    |
| Set-Cookie: TS0a1b2c3d4e5=...  <-- the F5 TS cookie is HERE |
| X-Frame-Options: SAMEORIGIN                                |
|                                                            |
| <html> ... block page ... </html>                          |
+------------------------------------------------------------+
```

There is also a second, independent bug: real F5 ASM cookie names are longer than the `{3,8}` cap (commonly **11+ hex chars**, e.g. `TS0a1b2c3d4e5`), so even without the anchor the pattern would still miss them.

**Net effect:** a BIG-IP ASM host that returns a custom or localized block page (one not also caught by an English-text matcher) is reported as having no WAF.

## Fix

A single-line change. The broken anchored pattern is replaced with a header-scoped one:

```diff
        regex:
          - '(?i)\ATS\w{4,}='
          - '(?i)bigipserver(.i)?|bigipserverinternal'
-          - '(?i)^TS[a-zA-Z0-9]{3,8}='
+          - '(?i)Set-Cookie:\s*TS[a-f0-9]{6,}='
          - '(?i)BigIP|BIG-IP|BIGIP'
          - '(?i)bigipserver'
        condition: or
        part: response
```

> **On false positives:** the new pattern matches only inside the `Set-Cookie` response header, never the response body. The matched `TS...=` value can therefore only be a cookie the server actually set. This makes it strictly *narrower* than an unanchored or body-wide match, so it does **not** increase false-positive risk.

### Why this is correct (and low false-positive)

| Property | Effect |
| --- | --- |
| Unanchored | Matches the cookie wherever it appears in the response, instead of requiring it at the very start. |
| Scoped to `Set-Cookie:` | The value can only ever be a server-set cookie. An F5 `TS` cookie is only emitted in a `Set-Cookie` header, so this cannot false-positive on body content that merely contains a `TS...=` substring. |
| Hex class `[a-f0-9]`, no upper bound | Matches F5's documented cookie format and longer ASM cookie names, while staying narrow enough to avoid noise. |

The other OR-branches of the `bigip` matcher (`bigipserver`, `BIG-IP`, ...) are left **untouched**, so nothing that matched before stops matching.

**Reference:** F5 persistence / ASM cookie format - https://my.f5.com/manage/s/article/K6850

## Validation

`nuclei -validate` reports `All templates validated successfully`.

| Scenario | Before | After |
| --- | --- | --- |
| BIG-IP ASM host, block page with English text | detected (via other matcher) | detected |
| BIG-IP ASM host, custom/localized block page + `TS` cookie | not detected | detected (`bigip`) |
| Non-F5 host with `TS...=` only in body | not detected | not detected (header-scoped) |

### Debug evidence (host redacted)

**Before** - F5 ASM block response, but `No results`:

```
$ nuclei -t http/technologies/waf-detect.yaml -u <REDACTED> -debug -fhr

[waf-detect] Dumped HTTP response
HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Type: text/html; charset=utf-8
Set-Cookie: TS0a1b2c3d4e5=<redacted>; Path=/      # F5 BIG-IP TS cookie (11 hex chars)
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN

<html><head><title><redacted></title></head>
<body> ... localized F5 ASM block page ... </body></html>

[INF] Scan completed. No results found.
```

**After** - patched template:

```
$ nuclei -t http/technologies/waf-detect.yaml -u <REDACTED> -fhr

[waf-detect:bigip] [http] [info] https://<REDACTED>
```

We also cross-verified the affected hosts with other independent WAF fingerprinting tools, which identify the same targets as **F5 BIG-IP ASM**.
