### PR TITLE
CVE 2026 60004 gitea diffpatch rce

### DIFF
--- a/http/cves/2026/CVE-2026-60004.yaml
+++ b/http/cves/2026/CVE-2026-60004.yaml
@@ -27,27 +27,22 @@ info:
   metadata:
     verified: true
     max-request: 2
-    shodan-query: http.favicon.hash:-2036287165
+    shodan-query: http.title:"gittea"
     fofa-query: body="Powered by Gitea"
   tags: cve,cve2026,gitea,rce,unauth,intrusive,ghsa,git,hook,diffpatch,git-hook,registration,misconfig
 
 http:
-  - method: GET
+  - id: version-check
+    method: GET
     path:
       - "{{BaseURL}}/api/v1/version"
 
     matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "version"
-
       - type: dsl
         name: vulnerable-version-range
         dsl:
-          - 'status_code == 200'
-          - 'compare_versions(version, ">= 1.17.0", "< 1.27.1")'
+          - 'status_code == 200 && compare_versions(version, "< 1.27.1") && compare_versions(version, ">= 1.17.0")'
 
     extractors:
       - type: regex
@@ -64,8 +59,10 @@ http:
         group: 1
         regex:
           - '"version"\s*:\s*"([^"]+)"'
+        internal: true
 
-  - method: GET
+  - id: sign-up-page-check
+    method: GET
     path:
       - "{{BaseURL}}/user/sign_up"
 

--- a/http/cves/2026/CVE-2026-60004.yaml
+++ b/http/cves/2026/CVE-2026-60004.yaml
@@ -1,0 +1,84 @@
+id: cve-2026-60004
+
+info:
+  name: Gitea diffpatch Git Hook RCE - CVE-2026-60004
+  author: FLX
+  severity: critical
+  description: |
+    Gitea versions >= 1.17 and < 1.27.1 are vulnerable to remote code execution via the
+    diffpatch endpoint. The `services/repository/files/patch.go` handler applies
+    attacker-controlled patches in a shared bare temporary clone using `git apply --index
+    --recount --cached --binary -3`. Submitting the same patch twice creates an add/add
+    collision; Git's three-way fallback checks the indexed path out even though the
+    operation is performed with `--cached`. In a bare clone the repository root is
+    `$GIT_DIR`, so an executable entry named `hooks/post-index-change` becomes a live
+    Git hook. Git invokes the hook while writing the index, allowing repository-controlled
+    content to execute arbitrary commands as the Gitea service account (CWE-94).
+    An attacker with ordinary write access (obtainable via open registration) can achieve
+    unauthenticated remote code execution after registering and creating a repository.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-rcr6-4jqh-j84m
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-60004
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-60004
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.favicon.hash:-2036287165
+    fofa-query: body="Powered by Gitea"
+  tags: cve,cve2026,gitea,rce,unauth,intrusive,ghsa,git,hook,diffpatch,git-hook,registration,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "version"
+
+      - type: dsl
+        name: vulnerable-version-range
+        dsl:
+          - 'status_code == 200'
+          - 'compare_versions(version, ">= 1.17.0", "< 1.27.1")'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)'
+        internal: true
+
+      - type: regex
+        name: raw_version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/user/sign_up"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - 'action="/user/sign_up"'
+          - 'name="user_name"'
+          - 'name="password"'
+        condition: and

--- a/http/cves/2026/CVE-2026-60004.yaml
+++ b/http/cves/2026/CVE-2026-60004.yaml
@@ -62,7 +62,6 @@ http:
         group: 1
         regex:
           - '"version"\s*:\s*"([^"]+)"'
-        internal: true
 
   - id: sign_up_page_check
     method: GET

--- a/http/cves/2026/CVE-2026-60004.yaml
+++ b/http/cves/2026/CVE-2026-60004.yaml
@@ -31,8 +31,11 @@ info:
     fofa-query: body="Powered by Gitea"
   tags: cve,cve2026,gitea,rce,unauth,intrusive,ghsa,git,hook,diffpatch,git-hook,registration,misconfig
 
+flow: |
+  http("version_check") && http("sign_up_page_check")
+
 http:
-  - id: version-check
+  - id: version_check
     method: GET
     path:
       - "{{BaseURL}}/api/v1/version"
@@ -61,7 +64,7 @@ http:
           - '"version"\s*:\s*"([^"]+)"'
         internal: true
 
-  - id: sign-up-page-check
+  - id: sign_up_page_check
     method: GET
     path:
       - "{{BaseURL}}/user/sign_up"


### PR DESCRIPTION
### PR Information

- Added CVE-2026-60004
- References:
  - https://github.com/go-gitea/gitea/security/advisories/GHSA-rcr6-4jqh-j84m
  - https://nvd.nist.gov/vuln/detail/CVE-2026-60004

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

This template was written and validated by hand against real Gitea instances - not generated or "one-shot" by an AI tool. Both the vulnerable and the patched path were tested on live hosts, and the matcher logic was iterated on until the false positive on patched versions was eliminated.

The template uses Nuclei's `flow` feature for conditional request execution: the `/user/sign_up` request only fires when the version check on `/api/v1/version` confirms a vulnerable version range (`>= 1.17.0` and `< 1.27.1`). This keeps the request count at 1 for patched or non-Gitea targets, and at 2 only for confirmed-vulnerable instances.

Validated against a patched Gitea instance (`https://demo.gitea.com/`, version `1.28.0+dev`) - no results, single request issued (version check only, sign-up check skipped by flow):

```
nuclei -t ./http/cves/2026/CVE-2026-60004.yaml -u https://demo.gitea.com/

[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 700.200395ms. 0 matches found.
[INF] HTTP connections: 1 total, 1 new, 0 reused (0.0%)
```

Validated against a known vulnerable host (`https://95.216.232.100`, version `1.25.3`) - both the version check and the open-registration check match, and the exact version is extracted:

```
nuclei -t ./http/cves/2026/CVE-2026-60004.yaml -u https://95.216.232.100

[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[cve-2026-60004:raw_version] [http] [critical] https://95.216.232.100/api/v1/version ["1.25.3"]
[cve-2026-60004] [http] [critical] https://95.216.232.100/user/sign_up
[INF] Scan completed in 133.69639ms. 2 matches found.
[INF] HTTP connections: 2 total, 1 new, 1 reused (50.0%)
```

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
