### PR TITLE
fix empty operators

### DIFF
--- a/dns/dns-saas-service-detection.yaml
+++ b/dns/dns-saas-service-detection.yaml
@@ -253,9 +253,11 @@ dns:
           - mktossl.com
           - mktoweb.com
 
-      - type: word
+      - type: regex
         part: answer
-        name: adobe-marketo - 'mkto-.{5,8}\.com'
+        name: adobe-marketo
+        regex:
+          - 'mkto-.{5,8}\.com'
 
       - type: word
         part: answer

--- a/http/cves/2021/CVE-2021-44228.yaml
+++ b/http/cves/2021/CVE-2021-44228.yaml
@@ -70,6 +70,7 @@ http:
     extractors:
       - type: kval
         kval:
+          - interactsh_ip
       - type: regex
         group: 2
         regex:

--- a/http/cves/2021/CVE-2021-45046.yaml
+++ b/http/cves/2021/CVE-2021-45046.yaml
@@ -64,6 +64,7 @@ http:
     extractors:
       - type: kval
         kval:
+          - interactsh_ip
       - type: regex
         group: 2
         regex:

--- a/http/cves/2026/CVE-2026-42281.yaml
+++ b/http/cves/2026/CVE-2026-42281.yaml
@@ -65,6 +65,7 @@ http:
 
       - type: dsl
         name: dns
+        dsl:
           - "contains(interactsh_protocol,'dns')"
           - status_code == 200
         condition: and


### PR DESCRIPTION
## Summary
- Restore missing matcher/extractor values in 4 templates that silently no-op today
- Needed so these templates keep working once nuclei rejects empty operators ([projectdiscovery/nuclei#7605](https://github.com/projectdiscovery/nuclei/pull/7605))

## Changes
- `CVE-2021-44228` / `CVE-2021-45046`: restore `kval: [interactsh_ip]`
- `CVE-2026-42281`: add missing `dsl:` key on the dns matcher
- `dns-saas-service-detection`: turn broken adobe-marketo word matcher into a regex matcher