### PR TITLE
Add Qualys Cloud Platform login panel

### DIFF
--- a/http/exposed-panels/qualys-cloud-platform-login.yaml
+++ b/http/exposed-panels/qualys-cloud-platform-login.yaml
@@ -1,0 +1,46 @@
+id: qualys-cloud-platform-login
+
+info:
+  name: Qualys Cloud Platform Login Panel - Detect
+  author: rxerium
+  severity: info
+  description: Qualys Cloud Platform login panel was detected.
+  reference:
+    - https://www.qualys.com/cloud-platform/
+  classification:
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+    vendor: qualys
+    product: qualys_cloud_platform
+    shodan-query: http.title:"Qualys"
+  tags: panel,qualys,cloud,login,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/fo/login.php"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Qualys - Login</title>"
+          - "<title>Qualys&reg;</title>"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "top.location='fo/user_login.php'"
+          - "/fo/user_login.php"
+          - "id=\"myform_UserLogin\""
+          - "/images/qualys/product.png"
+        condition: or
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Hey team,

I have added a new detection template for the Qualys Cloud Platform login panel. The template uses the Shodan query `http.title:"Qualys"` and matches the Qualys login redirect/title markers exposed on live Qualys Cloud Platform instances.

Many thanks,

Rishi