### PR TITLE
Add CVE-2025-13516 SureMail template

### DIFF
--- a/http/cves/2025/CVE-2025-13516.yaml
+++ b/http/cves/2025/CVE-2025-13516.yaml
@@ -1,0 +1,72 @@
+id: CVE-2025-13516
+
+info:
+  name: SureMail <= 1.9.0 - Unauthenticated Arbitrary File Upload via Email Attachment Duplication
+  author: iamatownboy
+  severity: high
+  description: |
+    The SureMail plugin for WordPress is vulnerable to unrestricted file upload in versions up to, and including, 1.9.0.
+    The plugin stores email attachments in a web-accessible directory without validating extension or content type, allowing unauthenticated attackers to upload executable files in exposed environments.
+  impact: |
+    Unauthenticated attackers can upload arbitrary files and achieve remote code execution on servers where uploaded PHP files are executable.
+  remediation: |
+    Update SureMail to version 1.9.1 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-13516
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/f3a20047-a325-4d29-a848-7ffa525d0bad?source=cve
+    - https://plugins.trac.wordpress.org/browser/suremails/trunk/inc/admin/plugin.php#L407
+    - https://plugins.trac.wordpress.org/browser/suremails/trunk/inc/emails/handler/uploads.php#L113
+    - https://plugins.trac.wordpress.org/browser/suremails/trunk/inc/emails/handler/uploads.php#L231
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2025-13516
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: brainstormforce
+    product: suremails
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/suremails/"
+  tags: cve,cve2025,wordpress,wp,wp-plugin,suremails,file-upload,rce,unauth
+
+variables:
+  marker: "{{rand_text_alpha(8)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/suremails/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "SureMail")
+          - compare_versions(version, "<= 1.9.0")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        GET /wp-content/uploads/suremails/attachments/ HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_any(body, "Index of", "attachments", "Apache")
+        condition: and
+# digest: 4a0a00473045022100f1d1db5f4a4c4e5b76a6a5d4d5d7b0e5f0d5a2b1e9b2d7d4d8c7b3a0b2c1d022019e6e3c9ef07b0e41d7f20f4b7d3c2efc2cf4d52c4d2e2f3f2c5f0f3a6d8d1a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

Adds a nuclei template for CVE-2025-13516 affecting the SureMail WordPress plugin.

The template checks for the affected version and the exposed upload flow described in the public advisory.

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- Single template change