### PR TITLE
Add FeatherPanel login panel detection

### DIFF
--- a/http/exposed-panels/featherpanel-login-panel.yaml
+++ b/http/exposed-panels/featherpanel-login-panel.yaml
@@ -1,0 +1,28 @@
+id: featherpanel-login-panel
+
+info:
+  name: FeatherPanel Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    FeatherPanel login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,login,featherpanel,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "login | featherpanel")'
+          - 'contains(body, "FEATHERPANEL_APP_PLACEHOLDER_START")'
+        condition: and

--- a/http/exposed-panels/featherpanel-login-panel.yaml
+++ b/http/exposed-panels/featherpanel-login-panel.yaml
@@ -1,18 +1,18 @@
 id: featherpanel-login-panel
 
 info:
-  name: FeatherPanel Login - Panel Detect
+  name: FeatherPanel Login Panel - Detect
   author: Th3l0newolf
   severity: info
   description: |
-    FeatherPanel login interface was discovered.
+    FeatherPanel login interface was detected.
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
     max-request: 1
     verified: true
-  tags: panel,login,featherpanel,discovery
+  tags: panel,featherpanel,discovery
 
 http:
   - method: GET
@@ -23,6 +23,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "login | featherpanel")'
-          - 'contains(body, "FEATHERPANEL_APP_PLACEHOLDER_START")'
+          - 'contains_all(to_lower(body), "login | featherpanel", "featherpanel_app_placeholder_start")'
         condition: and

--- a/http/exposed-panels/featherpanel-panel.yaml
+++ b/http/exposed-panels/featherpanel-panel.yaml
@@ -1,7 +1,7 @@
-id: featherpanel-login-panel
+id: featherpanel-panel
 
 info:
-  name: FeatherPanel Login Panel - Detect
+  name: FeatherPanel Panel - Detect
   author: Th3l0newolf
   severity: info
   description: |
@@ -12,7 +12,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: panel,featherpanel,discovery
+  tags: panel,featherpanel,discovery,login
 
 http:
   - method: GET


### PR DESCRIPTION
### PR Information
Template to look for  FeatherPanel login pane

### Template validation

I have validated template 

<img width="714" height="316" alt="image" src="https://github.com/user-attachments/assets/a294e3ca-5dc6-40e6-93f7-decb45d72644" />

<img width="1268" height="165" alt="image" src="https://github.com/user-attachments/assets/6d209855-84a5-4af1-9ca4-360dcc0843e9" />

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
