### PR TITLE
fix: normalize unsigned template line endings

### DIFF
--- a/file/logs/aspnet-framework-exceptions.yaml
+++ b/file/logs/aspnet-framework-exceptions.yaml
@@ -22,4 +22,3 @@ file:
           - 'InvalidOperationException'
           - 'UnauthorizedAccessException'
           - 'NotFound'
-# digest: 490a0046304402200a0d937b40dc34c8a8ab1f1fd16574f0eae5fc22ac7d72465c7320fb566ba9900220252bf3c18361c233d33ac30d666150318571673ba7c2af8ab6ecc458c4a69131:922c64590222798bb761d5b6d8e72950

--- a/file/logs/nodejs-framework-exceptions.yaml
+++ b/file/logs/nodejs-framework-exceptions.yaml
@@ -30,4 +30,3 @@ file:
           - 'BadRequestError'
           - 'MongoError'
           - 'SequelizeDatabaseError'
-# digest: 4a0a00473045022100892734dc3d276c4ff2ac0c746b69eb028a6dcab39d588b0902f38321b3b2a83102206bc4c11b34714ae260f2851cc8d41ad621c21ab6be57ccd5503651decca09798:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/Wix-detect.yaml
+++ b/http/technologies/Wix-detect.yaml
@@ -58,4 +58,3 @@ http:
         regex:
           - 'wix-id=([a-z0-9]+)'
           - 'siteid="([a-zA-Z0-9]+)"'
-# digest: 4a0a00473045022066ff55cb55c444adb14760a6d7b6e7e94282a66c22915395d872891897addb60022100ae4e9a8d9564f76fc157e3c61041bedc96e09231c655cdfc2261d3a21b5f2bc5:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/bigcommerce-detect.yaml
+++ b/http/technologies/bigcommerce-detect.yaml
@@ -54,4 +54,3 @@ http:
           - 'bigcommerce-site-id=([a-z0-9]+)'
           - 'bc-site-id="([a-zA-Z0-9]+)"'
           - 'bigcommerce\.com/([^/]+)'
-# digest: 490a00463044022039f5bbeb419eb2b78d28b8ae926e917b712a90ffbffe0779c5efee369c035f5e022032937e2618ddaa29d85a059e7d2d9b356071f1ee05888bac8c1aa551eed1ecc2:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/bitrix-detect.yaml
+++ b/http/technologies/bitrix-detect.yaml
@@ -54,4 +54,3 @@ http:
         regex:
           - 'bitrix-site-id=([a-z0-9]+)'
           - 'bitrix\.com/([^/]+)'
-# digest: 490a00463044022034660bd6ba30daf1114fb57b72a573e2883755d927f12bd6bdab62fdb2cb052702204357be8e5bdc4ffa7048fe8bfaf1e2bbd8e295587f7529824b1fd0665ec3286a:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/blogger-detect.yaml
+++ b/http/technologies/blogger-detect.yaml
@@ -53,4 +53,3 @@ http:
         regex:
           - 'blogger-id=([a-z0-9]+)'
           - 'blogspot\.com/([^/]+)'
-# digest: 490a0046304402206290d7b5a30202340c0245d543e1cea1304aad0d4b3899638b01b3d7e34be3fa02201cbff26a4c4c306c6191205e339ca15b1e546c7acce81b11e9b0d5b7edef73c2:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/concrete5-detect.yaml
+++ b/http/technologies/concrete5-detect.yaml
@@ -52,4 +52,3 @@ http:
         regex:
           - 'concrete5-site-id=([a-z0-9]+)'
           - 'concrete5\.org/([^/]+)'
-# digest: 4b0a00483046022100bb9b272f280db05f778f514e88e2976be74a929c4c0d72c00d4562bcbfde9422022100abbee645c74678ffdd3f8fa27a7aae3935d6d74979c58ebf26257569b6a42c8f:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/django-detect.yaml
+++ b/http/technologies/django-detect.yaml
@@ -58,4 +58,3 @@ http:
         regex:
           - 'django-site-id=([a-z0-9]+)'
           - 'django\.org/([^/]+)'
-# digest: 490a0046304402201d4a37f28c8e143fe4f91b25d2b2cdc6205acba9be2a71774514cfa4daef004c0220013a05b833553f84be933098b707528a819528d165dc35691e1a99b696a2330e:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/expressionengine-detect.yaml
+++ b/http/technologies/expressionengine-detect.yaml
@@ -54,4 +54,3 @@ http:
         regex:
           - 'expressionengine-site-id=([a-z0-9]+)'
           - 'expressionengine\.com/([^/]+)'
-# digest: 4a0a0047304502205798a10bda6905aee1e86777322af3a26f9e42619dcaa569d648c4b948cced00022100c13b833e17550e5ca4965d0541726e44ac696e9e685cc2f0f1b33c394ba12a67:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/flask-detect.yaml
+++ b/http/technologies/flask-detect.yaml
@@ -53,4 +53,3 @@ http:
         regex:
           - 'flask-site-id=([a-z0-9]+)'
           - 'flask\.palletsprojects\.com/([^/]+)'
-# digest: 4a0a00473045022029a82df9f4b54ac7785b74e619facbaf14261043dbceb7a078fa28a2ec952705022100cb317d00b65093865ac95ad2abd5f469817a7f1bd896409d2f3ce006daab3a89:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/mezzanine-cms-detect.yaml
+++ b/http/technologies/mezzanine-cms-detect.yaml
@@ -42,4 +42,3 @@ http:
         regex:
           - "(?i)mezzanine\\s+(v[0-9.]+)"
           - "(?i)<title>Mezzanine CMS"
-# digest: 4b0a00483046022100c4c813eebf778988c3aa8c4793a2019289e8053216a76e46293608dbed93d8e9022100a5770ea3b6e9677f65001da9d0a6ac793d0524b462ea3e4f630f02676d526ad7:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/opencart-detect.yaml
+++ b/http/technologies/opencart-detect.yaml
@@ -53,4 +53,3 @@ http:
         regex:
           - 'opencart-store-id=([a-z0-9]+)'
           - 'oc-admin/([^/]+)'
-# digest: 4a0a004730450221009bb9e104df508454e594cdd2ef5ac07c5cb105742519761ce1bee446659778ee022050f7cfaadde19d2717297bd0403949a982ec67e46b73e4e6d7ce5843bf72992f:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/oscommerce-detect.yaml
+++ b/http/technologies/oscommerce-detect.yaml
@@ -53,4 +53,3 @@ http:
         regex:
           - 'oscommerce-site-id=([a-z0-9]+)'
           - 'oscommerce\.com/([^/]+)'
-# digest: 4b0a00483046022100bf0f38462b6e0c069b708f0ba1d646cca1d80ab36c2b0b59cb82b1ba94296333022100a49b204e6009effea5c7205d59c0306b5ce62f727d3e8ce03f15dfe5e85f208d:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/shopify-detect.yaml
+++ b/http/technologies/shopify-detect.yaml
@@ -57,4 +57,3 @@ http:
         regex:
           - 'shop_id=([0-9]+)'
           - 'shopify://([0-9a-zA-Z]+)'
-# digest: 4a0a00473045022100ca3e97cd9f6bd09fc2dd2a96c9b7a7d8cccc2cc181fbc8298eb9a0e332d1b3390220081f5b2e80d6d7f3b5f5befbd3c9e4f28580f14367dbb025f3922993a74f3beb:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/silverstripe-detect.yaml
+++ b/http/technologies/silverstripe-detect.yaml
@@ -54,4 +54,3 @@ http:
         regex:
           - 'silverstripe-site-id=([a-z0-9]+)'
           - 'silverstripe\.org/([^/]+)'
-# digest: 490a004630440220655345919a45b867c2e25c382e282e3169c37bc9d3cc4a58b0c2be0b757ae7fe02207ed6325fcb7084b3fa3e92c79e4f800c45d2ae22a8afee12481939d6417f6af6:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/squarespace-detect.yaml
+++ b/http/technologies/squarespace-detect.yaml
@@ -55,4 +55,3 @@ http:
           - 'squarespace-site-id=([a-z0-9]+)'
           - 'siteid="([a-zA-Z0-9]+)"'
           - 'squarespace\.com/([^/]+)'
-# digest: 490a0046304402203c5bcb8e14e76c5531b012ac3fee9c261c01a45c0fa02554f5fcb135d66ea19b02202e0412f791ee05789365f98e73ec89b826ecff497eb76d41d8bfc5ce962b6c61:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/weebly-detect.yaml
+++ b/http/technologies/weebly-detect.yaml
@@ -53,4 +53,3 @@ http:
         regex:
           - 'weebly-site-id=([a-z0-9]+)'
           - 'weebly\.com/([^/]+)'
-# digest: 4a0a00473045022065a36e381d7f0d082072644b92b63a65b896946f79fa6d866aef10aeddb607a6022100e64c8a380e9b837862761bc398325cbe745fced108eaac8ed378949114bcb7f4:922c64590222798bb761d5b6d8e72950

--- a/network/detection/unauth-java-message-broker-detect.yaml
+++ b/network/detection/unauth-java-message-broker-detect.yaml
@@ -30,4 +30,3 @@ tcp:
       - type: regex
         regex:
           - "imqbroker ([0-9.]+)"
-# digest: 4b0a00483046022100d30b63db809e04d8118ca4f5cde5ef4a40a0e0a40c491d7ec4e4ff0df48d62d3022100bf0e3a44f0f30110ffaca0d0826851c42424566f4606dcdce753b312b1f1e6ca:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- Normalizes line endings (CRLF -> LF) on 18 templates that were flagged as **unsigned** because they carried Windows line endings.
- Drops the now-stale `# digest:` line on each touched file so the upstream signing pipeline re-signs them cleanly.
- This is a **formatting/signature** fix only — no detection logic is changed.

This replaces #16493, which went `CONFLICTING` after upstream pushed fresh EPSS/digest churn. I re-applied the normalization on top of current `main` in a clean branch. The CRLF issue still reproduces on `main` (all 18 files verified to contain `\r\n`), so the fix is still relevant.

## Validation
- Verified all 18 files contained `\r\n` on current `upstream/main`; after the patch they are pure LF with no stale digest.
- `nuclei -validate` passes on representative templates:
  `nuclei -validate -t http/technologies/flask-detect.yaml -t http/technologies/shopify-detect.yaml -t network/detection/unauth-java-message-broker-detect.yaml -duc` -> `All templates validated successfully` (nuclei v3.8.0).
- Branch rebased fresh on `main`; collision check done against the prior PR (#16493).
