### PR TITLE
fix(open-proxy-portscan): reject HTML bodies to prevent WAF false positives

### DIFF
--- a/http/misconfiguration/proxy/open-proxy-portscan.yaml
+++ b/http/misconfiguration/proxy/open-proxy-portscan.yaml
@@ -2,7 +2,7 @@ id: open-proxy-portscan
 
 info:
   name: Open Proxy to Ports on the Proxy's localhost Interface
-  author: sullo
+  author: sullo,s4e-io
   severity: high
   description: The host is configured as a proxy which allows access to its internal interface
   remediation: Disable the proxy or restrict configuration to only allow access to approved hosts/ports.
@@ -57,8 +57,7 @@ http:
       - type: dsl
         condition: or
         dsl:
-          - (!regex("(?i)FTP",body_1)) && (!regex("(?i)FTP",body_2)) && (regex("(?i)FTP",body_3))
-          - (!regex("(?i)SSH-[.]+-+",body_1)) && (!regex("(?i)SSH-[.]+-+",body_2)) && (regex("(?i)SSH-[.]+-+",body_4))
-          - (!regex("(?i)POP3",body_1)) && (!regex("(?i)POP3",body_2)) && (regex("(?i)POP3",body_6))
-          - (!regex("(?i)SMTP",body_1)) && (!regex("(?i)SMTP",body_2)) && ((regex("(?i)SMTP",body_5)) || (regex("(?i)SMTP",body_7)) || (regex("(?i)SMTP",body_8)))
-# digest: 4b0a00483046022100f510b20873df4e7e259a5ec67f7b153af43927d503083b11f251f723acf867d202210090ab09353a51bf63a23ea023f7cc67fd4d768961e853e4cf8bdebec7271bb3a7:922c64590222798bb761d5b6d8e72950
+          - (!regex("(?i)FTP",body_1)) && (!regex("(?i)FTP",body_2)) && (regex("(?i)FTP",body_3)) && (!regex("(?i)<html",body_3))
+          - (!regex("(?i)SSH-[.]+-+",body_1)) && (!regex("(?i)SSH-[.]+-+",body_2)) && (regex("(?i)SSH-[.]+-+",body_4)) && (!regex("(?i)<html",body_4))
+          - (!regex("(?i)POP3",body_1)) && (!regex("(?i)POP3",body_2)) && (regex("(?i)POP3",body_6)) && (!regex("(?i)<html",body_6))
+          - (!regex("(?i)SMTP",body_1)) && (!regex("(?i)SMTP",body_2)) && ((regex("(?i)SMTP",body_5) && !regex("(?i)<html",body_5)) || (regex("(?i)SMTP",body_7) && !regex("(?i)<html",body_7)) || (regex("(?i)SMTP",body_8) && !regex("(?i)<html",body_8)))


### PR DESCRIPTION
fix(open-proxy-portscan): reject HTML responses to prevent false positives from WAF/filter block pages

## Summary

`open-proxy-portscan` identifies an open proxy by diffing response bodies across eight requests: two baseline requests establish what a "clean" response looks like, and six probe requests attempt to reach internal loopback services (FTP, SSH, SMTP, POP3) through the proxy. If a service keyword is absent from the baseline but present in a probe response, the host is flagged as vulnerable.

This produces a false positive whenever a WAF or content-filtering appliance sits in front of the target and intercepts the proxy-style probe requests, answering with a generic HTML block page instead of letting them reach the backend. If that static page happens to contain one of the four keywords anywhere in its markup — including inside embedded binary assets — the differential check is satisfied even though no internal service was ever reached.

## Real-world reproduction

| Field | Value |
|---|---|
| Target | `REDACTED` |
| Observed behavior | Every probe request is intercepted by a content-filtering appliance and answered with a static 403 block page |
| Matcher triggered | The `FTP` condition |
| Reproducibility | Confirmed on the live target and independently against the completely unmodified upstream template — this is existing matcher behavior, not something introduced by a local change |

The block page embeds a base64-encoded PNG logo. Decoded as text, that base64 blob coincidentally contains the case-insensitive substring `FTP`:

```
...MoaAbX680axO3M6IhL6xHhlDBIgAESACXY5AKwi7FTpaCTMJvZVoUhcRIAJdgQDW5AffEBjmmO19H5Zmca2...
```

The fragment `FTp` above is random base64 noise from an image asset — not a protocol banner. Because `regex("(?i)FTP", body_3)` only checks for substring presence, it matches regardless.

## Fix

Added one guard to each of the four differential conditions:

```
&& (!regex("(?i)<html", body_N))
```

A genuine open-proxy response is a raw protocol banner — `220 (vsFTPd 3.0.3)`, `SSH-2.0-OpenSSH_8.9`, `220 mail.example.com ESMTP Postfix`, `+OK POP3 server ready` — never an HTML document. The guard is therefore a no-op on a real vulnerable target and only excludes the false-positive class described above.

## Result

| Scenario | Before | After |
|---|---|---|
| Target behind a WAF/content filter (this report) | False match on `FTP` | No match |
| Target returning a genuine service banner | Match | Match (unaffected) |

---

### PR Information

- Fixed False Positive: `open-proxy-portscan`
- References:
  - https://blog.projectdiscovery.io/abusing-reverse-proxies-internal-access/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against a host with a vulnerable open-proxy configuration to confirm the fix continues to detect the internal-port banner correctly, in addition to the false-positive reproduction above.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
