### PR TITLE
Add jotty-page login panel detection

### DIFF
--- a/http/exposed-panels/jotty-page-login-panel.yaml
+++ b/http/exposed-panels/jotty-page-login-panel.yaml
@@ -12,6 +12,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    shodan-query: http.title:"jotty·page"
   tags: panel,login,jotty,page,discovery
 
 http:

--- a/http/exposed-panels/jotty-page-login-panel.yaml
+++ b/http/exposed-panels/jotty-page-login-panel.yaml
@@ -1,0 +1,27 @@
+id: jotty-page-login-panel
+
+info:
+  name: jotty·page Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    jotty·page login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+  tags: panel,login,jotty,page,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/login"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>jotty·page</title>")'
+        condition: and


### PR DESCRIPTION
### PR Information
Template to discover jotty page 

### Template validation

I have validated this template

<img width="817" height="328" alt="image" src="https://github.com/user-attachments/assets/b18342ba-f1ce-4121-9925-78a2baab5ec2" />

<img width="1292" height="189" alt="image" src="https://github.com/user-attachments/assets/94a10d94-06a0-4fbe-95da-d690684d27f9" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
