### PR TITLE
fix(thinkphp6-arbitrary-write): the dsl variable is status_code_2, not status_2

### DIFF
--- a/http/vulnerabilities/thinkphp/thinkphp6-arbitrary-write.yaml
+++ b/http/vulnerabilities/thinkphp/thinkphp6-arbitrary-write.yaml
@@ -44,4 +44,3 @@ http:
       - type: dsl
         dsl:
           - "status_code_2 == 200"
-# digest: 4a0a0047304502200d8d1bea0f0853a869dbe8b9e79e55afeac57042ff2dddd390c33c67c27c36d7022100d19f40739f3a1fe0b0914f69079bb4762e9e3a2e0aae640f0f0d810a4c4d4f3d:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/thinkphp/thinkphp6-arbitrary-write.yaml
+++ b/http/vulnerabilities/thinkphp/thinkphp6-arbitrary-write.yaml
@@ -43,5 +43,5 @@ http:
 
       - type: dsl
         dsl:
-          - "status_2 == 200"
+          - "status_code_2 == 200"
 # digest: 4a0a0047304502200d8d1bea0f0853a869dbe8b9e79e55afeac57042ff2dddd390c33c67c27c36d7022100d19f40739f3a1fe0b0914f69079bb4762e9e3a2e0aae640f0f0d810a4c4d4f3d:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### What

`thinkphp6-arbitrary-write` checks the second response with `status_2 == 200`. nuclei exposes per-request values as `status_code_2`, `body_2`, `header_2` — there is no `status_2`. The name resolves to nothing, the `dsl` matcher never passes, and since the template is `matchers-condition: and`, **it can never fire.**

```yaml
matchers-condition: and
matchers:
  - type: word
    part: header_1
    words:
      - "Set-Cookie: PHPSESSID=%2F..%2F..%2F..%2Fpublic%2F{{random_filename}}.php"

  - type: dsl
    dsl:
      - "status_2 == 200"      # <- never true
```

Severity is `critical`, so a working ThinkPHP 6 arbitrary-file-write goes unreported.

### Verified against a target

Built nuclei from `dev` and stood up a server that mimics the vulnerable behaviour — echoes the traversal cookie back in `Set-Cookie` on the first request, serves the written file on the second:

```text
$ curl -sD- -H 'Cookie: PHPSESSID=/../../../public/abc.php' http://127.0.0.1:8762/
Set-Cookie: PHPSESSID=%2F..%2F..%2F..%2Fpublic%2Fabc.php

before:  (no output)
after:   [thinkphp6-arbitrary-write] [http] [critical] http://127.0.0.1:8762/4zdzkqh4xhz.php
```

I also isolated the variable name on a minimal two-request template first, so the result is about the name rather than anything else in this file:

```text
"status_2 == 200"        no match
"status_code_2 == 200"   matched
```

(and `status_code_2` works with or without `req-condition`, so no other change is needed here).

### Why it survived

`nuclei -validate` reports success on the broken template and the fixed one alike:

```text
$ nuclei -validate -t thinkphp6-arbitrary-write.yaml    # before
[INF] All templates validated successfully
```

An unknown dsl identifier is not a validation error — it just makes the expression fail at match time, silently.

### Scope

One line. `grep -rn 'status_[0-9]' --include='*.yaml' .` excluding `status_code` returns nothing else in the tree, so this was the only occurrence.

I checked one other candidate my scan flagged and **rejected it**: `nacos-info-leak.yaml` uses `content_disposition`, which I assumed was undefined. It is not — nuclei exposes response headers under their normalised names, and both `content_disposition` and `content_type` match at runtime. Verified rather than assumed, and left alone.

### Related

Fourth in the same family as [#16665](https://github.com/projectdiscovery/nuclei-templates/pull/16665), [#16666](https://github.com/projectdiscovery/nuclei-templates/pull/16666) and [#16667](https://github.com/projectdiscovery/nuclei-templates/pull/16667): a template that reports success while a part of it silently does nothing. Independent of all three.
