### PR TITLE
feat: add CVE-2026-54806 - WP Activity Log <= 5.6.3.1 Unauthenticated PHP Object Injection

### DIFF
--- a/http/cves/2026/CVE-2026-54806.yaml
+++ b/http/cves/2026/CVE-2026-54806.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-54806
+
+info:
+  name: WP Activity Log <= 5.6.3.1 - Unauthenticated PHP Object Injection
+  author: VixianSchool
+  severity: critical
+  description: |
+    The WP Activity Log WordPress plugin (wp-security-audit-log) versions 5.6.3.1
+    and below are vulnerable to unauthenticated PHP Object Injection (CWE-502). The
+    plugin logs the User-Agent header on any event it tracks (including failed login
+    attempts) and stores it in the database without sanitization. When the stored
+    log entry is later deserialized, attacker-controlled PHP objects are instantiated.
+    Combined with the WP_HTML_Token gadget chain available in WordPress 6.4.0–6.4.1,
+    this leads to blind unauthenticated Remote Code Execution when an administrator
+    views the WordPress dashboard.
+  impact: |
+    An unauthenticated attacker can inject a serialized PHP object via the User-Agent
+    header during a logged event (e.g. a failed login). When an administrator visits
+    the WordPress dashboard, the payload deserializes and executes attacker-controlled
+    code via the WP_HTML_Token gadget chain, achieving blind RCE.
+  remediation: |
+    Update the WP Activity Log plugin to version 5.6.4 or later. Also update
+    WordPress core to 6.4.2 or later, which blocks the WP_HTML_Token gadget chain.
+  reference:
+    - https://github.com/joshuavanderpoll/CVE-2026-54806
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54806
+    - https://patchstack.com/database/wordpress/plugin/wp-security-audit-log/vulnerability/wordpress-wp-activity-log-plugin-5-6-3-1-php-object-injection-vulnerability
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-54806
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: melapress
+    product: wp-security-audit-log
+    fofa-query: body="wp-security-audit-log"
+    shodan-query: http.html:"wp-security-audit-log"
+  tags: cve,cve2026,wordpress,wp-plugin,php,deserialization,object-injection,rce,unauth
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/wp-security-audit-log/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: plugin_version
+        part: body
+        group: 1
+        regex:
+          - '(?m)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "WP Activity Log", "Stable tag:")'
+          - 'compare_versions(plugin_version, "<= 5.6.3.1")'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a nuclei template for **CVE-2026-54806** — Unauthenticated PHP Object Injection in WP Activity Log (wp-security-audit-log) <= 5.6.3.1 leading to blind RCE.

---

## Vulnerability

The WP Activity Log plugin logs the User-Agent header for any tracked event (including failed logins) and stores it without sanitization. When the WordPress admin dashboard later displays these logs, the stored User-Agent value is **deserialized without restrictions**, allowing an unauthenticated attacker to achieve PHP Object Injection.

Combined with the `WP_HTML_Token` gadget chain available in WordPress 6.4.0–6.4.1 (all-public properties, survives `sanitize_text_field()`, triggers `call_user_func()` on `__destruct`), this achieves **blind unauthenticated RCE** — the payload fires when an admin visits the dashboard.

**Fixed in WP Activity Log 5.6.4** (input sanitized before storage). WordPress 6.4.2 also blocks the gadget chain as defense-in-depth.

---

## Detection Logic

Version-based detection via plugin `readme.txt`:

```
GET /wp-content/plugins/wp-security-audit-log/readme.txt
→ Extract "Stable tag: X.X.X.X"
→ Flag if compare_versions(version, "<= 5.6.3.1")
```

Single non-invasive request. Uses nuclei's `compare_versions()` DSL helper for accurate 4-part version comparison.

---

## Metadata

- **CVE**: CVE-2026-54806
- **CVSS**: 9.8 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)
- **CWE**: CWE-502 (Deserialization of Untrusted Data)
- **Affected**: WP Activity Log <= 5.6.3.1 (400,000+ active installs)
- **Fixed**: WP Activity Log 5.6.4
- **PoC**: https://github.com/joshuavanderpoll/CVE-2026-54806
- **max-request**: 1