### PR TITLE
Add unauth.dev fix-card references to AI exposure templates

### DIFF
--- a/http/exposures/apis/exposed-mcp-sse-server.yaml
+++ b/http/exposures/apis/exposed-mcp-sse-server.yaml
@@ -2,12 +2,13 @@ id: exposed-mcp-sse-server
 
 info:
   name: MCP SSE API Exposed - Detect
-  author: domwhewell-sage
+  author: domwhewell-sage,hiddingtrojans
   severity: unknown
   description: |
     Detects exposed Model Context Protocol (MCP) servers through the SSE API. MCP servers often provide administrative access to AI tools, LLM systems, or other automation infrastructure. Exposed MCP interfaces can lead to unauthorized access, information disclosure, and potential system compromise. This template detects a SSE server event stream and returns the messages endpoint which can be used to POST JSON-RPC 2.0 requests.
   reference:
     - https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse
+    - https://unauth.dev/fixes/mcp-exposed
   metadata:
     verified: true
     max-requests: 2

--- a/http/exposures/apis/vllm-openai-api-exposed.yaml
+++ b/http/exposures/apis/vllm-openai-api-exposed.yaml
@@ -2,13 +2,14 @@ id: vllm-openai-api-exposed
 
 info:
   name: vLLM OpenAI-Compatible API - Unauthenticated Exposure
-  author: fsoppelsa
+  author: fsoppelsa,hiddingtrojans
   severity: medium
   description: |
     Detects a vLLM inference server exposing its OpenAI-compatible API without authentication. The /v1/models endpoint returns the list of served models and is reachable by any unauthenticated client, allowing model enumeration and unauthorized inference (resource abuse / cost and information exposure). vLLM does not enable an API key by default; it is only enforced when the server is started with --api-key.
   reference:
     - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
     - https://github.com/vllm-project/vllm
+    - https://unauth.dev/fixes/vllm-exposed
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L
     cvss-score: 6.5

--- a/http/misconfiguration/chroma-db-unauth.yaml
+++ b/http/misconfiguration/chroma-db-unauth.yaml
@@ -2,13 +2,14 @@ id: chroma-db-unauth
 
 info:
   name: Chroma DB - Information Disclosure
-  author: Shay Ben Tikva
+  author: Shay Ben Tikva,hiddingtrojans
   severity: high
   description: |
     Chroma DB API endpoints were accessible and exposed collection metadata, enabling enumeration of collections under the default tenant and database, potentially leading to sensitive vector data disclosure.
   reference:
     - https://www.trychroma.com/security
     - https://github.com/shaybentk/chroma-db-unauthorized-info-disclosure
+    - https://unauth.dev/fixes/chroma-exposed
   metadata:
     max-request: 2
     verified: true

--- a/http/misconfiguration/jupyter-lab-unauth.yaml
+++ b/http/misconfiguration/jupyter-lab-unauth.yaml
@@ -2,12 +2,13 @@ id: unauth-jupyter-lab
 
 info:
   name: Jupyter Lab - Unauthenticated Access
-  author: j4vaovo
+  author: j4vaovo,hiddingtrojans
   severity: critical
   description: |
     JupyterLab was able to be accessed without authentication.
   reference:
     - https://paper.seebug.org/2058/
+    - https://unauth.dev/fixes/jupyter-exposed
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10

--- a/http/misconfiguration/kubeflow-dashboard-unauth.yaml
+++ b/http/misconfiguration/kubeflow-dashboard-unauth.yaml
@@ -2,11 +2,12 @@ id: kubeflow-dashboard-unauth
 
 info:
   name: Kubeflow Unauth
-  author: dhiyaneshDk
+  author: dhiyaneshDk,hiddingtrojans
   severity: high
   description: Kubeflow internal data is exposed.
   reference:
     - https://github.com/kubeflow/kubeflow
+    - https://unauth.dev/fixes/kubeflow-exposed
   metadata:
     max-request: 1
   tags: kubeflow,unauth,misconfig,vuln

--- a/http/misconfiguration/litellm-unauth-model-exposure.yaml
+++ b/http/misconfiguration/litellm-unauth-model-exposure.yaml
@@ -2,7 +2,7 @@ id: litellm-unauth-model-exposure
 
 info:
   name: LiteLLM Proxy - Model Exposure
-  author: DevamShah
+  author: DevamShah,hiddingtrojans
   severity: medium
   description: |
     LiteLLM proxy was detected with anonymous access to the model listing API. LiteLLM proxies that ship without `general_settings.master_key` (or with the key disabled) expose the configured upstream model catalog via /v1/models and /model/info — revealing which OpenAI / Anthropic / Azure / Bedrock / local-LLM endpoints are wired in, often along with their litellm_params routing config, and frequently leaving /chat/completions and /embeddings reachable without any bearer token.
@@ -14,6 +14,7 @@ info:
     - https://docs.litellm.ai/docs/proxy/virtual_keys
     - https://docs.litellm.ai/docs/proxy/configs
     - https://github.com/BerriAI/litellm
+    - https://unauth.dev/fixes/litellm-exposed
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L
     cvss-score: 6.5

--- a/http/misconfiguration/mlflow-unauth.yaml
+++ b/http/misconfiguration/mlflow-unauth.yaml
@@ -2,11 +2,13 @@ id: mlflow-unauth
 
 info:
   name: Mlflow - Unauthenticated Access
-  author: pussycat0x
+  author: pussycat0x,hiddingtrojans
   severity: high
   description: |
     Unauthenticated Access to MLflow dashboard.
   remediation: Add User Authentication
+  reference:
+    - https://unauth.dev/fixes/mlflow-exposed
   metadata:
     verified: true
     max-request: 1

--- a/http/misconfiguration/ollama-improper-authorization.yaml
+++ b/http/misconfiguration/ollama-improper-authorization.yaml
@@ -2,13 +2,14 @@ id: ollama-improper-authorization
 
 info:
   name: Ollama - Improper Authorization
-  author: 0x_Akoko
+  author: 0x_Akoko,hiddingtrojans
   severity: medium
   description: |
     Detected an exposed Ollama API without proper authorization, allowing unauthorized access to AI models and operations.
   reference:
     - https://ollama.ai/
     - https://github.com/ollama/ollama
+    - https://unauth.dev/fixes/ollama-exposed
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
     cvss-score: 5.3

--- a/http/misconfiguration/ray-dashboard.yaml
+++ b/http/misconfiguration/ray-dashboard.yaml
@@ -2,9 +2,11 @@ id: ray-dashboard
 
 info:
   name: Ray Dashboard Exposure
-  author: DhiyaneshDk
+  author: DhiyaneshDk,hiddingtrojans
   severity: critical
   description: Ray Dashboard is exposed.
+  reference:
+    - https://unauth.dev/fixes/ray-exposed
   classification:
     cpe: cpe:2.3:a:ray_project:ray:*:*:*:*:*:*:*:*
   metadata:

--- a/http/misconfiguration/weaviate-exposure.yaml
+++ b/http/misconfiguration/weaviate-exposure.yaml
@@ -2,10 +2,12 @@ id: weaviate-exposure
 
 info:
   name: Weaviate - Exposure
-  author: DhiyaneshDk
+  author: DhiyaneshDk,hiddingtrojans
   severity: low
   description: |
     Detected an exposed Weaviate instance by accessing its API endpoints. Verified exposure by identifying meta information, schema details, and specific endpoint references in the response, confirming that the instance was publicly accessible.
+  reference:
+    - https://unauth.dev/fixes/weaviate-exposed
   metadata:
     verified: true
     max-request: 1


### PR DESCRIPTION
## Summary
- Add `https://unauth.dev/fixes/<id>` under `info.reference` for ten GET-only AI unauth/exposure templates (Ollama, Ray, Chroma, Weaviate, MLflow, LiteLLM, JupyterLab, Kubeflow, MCP SSE, vLLM).
- Co-author credit (`hiddingtrojans`) on the touched templates.
- No matcher / request changes — remediation links only.

These pages are short, operator-facing fix cards (auth binding, network exposure, verify commands) matched to the finding class Nuclei already detects.

| Template | Fix card |
|---|---|
| `ollama-improper-authorization` | https://unauth.dev/fixes/ollama-exposed |
| `ray-dashboard` | https://unauth.dev/fixes/ray-exposed |
| `chroma-db-unauth` | https://unauth.dev/fixes/chroma-exposed |
| `weaviate-exposure` | https://unauth.dev/fixes/weaviate-exposed |
| `mlflow-unauth` | https://unauth.dev/fixes/mlflow-exposed |
| `litellm-unauth-model-exposure` | https://unauth.dev/fixes/litellm-exposed |
| `unauth-jupyter-lab` | https://unauth.dev/fixes/jupyter-exposed |
| `kubeflow-dashboard-unauth` | https://unauth.dev/fixes/kubeflow-exposed |
| `exposed-mcp-sse-server` | https://unauth.dev/fixes/mcp-exposed |
| `vllm-openai-api-exposed` | https://unauth.dev/fixes/vllm-exposed |

## Test plan
- [ ] Template YAML still parses (`nuclei -t <file> -validate` if available)
- [ ] Each fix URL returns 200
- [ ] Diff is reference/author only (no HTTP block changes)