### PR TITLE
feat: add CVE-2024-45436 - Ollama < 0.1.47 Zip Slip Path Traversal

### DIFF
--- a/http/cves/2024/CVE-2024-45436.yaml
+++ b/http/cves/2024/CVE-2024-45436.yaml
@@ -1,0 +1,64 @@
+id: CVE-2024-45436
+
+info:
+  name: Ollama < 0.1.47 - Zip Slip Path Traversal
+  author: VixianSchool
+  severity: critical
+  description: |
+    Ollama before version 0.1.47 is vulnerable to Zip Slip (CWE-22). The
+    `extractFromZipFile` function in `model.go` does not validate archive entry
+    paths during model file extraction, allowing members of a ZIP archive to be
+    written outside the intended parent directory. An attacker who can make the
+    server pull a malicious model (e.g. from a rogue registry or via a crafted
+    Modelfile) can overwrite arbitrary files on the filesystem — including
+    `/etc/ld.so.preload` — achieving Remote Code Execution with the privileges
+    of the Ollama process (often root).
+  impact: |
+    An attacker who can reach the Ollama API (typically port 11434, often
+    unauthenticated) can cause the server to extract a malicious ZIP with
+    path-traversal entries, overwriting arbitrary filesystem paths and achieving
+    Remote Code Execution.
+  remediation: |
+    Update Ollama to version 0.1.47 or later. Additionally, restrict network
+    access to the Ollama API (bind to 127.0.0.1 only) and run Ollama with
+    minimal privileges rather than as root.
+  reference:
+    - https://github.com/srcx404/CVE-2024-45436
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-45436
+    - https://github.com/ollama/ollama/releases/tag/v0.1.47
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2024-45436
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ollama
+    product: ollama
+    shodan-query: "Ollama" port:11434
+    fofa-query: body="Ollama" && port="11434"
+  tags: cve,cve2024,ollama,path-traversal,zip-slip,rce,ai,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        regex:
+          - '"version":\s*"([^"]+)"'
+        group: 1
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "\"version\"")'
+          - 'regex("^0\\.0\\.", version) || (regex("^0\\.1\\.\\d+$", version) && to_number(split(version, ".")[2]) < 47)'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a nuclei template for **CVE-2024-45436** — Zip Slip path traversal in Ollama < 0.1.47 leading to arbitrary file write and RCE.

Closes #11347

---

## Vulnerability

The `extractFromZipFile` function in `model.go` extracts model archive entries without validating their paths for directory traversal sequences (`../`). An attacker who can reach the Ollama API can trigger a model pull from a rogue registry (or craft a Modelfile that references a malicious blob), causing the server to extract ZIP entries outside the intended directory.

By writing `/etc/ld.so.preload` pointing to a malicious shared object also written via the traversal, the attacker achieves RCE with the privileges of the Ollama process (often root).

**Fixed in v0.1.47**, which validates that extracted paths remain within the model directory.

---

## Detection Logic

Version-based detection via `/api/version`:

```
GET /api/version → {"version": "0.1.x"}
```

The template extracts the version string and flags instances where:
- Version matches `0.0.x` (all pre-0.1.0 builds), OR
- Version matches `0.1.x` where `x < 47`

| Version | Vulnerable |
|---------|-----------|
| `0.0.*` | Yes |
| `0.1.0` – `0.1.46` | Yes |
| `0.1.47` | No (patched) |
| `0.2.x+` | No (patched) |

This is non-invasive (single GET, no exploitation) and has no false positive risk since version comparison is deterministic.

---

## Metadata

- **CVE**: CVE-2024-45436
- **CVSS**: 9.1 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N)
- **CWE**: CWE-22 (Path Traversal / Zip Slip)
- **Affected**: Ollama < 0.1.47
- **Fixed**: Ollama 0.1.47+
- **PoC**: https://github.com/srcx404/CVE-2024-45436
- **max-request**: 1