### PR TITLE
Add CVE-2026-22778 vLLM multimodal heap-address info-leak template

### DIFF
--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-22778
+
+info:
+  name: vLLM - Multimodal Heap-Address Information Leak (RCE Chain)
+  author: kenlacroix
+  severity: critical
+  description: |
+    vLLM 0.8.3 through 0.14.0 returns Pillow's UnidentifiedImageError verbatim
+    when an invalid image is sent to a multimodal endpoint. The error embeds the
+    Python repr of the underlying BytesIO buffer ("<_io.BytesIO object at 0x...>"),
+    leaking a live heap address to an unauthenticated client. This defeats ASLR
+    and is the first stage of a chain that ends in a JPEG2000 heap overflow in the
+    bundled FFmpeg/OpenCV video decoder, yielding remote code execution. The fix
+    in 0.14.1 sanitizes the address out of the message.
+  impact: |
+    An unauthenticated attacker can leak heap addresses and, on deployments
+    serving a video-capable model, chain the leak into remote code execution as
+    the vLLM server process.
+  remediation: |
+    Upgrade to vLLM 0.14.1 or later. Do not expose the OpenAI-compatible API to
+    untrusted networks without authentication.
+  reference:
+    - https://github.com/vllm-project/vllm/security/advisories/GHSA-4r2x-xpjr-7cvv
+    - https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22778
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-22778
+    cwe-id: CWE-209
+  metadata:
+    max-request: 2
+    vendor: vllm
+    product: vllm
+    shodan-query: http.html:"vllm"
+  tags: cve,cve2026,vllm,llm,ai,info-leak,intrusive
+
+http:
+  - raw:
+      - |
+        GET /v1/models HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+      - |
+        POST /v1/chat/completions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"model":"{{model}}","messages":[{"role":"user","content":[{"type":"text","text":"{{rand_base(4)}}"},{"type":"image_url","image_url":{"url":"data:image/png;base64,bm90YW5pbWFnZQ=="}}]}],"max_tokens":1}
+
+    req-condition: true
+
+    extractors:
+      - type: regex
+        name: model
+        part: body_1
+        internal: true
+        group: 1
+        regex:
+          - '"id"\s*:\s*"([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        condition: and
+        dsl:
+          - 'status_code_2 == 400'
+          - 'contains(body_2, "_io.BytesIO object at 0x")'

--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-22778
 
 info:
-  name: vLLM 0.8.3 - 0.14.0 - Multimodal Heap Address Information Leak
+  name: vLLM 0.8.3 - 0.14.0 - Information Disclosure
   author: kenlacroix
   severity: critical
   description: |
@@ -25,7 +25,7 @@ info:
     vendor: vllm
     product: vllm
     shodan-query: http.html:"/v1/models" http.html:"vllm"
-    tags: cve,cve2026,vllm,llm,ai,info-leak,intrusive
+    tags: cve,cve2026,vllm,llm,ai,disclosure,exposure,intrusive
 
 flow: http(1) && http(2)
 

--- a/http/cves/2026/CVE-2026-22778.yaml
+++ b/http/cves/2026/CVE-2026-22778.yaml
@@ -1,24 +1,15 @@
 id: CVE-2026-22778
 
 info:
-  name: vLLM - Multimodal Heap-Address Information Leak (RCE Chain)
+  name: vLLM 0.8.3 - 0.14.0 - Multimodal Heap Address Information Leak
   author: kenlacroix
   severity: critical
   description: |
-    vLLM 0.8.3 through 0.14.0 returns Pillow's UnidentifiedImageError verbatim
-    when an invalid image is sent to a multimodal endpoint. The error embeds the
-    Python repr of the underlying BytesIO buffer ("<_io.BytesIO object at 0x...>"),
-    leaking a live heap address to an unauthenticated client. This defeats ASLR
-    and is the first stage of a chain that ends in a JPEG2000 heap overflow in the
-    bundled FFmpeg/OpenCV video decoder, yielding remote code execution. The fix
-    in 0.14.1 sanitizes the address out of the message.
+    vLLM 0.8.3 to - 0.14.1 contains an information disclosure caused by leaking a heap address in error messages from the multimodal endpoint when processing invalid images, letting remote attackers reduce ASLR entropy, exploit requires sending invalid images.
   impact: |
-    An unauthenticated attacker can leak heap addresses and, on deployments
-    serving a video-capable model, chain the leak into remote code execution as
-    the vLLM server process.
+    Remote attackers can leak heap addresses, significantly reducing ASLR effectiveness and enabling further exploitation like remote code execution.
   remediation: |
-    Upgrade to vLLM 0.14.1 or later. Do not expose the OpenAI-compatible API to
-    untrusted networks without authentication.
+    Upgrade to version 0.14.1 or later.
   reference:
     - https://github.com/vllm-project/vllm/security/advisories/GHSA-4r2x-xpjr-7cvv
     - https://orca.security/resources/blog/cve-2026-22778-vllm-rce-vulnerability/
@@ -29,11 +20,14 @@ info:
     cve-id: CVE-2026-22778
     cwe-id: CWE-209
   metadata:
+    verified: true
     max-request: 2
     vendor: vllm
     product: vllm
-    shodan-query: http.html:"vllm"
-  tags: cve,cve2026,vllm,llm,ai,info-leak,intrusive
+    shodan-query: http.html:"/v1/models" http.html:"vllm"
+    tags: cve,cve2026,vllm,llm,ai,info-leak,intrusive
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -41,28 +35,35 @@ http:
         GET /v1/models HTTP/1.1
         Host: {{Hostname}}
         Accept: application/json
-      - |
-        POST /v1/chat/completions HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
 
-        {"model":"{{model}}","messages":[{"role":"user","content":[{"type":"text","text":"{{rand_base(4)}}"},{"type":"image_url","image_url":{"url":"data:image/png;base64,bm90YW5pbWFnZQ=="}}]}],"max_tokens":1}
-
-    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"id\":")'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
         name: model
-        part: body_1
+        part: body
         internal: true
         group: 1
         regex:
           - '"id"\s*:\s*"([^"]+)"'
 
-    matchers-condition: and
+  - raw:
+      - |
+        POST /v1/chat/completions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"model":"{{model}}","messages":[{"role":"user","content":[{"type":"text","text":"{{randstr}}"},{"type":"image_url","image_url":{"url":"data:image/png;base64,bm90YW5pbWFnZQ=="}}]}],"max_tokens":1}
+
     matchers:
       - type: dsl
-        condition: and
         dsl:
-          - 'status_code_2 == 400'
-          - 'contains(body_2, "_io.BytesIO object at 0x")'
+          - 'status_code == 400'
+          - 'contains(body, "_io.BytesIO object at 0x")'
+        condition: and


### PR DESCRIPTION
Adds a template for **CVE-2026-22778** (CVSS 9.8, GHSA-4r2x-xpjr-7cvv) in vLLM.

vLLM `0.8.3`–`0.14.0` returns Pillow's `UnidentifiedImageError` verbatim when an invalid image is sent to a multimodal endpoint, leaking the underlying `BytesIO` heap address (`<_io.BytesIO object at 0x...>`) to an unauthenticated client. This defeats ASLR and is the first stage of a JPEG2000 heap-overflow RCE chain in the bundled FFmpeg/OpenCV video decoder. Fixed in `0.14.1` (`sanitize_message` strips the address).

The template:
1. `GET /v1/models` and extracts the served model id (internal extractor),
2. `POST /v1/chat/completions` with a benign malformed base64 image,
3. matches a `400` whose body contains `_io.BytesIO object at 0x` — present only on vulnerable builds (the patch collapses it to `<_io.BytesIO object>`).

It never sends a video URL and never reaches the overflow code path.

### Verification
- `nuclei -validate`: passes.
- Live vLLM `0.23.0` (patched, real LLaVA model): no match (sanitized response).
- Vulnerable response fixture (`0x`-bearing error): matches `critical`.

### References
- https://github.com/vllm-project/vllm/security/advisories/GHSA-4r2x-xpjr-7cvv
- https://nvd.nist.gov/vuln/detail/CVE-2026-22778

🤖 Generated with [Claude Code](https://claude.com/claude-code)