### PR TITLE
feat: add nuclei template for CVE-2026-53523

### DIFF
--- a/http/cves/2026/CVE-2026-53523.yaml
+++ b/http/cves/2026/CVE-2026-53523.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-53523
+
+info:
+  name: Nezha Monitoring - OAuth2 Redirect URL Host Header Injection
+  author: Hardik-369
+  severity: medium
+  description: |
+    Nezha Monitoring versions 1.0.0 through 2.1.x contain an open redirect vulnerability in the OAuth2 callback URL construction. The getRedirectURL function in oauth2.go concatenates the request's Host header with a fixed path without validation, allowing an attacker to supply a forged Host header and cause the OAuth2 callback to point to an arbitrary domain. This can be leveraged for phishing attacks to steal OAuth authorization codes.
+  impact: |
+    An attacker can perform host header injection to redirect OAuth2 authorization codes to an attacker-controlled server, potentially hijacking user accounts.
+  remediation: |
+    Upgrade to Nezha Monitoring version 2.2.0 or later.
+  reference:
+    - https://github.com/nezhahq/nezha/security/advisories/GHSA-9rc6-8cjv-rcvx
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53523
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N
+    cvss-score: 6.8
+    cve-id: CVE-2026-53523
+    cwe-id: CWE-601
+  metadata:
+    max-request: 1
+    verified: false
+    vendor: nezhahq
+    product: nezha
+    fofa-query: body="Nezha Monitoring"
+  tags: cve,cve2026,nezha,open-redirect,host-header-injection,oauth
+
+http:
+  - raw:
+      - |
+        GET /api/v1/oauth2/redirect HTTP/1.1
+        Host: {{Hostname}}
+        Referer: https://{{Hostname}}/
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "oauth2"
+          - "redirect"
+          - "callback"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds Nuclei template for CVE-2026-53523 - Nezha Monitoring OAuth2 Redirect URL Host Header Injection