### PR TITLE
fix: replace an unsupported lookahead that made home-env-permission fail to load

### DIFF
--- a/code/linux/audit/home-env-permission.yaml
+++ b/code/linux/audit/home-env-permission.yaml
@@ -21,7 +21,10 @@ code:
         HOME_DIR=$(eval echo ~$user)
         find "$HOME_DIR" -maxdepth 1 -type f \
           \( -name ".bashrc" -o -name ".bash_profile" -o -name ".bash_logout" \) \
-          -exec ls -l {} \; | awk -v usr="$user" '{print $0, "EXPECTED_USER="usr}'
+          -exec ls -l {} \; | awk -v usr="$user" '{
+            if ($3 != "root" && $3 != usr) print "INVALID_OWNER", $0
+            else print $0
+          }'
       done
 
     matchers:
@@ -36,5 +39,5 @@ code:
         name: invalid-owner
         part: response
         regex:
-          - "^\\S+\\s+\\S+\\s+(?!root|.*EXPECTED_USER=)"
+          - "^INVALID_OWNER"
 # digest: 490a0046304402200d1c1eb3e56074bf3daf7445e93706d95501decf32ee59f9d155f9d07f56d988022070e34135003e30cdd8a2aea1d25fef4df3cb8b9e354d0511a38a1dace28b16b0:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### The template never loads

`home-env-permission.yaml`'s `invalid-owner` matcher uses a negative lookahead:

```
^\S+\s+\S+\s+(?!root|.*EXPECTED_USER=)
```

Go's RE2 has no lookahead, so it cannot compile and nuclei drops the **whole template**:

```
$ nuclei -t code/linux/audit/home-env-permission.yaml -u localhost -code -v
[WRN] Could not parse template home-env-permission.yaml: could not compile request:
      cause="could not compile regex: ^\S+\s+\S+\s+(?!root|.*EXPECTED_USER=)"
      chain="could not compile operators"
[WRN] Found 1 templates with runtime error (use -validate flag for further examination)
```

Both matchers are lost, including the `insecure-perms` one that is perfectly valid — so this compliance check has never run.

### Why not just rewrite the regex

The condition is *"owner is neither `root` nor the expected user"*, which relates **two fields of the same line** (`$3` and the `EXPECTED_USER=` value). RE2 cannot express that at any complexity — I tried, and every lookahead-free variant either still needs `(?!` or matches all three sample rows.

The shell pipeline already has both values, so `awk` decides and tags the line; the matcher then looks for the tag.

### Verification

Against sample `ls -l` output:

```
-rw-r--r-- 1 mallory mallory ... EXPECTED_USER=bob     -> INVALID_OWNER   (flagged)
-rw-r--r-- 1 alice   alice   ... EXPECTED_USER=alice   -> not flagged
-rw-r--r-- 1 root    root    ... EXPECTED_USER=alice   -> not flagged
```

Only the foreign-owner row is flagged, which is the intent.

Loading the template with nuclei:

```
before:  could not compile regex ... Found 1 templates with runtime error
after:   loads, no runtime error
```

### How it was found

Compiled every regex in the repo with Go: **10,088 patterns across 13,451 templates**. This is the **only** one Go cannot compile — after this change the scan is clean.

### Worth flagging separately

`-validate` reports **success** on this template, both before and after:

```
$ nuclei -validate -t code/linux/audit/home-env-permission.yaml
[INF] All templates validated successfully
```

So the runtime warning tells users to run `-validate`, and `-validate` then says the template is fine. That is a nuclei-side gap, not a template one — I've opened projectdiscovery/nuclei#7602 with a fix in #7603. This template is a real example of it: without checking the runtime log, nothing would tell an author their check has never executed.
