### PR TITLE
Add CVE-2026-55040 Microsoft SharePoint JWT Auth Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-55040.yaml
+++ b/http/cves/2026/CVE-2026-55040.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-55040
+
+info:
+  name: Microsoft SharePoint Server - JWT Auth Bypass
+  author: YOUR_GITHUB_HANDLE
+  severity: critical
+  description: |
+    Microsoft SharePoint Server 2016, 2019, and Subscription Edition contain
+    a critical authentication bypass vulnerability (CWE-1390) in the JWT token
+    validation pipeline. A remote unauthenticated attacker can forge tokens to
+    impersonate any SharePoint site user or administrator.
+  impact: |
+    An attacker can perform any SharePoint operation as any user without
+    credentials. Can be chained with a second vulnerability for full unauth RCE.
+  remediation: |
+    Apply Microsoft's July 2026 Patch Tuesday updates (KB articles per version).
+    SharePoint Server 2016: KB5002700
+    SharePoint Server 2019: KB5002698
+    SharePoint Subscription Edition: KB5002699
+  reference:
+    - https://www.rapid7.com/blog/post/ve-cve-2026-55040-microsoft-sharepoint-jwt-token-authentication-bypass-fixed/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55040
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-55040
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-55040
+    cwe-id: CWE-1390
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: microsoft
+    product: sharepoint-server
+    shodan-query: http.title:"SharePoint" http.component:"SharePoint"
+    fofa-query: app="Microsoft-SharePoint"
+  tags: cve,cve2026,sharepoint,microsoft,auth-bypass,jwt,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/_layouts/15/start.aspx"
+      - "{{BaseURL}}/_vti_bin/authentication.asmx"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SharePoint"
+          - "Microsoft"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "MicrosoftSharePointTeamServices"
+
+      - type: status
+        status:
+          - 200
+          - 302
+
+    extractors:
+      - type: regex
+        name: sharepoint-version
+        part: header
+        group: 1
+        regex:
+          - "MicrosoftSharePointTeamServices: ([0-9.]+)"


### PR DESCRIPTION
### PR Information

Added CVE-2026-55040 - Microsoft SharePoint Server JWT Authentication Bypass

- References:
  - https://www.rapid7.com/blog/post/ve-cve-2026-55040-microsoft-sharepoint-jwt-token-authentication-bypass-fixed/
  - https://nvd.nist.gov/vuln/detail/CVE-2026-55040
  - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-55040

### Template validation

Template structure validated locally with nuclei v3.10.0. No live vulnerable 
SharePoint instance available for true positive validation at time of submission. 
Set verified: false accordingly.

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

CVE-2026-55040 is a critical (CVSS 9.1) JWT token authentication bypass in 
Microsoft SharePoint Server 2016, 2019, and Subscription Edition. Patched 
July 14, 2026. Can be chained with an unpatched RCE component for full 
unauthenticated code execution. CISA flagged.

Template type: version detection + panel fingerprint (no exploit traffic sent).