### PR TITLE
feat: add CVE-2026-48908 - JoomShaper SP Page Builder Unauthenticated File Upload / RCE

### DIFF
--- a/http/cves/2026/CVE-2026-48908.yaml
+++ b/http/cves/2026/CVE-2026-48908.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-48908
+
+info:
+  name: JoomShaper SP Page Builder <= 6.6.1 - Unauthenticated Arbitrary File Upload
+  author: VixianSchool
+  severity: critical
+  description: |
+    JoomShaper SP Page Builder (com_sppagebuilder) versions 6.6.1 and below expose the
+    `asset.uploadCustomIcon` controller task without any authentication or CSRF validation.
+    The endpoint accepts a ZIP archive (field `custom_icon`) and extracts its contents
+    into a publicly web-served directory under the document root
+    (`/media/com_sppagebuilder/assets/iconfont/<name>/`), enabling unauthenticated
+    arbitrary file write. Combined with a case-sensitive blocklist bypass or a dropped
+    `.htaccess` re-registering PHP handlers, this leads to unauthenticated Remote Code
+    Execution. Patched in SP Page Builder 6.6.2, which adds authentication, authorization,
+    and CSRF checks to the upload task.
+  impact: |
+    An unauthenticated attacker can upload arbitrary files to a web-served directory.
+    Where PHP execution is permitted in that directory (or can be enabled via a dropped
+    `.htaccess`), this results in full unauthenticated Remote Code Execution.
+  remediation: |
+    Update SP Page Builder to version 6.6.2 or later. As defense-in-depth, disable PHP
+    execution in upload directories (`/media/`, `/images/`, `/tmp/`) and set
+    `AllowOverride None` on those directories.
+  reference:
+    - https://github.com/papageo75/CVE-2026-48908-PoC
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48908
+    - https://www.joomshaper.com/page-builder
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-48908
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: joomshaper
+    product: sp-page-builder
+    publicwww-query: "/components/com_sppagebuilder/"
+  tags: cve,cve2026,joomla,php,file-upload,rce,unauth,sp-page-builder
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php?option=com_sppagebuilder"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "com_sppagebuilder", "sppagebuilder", "SP Page Builder")'
+        condition: and
+        internal: true
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon"
+
+    headers:
+      Content-Type: "multipart/form-data; boundary=NucleiProbe001"
+
+    body: "--NucleiProbe001\r\nContent-Disposition: form-data; name=\"custom_icon\"; filename=\"probe.zip\"\r\nContent-Type: application/zip\r\n\r\nnot-a-zip\r\n--NucleiProbe001--\r\n"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!contains_any(body, "You require admin access", "task=users.login", "option=com_users")'
+          - 'contains_any(body, "\"status\"", "\"message\"", "\"data\"")'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a nuclei template for **CVE-2026-48908** — Unauthenticated Arbitrary File Upload leading to RCE in JoomShaper SP Page Builder (com_sppagebuilder) <= 6.6.1.

Closes #16467

---

## Vulnerability

SP Page Builder exposes the `asset.uploadCustomIcon` task without any authentication or CSRF validation:

```
POST /index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon
```

In affected versions (1.0.0 – 6.6.1), this task is reachable pre-authentication. It accepts a ZIP archive via the `custom_icon` multipart field and **extracts its contents into a publicly web-served directory**:

```
/media/com_sppagebuilder/assets/iconfont/<name>/
```

This enables unauthenticated arbitrary file write. Combined with a case-sensitive blocklist bypass (`.PHP` variant) or a dropped `.htaccess` registering `.PHP` as a PHP handler, this achieves full unauthenticated RCE.

**Fixed in SP Page Builder 6.6.2**, which adds authentication, authorization, and CSRF checks to the upload task.

---

## Detection Logic

The patched version (6.6.2+) fires an auth check **before** any upload processing, returning `"You require admin access"` in the response. The vulnerable version reaches the upload handler and returns a JSON response regardless of ZIP validity.

| Step | Request | Vulnerable Response |
|------|---------|---------------------|
| 1 | `GET /index.php?option=com_sppagebuilder` | 200 with component indicators |
| 2 | `POST .../task=asset.uploadCustomIcon` (unauthenticated, probe ZIP) | JSON body (`"status"`, `"message"`, or `"data"`) WITHOUT `"You require admin access"` |

The probe in http(2) sends a minimal multipart request with a non-harmful file — no PHP code, no valid ZIP structure. This is sufficient because the auth check (patched) fires before any file processing.

---

## Metadata

- **CVE**: CVE-2026-48908
- **CVSS**: 10.0 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H)
- **CWE**: CWE-284 (Improper Access Control)
- **Affected**: SP Page Builder 1.0.0 – 6.6.1
- **Fixed**: SP Page Builder >= 6.6.2
- **PoC**: https://github.com/papageo75/CVE-2026-48908-PoC
- **max-request**: 2

/claim #16467