### PR TITLE
fix: three CVE templates put regexes in word matchers, so they never fire

### DIFF
--- a/http/cves/2017/CVE-2017-5521.yaml
+++ b/http/cves/2017/CVE-2017-5521.yaml
@@ -37,9 +37,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
+        regex:
           - "right\">Router\\s*Admin\\s*Username<"
           - "right\">Router\\s*Admin\\s*Password<"
         condition: and

--- a/http/cves/2017/CVE-2017-7615.yaml
+++ b/http/cves/2017/CVE-2017-7615.yaml
@@ -51,9 +51,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
+        regex:
           - "<input type=\"hidden\" name=\"account_update_token\" value=\"([a-zA-Z0-9_-]+)\""
 
       - type: status

--- a/http/cves/2020/CVE-2020-23575.yaml
+++ b/http/cves/2020/CVE-2020-23575.yaml
@@ -37,9 +37,9 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
+        regex:
           - "root:.*:0:0:"
           - "bin:.*:1:1"
         condition: or


### PR DESCRIPTION
### What

Three CVE templates put regular expressions inside a `word` matcher. A `word` matcher is `strings.Contains`, so `\s*`, `.*` and `([a-zA-Z0-9_-]+)` have to appear **verbatim** in the response. None of these three can detect the vulnerability it targets.

```
CVE-2017-5521   "right\">Router\\s*Admin\\s*Username<"
CVE-2017-7615   "<input type=\"hidden\" name=\"account_update_token\" value=\"([a-zA-Z0-9_-]+)\""
CVE-2020-23575  "root:.*:0:0:"  /  "bin:.*:1:1"
```

### Verified against targets serving exactly what they look for

nuclei built from `dev`, three local servers.

**CVE-2020-23575** (Kyocera directory traversal, `high`, EPSS 98th percentile). Body was a real `/etc/passwd`:

```text
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
```

```text
before  [INF] Scan completed in 764.792µs. No results found.
after   [CVE-2020-23575] [http] [high] .../../../../../../../../etc/passwd%00index.htm
```

**CVE-2017-7615** (MantisBT password reset, `high`). Its regex is the template's **only** matcher besides the status check, so the template is entirely inert:

```text
before  [INF] Scan completed in 2.192625ms. No results found.
after   [CVE-2017-7615] [http] [high] .../verify.php?id=1&confirm_hash
```

**CVE-2017-5521** (NETGEAR password disclosure, `high`). `condition: and` on two words, neither matchable:

```text
before  [INF] Scan completed in 829.625µs. No results found.
after   [CVE-2017-5521] [http] [high] .../passwordrecovered.cgi?id=U0uI0
```

### The change

`type: word` → `type: regex` and the `words:` key → `regex:`. **Every pattern is byte-identical**; severity, condition, part, matcher order and metadata are untouched. Six changed lines across three files.

The patterns are already valid Go regexes, so nothing needed rewriting — they were written as regexes and filed under the wrong matcher type.

`nuclei -validate` passes on all three afterwards.

### Scope, and what I deliberately left alone

Scanned the whole tree for the same mistake: **13,451** files, **21,434** words in `word` matchers, **28** containing regex metacharacters. The other 25 are literal text that happens to include one, and are correct as words:

```
"ExePath=\Windows"                        Windows path, literal backslash
"<title>yii\base\ErrorException</title>"  PHP namespace separator
":$apr1$"  /  ":$2y$"                     htpasswd hash prefixes
"nt authority\system"                     literal
```

These three are the ones where the metacharacter is doing regex work and therefore cannot match.

One I checked and left: `npmignore-disclosure.yaml` has `".*"` in a word matcher, but that file is a `.npmignore` listing where `.*` is a literal glob line, and the matcher is `condition: or` alongside `"*~"`, `"*.swp"`. It is doing what it intends.

`empirec2-default-login.yaml` has `'{"token":".*"}'` under `condition: or` next to a plain `'access_token'`, so the working word carries it. Left alone rather than widen this PR.

The `digest` lines are unchanged, since `template-sign.yml` regenerates them on merge.

### Related

Same class of defect as [#16665](https://github.com/projectdiscovery/nuclei-templates/pull/16665) (regex extractors declaring a capture group their pattern does not have): a template that reports success while silently doing nothing. Independent of it — different files, different matchers, and neither depends on the other.
