### PR TITLE
Add vLLM OpenAI-compatible API unauthenticated exposure template

### DIFF
--- a/http/exposures/apis/vllm-openai-api-exposed.yaml
+++ b/http/exposures/apis/vllm-openai-api-exposed.yaml
@@ -5,12 +5,7 @@ info:
   author: fsoppelsa
   severity: medium
   description: |
-    Detects a vLLM inference server exposing its OpenAI-compatible API
-    without authentication. The /v1/models endpoint returns the list of
-    served models and is reachable by any unauthenticated client, allowing
-    model enumeration and unauthorized inference (resource abuse / cost and
-    information exposure). vLLM does not enable an API key by default; it is
-    only enforced when the server is started with --api-key.
+    Detects a vLLM inference server exposing its OpenAI-compatible API without authentication. The /v1/models endpoint returns the list of served models and is reachable by any unauthenticated client, allowing model enumeration and unauthorized inference (resource abuse / cost and information exposure). vLLM does not enable an API key by default; it is only enforced when the server is started with --api-key.
   reference:
     - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
     - https://github.com/vllm-project/vllm
@@ -19,9 +14,10 @@ info:
     cvss-score: 6.5
     cwe-id: CWE-306
   metadata:
+    verified: true
     max-request: 1
     shodan-query: title:"vLLM"
-    verified: true
+    fofa-query: title="vLLM"
   tags: exposure,vllm,llm,ai,api,unauth,misconfig
 
 http:
@@ -31,20 +27,13 @@ http:
 
     matchers-condition: and
     matchers:
-      # Strict: vLLM /v1/models returns an OpenAI-style list object.
-      # Match on JSON structure, not loose strings.
-      - type: word
-        part: body
-        words:
-          - '"object":"list"'
-          - '"object": "list"'
-        condition: or
+      - type: regex
+        regex:
+          - '"object"\s*:\s*"list"'
 
-      - type: word
-        part: body
-        words:
-          - '"owned_by":"vllm"'
-          - '"owned_by": "vllm"'
+      - type: regex
+        regex:
+          - '"owned_by"\s*:\s*"vllm'
           - '"max_model_len"'
         condition: or
 

--- a/http/exposures/apis/vllm-openai-api-exposed.yaml
+++ b/http/exposures/apis/vllm-openai-api-exposed.yaml
@@ -1,0 +1,64 @@
+id: vllm-openai-api-exposed
+
+info:
+  name: vLLM OpenAI-Compatible API - Unauthenticated Exposure
+  author: fsoppelsa
+  severity: medium
+  description: |
+    Detects a vLLM inference server exposing its OpenAI-compatible API
+    without authentication. The /v1/models endpoint returns the list of
+    served models and is reachable by any unauthenticated client, allowing
+    model enumeration and unauthorized inference (resource abuse / cost and
+    information exposure). vLLM does not enable an API key by default; it is
+    only enforced when the server is started with --api-key.
+  reference:
+    - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+    - https://github.com/vllm-project/vllm
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L
+    cvss-score: 6.5
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+    shodan-query: title:"vLLM"
+    verified: true
+  tags: exposure,vllm,llm,ai,api,unauth,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/v1/models"
+
+    matchers-condition: and
+    matchers:
+      # Strict: vLLM /v1/models returns an OpenAI-style list object.
+      # Match on JSON structure, not loose strings.
+      - type: word
+        part: body
+        words:
+          - '"object":"list"'
+          - '"object": "list"'
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - '"owned_by":"vllm"'
+          - '"owned_by": "vllm"'
+          - '"max_model_len"'
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - ".data[].id"


### PR DESCRIPTION
### PR Information
<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
- Added `http/exposures/apis/vllm-openai-api-exposed.yaml` — detects a vLLM inference server exposing its OpenAI-compatible API without authentication.
- By default vLLM does not enforce an API key (only when started with `--api-key`), so a plain `vllm serve <model>` leaves `/v1/models` reachable by any unauthenticated client, allowing model enumeration, model-path disclosure (the `root` field, e.g. the HuggingFace repo id), and unauthorized inference against the host's GPUs (resource / cost abuse).
- References:
  - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
  - https://github.com/vllm-project/vllm

### Template validation
<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->
- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)
<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
**True positive** — vLLM started without `--api-key`:
```
nuclei -u http://127.0.0.1:8000 -t vllm-openai-api-exposed.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

                projectdiscovery.io

[INF] Current nuclei version: v3.9.0 (latest)
[INF] Current nuclei-templates version: v10.4.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 86
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [vllm-openai-api-exposed] Dumped HTTP request for http://127.0.0.1:8000/v1/models

GET /v1/models HTTP/1.1
Host: 127.0.0.1:8000
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Version/16.2 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [vllm-openai-api-exposed] Dumped HTTP response http://127.0.0.1:8000/v1/models

HTTP/1.1 200 OK
Connection: close
Content-Length: 478
Content-Type: application/json
Date: Sat, 27 Jun 2026 17:48:29 GMT
Server: uvicorn

{"object":"list","data":[{"id":"<MODEL>","object":"model","created":1782582509,"owned_by":"vllm","root":"<PROVIDER>/<MODEL>","parent":null,"max_model_len":16384,"permission":[{"id":"modelperm-88535f02f76fdde0","object":"model_permission","created":1782582509,"allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true,"allow_search_indices":false,"allow_view":true,"allow_fine_tuning":false,"organization":"*","group":null,"is_blocking":false}]}]}
[vllm-openai-api-exposed:word-1] [http] [medium] http://127.0.0.1:8000/v1/models ["<MODEL>"]
[vllm-openai-api-exposed:word-2] [http] [medium] http://127.0.0.1:8000/v1/models ["<MODEL>"]
[vllm-openai-api-exposed:word-3] [http] [medium] http://127.0.0.1:8000/v1/models ["<MODEL>"]
[vllm-openai-api-exposed:status-4] [http] [medium] http://127.0.0.1:8000/v1/models ["<MODEL>"]
[INF] Scan completed in 4.927503ms. 4 matches found.
```
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Validated with `nuclei v3.9.0` / templates `v10.4.5`.


**True negative (no false positive)** — same server started with `--api-key <key>`: `/v1/models` returns `401 Unauthorized` and the template does not match.
```
nuclei -u http://127.0.0.1:8000 -t vllm-openai-api-exposed.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

                projectdiscovery.io

[INF] Current nuclei version: v3.9.0 (latest)
[INF] Current nuclei-templates version: v10.4.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 86
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [vllm-openai-api-exposed] Dumped HTTP request for http://127.0.0.1:8000/v1/models

GET /v1/models HTTP/1.1
Host: 127.0.0.1:8000
User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [vllm-openai-api-exposed] Dumped HTTP response http://127.0.0.1:8000/v1/models

HTTP/1.1 401 Unauthorized
Connection: close
Content-Length: 24
Content-Type: application/json
Date: Sat, 27 Jun 2026 17:45:40 GMT
Server: uvicorn

{"error":"Unauthorized"}
[INF] Scan completed in 4.435534ms. No results found.
```

**Reproduction (Docker, ~1 min):**

```bash
docker run --rm -p 8000:8000 vllm/vllm-openai:latest --model Qwen/Qwen2.5-0.5B-Instruct
curl -s http://127.0.0.1:8000/v1/models      # returns model list, no auth
nuclei -u http://127.0.0.1:8000 -t vllm-openai-api-exposed.yaml
```

**Docker / Shodan:** `vllm/vllm-openai` · `Server: uvicorn` + path `/v1/models` returning an OpenAI list object.

**Severity:** `medium` / CWE-306 (Missing Authentication for Critical Function) — deployment exposure rather than a vLLM software vulnerability, but an internet-reachable endpoint enables model enumeration, model-path disclosure, and free inference on the host's GPU.

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)

First contribution to nuclei-templates: Feedback welcome.