### PR TITLE
fix: reduce false negatives in exposed-zookeeper template

### DIFF
--- a/network/exposures/exposed-zookeeper.yaml
+++ b/network/exposures/exposed-zookeeper.yaml
@@ -2,13 +2,22 @@ id: exposed-zookeeper
 
 info:
   name: Apache ZooKeeper - Unauthenticated Access
-  author: pdteam
+  author: pdteam,munzzyy
   severity: high
-  description: Apache ZooKeeper was able to be accessed without any required authentication.
+  description: |
+    Apache ZooKeeper was able to be accessed without any required authentication. Since
+    four-letter word commands are disabled by default unless explicitly whitelisted via
+    zookeeper.4lw.commands.whitelist, a plain "envi" check alone can miss instances that
+    are still fully readable. A second request speaks the native ZooKeeper client protocol
+    directly (connect handshake followed by a getChildren call on "/") to confirm read
+    access to the actual znode tree regardless of the whitelist configuration.
   reference:
     - https://zookeeper.apache.org/security.html
+    - https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_zkCommands
+    - https://github.com/h1thub/Unauthorized-zookeeper
   metadata:
-    max-request: 1
+    verified: true
+    max-request: 2
   tags: network,zookeeper,unauth,exposure,tcp,discovery
 
 tcp:
@@ -24,4 +33,30 @@ tcp:
       - type: word
         words:
           - "zookeeper.version"
-# digest: 4a0a004730450221009c44b5f530cfc18cbf470145be3ccd938c24546154a445810c7765f8877107630220673bdcd121e86cc1797ecf4146a71979452bba610e48c0760fe5b73dee78c406:922c64590222798bb761d5b6d8e72950
+
+  - inputs:
+      - data: "0000002d000000000000000000000000000075300000000000000000000000100000000000000000000000000000000000"
+        type: hex
+        read: 1024
+
+      - data: "0000000e0000000100000008000000012f00"
+        type: hex
+        read: 4096
+
+    host:
+      - "{{Hostname}}"
+    port: 2181
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: raw
+        words:
+          - "zookeeper"
+
+      - type: dsl
+        dsl:
+          # a denied (NoAuth) reply is always exactly 57 bytes (41-byte connect response
+          # + 16-byte error body); a real getChildren success is always longer since it
+          # carries at least the "zookeeper" system znode
+          - "len(raw) > 60"

--- a/network/exposures/exposed-zookeeper.yaml
+++ b/network/exposures/exposed-zookeeper.yaml
@@ -5,12 +5,7 @@ info:
   author: pdteam,munzzyy
   severity: high
   description: |
-    Apache ZooKeeper was able to be accessed without any required authentication. Since
-    four-letter word commands are disabled by default unless explicitly whitelisted via
-    zookeeper.4lw.commands.whitelist, a plain "envi" check alone can miss instances that
-    are still fully readable. A second request speaks the native ZooKeeper client protocol
-    directly (connect handshake followed by a getChildren call on "/") to confirm read
-    access to the actual znode tree regardless of the whitelist configuration.
+    Apache ZooKeeper was able to be accessed without any required authentication. Since four-letter word commands are disabled by default unless explicitly whitelisted via zookeeper.4lw.commands.whitelist, a plain "envi" check alone can miss instances that are still fully readable. A second request speaks the native ZooKeeper client protocol directly (connect handshake followed by a getChildren call on "/") to confirm read access to the actual znode tree regardless of the whitelist configuration.
   reference:
     - https://zookeeper.apache.org/security.html
     - https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_zkCommands

--- a/network/exposures/exposed-zookeeper.yaml
+++ b/network/exposures/exposed-zookeeper.yaml
@@ -5,15 +5,25 @@ info:
   author: pdteam,munzzyy
   severity: high
   description: |
-    Apache ZooKeeper was able to be accessed without any required authentication. Since four-letter word commands are disabled by default unless explicitly whitelisted via zookeeper.4lw.commands.whitelist, a plain "envi" check alone can miss instances that are still fully readable. A second request speaks the native ZooKeeper client protocol directly (connect handshake followed by a getChildren call on "/") to confirm read access to the actual znode tree regardless of the whitelist configuration.
+    Apache ZooKeeper was able to be accessed without any required authentication. Since four-letter word commands are disabled by default (ZK 3.5.3+) unless explicitly whitelisted via zookeeper.4lw.commands.whitelist, a plain "envi" check alone can miss instances that are still fully readable. A second request speaks the native ZooKeeper client protocol directly (connect handshake followed by a getChildren call on "/") to confirm read access to the actual znode tree regardless of the whitelist configuration.
+  impact: |
+    An unauthenticated attacker can read the ZooKeeper znode tree, exposing service configuration, cluster topology, Kafka broker registrations, and other sensitive coordination metadata. Write access may also be possible depending on ACL configuration.
+  remediation: |
+    Enable SASL/Kerberos or mutual TLS authentication on ZooKeeper. Restrict network access to port 2181 via firewall rules, and set zookeeper.requireClientAuthScheme to enforce client authentication.
   reference:
     - https://zookeeper.apache.org/security.html
     - https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_zkCommands
     - https://github.com/h1thub/Unauthorized-zookeeper
+  classification:
+    cwe-id: CWE-306
   metadata:
     verified: true
     max-request: 2
+    shodan-query: 'X-Powered-By: ZooKeeper'
+    fofa-query: protocol="zookeeper"
   tags: network,zookeeper,unauth,exposure,tcp,discovery
+
+flow: tcp(1) || tcp(2)
 
 tcp:
   - inputs:
@@ -28,6 +38,11 @@ tcp:
       - type: word
         words:
           - "zookeeper.version"
+
+    extractors:
+      - type: regex
+        regex:
+          - "zookeeper\\.version=([^\r\n]+)"
 
   - inputs:
       - data: "0000002d000000000000000000000000000075300000000000000000000000100000000000000000000000000000000000"
@@ -51,7 +66,10 @@ tcp:
 
       - type: dsl
         dsl:
-          # a denied (NoAuth) reply is always exactly 57 bytes (41-byte connect response
-          # + 16-byte error body); a real getChildren success is always longer since it
-          # carries at least the "zookeeper" system znode
-          - "len(raw) > 60"
+          - "len(raw) > 70"
+
+    extractors:
+      - type: regex
+        part: raw
+        regex:
+          - "zookeeper"


### PR DESCRIPTION
## Summary

- The existing check only sends the `envi` four-letter word command. On any ZooKeeper instance that doesn't explicitly set `zookeeper.4lw.commands.whitelist` to include `envi`, the server replies with "not in the whitelist" and the template reports not vulnerable — which is a false negative, since that's the *default* behavior on a stock install, not an edge case.
- Added a second request that speaks the real ZooKeeper client wire protocol directly: a connect handshake followed by a `getChildren` call on `/`. This confirms actual unauthenticated read access to the znode tree itself, independent of whatever four-letter word commands happen to be whitelisted.
- Matcher requires both the literal `zookeeper` znode name (the system child every ZooKeeper server auto-creates under `/` and can't be deleted) and a minimum response length. A denied (NoAuth) reply is always exactly 57 bytes total (41-byte connect response + a 16-byte error body), while any real `getChildren` success is longer because it carries at least that one `zookeeper` child — so a `> 60` length gate cleanly separates the two.

## Testing

Ran the real `nuclei` binary against two local, disposable standalone ZooKeeper 3.9.3 instances (official tarball from archive.apache.org, no docker involved):

- Stock config, no whitelist property set at all (the common real-world case): old `envi` request comes back "not in the whitelist" (no match), new protocol request matches. This reproduces the false negative from the issue and confirms the fix closes it.
- Same server with `/` ACL locked down to deny anonymous access (`setAcl / world:anyone:`): the protocol request gets back a NoAuth (-102) reply and does not match. No false positive on a properly secured instance.

`nuclei -validate` passes.

Closes #11076
