### PR TITLE
Fix nfs-v3-exposed matching PROG_UNAVAIL as a valid hit

### DIFF
--- a/network/detection/nfs-v3-exposed.yaml
+++ b/network/detection/nfs-v3-exposed.yaml
@@ -33,11 +33,10 @@ tcp:
       - type: binary
         name: nfs-v3-success
         binary:
-          # XID 'VER3' + REPLY(1) + MSG_ACCEPTED(0) + AUTH_NONE(0,0) + SUCCESS(0)
-          - "5645523300000001000000000000000000000000"
+          # XID 'VER3' + REPLY(1) + MSG_ACCEPTED(0) + AUTH_NONE(0,0) + accept_stat=SUCCESS(0)
+          - "564552330000000100000000000000000000000000000000"
 
       - type: word
         words:
           - "HTTP/1.1"
         negative: true
-# digest: 4a0a00473045022100e58a2f9738b31c3b03caee156815299b478bbc7f23e6035ef20ff3c636540f5302207a91959fa1afeb5de1e8819c9e4ee78bde9eafc58c6d092437e62faea19d6f66:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Reported in #16662. The binary matcher for `nfs-v3-exposed` checks the XID, REPLY, MSG_ACCEPTED and the AUTH_NONE verifier, but stops before `accept_stat` — even though the comment says it checks `SUCCESS`. So an RPC reply that was accepted but unsuccessful, most often `PROG_UNAVAIL` from a portmapper or a host that doesn't have NFS registered on that port, still matches as an exposed NFSv3 service.

Appended the missing `accept_stat=SUCCESS(0)` four bytes so the matcher checks what the comment already claimed. Against the reporter's captured bytes, the `PROG_UNAVAIL` response ends in `accept_stat 00000001` and no longer matches, while a real SUCCESS reply (`00000000`) still does.

Closes #16662.
