### PR TITLE
Add MCP server unauthenticated tools/list exposure detector

### DIFF
--- a/http/misconfiguration/mcp/mcp-server-unauth-tools-list.yaml
+++ b/http/misconfiguration/mcp/mcp-server-unauth-tools-list.yaml
@@ -1,0 +1,88 @@
+id: mcp-server-unauth-tools-list
+
+info:
+  name: Model Context Protocol (MCP) Server - Unauthenticated tools/list Exposure
+  author: shadowhunter-92
+  severity: high
+  description: |
+    A Model Context Protocol (MCP) server was detected responding to the JSON-RPC 2.0 `tools/list` method WITHOUT any authentication. MCP is the open protocol used by AI agents (Claude, ChatGPT, Cursor, Windsurf, custom LangChain agents, etc.) to invoke external tools; each tool the server exposes can be called via the `tools/call` method with arbitrary arguments. When `tools/list` is reachable unauthenticated, the tools it enumerates are typically also invocable unauthenticated, allowing an attacker to enumerate and execute all server-side tool capabilities: file I/O, shell command execution, database queries, API calls, credential lookups, etc. — whatever the operator implemented. Real-world exploitations of this pattern include CVE-2026-59822 (LiteLLM MCP proxy authentication bypass) and the mem0 unauthenticated API family (CVE-2026-59705 / CVE-2026-59706). A public survey of 9,695 exposed MCP servers found 2,054 (21%) had NO authentication at all.
+  reference:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+    - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59822
+    - https://github.com/webpro255/awesome-ai-agent-attacks
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 4
+    shodan-query: "jsonrpc"
+  tags: exposure,mcp,jsonrpc,ai,anthropic,unauth,misconfig
+
+http:
+  - method: POST
+    host-redirects: true
+    max-redirects: 2
+    path:
+      - "{{BaseURL}}/mcp"
+      - "{{BaseURL}}/messages"
+      - "{{BaseURL}}/sse"
+      - "{{BaseURL}}/"
+
+    headers:
+      Content-Type: application/json
+      Accept: application/json, text/event-stream
+
+    body: '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc":"2.0"'
+          - '"jsonrpc": "2.0"'
+        condition: or
+
+      - type: word
+        part: body
+        words:
+          - '"result"'
+
+      - type: word
+        part: body
+        words:
+          - '"tools"'
+          - '"inputSchema"'
+        condition: or
+
+      - type: word
+        part: body
+        negative: true
+        words:
+          - '"error"'
+          - '"code":-32'
+          - '"Unauthorized"'
+          - '"401"'
+        condition: or
+
+    extractors:
+      - type: regex
+        name: tool_names
+        part: body
+        regex:
+          - '"name"\s*:\s*"([a-zA-Z0-9_.-]+)"'
+
+      - type: regex
+        name: tool_descriptions
+        part: body
+        regex:
+          - '"description"\s*:\s*"([^"]{1,120})"'


### PR DESCRIPTION
### Summary

Adds `http/misconfiguration/mcp/mcp-server-unauth-tools-list.yaml` — detects Model Context Protocol (MCP) servers responding to the JSON-RPC 2.0 `tools/list` method without any authentication.

Closes #16735.

### Why this matters

MCP is the open protocol AI agents (Claude, ChatGPT, Cursor, Windsurf, custom LangChain / LangGraph deployments, etc.) use to invoke external tools. Every tool an MCP server exposes is discovered via `tools/list` and invoked via `tools/call` — both plain JSON-RPC 2.0. When authentication is missing, an unauthenticated caller can enumerate and invoke every tool the server exposes: file I/O, shell exec, DB queries, cloud-API calls, credential lookups, whatever the operator wired up.

**Documented real-world impact:**
- CVE-2026-59822 — LiteLLM MCP proxy auth bypass
- CVE-2026-59705 / CVE-2026-59706 — mem0 unauthenticated API family
- Public survey: **2,054 of 9,695 exposed MCP servers had NO authentication** (~21%). This is a huge live population.

Zero existing nuclei-templates coverage for this class.

### Detection design

Four POST paths tried in a single template:
- `/mcp` — common for gateway-style deployments
- `/messages` — JSON-RPC-over-HTTP transport variant
- `/sse` — SSE transport variant (some accept POST on the same path)
- `/` — minimal implementations mounted at root

Body: `{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}`.

Matchers (AND, all must match):
1. Status 200
2. Body contains `\"jsonrpc\": \"2.0\"` (protocol header)
3. Body contains `\"result\"` (successful RPC)
4. Body contains `\"tools\"` OR `\"inputSchema\"` (positive proof of tools/list response, not arbitrary JSON)
5. Body does NOT contain any of `\"error\"`, `\"code\":-32`, `\"Unauthorized\"`, `\"401\"` (negative suppression — auth-required responses ignored)

Extractors pull the enumerated **tool names** and **descriptions** so operators immediately see what leaked.

### False-positive control

The stacked positive requirements (jsonrpc header + result + tools/inputSchema) plus the negative suppression on any error-shaped response mean an arbitrary REST/JSON API returning `{\"status\":\"ok\",\"result\":{...}}` correctly does NOT match. Regex-tested locally against 4 fixtures: real MCP response fires; auth-required MCP response suppressed; unrelated JSON API missed; HTML page missed.

### Severity

`high` / CVSS 9.8 (CWE-306 Missing Authentication for Critical Function). Many MCP deployments expose read-only or narrow tools, so calibrated as `high` rather than `critical`.

### Related merged contributions from this contributor

- PR #16699 — Anthropic sk-ant-* API-key detector (merged)
- PR #16701 — .claude/settings.json / .mcp.json exposure detector (merged)
- PR #16734 — .claude/agents/*.md subagent config exposure detector (open, CI green)

This one extends the AI-agent coverage from Anthropic-specific to the whole MCP ecosystem.