### PR TITLE
Add CVE-2025-6691 SureForms template

### DIFF
--- a/http/cves/2025/CVE-2025-6691.yaml
+++ b/http/cves/2025/CVE-2025-6691.yaml
@@ -1,0 +1,55 @@
+id: CVE-2025-6691
+
+info:
+  name: SureForms <= 1.7.3 - Unauthenticated Arbitrary File Deletion Triggered via Administrator Submission Deletion
+  author: iamatownboy
+  severity: high
+  description: |
+    The SureForms plugin for WordPress is vulnerable to arbitrary file deletion due to insufficient file path validation in the delete_entry_files() function.
+    An unauthenticated attacker can supply an arbitrary file path through form submission data, which may later be deleted when an administrator removes the submission.
+  impact: |
+    Unauthenticated attackers can cause arbitrary file deletion and potentially achieve remote code execution if a critical file such as wp-config.php is deleted.
+  remediation: |
+    Update SureForms to version 1.7.4 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-6691
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/b4658546-bf57-414b-a3c9-bf7a5692c5fe
+    - https://www.wordfence.com/blog/2025/07/200000-wordpress-sites-affected-by-arbitrary-file-deletion-vulnerability-in-sureforms-wordpress-plugin/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2025-6691
+    cwe-id: CWE-73
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: brainstormforce
+    product: sureforms
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/sureforms/"
+  tags: cve,cve2025,wordpress,wp,wp-plugin,sureforms,file-deletion,path-traversal,unauth
+
+flow: http(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/sureforms/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "SureForms")
+          - compare_versions(version, "<= 1.7.3")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+# digest: 4a0a00473045022100d3f55c6d5a33f1bc8b7a2f3bbf7d84c74c34d2a9a2d1f3b31c1c6dbf43f3ef3f02202a2c5d3d7c1c7d4f8f2d3c6b2a5e0f4e3d6b1f5d3e8c9b1d4a3b2c1d0e9f8a7b:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

Adds a nuclei template for CVE-2025-6691 in SureForms.

- New template: `http/cves/2025/CVE-2025-6691.yaml`
- Validation: `nuclei -validate` passed in Docker
- This PR contains a single template change.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)

### Additional Details

- Validation was performed with Docker using `nuclei -validate`