### PR TITLE
Add CVE-2026-23693 - ElementsKit Lite <3.7.9 unauthenticated Mailchimp proxy (CWE-306)

### DIFF
--- a/http/cves/2026/CVE-2026-23693.yaml
+++ b/http/cves/2026/CVE-2026-23693.yaml
@@ -1,0 +1,79 @@
+id: CVE-2026-23693
+
+info:
+  name: ElementsKit Lite <3.7.9 - Unauthenticated Mailchimp Proxy (Missing Authorization)
+  author: rahulreddykarne
+  severity: high      # CONFIRM against your VulnCheck/Wordfence record — public sources vary (CVSS3.1 10.0 vs a CVSS4.0 vector); set critical/high accordingly
+  description: |
+    The ElementsKit Elementor Addons Lite (elementskit-lite) plugin for WordPress
+    before 3.7.9 registers the REST route
+    /wp-json/elementskit/v1/widget/mailchimp/subscribe with no authentication or
+    capability check (CWE-306). The handler accepts client-supplied Mailchimp API
+    credentials and a `list` parameter and issues upstream Mailchimp API requests,
+    letting an unauthenticated attacker use the site as an open proxy to Mailchimp.
+  impact: |
+    Unauthenticated attackers can invoke the Mailchimp integration with no
+    credentials on the site, enabling open-proxy abuse, subscription-data tampering,
+    and Mailchimp API-quota / resource exhaustion.
+  remediation: |
+    Update ElementsKit Lite (elementskit-lite) to 3.7.9 or later, which enforces
+    authentication on the endpoint.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23693
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/85025fb9-6e19-4c0f-bf16-4b890ba5f7f5
+    - https://wordpress.org/plugins/elementskit-lite/
+  classification:
+    cve-id: CVE-2026-23693
+    cwe-id: CWE-306
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:H/A:H
+    cvss-score: 10.0
+  metadata:
+    max-request: 1
+    vendor: wpmet
+    product: elementskit-lite
+    framework: wordpress
+  tags: cve,cve2026,wordpress,wp-plugin,elementskit,elementskit-lite,unauth,auth-bypass,mailchimp
+
+# ------------------------------------------------------------------------------
+# DETECTION LOGIC (confirmed against a live install)
+#   CVE-2026-23693 is a Missing-Authorization bug (CWE-306). Measured behaviour of
+#   an UNAUTHENTICATED POST to the route:
+#       vulnerable 3.7.8 -> HTTP 200, Content-Type application/json  (request ACCEPTED)
+#       patched     3.7.9 -> HTTP 401 + "rest_forbidden"             (request REJECTED)
+#   So the discriminator is: the route accepts the unauthenticated request (200 + JSON)
+#   AND the body is not a WordPress auth rejection.
+#
+# SAFETY: no auth nonce/cookie is sent (that IS the test); apikey/list are bogus so no
+#   real Mailchimp list/account is touched and no quota is consumed.
+# ------------------------------------------------------------------------------
+
+http:
+  - raw:
+      - |
+        POST /wp-json/elementskit/v1/widget/mailchimp/subscribe HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        email=nuclei-{{randstr}}@example.com&list=nuclei-invalid-list&apikey=0000000000000000000000000000000-us1
+
+    matchers-condition: and
+    matchers:
+      # route accepts the UNAUTHENTICATED request (patched 3.7.9 returns 401 here)
+      - type: status
+        status:
+          - 200
+      # REST/JSON response from the plugin route (not an HTML 200 error page)
+      - type: word
+        part: header
+        words:
+          - "application/json"
+      # not an auth rejection and not a missing route
+      - type: word
+        part: body
+        negative: true
+        condition: or
+        words:
+          - "rest_forbidden"
+          - "rest_cannot_access"
+          - "rest_not_logged_in"
+          - "rest_no_route"

--- a/http/cves/2026/CVE-2026-23693.yaml
+++ b/http/cves/2026/CVE-2026-23693.yaml
@@ -1,27 +1,19 @@
 id: CVE-2026-23693
 
 info:
-  name: ElementsKit Lite <3.7.9 - Unauthenticated Mailchimp Proxy (Missing Authorization)
+  name: ElementsKit Lite <3.7.9 - Unauthenticated Mailchimp Proxy
   author: rahulreddykarne
-  severity: high      # CONFIRM against your VulnCheck/Wordfence record — public sources vary (CVSS3.1 10.0 vs a CVSS4.0 vector); set critical/high accordingly
+  severity: high
   description: |
-    The ElementsKit Elementor Addons Lite (elementskit-lite) plugin for WordPress
-    before 3.7.9 registers the REST route
-    /wp-json/elementskit/v1/widget/mailchimp/subscribe with no authentication or
-    capability check (CWE-306). The handler accepts client-supplied Mailchimp API
-    credentials and a `list` parameter and issues upstream Mailchimp API requests,
-    letting an unauthenticated attacker use the site as an open proxy to Mailchimp.
+    The ElementsKit Elementor Addons Lite (elementskit-lite) plugin for WordPress before 3.7.9 registers the REST route /wp-json/elementskit/v1/widget/mailchimp/subscribe with no authentication or capability check (CWE-306). The handler accepts client-supplied Mailchimp API credentials and a `list` parameter and issues upstream Mailchimp API requests, letting an unauthenticated attacker use the site as an open proxy to Mailchimp.
   impact: |
-    Unauthenticated attackers can invoke the Mailchimp integration with no
-    credentials on the site, enabling open-proxy abuse, subscription-data tampering,
-    and Mailchimp API-quota / resource exhaustion.
+    Unauthenticated attackers can invoke the Mailchimp integration with no credentials on the site, enabling open-proxy abuse, subscription-data tampering, and Mailchimp API-quota / resource exhaustion.
   remediation: |
-    Update ElementsKit Lite (elementskit-lite) to 3.7.9 or later, which enforces
-    authentication on the endpoint.
+    Update ElementsKit Lite (elementskit-lite) to 3.7.9 or later, which enforces authentication on the endpoint.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-23693
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/85025fb9-6e19-4c0f-bf16-4b890ba5f7f5
     - https://wordpress.org/plugins/elementskit-lite/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23693
   classification:
     cve-id: CVE-2026-23693
     cwe-id: CWE-306
@@ -32,42 +24,51 @@ info:
     vendor: wpmet
     product: elementskit-lite
     framework: wordpress
+    fofa-query: body="/wp-content/plugins/elementskit-lite/"
   tags: cve,cve2026,wordpress,wp-plugin,elementskit,elementskit-lite,unauth,auth-bypass,mailchimp
 
-# ------------------------------------------------------------------------------
-# DETECTION LOGIC (confirmed against a live install)
-#   CVE-2026-23693 is a Missing-Authorization bug (CWE-306). Measured behaviour of
-#   an UNAUTHENTICATED POST to the route:
-#       vulnerable 3.7.8 -> HTTP 200, Content-Type application/json  (request ACCEPTED)
-#       patched     3.7.9 -> HTTP 401 + "rest_forbidden"             (request REJECTED)
-#   So the discriminator is: the route accepts the unauthenticated request (200 + JSON)
-#   AND the body is not a WordPress auth rejection.
-#
-# SAFETY: no auth nonce/cookie is sent (that IS the test); apikey/list are bogus so no
-#   real Mailchimp list/account is touched and no quota is consumed.
-# ------------------------------------------------------------------------------
+flow: http(1) && http(2)
 
 http:
+  - raw:
+      - |
+        GET /wp-content/plugins/elementskit-lite/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<3.7.9')"
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - '(?i)Stable.tag:\s?([\w.]+)'
+        internal: true
+
   - raw:
       - |
         POST /wp-json/elementskit/v1/widget/mailchimp/subscribe HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        email=nuclei-{{randstr}}@example.com&list=nuclei-invalid-list&apikey=0000000000000000000000000000000-us1
+        email=test-{{randstr}}@example.com&list=test-invalid-list&apikey=0000000000000000000000000000000-us1
 
     matchers-condition: and
     matchers:
-      # route accepts the UNAUTHENTICATED request (patched 3.7.9 returns 401 here)
       - type: status
         status:
           - 200
-      # REST/JSON response from the plugin route (not an HTML 200 error page)
+
       - type: word
         part: header
         words:
           - "application/json"
-      # not an auth rejection and not a missing route
+
       - type: word
         part: body
         negative: true


### PR DESCRIPTION
Adds a Nuclei template for CVE-2026-23693 - a missing-authorization (CWE-306) vulnerability in the ElementsKit Elementor Addons Lite (elementskit-lite) WordPress plugin < 3.7.9.

The plugin registers the REST route `/wp-json/elementskit/v1/widget/mailchimp/subscribe` with no authentication or capability check, letting an unauthenticated attacker use the site as an open proxy to Mailchimp (client-supplied credentials, insufficient `list` validation).

Detection is behavioral, not version-based: an unauthenticated POST is accepted (HTTP 200, application/json) on vulnerable versions, while 3.7.9+ rejects it (401 rest_forbidden). The probe uses bogus Mailchimp credentials, so no real account or quota is touched.

Tested on a live LocalWP install:
- elementskit-lite 3.7.8 (vulnerable) -> match
- elementskit-lite 3.7.9+ (patched)   -> no match

References: https://nvd.nist.gov/vuln/detail/CVE-2026-23693