### PR TITLE
fix(CVE-2024-5333): add plugin version check to prevent false positives

### DIFF
--- a/http/cves/2024/CVE-2024-5333.yaml
+++ b/http/cves/2024/CVE-2024-5333.yaml
@@ -1,11 +1,11 @@
 id: CVE-2024-5333
 
 info:
-  name: WordPress Events Calendar 6.8.2.1 - Information Disclosure
+  name: The Events Calendar < 6.8.2.1 - Information Disclosure
   author: DhiyaneshDk
   severity: medium
   description: |
-    The Events Calendar WordPress plugin 6.8.2.1 contains missing access checks in the REST API, letting unauthenticated users access information about password protected events, exploit requires no authentication.
+    The Events Calendar WordPress plugin prior to 6.8.2.1 contains missing access checks in the REST API, letting unauthenticated users access information about password protected events, exploit requires no authentication.
   impact: |
     Unauthenticated users can access sensitive event information, potentially leading to information disclosure.
   remediation: |
@@ -22,7 +22,7 @@ info:
     epss-percentile: 0.62119
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: stellarwp
     product: the_events_calendar
     framework: wordpress
@@ -30,7 +30,31 @@ info:
     shodan-query: html:"/wp-content/plugins/the-events-calendar/"
   tags: cve,cve2024,wordpress,wp,wp-plugin,the-events-calendar,disclosure
 
+flow: http(1) && http(2)
+
 http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/the-events-calendar/readme.txt"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "The Events Calendar")'
+          - 'compare_versions(version, "< 6.8.2.1")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true
+
   - method: GET
     path:
       - "{{BaseURL}}/wp-json/tribe/events/v1/events/"
@@ -53,4 +77,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100d2918f780f99b2ebee7742d015f30f22be39f21ab8c4a488e960e37b6587a69a022000a314d63eba04371502611f43e18ef6963d6e859991cecbdc2e3b79baac8c06:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### Summary

The template matched any site where `/wp-json/tribe/events/v1/events/` simply exists and returns JSON, so it flagged fully patched sites too (reported on The Events Calendar 6.17.1 in #16655). The REST endpoint is enabled in all versions of the plugin, not only vulnerable ones.

### Fix

Added a version gate ahead of the existing check:

- `flow: http(1) && http(2)`
- First request fetches `/wp-content/plugins/the-events-calendar/readme.txt` and extracts the version from `Stable tag` (internal matcher, no finding on its own). The template only proceeds when the plugin version is `< 6.8.2.1`, which is the range affected by CVE-2024-5333 (fixed in 6.8.2.1).
- Second request keeps the existing REST endpoint check unchanged as confirmation of the exposed endpoint.

Both requests are GET-only; `max-request` bumped to 2. If the readme is not readable the template stays silent instead of guessing, which is the safe side for this FP.

Validated locally with `nuclei -validate` and yamllint against the repo config.

Closes #16655
