### PR TITLE
feat: add nuclei template for CVE-2026-50744

### DIFF
--- a/http/cves/2026/CVE-2026-50744.yaml
+++ b/http/cves/2026/CVE-2026-50744.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-50744
+
+info:
+  name: Revive Adserver - XML-RPC Session Leak
+  author: Hardik-369
+  severity: medium
+  description: |
+    A bypass to the admin-only restriction of the XML-RPC API in Revive Adserver 6.0.7. The API response for the ox.login method returned a session ID cookie in the HTTP headers, and although the method correctly returned an error, the associated session was not invalidated. As a result, the leaked session ID could be used to perform subsequent API calls without restrictions.
+  impact: |
+    An attacker can obtain a valid session ID from a failed login attempt and reuse it to bypass admin restrictions on the XML-RPC API.
+  remediation: |
+    Update Revive Adserver to version 6.0.8 or later.
+  reference:
+    - https://www.revive-adserver.com/security/revive-sa-2026-003/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50744
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+    cve-id: CVE-2026-50744
+    cwe-id: CWE-284
+  metadata:
+    max-request: 1
+    verified: false
+    vendor: revive
+    product: adserver
+    fofa-query: body="Revive Adserver"
+  tags: cve,cve2026,revive,xmlrpc,session-leak
+
+http:
+  - raw:
+      - |
+        POST /www/api/v1/xmlrpc/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml
+
+        <?xml version="1.0"?>
+        <methodCall>
+          <methodName>ox.login</methodName>
+          <params>
+            <param><value><string>invalid</string></value></param>
+            <param><value><string>invalid</string></value></param>
+          </params>
+        </methodCall>
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "faultCode"
+          - "faultString"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "PHPSESSID"
+          - "session"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds Nuclei template for CVE-2026-50744 - Revive Adserver XML-RPC API session leak bypass