### PR TITLE
fix(wordpress-eol): reduce false positives from generic version regex

### DIFF
--- a/http/technologies/eol/wordpress-eol.yaml
+++ b/http/technologies/eol/wordpress-eol.yaml
@@ -35,9 +35,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(to_lower(body), "/wp-content/")'
-          - 'contains(to_lower(body), "/wp-includes/")'
-          - 'contains(to_lower(body), "/wp-json/")'
+          - 'contains_any(to_lower(body), "/wp-content/","/wp-includes/","/wp-json/")'
         condition: or
 
       - type: dsl

--- a/http/technologies/eol/wordpress-eol.yaml
+++ b/http/technologies/eol/wordpress-eol.yaml
@@ -27,9 +27,19 @@ http:
         group: 1
         regex:
           - '(?i)<meta[^>]*name=["\'']?generator["\'']?[^>]*content=["\'']?WordPress\s+([0-9.]+)'
-          - '(?i)Version\s+([0-9]+\.[0-9.]+)'
-
+          - 'wp-includes/js/wp-emoji-release(?:\.min)?\.js\?ver=([0-9]+\.[0-9.]+)'
+          - 'wp-includes/css/dist/block-library/style(?:\.min)?\.css\?ver=([0-9]+\.[0-9.]+)'
+          - 'wp-includes/blocks/[a-z-]+/style(?:\.min)?\.css\?ver=([0-9]+\.[0-9.]+)'
+    
+    matchers-condition: and
     matchers:
+      - type: dsl
+        dsl:
+          - 'contains(to_lower(body), "/wp-content/")'
+          - 'contains(to_lower(body), "/wp-includes/")'
+          - 'contains(to_lower(body), "/wp-json/")'
+        condition: or
+
       - type: dsl
         dsl:
           - 'len(version) > 0'

--- a/http/technologies/eol/wordpress-eol.yaml
+++ b/http/technologies/eol/wordpress-eol.yaml
@@ -30,7 +30,7 @@ http:
           - 'wp-includes/js/wp-emoji-release(?:\.min)?\.js\?ver=([0-9]+\.[0-9.]+)'
           - 'wp-includes/css/dist/block-library/style(?:\.min)?\.css\?ver=([0-9]+\.[0-9.]+)'
           - 'wp-includes/blocks/[a-z-]+/style(?:\.min)?\.css\?ver=([0-9]+\.[0-9.]+)'
-    
+
     matchers-condition: and
     matchers:
       - type: dsl
@@ -43,4 +43,3 @@ http:
           - 'len(version) > 0'
           - 'compare_versions(version, "<6.9")'
         condition: and
-# digest: 490a00463044022024fa95d02afd05b1d4107c2353783cdd1079c1dd6024073447d0d6db1004bee6022051acc960c967dc15e4798219b0dc495da95de26f73b6804479c41886b245c2b3:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION


### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed overwhelming false positives from generic `Version\s+([0-9]+\.[0-9.]+)` pattern against the full response body.


### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

-   Removed the generic version regex.
-   Version extraction now uses the `generator` meta tag, plus specific `wp-includes` assets that inherit the core version (`wp-emoji-release.js`, `css/dist/block-library/style.css`, `blocks/*/style.css`). A directory-wide `wp-includes/...?ver=` pattern was deliberately avoided: bundled libraries such as jQuery are registered with their own versions and would be misread as core.
-   Added `matchers-condition: and` with a word matcher requiring `wp-content` or `wp-includes`, so a WordPress fingerprint is required before the version comparison applies.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
