### PR TITLE
Fix nh-c2 dsl matcher that can never match

### DIFF
--- a/http/exposed-panels/c2/nh-c2.yaml
+++ b/http/exposed-panels/c2/nh-c2.yaml
@@ -21,7 +21,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code == 301 && status_code == 302"
+          - "status_code == 301 || status_code == 302"
           - "(\"03609e8e4a0a0ef888327d64ae2dc8950664219e\" == sha1(body))"
         condition: and
-# digest: 4b0a00483046022100a20c46b53d0edb57cb0ba284a1830dd66f552a46b01e9de66bd87c6f3e3531d6022100b4e6b964fbaeee62c53249434fbfa5fb5db288c782ac2e63f2d739a409059029:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

http/exposed-panels/c2/nh-c2.yaml has a dsl matcher that requires `status_code == 301 && status_code == 302`. No single response can carry both status codes, so with `condition: and` the expression is always false and the template never fires. NH C2 panels answer the root path with a redirect, so the intent is 301 or 302, not both. I changed `&&` to `||`. The `sha1(body)` fingerprint is untouched and still gates the result. I also removed the stale `# digest` line so the signing workflow re-signs it on merge.

- References: https://twitter.com/MichalKoczwara/status/1616179246216396806

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

I do not have an NH C2 panel to point at, so I reproduced the matcher logic with nuclei v3.11.0 against a local host. I copied the template twice and swapped the sha1 fingerprint for the hash of the body my test host returns, so the only thing left differing between the two copies is the status operator:

```
current (&&) vs 301 : no match
current (&&) vs 302 : no match
patched (||) vs 301 : match
patched (||) vs 302 : match
patched (||) vs 200 : no match
```

`nuclei -validate` on the changed template passes.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
