### PR TITLE
Severity fix

### DIFF
--- a/http/misconfiguration/directory-listing-no-host-header.yaml
+++ b/http/misconfiguration/directory-listing-no-host-header.yaml
@@ -3,7 +3,7 @@ id: directory-listing-no-host-header
 info:
   name: Directory Listing - No Host header
   author: kazet
-  severity: unknown
+  severity: medium
   description: |
     The HTTP server is configured to list files in the root directory when no Host header is provided.
   metadata:

--- a/http/misconfiguration/directory-listing-no-host-header.yaml
+++ b/http/misconfiguration/directory-listing-no-host-header.yaml
@@ -41,4 +41,3 @@ http:
           - 'contains_any(body,"<title>Index of","<title>Directory listing of")'
           - 'status_code == 200'
         condition: and
-# digest: 4a0a00473045022100b125863c5fdd8b60833cdebe6b2c666128e6118dd626870844708acca006ea1a02200444a9b60d7fb343bf0948d7f4781b0fd5c4ce2d3a8743d3d1734e8fb894de68:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/directory-listing-no-host-header.yaml
+++ b/http/misconfiguration/directory-listing-no-host-header.yaml
@@ -3,7 +3,7 @@ id: directory-listing-no-host-header
 info:
   name: Directory Listing - No Host header
   author: kazet
-  severity: medium
+  severity: unknown
   description: |
     The HTTP server is configured to list files in the root directory when no Host header is provided.
   metadata:


### PR DESCRIPTION
### PR Information

Fixing severity info in http/misconfiguration/directory-listing-no-host-header.yaml