### PR TITLE
Rename XOOPS Installation Wizard to Installer

### DIFF
--- a/http/misconfiguration/installer/xoops-installer.yaml
+++ b/http/misconfiguration/installer/xoops-installer.yaml
@@ -26,4 +26,3 @@ http:
           - "(?i)(<title>(.*)XOOPS Installation Wizard(.*)</title>)"
           - "(?i)(<title>(.*)XOOPS 安裝精靈(.*)</title>)"
         condition: or
-# digest: 4b0a00483046022100fbe4198dedce406709692594ce470948585ef9e91db9b6815a5132d3874535bc022100ffcbb4cc86ed6f0b514696f73b70c45ec216db54c1d68dc5f416ea59b608ce28:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/installer/xoops-installer.yaml
+++ b/http/misconfiguration/installer/xoops-installer.yaml
@@ -1,17 +1,18 @@
-id: xoops-installation-wizard
+id: xoops-installer
 
 info:
-  name: XOOPS Installation Wizard Panel - Detect
+  name: XOOPS Installation Page - Exposure
   author: princechaddha
-  severity: low
-  description: XOOPS Installation Wizard panel was detected.
+  severity: high
+  description: |
+    Detects exposed XOOPS Installation page.
   classification:
     cpe: cpe:2.3:a:xoops:xoops:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
     vendor: xoops
     product: xoops
-  tags: panel,xoops,discovery
+  tags: misconfig,install,exposure,xoops,vuln
 
 http:
   - method: GET


### PR DESCRIPTION
Updated the XOOPS installation panel configuration to reflect a change in name and description, indicating exposure risk.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
