### PR TITLE
Add zer0p0int contributor social profile

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1529,5 +1529,15 @@
             "website": "https://marcialpaulg.com",
             "email": "im.codename@gmail.com"
         }
+    },
+    {
+        "author": "zer0p0int",
+        "links": {
+            "github": "https://github.com/zer0p0intvvv",
+            "twitter": "",
+            "linkedin": "",
+            "website": "",
+            "email": ""
+        }
     }
 ]


### PR DESCRIPTION
## Summary

- add the `zer0p0int` contributor profile
- link the verified GitHub account `zer0p0intvvv`
- leave unavailable social fields empty

## Validation

- parsed `contributors.json` successfully
- verified exactly one matching author entry
- confirmed the diff only adds 10 lines to `contributors.json`