### PR TITLE
Add Claude Code subagent (.claude/agents/*.md) exposure detector

### DIFF
--- a/http/exposures/configs/claude-code-agents-exposure.yaml
+++ b/http/exposures/configs/claude-code-agents-exposure.yaml
@@ -1,0 +1,66 @@
+id: claude-code-agents-exposure
+
+info:
+  name: Claude Code Subagent Configuration Exposure
+  author: shadowhunter-92
+  severity: medium
+  description: |
+    Claude Code subagent configuration files under `.claude/agents/` were detected on the web server. Each `.md` file in this directory defines a specialized AI subagent (name, description, tool allow-list, system prompt) that Claude Code will delegate work to. Exposure of these files can leak custom system prompts (often containing internal API endpoints, business logic, prompt-engineering secrets), tool permission grants, and information about the project's internal automation setup. Directory listings on `.claude/agents/` further expose the full inventory of subagents defined for a project.
+  reference:
+    - https://docs.claude.com/en/docs/claude-code/sub-agents
+    - https://docs.claude.com/en/docs/claude-code/settings
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    verified: true
+    max-request: 4
+    shodan-query: http.html:"claude"
+  tags: config,exposure,claude,claude-code,anthropic,ai,subagent
+
+http:
+  - method: GET
+    host-redirects: true
+    max-redirects: 2
+    path:
+      - "{{BaseURL}}/.claude/agents/"
+      - "{{BaseURL}}/.claude/agents/index.md"
+      - "{{BaseURL}}/.claude/agents/README.md"
+      - "{{BaseURL}}/.claude/agents/code-reviewer.md"
+
+    stop-at-first-match: false
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        part: body
+        condition: or
+        regex:
+          - '(?s)^---\s*\n.*?\bname:\s*[A-Za-z0-9_-]+.*?\bdescription:\s*.*?\n---'
+          - '(?i)Index of /\.claude/agents'
+          - '(?i)Directory listing for /\.claude/agents'
+          - '>[a-zA-Z0-9_.-]+\.md<'
+
+    extractors:
+      - type: regex
+        name: agent_name
+        part: body
+        regex:
+          - 'name:\s*["'']?([a-zA-Z0-9_-]+)'
+
+      - type: regex
+        name: allowed_tools
+        part: body
+        regex:
+          - 'tools:\s*\[?([^\]\n]+)'
+
+      - type: regex
+        name: agent_files
+        part: body
+        regex:
+          - '>([a-zA-Z0-9_.-]+\.md)<'

--- a/http/exposures/configs/claude-code-agents.yaml
+++ b/http/exposures/configs/claude-code-agents.yaml
@@ -1,9 +1,9 @@
 id: claude-code-agents
 
 info:
-  name: Claude Code Subagent Configuration Exposure
+  name: Claude Code Subagent Configuration - Exposure
   author: shadowhunter-92
-  severity: medium
+  severity: low
   description: |
     Claude Code subagent configuration files under `.claude/agents/` were detected on the web server. Each `.md` file in this directory defines a specialized AI subagent (name, description, tool allow-list, system prompt) that Claude Code will delegate work to. Exposure of these files can leak custom system prompts (often containing internal API endpoints, business logic, prompt-engineering secrets), tool permission grants, and information about the project's internal automation setup. Directory listings on `.claude/agents/` further expose the full inventory of subagents defined for a project.
   reference:

--- a/http/exposures/configs/claude-code-agents.yaml
+++ b/http/exposures/configs/claude-code-agents.yaml
@@ -1,4 +1,4 @@
-id: claude-code-agents-exposure
+id: claude-code-agents
 
 info:
   name: Claude Code Subagent Configuration Exposure
@@ -21,8 +21,6 @@ info:
 
 http:
   - method: GET
-    host-redirects: true
-    max-redirects: 2
     path:
       - "{{BaseURL}}/.claude/agents/"
       - "{{BaseURL}}/.claude/agents/index.md"
@@ -31,12 +29,11 @@ http:
 
     stop-at-first-match: false
 
+    host-redirects: true
+    max-redirects: 2
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: regex
         part: body
         condition: or
@@ -45,6 +42,10 @@ http:
           - '(?i)Index of /\.claude/agents'
           - '(?i)Directory listing for /\.claude/agents'
           - '>[a-zA-Z0-9_.-]+\.md<'
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex


### PR DESCRIPTION
### Summary

Adds `http/exposures/configs/claude-code-agents-exposure.yaml` — detects Claude Code **subagent** configuration files exposed over HTTP.

Closes #16733.

### What this template covers

Claude Code (Anthropic's official CLI) supports **subagents** defined by `.md` files in a project's `.claude/agents/` directory. Each file has YAML frontmatter (`name`, `description`, optional `tools` allow-list) and a system prompt. See https://docs.claude.com/en/docs/claude-code/sub-agents.

Real example (verbatim from the official docs):
```markdown
---
name: code-reviewer
description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability.
tools: Read, Grep, Glob, Bash
---

You are a senior code reviewer ensuring high standards.
```

If these files are HTTP-exposed (misconfigured web root, backup, deploy artifact), an attacker can extract:
- Custom system prompts (often contain internal API endpoints, business logic, prompt-engineering IP)
- Tool permission grants per subagent (which subagents can invoke Bash, Write, WebFetch, MCP tools)
- The full subagent roster via directory listing
- Automation-surface intel about the target's Claude Code workflow

### Detection design

Four paths checked (`stop-at-first-match: false`):
- `/.claude/agents/`
- `/.claude/agents/index.md`
- `/.claude/agents/README.md`
- `/.claude/agents/code-reviewer.md` (the canonical example from Anthropic's docs)

Two matchers OR'd (gated by status 200):
1. Frontmatter regex requiring `---` delimiter + `name:` + `description:` keys — matches a real subagent file, rejects HTML pages that happen to contain the words.
2. `Index of /.claude/agents` / `Directory listing for /.claude/agents` / `>filename.md<` — Apache/nginx dir listing.

Extractors surface `agent_name`, `allowed_tools`, and `agent_files` from listings.

### False-positive control

Frontmatter matcher requires the leading `---` block plus BOTH `name:` and `description:` keys — HTML pages / prose containing those words as free text won't match. Directory-listing matcher requires the literal `Index of /.claude/agents` string or the specific `>*.md<` href pattern in a 200 response.

### Local validation

- YAML parses cleanly (`yaml.safe_load`).
- Regexes tested against: real subagent .md (matches), unrelated HTML with the words `name:`/`description:` (does NOT match), Apache dir listing (matches + extracts filenames).

### Severity

`medium` / CVSS 7.5 — matches the `.claude/settings.json` template's severity (PR #16701, also merged). Same class of exposure (project config file leak), same information-disclosure profile.

### Metadata / tags

`config,exposure,claude,claude-code,anthropic,ai,subagent` — parallel to the existing `claude-code-settings-exposure` template.

### Complements

- PR #16699 — Anthropic `sk-ant-*` API-key detector (merged)
- PR #16701 — `.claude/settings.json` / `.claude/settings.local.json` / `.mcp.json` exposure detector (merged)

Third template in a Claude Code coverage push.