### PR TITLE
fix(portal-api-ssrf): extractor part is interactsh_request, not interactsh

### DIFF
--- a/http/misconfiguration/portal-api-ssrf.yaml
+++ b/http/misconfiguration/portal-api-ssrf.yaml
@@ -34,7 +34,7 @@ http:
     extractors:
       - type: regex
         name: interaction_id
-        part: interactsh
+        part: interactsh_request
         regex:
           - "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 # digest: 4a0a00473045022100e789423acd6fd745ca0f216bc10c794200dee25d387552350cc97c00bde4cd2d02202413ca2cae084ba272cf9c2069ed339cc4248517d325eb8b174972117f957111:922c64590222798bb761d5b6d8e72950

--- a/http/misconfiguration/portal-api-ssrf.yaml
+++ b/http/misconfiguration/portal-api-ssrf.yaml
@@ -37,4 +37,3 @@ http:
         part: interactsh_request
         regex:
           - "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-# digest: 4a0a00473045022100e789423acd6fd745ca0f216bc10c794200dee25d387552350cc97c00bde4cd2d02202413ca2cae084ba272cf9c2069ed339cc4248517d325eb8b174972117f957111:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### What

`portal-api-ssrf.yaml` extracts the OAST interaction id from `part: interactsh`. nuclei never sets a key by that name, so the extractor resolves to nothing and the finding ships without the interaction id it is meant to carry.

The keys nuclei actually sets, from [`pkg/protocols/common/interactsh/interactsh.go`](https://github.com/projectdiscovery/nuclei/blob/dev/pkg/protocols/common/interactsh/interactsh.go):

```go
data.Event.InternalEvent["interactsh_protocol"] = interaction.Protocol
data.Event.InternalEvent["interactsh_request"]  = interaction.RawRequest
data.Event.InternalEvent["interactsh_response"] = interaction.RawResponse
data.Event.InternalEvent["interactsh_ip"]       = interaction.RemoteAddress
```

There is no plain `interactsh`.

### The template already knows the right name

Its own dsl matcher uses it:

```yaml
matchers:
  - type: dsl
    dsl:
      - 'contains(interactsh_protocol, "http")'
      - 'contains(interactsh_request, "/api/v3/portal")'
```

Only the extractor disagrees. So the template detects the SSRF correctly and then fails to report *which* interaction proved it.

### Why it was invisible

An unrecognised `part` fails silently rather than erroring, and `nuclei -validate` passes either way. Confirmed with nuclei built from `dev`:

```text
part: interactsh              ->  [ix-bad]        (no extraction)
part: totally-made-up-header  ->  [ix-hdr]        (no extraction)
part: header                  ->  [ix-good:got]   ["TestServer/9.9.9"]
```

```text
$ nuclei -validate -t portal-api-ssrf.yaml     # before the fix
[INF] All templates validated successfully
```

### Scope

Scanned every `part:` on every HTTP extractor in the tree: **13,451 files, 4,195 extractors**. After allowing the forms that are legitimate — the documented parts, multi-request suffixes (`body_2`, `header_1`), and arbitrary header names (`server`, `location`, which nuclei resolves against response headers) — **this is the only one left.** Every other OAST extractor in the repo already uses `interactsh_request` (`CVE-2026-35029`, `CVE-2021-2135`, `dast/ai/ai-data-exfiltration`).

One line changed. The regex, matchers, severity and metadata are untouched, and `-validate` still passes.

### Related

Third in the same family as [#16665](https://github.com/projectdiscovery/nuclei-templates/pull/16665) (regex extractors with a capture group their pattern cannot produce) and [#16666](https://github.com/projectdiscovery/nuclei-templates/pull/16666) (regexes in `word` matchers): a template that reports success while a part of it silently does nothing. Independent of both — different file, different mechanism.
