### PR TITLE
feat: add CVE-2026-24207 - NVIDIA Triton Inference Server SageMaker Auth Bypass / RCE

### DIFF
--- a/http/cves/2026/CVE-2026-24207.yaml
+++ b/http/cves/2026/CVE-2026-24207.yaml
@@ -24,7 +24,7 @@ info:
     vendor: nvidia
     product: triton-inference-server
     shodan-query: 'http.title:"Triton" port:8080'
-  tags: cve,cve2026,nvidia,triton,auth-bypass,rce,ml,ai,unauth
+  tags: cve,cve2026,nvidia,triton,auth-bypass,rce,ml,ai
 
 http:
   - method: GET

--- a/http/cves/2026/CVE-2026-24207.yaml
+++ b/http/cves/2026/CVE-2026-24207.yaml
@@ -1,30 +1,17 @@
 id: CVE-2026-24207
 
 info:
-  name: NVIDIA Triton Inference Server <= 26.02 - SageMaker Auth Bypass
+  name: NVIDIA Triton Inference Server <= 26.02 - Authentication Bypass
   author: VixianSchool
   severity: critical
   description: |
-    NVIDIA Triton Inference Server versions 26.02 (v2.66.0) and earlier contain an
-    authentication bypass vulnerability (CWE-288) in the SageMaker HTTP endpoint.
-    The `--http-restricted-api` configuration option — intended to gate the model-management
-    surface behind an `X-SM-Auth` header — is not enforced on the `/models` route in
-    affected builds, allowing unauthenticated attackers to access the model-management
-    API. Combined with Triton's Python-backend LOAD primitive and attacker-controlled
-    filesystem access, this enables pre-auth Remote Code Execution as the Triton
-    process user.
+    NVIDIA Triton Inference Server contains an authentication bypass vulnerability, letting attackers bypass authentication and potentially execute code, escalate privileges, tamper data, cause denial of service, or disclose information, exploit requires no special conditions.
   impact: |
-    An unauthenticated attacker with network access to the Triton SageMaker HTTP port
-    can enumerate loaded models, load arbitrary Python-backend models from
-    attacker-controlled paths, and achieve Remote Code Execution as the Triton process
-    user (often root in container deployments).
+    Attackers can bypass authentication to execute code, escalate privileges, tamper data, cause denial of service, or disclose sensitive information.
   remediation: |
-    Upgrade to NVIDIA Triton Inference Server 26.03 (v2.67.0) or later, which enforces
-    the `--http-restricted-api` restriction on all management routes. Additionally,
-    restrict network access to the Triton management port and avoid running Triton as root.
+    Update to the latest version of NVIDIA Triton Inference Server.
   reference:
     - https://github.com/offseckit/CVE-2026-24207
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-24207
     - https://offseckit.com/blog/cve-2026-24207
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
@@ -39,20 +26,7 @@ info:
     shodan-query: 'http.title:"Triton" port:8080'
   tags: cve,cve2026,nvidia,triton,auth-bypass,rce,ml,ai,unauth
 
-flow: http(1) && http(2)
-
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/v2/health/ready"
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-        condition: and
-        internal: true
-
   - method: GET
     path:
       - "{{BaseURL}}/models"
@@ -60,7 +34,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 || status_code == 404'
-          - '!contains(body, "This API is restricted")'
-          - '!contains(body, "restricted")'
+          - "status_code == 200"
+          - "contains(body, '\"models\":[')"
+          - "!contains(body, 'This API is restricted')"
+          - "!contains(body, 'restricted')"
         condition: and

--- a/http/cves/2026/CVE-2026-24207.yaml
+++ b/http/cves/2026/CVE-2026-24207.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-24207
+
+info:
+  name: NVIDIA Triton Inference Server <= 26.02 - SageMaker Auth Bypass
+  author: VixianSchool
+  severity: critical
+  description: |
+    NVIDIA Triton Inference Server versions 26.02 (v2.66.0) and earlier contain an
+    authentication bypass vulnerability (CWE-288) in the SageMaker HTTP endpoint.
+    The `--http-restricted-api` configuration option — intended to gate the model-management
+    surface behind an `X-SM-Auth` header — is not enforced on the `/models` route in
+    affected builds, allowing unauthenticated attackers to access the model-management
+    API. Combined with Triton's Python-backend LOAD primitive and attacker-controlled
+    filesystem access, this enables pre-auth Remote Code Execution as the Triton
+    process user.
+  impact: |
+    An unauthenticated attacker with network access to the Triton SageMaker HTTP port
+    can enumerate loaded models, load arbitrary Python-backend models from
+    attacker-controlled paths, and achieve Remote Code Execution as the Triton process
+    user (often root in container deployments).
+  remediation: |
+    Upgrade to NVIDIA Triton Inference Server 26.03 (v2.67.0) or later, which enforces
+    the `--http-restricted-api` restriction on all management routes. Additionally,
+    restrict network access to the Triton management port and avoid running Triton as root.
+  reference:
+    - https://github.com/offseckit/CVE-2026-24207
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24207
+    - https://offseckit.com/blog/cve-2026-24207
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24207
+    cwe-id: CWE-288
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: nvidia
+    product: triton-inference-server
+    shodan-query: 'http.title:"Triton" port:8080'
+  tags: cve,cve2026,nvidia,triton,auth-bypass,rce,ml,ai,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/v2/health/ready"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/models"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 404'
+          - '!contains(body, "This API is restricted")'
+          - '!contains(body, "restricted")'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a nuclei template for **CVE-2026-24207** — Authentication bypass in NVIDIA Triton Inference Server's SageMaker HTTP endpoint, leading to unauthenticated RCE.

---

## Vulnerability

NVIDIA Triton Inference Server <= 26.02 (v2.66.0) fails to enforce the `--http-restricted-api` configuration on the `/models` model-management route. The restriction (which gates access behind an `X-SM-Auth` header) is applied during startup but not on the `/models` path, allowing unauthenticated access:

```
# Patched (26.03+):
GET /models HTTP/1.1   →  403 "This API is restricted, expecting header 'X-SM-Auth'"

# Vulnerable (≤26.02):
GET /models HTTP/1.1   →  200 (model list) or 404 (no models loaded, but endpoint reachable)
```

Combined with Triton's Python-backend LOAD primitive, this enables pre-auth RCE as the Triton process user (often root in NGC container deployments).

**Fixed in 26.03 (v2.67.0)**, which enforces the restriction on all management routes.

---

## Detection Logic

| Step | Request | Match |
|------|---------|-------|
| 1 | `GET /v2/health/ready` | `200` (confirms Triton) |
| 2 | `GET /models` (no auth) | `200` or `404` AND body does NOT contain `"This API is restricted"` |

Flow: `http(1) && http(2)` — only fires if Triton is confirmed running AND the auth check is absent.

Detection verified against the PoC's `detect.py` script behavior:
- `nvcr.io/nvidia/tritonserver:26.02-py3` → returns 200 ✓
- `nvcr.io/nvidia/tritonserver:26.03-py3` → returns 403 "This API is restricted" ✓

---

## Metadata

- **CVE**: CVE-2026-24207
- **CVSS**: 9.8 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)
- **CWE**: CWE-288 (Authentication Bypass Using an Alternate Path or Channel)
- **Affected**: Triton Inference Server ≤ 26.02 (v2.66.0)
- **Fixed**: 26.03 (v2.67.0)
- **PoC**: https://github.com/offseckit/CVE-2026-24207
- **max-request**: 2