### PR TITLE
fix(CVE-2025-2075): mark the setup-stage matchers internal

### DIFF
--- a/http/cves/2025/CVE-2025-2075.yaml
+++ b/http/cves/2025/CVE-2025-2075.yaml
@@ -51,10 +51,12 @@ http:
           - '/wp-admin'
           - 'wordpress_logged_in'
         condition: and
+        internal: true
 
       - type: status
         status:
           - 302
+        internal: true
 
   - raw:
       - |
@@ -82,6 +84,7 @@ http:
       - type: status
         status:
           - 200
+        internal: true
 
   - raw:
       - |


### PR DESCRIPTION
### What

`CVE-2025-2075` (Uncanny Automator privilege escalation, `high`) chains four requests. Two are **setup** — logging in with valid credentials, and firing the `uap` async_action request — and both carry matchers that are not marked `internal`. nuclei reports every block whose matchers pass, so an ordinary WordPress is reported as vulnerable.

Block 3 is the sharper case. The exploit POST is matched on **status 200 alone**, and WordPress returns 200 with `{"code":"rest_no_route"}` for a REST route that does not exist. **The absence of the plugin is indistinguishable from its presence.**

### Reproduced both directions

**Non-vulnerable WordPress** — accepts the login, has no vulnerable plugin:

```text
before:  [CVE-2025-2075] [high] .../wp-login.php
         [CVE-2025-2075] [high] .../wp-json/uap/v2/async_action/
after:   (nothing)
```

**Host where the escalation succeeds** — the user is listed on the administrators page afterwards:

```text
before:  [CVE-2025-2075] [high] .../wp-login.php                        <- setup
         [CVE-2025-2075] [high] .../wp-json/uap/v2/async_action/        <- setup
         [CVE-2025-2075] [high] .../wp-admin/users.php?role=administrator
after:   [CVE-2025-2075] [high] .../wp-admin/users.php?role=administrator
```

Three findings become one, and the one that remains is the only one that proves anything.

### The detection is untouched

The final block still requires `'Howdy,'` **and** `'>Select {{username}}<'` on the administrators page under `condition: and`. That is the evidence the role actually changed, and this PR does not modify it.

Chain integrity checked in both directions: **all 4 blocks execute before and after** the change, and the vulnerable host still reports.

### Precedent

Same pattern `CVE-2026-23696` uses for its `flow:` stages — intermediate matchers marked `internal: true` so they gate without reporting.

Three added lines. `nuclei -validate` passes before and after.

### One candidate I rejected

The same scan flagged `CVE-2017-18349` (fastjson RCE, `critical`, 4 blocks). **It is a false positive and I left it alone.** Its four blocks are not a chain — each is an independent payload variant (`rmi://`, `ldap://`, different paths), and every one requires `contains(interactsh_protocol,'dns')`. Reporting from any of them is correct, because any of them landing *is* the finding. My scanner treated `{{rmi_payload}}` as evidence of chaining; it is a variable, not a dependency.

### Related

Companion to [#16670](https://github.com/projectdiscovery/nuclei-templates/pull/16670), which fixes the identical shape in `CVE-2024-0200`. Independent files; either can merge without the other.
