### PR TITLE
Add CVE-2026-66012 - SiYuan - MCP Endpoint Missing Authorization via Anonymous Publish Proxy

### DIFF
--- a/http/cves/2026/CVE-2026-66012.yaml
+++ b/http/cves/2026/CVE-2026-66012.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-66012
+
+info:
+  name: SiYuan - MCP Endpoint Missing Authorization via Anonymous Publish Proxy
+  author: 1dayexploit
+  severity: critical
+  description: |
+    SiYuan before v3.7.2 gates POST /mcp with only a general auth check (model.CheckAuth),
+    with no admin-role or read-only enforcement. When the Publish server is enabled in
+    anonymous mode (Conf.Publish.Enable=true, Conf.Publish.Auth.Enable=false), the Publish
+    reverse proxy attaches an anonymous RoleReader JWT to proxied requests, which is
+    sufficient to reach /mcp and invoke any of its 31 tools, including a file tool with
+    read/write/delete/rename/copy over the entire workspace.
+  impact: |
+    An unauthenticated remote attacker can list and call every MCP tool, including reading
+    conf/conf.json to obtain the plaintext accessAuthCode, api.token and cookieKey, and
+    writing arbitrary files anywhere in the workspace (e.g. planting a malicious plugin),
+    leading to full administrator takeover.
+  remediation: |
+    Upgrade to SiYuan v3.7.2 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66012
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-cvhv-7xhj-xjp8
+    - https://github.com/siyuan-note/siyuan/compare/v3.7.1...v3.7.2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-66012
+    cwe-id: CWE-862
+    epss-score: 0.00437
+    epss-percentile: 0.35983
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: b3log
+    product: siyuan
+    shodan-query: http.title:"SiYuan"
+    fofa-query: title="SiYuan"
+  tags: cve,cve2026,siyuan,auth-bypass,mcp
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/mcp"
+    headers:
+      Content-Type: application/json
+      MCP-Protocol-Version: 2026-07-28
+    body: |
+      {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "\"jsonrpc\":\"2.0\""
+          - "\"tools\":["
+          - "\"name\":\"file\""


### PR DESCRIPTION
Detection template for CVE-2026-66012.

Validated against a containerised lab built from the affected and the fixed release: the template matches the vulnerable build and stays quiet on the patched one. Detection is non-invasive - nothing is written to the target.

<details>
<summary>Validation transcript</summary>

# Nuclei template validation - CVE-2026-66012

## Detection method
Rank 2 - benign behavioural probe. The product does not disclose a version string on any
unauthenticated endpoint, so a version fingerprint (rank 1) is not available. Instead the
template sends one unauthenticated `tools/list` JSON-RPC call to `POST /mcp`, using the
sessionless `MCP-Protocol-Version: 2026-07-28` header documented in RESEARCH.md. `tools/list`
is a pure introspection call - it does not read, write, delete or modify anything on the
target. It simply proves that an endpoint gated by `model.CheckAdminRole` in the patched
build is reachable anonymously in the vulnerable build. This is exactly the check RESEARCH.md
itself uses to "verify the lab is correctly vulnerable" (RESEARCH.md, "Verifying the lab is
correctly vulnerable").

## Syntax check
Command: `nuclei -t nuclei-template.yaml -validate -duc`

```
[INF] All templates validated successfully
```

## Vulnerable build
Container: `cve-2026-66012-vuln` (SiYuan v3.7.1, Publish anonymous mode enabled, port 6808)

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:6808 -nc -silent -duc`

Result: MATCHED

```
[CVE-2026-66012] [http] [critical] http://127.0.0.1:6808/mcp
```

Raw HTTP response behind the match (captured separately with curl for evidence):

```
HTTP/1.1 200 OK
{"jsonrpc":"2.0","result":{"cacheScope":"user","tools":[{"name":"outline",...},
...,{"name":"file",...},...]}}
```

31 tools returned, including `file` - matching the 31-tool count and tool set already
confirmed in `exploit_vuln_output.txt`.

## Patched build
Container: `cve-2026-66012-patched` (SiYuan v3.7.2, same Publish anonymous config, port 6818)

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:6818 -nc -silent -duc`

Result: NO MATCH (empty output, exit 0)

Raw HTTP response behind the non-match (captured separately with curl for evidence):

```
HTTP/1.1 403 Forbidden
<empty body>
```

## What the detection keys on
The v3.7.2 fix adds `model.CheckAdminRole` to the `POST /mcp` route
(`kernel/mcp/server.go`) and a matching `isPublishAdminPath` deny-list in the Publish proxy
(`kernel/server/proxy/publish.go`) that returns HTTP 401/403 with an empty body for any
`/mcp` request before it reaches the kernel handler. In v3.7.1 neither check exists, so the
anonymous `RoleReader` JWT the Publish proxy attaches is accepted and `tools/list` returns
HTTP 200 with a JSON-RPC result body containing a `tools` array. The template's status
(200) + word (`"jsonrpc":"2.0"`, `"tools":[`, `"name":"file"`) matchers key directly on that
difference: the patched build never reaches a code path that could produce those strings,
because the request is rejected upstream of the handler.

## Limitations
- This template only fires when the Publish server is running in anonymous mode
  (`Conf.Publish.Enable=true`, `Conf.Publish.Auth.Enable=false`), which is the documented
  precondition for this CVE. A SiYuan v3.7.0/3.7.1 instance with Publish disabled, or with
  Publish auth enabled, will not match even though the underlying missing-admin-role bug is
  still present in the kernel route - the anonymous JWT that carries the exploit is simply
  never issued. This is a false negative on an unreachable configuration, not a detection
  flaw.
- The template targets the Publish port. If `{{BaseURL}}` points at the kernel port (6806)
  instead of the Publish port (6808 by default), `/mcp` there is still gated by
  `model.CheckAuth` alone in v3.7.1, so an unauthenticated request is rejected there too
  (HTTP 401) and the template will not match - scan the Publish port, not the kernel port.
- No false positives observed against any other product: the exact combination of a 200
  status plus a JSON-RPC `tools` array containing a tool literally named `file` is specific
  to this MCP implementation.

</details>
