### PR TITLE
Create CVE-2025-11953.yaml - React Native Community CLI - Unauthenticated OS Command Injection

### DIFF
--- a/http/cves/2025/CVE-2025-11953.yaml
+++ b/http/cves/2025/CVE-2025-11953.yaml
@@ -27,12 +27,11 @@ info:
     vendor: react-native-community
     product: react_native_community_cli
     fofa-query: title="React Native" && port="8081"
-  tags: cve,cve2025,react-native,metro,rce,command-injection,unauth,intrusive,kev
+  tags: cve,cve2025,react-native,metro,rce,unauth,intrusive,kev
 
 flow: http(1) && http(2)
 
 http:
-  # Confirm the target is a React Native packager before probing the vulnerable endpoint
   - raw:
       - |
         GET /status HTTP/1.1
@@ -47,8 +46,6 @@ http:
         condition: and
         internal: true
 
-  # The Content-Type header is required. Without it body-parser leaves req.body empty,
-  # open() receives undefined and the development server terminates on an unhandled rejection.
   - raw:
       - |
         POST /open-url HTTP/1.1
@@ -58,9 +55,6 @@ http:
         {"url":"nuclei-probe://{{randstr}}"}
 
     matchers:
-      # Vulnerable builds hand the unvalidated scheme to open() and answer 200 with an empty body.
-      # Patched builds reject the non http scheme with 400 and an "Invalid URL protocol" or "Invalid URL" body.
-      # Releases up to 16.0.3 use a protocol allowlist and answer 200 with the body "OK".
       - type: dsl
         dsl:
           - 'status_code == 200'

--- a/http/cves/2025/CVE-2025-11953.yaml
+++ b/http/cves/2025/CVE-2025-11953.yaml
@@ -1,0 +1,69 @@
+id: CVE-2025-11953
+
+info:
+  name: React Native Community CLI - Unauthenticated OS Command Injection
+  author: aryu-ru
+  severity: critical
+  description: |
+    The Metro development server started by the React Native Community CLI binds to external network interfaces by default and exposes an unauthenticated /open-url endpoint. Affected versions pass the attacker supplied url value straight to the open() helper without validating the scheme, allowing an unauthenticated attacker to launch arbitrary executables on the developer machine. On Windows the request is dispatched through cmd, which permits arbitrary shell commands with fully controlled arguments. The fix was released as a backport across several release lines, so the version number alone does not indicate whether an instance is affected, and this template probes the endpoint behaviour instead.
+  impact: |
+    An unauthenticated attacker with network access to the bundler port can execute arbitrary programs on a developer workstation, leading to compromise of the development environment along with any source code and credentials held on it.
+  remediation: |
+    Upgrade @react-native-community/cli-server-api to 17.0.1, 18.0.1, 19.1.2 or 20.0.0 and later, whichever is the fixed release for the line in use. Where upgrading is not immediately possible, bind the Metro development server to the loopback interface with --host 127.0.0.1 and block inbound access to the bundler port.
+  reference:
+    - https://jfrog.com/blog/cve-2025-11953-critical-react-native-community-cli-vulnerability/
+    - https://www.vulncheck.com/blog/metro4shell_eitw
+    - https://github.com/advisories/GHSA-399j-vxmf-hjvr
+    - https://github.com/react-native-community/cli/commit/15089907d1f1301b22c72d7f68846a2ef20df547
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-11953
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-11953
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: react-native-community
+    product: react_native_community_cli
+    fofa-query: title="React Native" && port="8081"
+  tags: cve,cve2025,react-native,metro,rce,command-injection,unauth,intrusive,kev
+
+flow: http(1) && http(2)
+
+http:
+  # Confirm the target is a React Native packager before probing the vulnerable endpoint
+  - raw:
+      - |
+        GET /status HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "packager-status:running")'
+          - 'contains(to_lower(header), "x-react-native-project-root")'
+        condition: and
+        internal: true
+
+  # The Content-Type header is required. Without it body-parser leaves req.body empty,
+  # open() receives undefined and the development server terminates on an unhandled rejection.
+  - raw:
+      - |
+        POST /open-url HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"url":"nuclei-probe://{{randstr}}"}
+
+    matchers:
+      # Vulnerable builds hand the unvalidated scheme to open() and answer 200 with an empty body.
+      # Patched builds reject the non http scheme with 400 and an "Invalid URL protocol" or "Invalid URL" body.
+      # Releases up to 16.0.3 use a protocol allowlist and answer 200 with the body "OK".
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'len(body) == 0'
+          - '!contains(body, "Invalid URL")'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2025-11953 for React Native Community CLI, unauthenticated OS command injection (CISA KEV, added 2026-02-05)

The Metro development server started by the React Native Community CLI binds to external interfaces by default and mounts an unauthenticated `/open-url` endpoint. In affected builds `openURLMiddleware` takes the JSON `url` value and hands it straight to `open()` with no validation, so anyone who can reach the bundler port can launch an executable on the developer's machine. On Windows the call goes through `cmd`, which allows arbitrary shell commands with controlled arguments. The template fingerprints the packager on `/status`, then sends a single `POST /open-url` carrying an inert, unregistered URL scheme. Fixed builds reject a non-http scheme with `400` and an `Invalid URL protocol` or `Invalid URL` body, while vulnerable builds accept it and answer `200` with an empty body.

This is detected by behaviour rather than by version on purpose. The fix shipped as a backport across four release lines (17.0.1, 18.0.1, 19.1.2, 20.0.0), so the version number on its own does not tell you whether an instance is affected. `17.0.1` is patched while the numerically higher `18.0.0` is not.

- References:
  - https://jfrog.com/blog/cve-2025-11953-critical-react-native-community-cli-vulnerability/
  - https://www.vulncheck.com/blog/metro4shell_eitw
  - https://github.com/advisories/GHSA-399j-vxmf-hjvr
  - https://github.com/react-native-community/cli/commit/15089907d1f1301b22c72d7f68846a2ef20df547
  - https://nvd.nist.gov/vuln/detail/CVE-2025-11953

**Classification.** `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` (9.8, critical) and `CWE-78` (OS Command Injection). Both are taken from the NVD record (`vulnStatus: Analyzed`). The only CVSS block present is the Secondary one from the CNA, `reefs@jfrog.com`. The `epss-*` fields and the `vkev` tag are left out so the scheduled workflows can own them.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Vulnerable environment**

`cli-server-api` is a library, so the lab mounts the package's own `createDevServerMiddleware()`, which is the exact middleware stack `react-native start` serves on 8081.

```bash
mkdir -p rn11953 && cd rn11953
cat > server.js <<'EOF'
const http = require('http');
const {createDevServerMiddleware} = require('@react-native-community/cli-server-api');
const port = Number(process.env.PORT || 8081);
const {middleware} = createDevServerMiddleware({host: 'localhost', port, watchFolders: []});
http.createServer(middleware).listen(port, '0.0.0.0');
EOF
printf '{"name":"lab","private":true}\n' > package.json

start() {  # $1 = version, $2 = host port, $3 = container name
  docker run -d --name "$3" -p 127.0.0.1:$2:8081 -v "$PWD":/src:ro -w /app node:20-alpine \
    sh -c "cp /src/server.js /src/package.json /app/ && npm i --silent @react-native-community/cli-server-api@$1 >/dev/null 2>&1 && node server.js"
}

start 17.0.0 18101 rn-1700     # vulnerable
start 18.0.0 18094 rn-1800     # vulnerable
start 19.0.0 18096 rn-1900     # vulnerable
start 19.1.1 18091 rn-vuln     # vulnerable
start 16.0.3 18100 rn-1603     # not affected (protocol allowlist)
start 18.0.1 18095 rn-1801     # patched
start 19.1.2 18092 rn-patched  # patched
start 20.2.0 18093 rn-latest   # patched
```

**Run**

```
$ nuclei -t http/cves/2025/CVE-2025-11953.yaml -l targets.txt

[CVE-2025-11953] [http] [critical] http://127.0.0.1:18091/open-url
[CVE-2025-11953] [http] [critical] http://127.0.0.1:18096/open-url
[CVE-2025-11953] [http] [critical] http://127.0.0.1:18101/open-url
[CVE-2025-11953] [http] [critical] http://127.0.0.1:18094/open-url
```

Four matches, exactly the four vulnerable builds.

| Target | Build | Expected | Result |
|---|---|---|---|
| 18101 | 17.0.0 | vulnerable | match |
| 18094 | 18.0.0 | vulnerable | match |
| 18096 | 19.0.0 | vulnerable | match |
| 18091 | 19.1.1 | vulnerable | match |
| 18100 | 16.0.3 | not affected | no match |
| 18095 | 18.0.1 | patched | no match |
| 18092 | 19.1.2 | patched | no match |
| 18093 | 20.2.0 | patched | no match |
| 18102 | Expo SDK 57 dev server | not affected | no match |
| 18097 | server returning 200 + empty body for every path | no match | no match |
| 18098 | nginx default | no match | no match |
| honey.scanme.sh | honeypot | no match | no match |

**Debug output, vulnerable (19.1.1)**

```
[INF] [CVE-2025-11953] Dumped HTTP request for http://127.0.0.1:18091/status
GET /status HTTP/1.1
Host: 127.0.0.1:18091

[DBG] [CVE-2025-11953] Dumped HTTP response http://127.0.0.1:18091/status
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
X-React-Native-Project-Root: /app

packager-status:running

[INF] [CVE-2025-11953] Dumped HTTP request for http://127.0.0.1:18091/open-url
POST /open-url HTTP/1.1
Host: 127.0.0.1:18091
Content-Type: application/json

{"url":"nuclei-probe://3HBHyGKvigUPJK3Ab5L5dgYYgJD"}

[DBG] [CVE-2025-11953] Dumped HTTP response http://127.0.0.1:18091/open-url
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff

[CVE-2025-11953:dsl-1] [http] [critical] http://127.0.0.1:18091/open-url
[INF] Scan completed in 4.439533ms. 1 matches found.
```

**Debug output, patched (19.1.2), same request**

```
[DBG] [CVE-2025-11953] Dumped HTTP response http://127.0.0.1:18092/open-url
HTTP/1.1 400 Bad Request
X-Content-Type-Options: nosniff

Invalid URL protocol

[INF] Scan completed in 2.861304ms. 0 matches found.
```

**Not a duplicate.** `grep -ril "CVE-2025-11953"` over the tree returns nothing, and there is no existing template that references `packager-status:running`, `openURLMiddleware`, `X-React-Native-Project-Root` or the bundler port. The only prior `react-native` string in the repo is an unrelated entry in `file/malware/shai-hulud-supply-chain.yaml`. No open or closed PR and no issue mentions this CVE.

### Notes for review

- **Why the second matcher keys on an empty body.** A vulnerable build answers `res.writeHead(200); res.end()`, so there is no success string to match on and the discriminator has to be the response shape. An OAST variant is not possible here, because patched builds still permit `http:` through to `open()` and a callback would therefore fire on patched and vulnerable alike. `len(body) == 0` is what carries the check, and it is load-bearing in two real cases. An Expo dev server serves the identical `/status` fingerprint and answers `POST /open-url` with a ~1.6 KB manifest from its catch-all, and `cli-server-api` up to 16.0.3 uses a protocol allowlist and answers `200 OK`. Both were stood up and confirmed silent.
- **The `Content-Type: application/json` header is required, not incidental.** Without it `body-parser` leaves `req.body` empty, `open()` receives `undefined`, and the dev server dies on an unhandled rejection. The request is written in `raw` form for that reason, and there is an inline comment so it is not refactored away. Every lab target answered `200` on `/status` after the scan.
- **Payload is inert.** The probe is an unregistered scheme with a random alphanumeric suffix and no shell metacharacters, so on a vulnerable host `open()` finds no handler and nothing launches. It still spawns a process on the developer machine, so the template is tagged `intrusive`.
- **Affected range is deliberately not asserted in metadata.** GHSA floors at 18.0.0 and omits 17.0.0, which the source shows is vulnerable, and the advisory's 4.8.0 floor is contradicted by 16.0.3 and earlier carrying a protocol allowlist. The description explains the backport situation instead of stating a range.
- **Port.** No port is pinned, following the usual `{{BaseURL}}` convention. Metro's port is configurable, so 8081 needs to be in the scan's port list.
- **Known false negative.** A reverse proxy that injects a body into empty 200 responses would suppress detection.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
