### PR TITLE
Add WordPress wp2shell detection template

### DIFF
--- a/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
@@ -7,6 +7,7 @@ info:
   description: Non-invasive check for affected WordPress versions with unauthenticated REST batch endpoint exposure.
   reference:
     - https://slcyber.io/research-center/wp2shell-pre-authentication-rce-in-wordpress-core
+    - https://www.aikido.dev/blog/unauthenticated-rce-in-wordpress-wp2shell
   metadata:
     max-request: 5
   tags: wordpress,wp,wp2shell,rce,exposure

--- a/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
@@ -5,6 +5,8 @@ info:
   author: mielverkerken
   severity: critical
   description: Non-invasive check for affected WordPress versions with unauthenticated REST batch endpoint exposure.
+  reference:
+    - https://slcyber.io/research-center/wp2shell-pre-authentication-rce-in-wordpress-core
   metadata:
     max-request: 5
   tags: wordpress,wp,wp2shell,rce,exposure

--- a/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
@@ -1,10 +1,10 @@
 id: wordpress-wp2shell
 
 info:
-  name: WordPress wp2shell - Safe Version and Batch API Exposure Check
+  name: wp2shell - Pre Authentication RCE in WordPress
   author: mielverkerken
   severity: critical
-  description: Non-invasive check for affected WordPress versions with unauthenticated REST batch endpoint exposure.
+  description: WordPress Core versions 6.9.0 through 6.9.4 and 7.0.0 through 7.0.1 are affected by a pre-authentication remote code execution vulnerability in the REST batch API.
   reference:
     - https://slcyber.io/research-center/wp2shell-pre-authentication-rce-in-wordpress-core
     - https://www.aikido.dev/blog/unauthenticated-rce-in-wordpress-wp2shell

--- a/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
@@ -1,0 +1,67 @@
+id: wordpress-wp2shell
+
+info:
+  name: WordPress wp2shell - Safe Version and Batch API Exposure Check
+  author: mielverkerken
+  severity: critical
+  description: Non-invasive check for affected WordPress versions with unauthenticated REST batch endpoint exposure.
+  metadata:
+    max-request: 5
+  tags: wordpress,wp,wp2shell,rce,exposure
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Accept: text/html
+
+      - |
+        GET /wp-json/ HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+      - |
+        GET /?feed=rss2 HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+      - |
+        POST /wp-json/batch/v1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {}
+
+      - |
+        POST /?rest_route=/batch/v1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {}
+
+    req-condition: true
+    stop-at-first-match: true
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        internal: true
+        group: 1
+        regex:
+          - '(?i)<meta[^>]*name=["''"]?generator["''"]?[^>]*content=["''"]?WordPress\s+([0-9.]+)'
+          - '(?i)wordpress\.org/\?v=([0-9.]+)'
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        name: affected-version
+        dsl:
+          - 'len(version) > 0 && (compare_versions(version, ">=6.9.0", "<=6.9.4") || compare_versions(version, ">=7.0.0", "<=7.0.1"))'
+
+      - type: dsl
+        name: unauth-batch-api-reachable
+        dsl:
+          - '(status_code_4 == 400 && contains(body_4, "rest_missing_callback_param") && contains(body_4, "requests")) || (status_code_5 == 400 && contains(body_5, "rest_missing_callback_param") && contains(body_5, "requests"))'

--- a/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
+++ b/http/vulnerabilities/wordpress/wordpress-wp2shell.yaml
@@ -5,6 +5,10 @@ info:
   author: mielverkerken
   severity: critical
   description: WordPress Core versions 6.9.0 through 6.9.4 and 7.0.0 through 7.0.1 are affected by a pre-authentication remote code execution vulnerability in the REST batch API.
+  remediation: |
+    Update WordPress to version 7.0.2, or to 6.9.5 if you are on the 6.9 branch.
+    If updating is not possible, temporarily block anonymous access to the batch API by installing a plugin that blocks anonymous REST API access, or by blocking /wp-json/batch/v1 and ?rest_route=/batch/v1 at the WAF level.
+    Temporary mitigations may affect legitimate site functionality and should only be used until WordPress can be updated.
   reference:
     - https://slcyber.io/research-center/wp2shell-pre-authentication-rce-in-wordpress-core
     - https://www.aikido.dev/blog/unauthenticated-rce-in-wordpress-wp2shell


### PR DESCRIPTION
## Summary
- Adds a safe WordPress wp2shell exposure check for affected version ranges.
- Verifies unauthenticated REST batch endpoint reachability without sending exploit payloads.

## Test plan
- [x] Ran `nuclei -validate -t http/vulnerabilities/wordpress/wordpress-wp2shell.yaml`