### PR TITLE
feat: add CVE-2026-48909 - JoomShaper SP LMS PHP Object Injection

### DIFF
--- a/http/cves/2026/CVE-2026-48909.yaml
+++ b/http/cves/2026/CVE-2026-48909.yaml
@@ -1,0 +1,70 @@
+id: CVE-2026-48909
+
+info:
+  name: JoomShaper SP LMS <= 4.1.3 - Unauthenticated PHP Object Injection
+  author: VixianSchool
+  severity: critical
+  description: |
+    JoomShaper SP LMS (com_splms) versions 4.1.3 and below are vulnerable to
+    unauthenticated PHP Object Injection. The component passes the `lmsOrders`
+    cookie directly to `unserialize()` without validation. On PHP 8 targets
+    a serialised `stdClass` triggers a `TypeError` from `count()`, returning
+    HTTP 500, while a benign non-PHP cookie returns HTTP 200 — providing a
+    side-channel to confirm the vulnerability without triggering the gadget chain.
+    When combined with Joomla's native `FormattedtextLogger` gadget chain on
+    Joomla < 5.2.2, this leads to unauthenticated Remote Code Execution.
+  impact: |
+    An unauthenticated attacker can achieve Remote Code Execution on Joomla
+    sites running SP LMS <= 4.1.3 and Joomla < 5.2.2 by injecting a malicious
+    serialized PHP object via the lmsOrders cookie, exploiting the
+    FormattedtextLogger gadget chain to write arbitrary files to disk.
+  remediation: |
+    Update SP LMS to version 4.1.4 or later. Additionally update Joomla to
+    5.2.2 or later, which patches the FormattedtextLogger gadget chain
+    (preventing the unserialise primitive from being leveraged for RCE).
+  reference:
+    - https://github.com/Is4yev/CVE-2026-48909
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48909
+    - https://www.joomshaper.com/joomla-extensions/sp-lms
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-48909
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: joomshaper
+    product: sp-lms
+    publicwww-query: "/components/com_splms/"
+  tags: cve,cve2026,joomla,php,deserialization,rce,object-injection,sp-lms,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php?option=com_splms&view=cart"
+
+    headers:
+      Cookie: "lmsOrders=bm90X3BocF9zZXJpYWxpemVkX2RhdGE="
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php?option=com_splms&view=cart"
+
+    headers:
+      Cookie: "lmsOrders=Tzo4OiJzdGRDbGFzcyI6MDp7fQ=="
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 500'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a nuclei template for **CVE-2026-48909** — Unauthenticated PHP Object Injection in JoomShaper SP LMS (com_splms) <= 4.1.3.

Closes #16447

---

## Vulnerability

JoomShaper SP LMS passes the `lmsOrders` cookie directly to `unserialize()` in `components/com_splms/models/cart.php`:

```php
$raw     = $cookie->get('lmsOrders', base64_encode(serialize(array())));
$decoded = base64_decode($raw);
$cartItems = unserialize($decoded);   // ← untrusted input
```

On PHP 8, a serialized `stdClass` object causes `count(stdClass)` to throw a `TypeError` (HTTP 500), while a benign non-PHP cookie returns HTTP 200 — a reliable side-channel to confirm the vulnerability without triggering any gadget chain.

When combined with Joomla < 5.2.2's `FormattedtextLogger` gadget chain, this achieves unauthenticated RCE.

---

## Detection Logic

| Request | Cookie | Expected (Vulnerable) |
|---------|--------|----------------------|
| 1 (benign) | `lmsOrders=bm90X3BocF9zZXJpYWxpemVkX2RhdGE=` | HTTP 200 |
| 2 (probe)  | `lmsOrders=Tzo4OiJzdGRDbGFzcyI6MDp7fQ==` | HTTP 500 |

Flow: `http(1) && http(2)` — only triggers if benign returns 200 **and** probe returns 500, preventing false positives from misconfigured servers or WAFs.

---

## Metadata

- **CVE**: CVE-2026-48909
- **CVSS**: 9.8 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)
- **CWE**: CWE-502 (Deserialization of Untrusted Data)
- **Affected**: SP LMS 1.0.0 – 4.1.3
- **Fixed**: SP LMS >= 4.1.4
- **PoC**: https://github.com/Is4yev/CVE-2026-48909
- **max-request**: 2

/claim #16447