### PR TITLE
prevent creds-stuffing/token-spray templates from sending requests wi…

### DIFF
--- a/http/credential-stuffing/cloud/atechmedia-codebase-login-check.yaml
+++ b/http/credential-stuffing/cloud/atechmedia-codebase-login-check.yaml
@@ -13,6 +13,11 @@ info:
 
 self-contained: true
 
+flow: |
+  if (template["username"] && template["password"]) {
+    http();
+  }
+
 http:
   - raw:
       - |
@@ -52,4 +57,3 @@ http:
       - type: status
         status:
           - 302
-# digest: 4a0a0047304502201d0976538553d5e9019320a5b30170f310554a6e16c5c0890456365906e903590221008f02abaf1f16492712cc6cbc07b16a2867d19d682b5d83da367a73d058c52262:922c64590222798bb761d5b6d8e72950

--- a/http/credential-stuffing/cloud/codepen-login-check.yaml
+++ b/http/credential-stuffing/cloud/codepen-login-check.yaml
@@ -13,6 +13,11 @@ info:
 
 self-contained: true
 
+flow: |
+  if (template["username"] && template["password"]) {
+    http();
+  }
+
 http:
   - raw:
       - |
@@ -50,4 +55,3 @@ http:
       - type: status
         status:
           - 302
-# digest: 4a0a00473045022016f5fd8f18542d0ddd93684d7cd69901f089c2e2950a384f04c1bf6287f57ad50221008253ef5d9e0e2ed653fd7d78e7ab566ee30f6a4a7b5b13eef9533d4fade2da87:922c64590222798bb761d5b6d8e72950

--- a/http/credential-stuffing/cloud/datadog-login-check.yaml
+++ b/http/credential-stuffing/cloud/datadog-login-check.yaml
@@ -13,6 +13,11 @@ info:
 
 self-contained: true
 
+flow: |
+  if (template["username"] && template["password"]) {
+    http();
+  }
+
 http:
   - raw:
       - |
@@ -50,4 +55,3 @@ http:
       - type: status
         status:
           - 302
-# digest: 4a0a0047304502207ffee6dea6b55c536124f12f76644e41caf3f789c5d9e70f3a2f2f5bae61b188022100c5e9fabafbc04710df4818c0958c53733a35df4505d9aa13611f55360074c044:922c64590222798bb761d5b6d8e72950

--- a/http/credential-stuffing/cloud/github-login-check.yaml
+++ b/http/credential-stuffing/cloud/github-login-check.yaml
@@ -13,6 +13,11 @@ info:
 
 self-contained: true
 
+flow: |
+  if (template["username"] && template["password"]) {
+    http();
+  }
+
 http:
   - raw:
       - |
@@ -72,4 +77,3 @@ http:
           - "contains(to_lower(header), 'set-cookie: user_session=')"
           - "status_code==302"
         condition: and
-# digest: 4a0a0047304502206877f036ee535cec118c15201dbd592497509ca61d0f654831a390fcfa1f7d7b022100a66280afce3ac4050744ea5290300a98b872bdf0bbb78c9bd03df695598ffe53:922c64590222798bb761d5b6d8e72950

--- a/http/credential-stuffing/cloud/postman-login-check.yaml
+++ b/http/credential-stuffing/cloud/postman-login-check.yaml
@@ -13,6 +13,11 @@ info:
 
 self-contained: true
 
+flow: |
+  if (template["username"] && template["password"]) {
+    http();
+  }
+
 http:
   - raw:
       - |
@@ -51,4 +56,3 @@ http:
           - "contains(to_lower(body), 'identity.postman.co/continue')"
           - "status_code==200"
         condition: and
-# digest: 490a004630440220691ace07791fce89c3448fcd1aba6fe68bbbbfa5611951514e71b8a08f96daa802200b5c9e06cc1a3653d566a8733a167e60e7f134ec44714b08f03c9fa51fc16ac6:922c64590222798bb761d5b6d8e72950

--- a/http/token-spray/api-mailchimp.yaml
+++ b/http/token-spray/api-mailchimp.yaml
@@ -11,6 +11,12 @@ info:
   tags: token-spray,mailchimp,tcp
 
 self-contained: true
+
+flow: |
+  if (template["token"]) {
+    tcp();
+  }
+
 tcp:
   - inputs:
       - data: "AUTH PLAIN {{base64(hex_decode('00')+'apikey'+hex_decode('00')+token)}}\r\n"
@@ -21,4 +27,3 @@ tcp:
       - type: word
         words:
           - "success"
-# digest: 4b0a00483046022100dcc914aa1252f5607d7f951213c5c81fb4f53d36b4a3548ab8f8307624adef6e022100f671dd86e29255cca370a3e2038e1c21e075857a08f08a18b950c9e8309f3e2c:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Problem
The login-check and mailchimp templates fire their first request even when no
`username`/`password`/`token` is supplied. Because the initial request (e.g. the
GET that scrapes the CSRF/authenticity token) contains no user-supplied variable,
nuclei sends it regardless, only skipping the later POST with
`unresolved variables found`. With `-enable-self-contained` this means outbound
connections to github.com, getpostman.com, app.datadoghq.com, etc. — and a TCP
dial to smtp.mandrillapp.com:465 — with no input provided.

### Fix
Added a `flow` guard that runs the protocol block only when the required inputs
are present, so no request is sent unless the operator supplies credentials:

```yaml
flow: |
  if (template["username"] && template["password"]) {
    http();
  }

(mailchimp gates on template["token"] and calls tcp().)

This sends zero extra bytes on the wire — nothing is dialed when input is absent —
rather than emitting a request that later errors out.

Templates updated

- http/credential-stuffing/cloud/github-login-check.yaml
- http/credential-stuffing/cloud/postman-login-check.yaml
- http/credential-stuffing/cloud/codepen-login-check.yaml
- http/credential-stuffing/cloud/atechmedia-codebase-login-check.yaml
- http/credential-stuffing/cloud/datadog-login-check.yaml
- http/token-spray/api-mailchimp.yaml

Verification

- No input, -esc: all 6 load, 0 requests sent, no unresolved variables warnings.
- With input: GET/POST flow runs normally; mailchimp dials 465 and sends its payload.
- nuclei -validate passes on all 6.

Other creds-stuffing and token-spray/api-* templates are single-request with the
input embedded in that request, so they already self-gate and need no change.