### PR TITLE
Add CVE-2026-44825.yaml - Apache Solr 9.4.0-9.10.1 / 10.0.0 - Hardcoded Default Credentials

### DIFF
--- a/http/cves/2026/CVE-2026-44825.yaml
+++ b/http/cves/2026/CVE-2026-44825.yaml
@@ -1,0 +1,133 @@
+id: CVE-2026-44825
+
+info:
+  name: Apache Solr 9.4.0-9.10.1 / 10.0.0 - Hardcoded Default Credentials
+  author: pdteam,0x_Akoko
+  severity: high
+  description: |
+   Apache Solr 9.4.0 through 9.10.1 and 10.0.0 contain a hardcoded credentials vulnerability caused by default Basic Authentication template users in bin/solr auth enable, letting remote attackers gain full administrative access, exploit requires use of default template users.
+  impact: |
+    Remote attackers can gain full administrative access to the cluster using default credentials.
+  remediation: |
+    Upgrade to versions 9.11.0, 10.1.0 or later; alternatively, delete template users or change their passwords in security.json.
+  reference:
+    - https://lists.apache.org/thread/5xg6xr99glocp3zsg9ht2zlbwlrst7ch
+    - http://www.openwall.com/lists/oss-security/2026/05/29/6
+    - https://github.com/shinthink/solrradar
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44825
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2026-44825
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 6
+    shodan-query: product:"Apache Solr" port:8983
+    fofa-query: app="Apache-Solr" || title="Solr Admin"
+  tags: cve,cve2026,apache,solr,default-login,kev
+
+flow: http(1) && http(2) && (http(3) || http(4) || http(5) || http(6))
+
+http:
+  - raw:
+      - |
+        GET /solr/admin/info/system?wt=json HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - '(status_code == 200 && contains_any(body, "solr-spec-version", "lucene", "solrHome")) || ((status_code == 401 || status_code == 403) && contains_any(to_lower(header), "solr", "basic"))'
+        internal: true
+
+  - raw:
+      - |
+        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 401 || status_code == 403'
+        internal: true
+
+  - raw:
+      - |
+        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic c29scjpTb2xyUm9ja3M=
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "responseHeader", "status")'
+          - '!contains(body, "Authentication")'
+        condition: and
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
+
+  - raw:
+      - |
+        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic YWRtaW46U29sclJvY2tz
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "responseHeader", "status")'
+          - '!contains(body, "Authentication")'
+        condition: and
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
+
+  - raw:
+      - |
+        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic c2VhcmNoOlNvbHJSb2Nrcw==
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "responseHeader", "status")'
+          - '!contains(body, "Authentication")'
+        condition: and
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
+
+  - raw:
+      - |
+        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic aW5kZXg6U29sclJvY2tz
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "responseHeader", "status")'
+          - '!contains(body, "Authentication")'
+        condition: and
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'

--- a/http/cves/2026/CVE-2026-44825.yaml
+++ b/http/cves/2026/CVE-2026-44825.yaml
@@ -5,7 +5,7 @@ info:
   author: pdteam,0x_Akoko
   severity: high
   description: |
-   Apache Solr 9.4.0 through 9.10.1 and 10.0.0 contain a hardcoded credentials vulnerability caused by default Basic Authentication template users in bin/solr auth enable, letting remote attackers gain full administrative access, exploit requires use of default template users.
+    Apache Solr 9.4.0 through 9.10.1 and 10.0.0 contain a hardcoded credentials vulnerability caused by default Basic Authentication template users in bin/solr auth enable, letting remote attackers gain full administrative access. Exploit requires use of default template users.
   impact: |
     Remote attackers can gain full administrative access to the cluster using default credentials.
   remediation: |
@@ -27,7 +27,7 @@ info:
     fofa-query: app="Apache-Solr" || title="Solr Admin"
   tags: cve,cve2026,apache,solr,default-login,kev
 
-flow: http(1) && http(2) && (http(3) || http(4) || http(5) || http(6))
+flow: http(1) && http(2) && http(3)
 
 http:
   - raw:
@@ -56,7 +56,25 @@ http:
       - |
         GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Basic c29scjpTb2xyUm9ja3M=
+        Authorization: Basic {{auth}}
+
+    payloads:
+
+      username:
+        - solr
+        - admin
+        - search
+        - index
+
+      auth:
+        - c29scjpTb2xyUm9ja3M=
+        - YWRtaW46U29sclJvY2tz
+        - c2VhcmNoOlNvbHJSb2Nrcw==
+        - aW5kZXg6U29sclJvY2tz
+
+    attack: pitchfork
+
+    stop-at-first-match: true
 
     matchers:
       - type: dsl
@@ -67,66 +85,10 @@ http:
         condition: and
 
     extractors:
-      - type: regex
-        group: 1
-        regex:
-          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
-
-  - raw:
-      - |
-        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
-        Host: {{Hostname}}
-        Authorization: Basic YWRtaW46U29sclJvY2tz
-
-    matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains_all(body, "responseHeader", "status")'
-          - '!contains(body, "Authentication")'
-        condition: and
+          - username
 
-    extractors:
-      - type: regex
-        group: 1
-        regex:
-          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
-
-  - raw:
-      - |
-        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
-        Host: {{Hostname}}
-        Authorization: Basic c2VhcmNoOlNvbHJSb2Nrcw==
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains_all(body, "responseHeader", "status")'
-          - '!contains(body, "Authentication")'
-        condition: and
-
-    extractors:
-      - type: regex
-        group: 1
-        regex:
-          - '"name"\s*:\s*"([a-zA-Z0-9_-]+)"'
-
-  - raw:
-      - |
-        GET /solr/admin/cores?action=STATUS&wt=json HTTP/1.1
-        Host: {{Hostname}}
-        Authorization: Basic aW5kZXg6U29sclJvY2tz
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains_all(body, "responseHeader", "status")'
-          - '!contains(body, "Authentication")'
-        condition: and
-
-    extractors:
       - type: regex
         group: 1
         regex:


### PR DESCRIPTION
Added CVE-2026-44825 for Apache Solr hardcoded credentials vulnerability, detailing severity, impact, remediation, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
