### PR TITLE
fix(dns/caa): prevent false positives by matching only ANSWER section

### DIFF
--- a/dns/caa-fingerprint.yaml
+++ b/dns/caa-fingerprint.yaml
@@ -17,12 +17,14 @@ dns:
   - name: "{{FQDN}}"
     type: CAA
     matchers:
-      - type: regex
-        regex:
-          - "IN\\s+CAA\\s+(.+)"
+      - type: word
+        words:
+          - "CAA"
+        part: answer
 
     extractors:
       - type: regex
+        part: answer
         group: 1
         regex:
           - 'issue "(.*)"'


### PR DESCRIPTION
### PR Information
### Problem
The `caa-fingerprint` (`/dns/caa-fingerprint.yml`) template previously used a regex matcher without specifying `part: answer`. This caused the matcher to also match on the **QUESTION** section of the DNS response (e.g., `IN CAA`), leading to false positives for domains that do not have any CAA record.

### Solution
- Changed the matcher type from `regex` to `word` and added `part: answer` so that it only looks for the word `CAA` in the ANSWER section.
- Added `part: answer` to the extractors to ensure extraction only happens when a record is actually present in the ANSWER section.

### Testing
- Verified (no CAA) > no findings (previously false positive).
- Verified on `google.com` (has CAA `0 issue "pki.goog"`) > successfully detected and extracted.

### Impact
- Eliminates false positives for domains without CAA records.
- Preserves accurate detection for domains that do have CAA records.