### PR TITLE
Added CVE-2026-11561 - Apinizer SSTI version detection

### DIFF
--- a/http/cves/2026/CVE-2026-11561.yaml
+++ b/http/cves/2026/CVE-2026-11561.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-11561
+
+info:
+  name: Apinizer < 2026.04.6 - Server-Side Template Injection
+  author: alperenkesk
+  severity: critical
+  description: |
+    Apinizer versions before 2026.04.6 are vulnerable to Server-Side Template Injection (SSTI)
+    in the admin panel's correlation ID handling. An unauthenticated attacker can inject EL expressions
+    via the X-APINIZER-CORRELATION-ID header, leading to Remote Code Execution.
+  impact: |
+    Successful exploitation allows an unauthenticated attacker to achieve Remote Code Execution
+    on the Apinizer admin panel server with the privileges of the application.
+  remediation: |
+    Upgrade to Apinizer version 2026.04.6 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11561
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-11561
+    cwe-id: CWE-94
+  metadata:
+    max-request: 2
+    vendor: apinizer
+    product: apinizer
+    shodan-query: http.title:"Apinizer"
+  tags: cve,cve2026,apinizer,ssti,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    extractors:
+      - type: regex
+        name: main_js
+        internal: true
+        group: 1
+        regex:
+          - '<script[^>]+src=["'']/?([^"'']*main\.[^"'']+\.js)["'']'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{main_js}}"
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'VERSION\s*:\s*["'']((202[0-5]|20[0-1][0-9])\.[0-9]{2}\.[0-9]+|2026\.(0[1-3])\.[0-9]+|2026\.04\.[0-5])["'']'
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - 'VERSION\s*:\s*["'']([0-9]{4}\.[0-9]{2}\.[0-9]+)["'']'

--- a/http/cves/2026/CVE-2026-11561.yaml
+++ b/http/cves/2026/CVE-2026-11561.yaml
@@ -44,16 +44,26 @@ http:
     path:
       - "{{BaseURL}}/{{main_js}}"
 
+    matchers-condition: and
     matchers:
+      - type: word
+        part: body
+        condition: or
+        words:
+          - "apinizerManagerApp"
+          - "ApinizerManagerDbToApiModule"
+          - "ApinizerManagerMockApiModule"
+          - "ApinizerManagerScriptToApiModule"
+
       - type: regex
         part: body
         regex:
-          - 'VERSION\s*:\s*["'']((202[0-5]|20[0-1][0-9])\.[0-9]{2}\.[0-9]+|2026\.(0[1-3])\.[0-9]+|2026\.04\.[0-5])["'']'
+          - 'VERSION\s*:\s*["'']((20[0-1][0-9]|202[0-5])\.[0-9]{2}\.[0-9]+|2026\.(0[1-3])\.[0-9]+|2026\.04\.[0-5])["'']'
 
     extractors:
       - type: regex
         part: body
-        name: version
+        name: CVE-2026-11561
         group: 1
         regex:
           - 'VERSION\s*:\s*["'']([0-9]{4}\.[0-9]{2}\.[0-9]+)["'']'


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
