### PR TITLE
Add root-level OIDC discovery

### DIFF
--- a/http/technologies/oidc-detect.yaml
+++ b/http/technologies/oidc-detect.yaml
@@ -13,6 +13,7 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/.well-known/openid-configuration"
+      - "{{RootURL}}/.well-known/openid-configuration"
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
### PR Information

This change extends OIDC discovery to support discovery from the root endpoint.

In some deployments, the OpenID Connect discovery document (.well-known/openid-configuration) is served from the root endpoint rather than a subpath. This change adds support for that configuration.

### Validation

- [x] Verified discovery still works for existing providers.
- [x] Verified discovery succeeds for providers exposing OIDC metadata from the root endpoint.