### PR TITLE
Add CVE-2026-56843 Plesk Authentication Bypass template

### DIFF
--- a/http/cves/2026/CVE-2026-56843.yaml
+++ b/http/cves/2026/CVE-2026-56843.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-56843
+
+info:
+  name: Plesk Authentication Bypass
+  author: "sourabh grover"
+  severity: critical
+  description: "Plesk versions before 18.0.78.4 are vulnerable to authentication bypass via /login_up.php"
+  tags: plesk,cve,cve2026,auth-bypass
+  metadata:
+    shodan-query: 'http.title:"Plesk" product:"Plesk"'
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login_up.php"
+    headers:
+      Cookie: "PLESKSESSID=x"
+    host-redirects: true
+    max-redirects: 3
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "plesk"
+        case-insensitive: true
+
+      - type: word
+        part: header
+        words:
+          - "PLESKSESSID"
+
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - 'Plesk(?: Obsidian)? v?(\d+\.\d+(?:\.\d+)+)'
+          - 'Version[:\s]+v?(\d+\.\d+(?:\.\d+)+)'
+          - 'Plesk\s+(\d+\.\d+(?:\.\d+)+)'


### PR DESCRIPTION
Adds nuclei template for CVE-2026-56843 - Plesk Authentication Bypass via /login_up.php affecting versions < 18.0.78.4. Includes Shodan query and version extraction.