### PR TITLE
Add CVE-2026-59206 - n8n Prototype Pollution to Unauthenticated User & Project Enumeration

### DIFF
--- a/http/cves/2026/CVE-2026-59206.yaml
+++ b/http/cves/2026/CVE-2026-59206.yaml
@@ -1,0 +1,75 @@
+id: CVE-2026-59206
+
+info:
+  name: n8n - Prototype Pollution to Unauthenticated User & Project Enumeration
+  author: assakafpix
+  severity: high
+  description: |
+    n8n before 1.123.61, 2.27.4, and 2.28.1 is vulnerable to prototype pollution in
+    replaceInvalidCredentials() (packages/cli/src/workflow-helpers.ts). An authenticated user with
+    the default workflow:create permission can pollute Object.prototype via a workflow saved,
+    updated, or imported through the workflow API. The polluted Object.prototype.user satisfies the
+    `if (req.user)` authentication check, exposing GET /rest/users and GET /rest/projects to
+    unauthenticated callers.
+  impact: |
+    Unauthenticated enumeration of every account on the instance (id, name, email, role, MFA status,
+    last-active) and of all projects — prime reconnaissance for follow-on phishing / credential
+    attacks — plus corruption of system state.
+  remediation: |
+    Upgrade to n8n 1.123.61, 2.27.4, or 2.28.1 (or later on the respective release train).
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-75qm-gp28-rcq9
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59206
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:L/VA:N/SC:L/SI:L/SA:N
+    cvss-score: 7.1
+    cve-id: CVE-2026-59206
+    cwe-id: CWE-1321
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n-io
+    product: n8n
+    shodan-query: http.favicon.hash:-831756631
+    fofa-query: icon_hash="-831756631"
+  tags: cve,cve2026,n8n,prototype-pollution,workflow,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/signin"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>n8n.io"
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - "compare_versions(version, '< 1.123.61') || compare_versions(version, '>= 2.0.0', '< 2.27.4') || compare_versions(version, '>= 2.28.0', '< 2.28.1')"
+
+    extractors:
+      - type: regex
+        name: base64_content
+        group: 1
+        regex:
+          - '<meta name="n8n:config:sentry" content="([A-Za-z0-9+/=]+)"'
+        internal: true
+
+      - type: dsl
+        name: version
+        dsl:
+          - 'replace_regex(base64_decode(base64_content), ".*n8n@([0-9]+\\.[0-9]+\\.[0-9]+).*", "$1")'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"n8n Version: " + version'


### PR DESCRIPTION
- Added **CVE-2026-59206** — n8n prototype pollution (via workflow credentials) leading to **unauthenticated user and project enumeration**.
- References:
  - https://github.com/n8n-io/n8n/security/advisories/GHSA-75qm-gp28-rcq9
  - https://nvd.nist.gov/vuln/detail/CVE-2026-59206

Passive, unauthenticated **version-based detection** via the `/signin` sentry meta tag, following the existing n8n template convention (`http/cves/2026/CVE-2026-21877.yaml`, which is also an authenticated bug detected by version).

**Detection-only by design:** the active PoC (a `__proto__` payload on `POST /rest/workflows`, requiring a `workflow:create` account) corrupts `Object.prototype` and leaves the instance throwing 500s until the process is restarted, and its payoff is a dump of the live user list (PII). Weaponising that in a scan template would be destructive and expose PII, so — consistent with the existing n8n template — this detects by version.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Vulnerable environment (Docker):

```bash
docker run -d -p 5678:5678 n8nio/n8n:2.27.3   # vulnerable (< 2.27.4)
docker run -d -p 5678:5678 n8nio/n8n:2.27.4   # patched (true-negative check)
```

Results (local Docker labs, no real-world host):

```
2.27.3  -> MATCH   extracted "n8n Version: 2.27.3"   severity: high
2.27.4  -> no match (true negative)
nuclei -validate -> All templates validated successfully
```

Affected versions (per advisory): `< 1.123.61`, `< 2.27.4`, `< 2.28.1` (patched on all three release trains).
Fingerprint: `GET /signin` -> `<meta name="n8n:config:sentry" content="<base64>">` decodes to `{"release":"n8n@X.Y.Z"}`; favicon hash `-831756631` (shodan/fofa).
