### PR TITLE
Add CVE-2026-56139 for Apache Camel Undertow vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-56139.yaml
+++ b/http/cves/2026/CVE-2026-56139.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-56139
+
+info:
+  name: Apache Camel Undertow REST DSL - muteException Stack Trace Disclosure
+  author: omarkurt
+  severity: medium
+  description: |
+    Apache Camel's camel-undertow component builds the REST DSL consumer's
+    RestUndertowHttpBinding with muteException hard-coded to false and never
+    copies the endpoint's configured value onto it. As a result,
+    camel.component.undertow.mute-exception=true (or a per-endpoint
+    muteException=true) is silently ignored for any route reachable through
+    the undertow REST DSL: an unhandled processing exception returns the
+    full Java stack trace to an unauthenticated client, while a plain
+    (non-REST-DSL) undertow endpoint with the identical setting correctly
+    returns an empty body. Disclosed details can include internal
+    hostnames, database connection strings, credential/vault references,
+    file paths, and library versions. Reported by Yu Bao (PayPal); fixed
+    together with the related CVE-2026-49365 (which corrected the
+    muteException default to true for camel-undertow and camel-netty-http)
+    under CAMEL-23651.
+  impact: |
+    An unauthenticated client can trigger any unhandled exception on a REST
+    DSL route served by camel-undertow and receive the full Java stack
+    trace in the response, even though the application explicitly enabled
+    muteException to prevent exactly that. Disclosed data can include
+    backend hostnames, database connection strings, credential or
+    secret-manager hints, internal file paths, and library/framework
+    versions, aiding further targeted attacks.
+  remediation: |
+    Upgrade camel-undertow to 4.14.8, 4.18.3, or 4.21.0. Until upgraded, add
+    a global onException(...).handled(true) handler that returns a generic
+    error body instead of relying on muteException for REST DSL consumers
+    served by camel-undertow.
+  reference:
+    - https://camel.apache.org/security/CVE-2026-56139.html
+    - https://github.com/apache/camel/pull/23913
+    - https://github.com/oscerd/CVE-2026-56139
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-56139
+    cwe-id: CWE-209
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: camel
+  tags: cve,cve2026,apache,camel,undertow,disclosure,cwe-209
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 500
+
+      - type: word
+        part: body
+        words:
+          - "org.apache.camel.component.undertow.UndertowConsumer"
+          - "org.apache.camel"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - '\tat [a-zA-Z0-9_.$]+\([A-Za-z0-9_.]+\.java:[0-9]+\)'


### PR DESCRIPTION
Added CVE-2026-56139 details for Apache Camel Undertow REST DSL vulnerability, including impact, remediation, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-56139
- References:  https://vulnerabletarget.com/VT-2026-56139 , https://github.com/oscerd/CVE-2026-56139

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
