### PR TITLE
Add Chatwoot Login Panel detection

### DIFF
--- a/http/exposed-panels/chatwoot-login-panel.yaml
+++ b/http/exposed-panels/chatwoot-login-panel.yaml
@@ -1,0 +1,33 @@
+id: chatwoot-login-panel
+
+info:
+  name: Chatwoot Login Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    Chatwoot login panel detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: html:"Chatwoot"
+  tags: panel,login,chatwoot,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/app/login"
+
+    redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Chatwoot")'
+          - 'contains(body, "window.chatwootConfig")'
+          - 'contains(body, "\"INSTALLATION_NAME\":\"Chatwoot\"")'
+        condition: and

--- a/http/exposed-panels/chatwoot-login-panel.yaml
+++ b/http/exposed-panels/chatwoot-login-panel.yaml
@@ -1,7 +1,7 @@
 id: chatwoot-login-panel
 
 info:
-  name: Chatwoot Login Panel Detect
+  name: Chatwoot Login Panel - Detect
   author: Th3l0newolf
   severity: info
   description: |
@@ -29,5 +29,5 @@ http:
           - 'status_code == 200'
           - 'contains(body, "Chatwoot")'
           - 'contains(body, "window.chatwootConfig")'
-          - 'contains(body, "\"INSTALLATION_NAME\":\"Chatwoot\"")'
+          - 'contains(body, "\"INSTALLATION_NAME\":\"Chatwoot")'
         condition: and


### PR DESCRIPTION
### PR Information
Added template for  Chatwoot Login Panel detection

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)

<img width="677" height="320" alt="image" src="https://github.com/user-attachments/assets/598f38c8-12b0-47c0-9c6e-dc07f40f0ada" />

<img width="633" height="127" alt="image" src="https://github.com/user-attachments/assets/d2a55247-b00a-4419-8389-b6fbb0490ffa" />


#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
