### PR TITLE
feat: add XSS fuzzing template

### DIFF
--- a/http/fuzzing/xss-fuzzing.yaml
+++ b/http/fuzzing/xss-fuzzing.yaml
@@ -1,0 +1,50 @@
+id: xss-fuzzing
+
+info:
+  name: Generic Cross Site Scripting
+  author: idalunalabs
+  severity: medium
+  description: |
+    Fuzzing template to detect Reflected and DOM-based Cross-Site Scripting (XSS) vulnerabilities.
+    Injects common XSS payloads into query parameters and checks for reflection in the response body.
+  reference:
+    - https://owasp.org/www-community/attacks/xss/
+    - https://portswigger.net/web-security/cross-site-scripting
+  tags: xss,rxss,dast
+
+variables:
+  first: "{{rand_int(10000, 99999)}}"
+
+http:
+  - payloads:
+      reflection:
+        - '"><h1>{{first}}</h1>'
+        - '"><img src=x onerror=alert(1)>'
+        - '"><svg onload=alert(1)>'
+
+    fuzzing:
+      - part: query
+        type: postfix
+        mode: single
+        fuzz:
+          - '{{reflection}}'
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<h1>{{first}}</h1>'
+          - '<img src=x onerror=alert(1)>'
+          - '<svg onload=alert(1)>'
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - text/html
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## New Fuzzing Template: XSS Detection

Expands fuzzing templates collection (#9693).

### Template: `xss-fuzzing`
- Uses `fuzzing:` block with `part: query`, `type: postfix`, `mode: single`
- 3 XSS payloads: `<h1>` reflection, `<img onerror>`, `<svg onload>`
- Random integer variable (`{{rand_int}}`) for unique payload marking
- Matchers: body reflection (or) + content-type header (text/html) + status 200
- `stop-at-first-match: true` for efficiency

### Format
Follows the existing `reflected-xss.yaml` and `dom-xss.yaml` patterns in the repo.
Uses the `fuzzing:` directive (not plain `http` + `payloads`).

### Validation
- YAML parses successfully ✅
- Format matches projectdiscovery/fuzzing-templates conventions
- Tags: `xss,rxss,dast`


Ref: #9693