### PR TITLE
Add detection of "SMA OpCon" login panel instances.

### DIFF
--- a/http/exposed-panels/sma-opcon-panel.yaml
+++ b/http/exposed-panels/sma-opcon-panel.yaml
@@ -25,7 +25,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(to_lower(body), "<title>sma opcon solution manager</title>", "content=\"sma opcon solution manager\"", "\"opconrestapiproductversion\"")'
+          - 'contains_any(to_lower(body), "<title>sma opcon solution manager</title>", "content=\"sma opcon solution manager\"", "\"opconrestapiproductversion\":")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/sma-opcon-panel.yaml
+++ b/http/exposed-panels/sma-opcon-panel.yaml
@@ -1,0 +1,35 @@
+id: sma-opcon-panel
+
+info:
+  name: SMA OpCon Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+     SMA OpCon was detected — a workload automation and orchestration software.
+  reference:
+    - https://smatechnologies.com/product-opcon
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"SMA OpCon"
+  tags: panel,sma,login,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+      - "{{BaseURL}}/login"
+    
+    stop-at-first-match: true 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>sma opcon solution manager</title>", "content=\"sma opcon solution manager\"", "\"opconrestapiproductversion\"")'
+        condition: and
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - '.opConRestApiProductVersion'

--- a/http/exposed-panels/sma-opcon-panel.yaml
+++ b/http/exposed-panels/sma-opcon-panel.yaml
@@ -19,8 +19,8 @@ http:
     path:
       - "{{BaseURL}}/api/version"
       - "{{BaseURL}}/login"
-    
-    stop-at-first-match: true 
+
+    stop-at-first-match: true
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### PR Information

Hi,

This PR propose a template to detect instance of the login panel for the **SAM OpCon** software: a workload automation and orchestration software

References:
- https://smatechnologies.com/product-opcon

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

**💡Note:** As the version of the software is available on path `/api/version`, I added a check on this path in addition to the `/login` path  to capture the version in order to print it when the instance is detected.

Template was developed and tested against the version **3.9.0** of nuclei.

### Additional Details (leave it blank if not applicable)

The Shodan query is into the template.

### Additional References:

None