### PR TITLE
Implement error checks for SNMP response validity

### DIFF
--- a/javascript/udp/detection/snmpv3-detect.yaml
+++ b/javascript/udp/detection/snmpv3-detect.yaml
@@ -88,4 +88,3 @@ javascript:
         group: 1
         regex:
           - "(.*)"
-# digest: 4b0a0048304602210094aea547ef8edbe734a64fbe3e4e8b1609c469f99e11708d6a074d71be3beccd022100ec05cd74b50383414a98a3580653cc1cabcfe4d5c678ddbadba6d6de0c6e83ff:922c64590222798bb761d5b6d8e72950

--- a/javascript/udp/detection/snmpv3-detect.yaml
+++ b/javascript/udp/detection/snmpv3-detect.yaml
@@ -33,7 +33,14 @@ javascript:
       const hexBuffer = new b.Buffer();
       hexBuffer.Write(resp);
       const respHex = hexBuffer.Hex()
+      
+      if (!resp || resp.length === 0) {
+        throw new Error("No SNMP response received");
+      }
 
+      if (!respHex || respHex.length === 0) {
+        throw new Error("Empty SNMP response");
+      }
 
       const known_vendors = {
         "80000009": "Cisco",

--- a/javascript/udp/detection/snmpv3-detect.yaml
+++ b/javascript/udp/detection/snmpv3-detect.yaml
@@ -33,7 +33,7 @@ javascript:
       const hexBuffer = new b.Buffer();
       hexBuffer.Write(resp);
       const respHex = hexBuffer.Hex()
-      
+
       if (!resp || resp.length === 0) {
         throw new Error("No SNMP response received");
       }


### PR DESCRIPTION
Add error handling for empty SNMP responses.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
There is no check if response is empty making this template validating those request resulting in 
Enterprise: unknown 
due to 
"Enterprise: " + (m ? m[0] : "unknown"
when actully the port udp 161 is not open.
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
this is output from an adjusted copy from this template. 
      const respHex = hexBuffer.Hex()

      console.log("resp:", resp);
      console.log("respHex:", respHex);
      console.log("length:", respHex.length);
      if (!resp || resp.length === 0) {
        throw new Error("No SNMP response received");
      }

      if (!respHex || respHex.length === 0) {
       throw new Error("Empty SNMP response");
      }
      
      --> gives output 
      
[INF] Current nuclei version: v3.11.0 (latest)
[INF] Current nuclei-templates version: v10.4.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 122
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from seqtalk
[INF] Targets loaded for current scan: 1
[DBG] JavaScript Protocol request variables: map[string]interface {}:4 {
  "FQDN": "192.168.88.120",
  "Host": "192.168.88.120",
  "Hostname": "192.168.88.120:161",
  "Port": "161",
}
[DBG] [snmpv3-detect] Executing Precondition for request
[DBG]  [snmpv3-detect] Javascript Code:

	isUDPPortOpen(Host, Port);

[DBG] [snmpv3-detect] Precondition for request was satisfied
[INF] resp:             <---- No output
[INF] respHex:      <---- No output
[INF] length: 0      <---- Lenght of 0
[DBG] [snmpv3-detect] Dumped Javascript request for 192.168.88.120:161:
Variables:
 map[string]interface {}:3 {
  "Timeout": "2",
  "Host": "192.168.88.120",
  "Port": "161",
} address=192.168.88.120:161
...........
[WRN] [snmpv3-detect] Could not execute request for 192.168.88.120: cause="Error: No SNMP response received at <eval>:17:9(78)"
[INF] Scan completed in 21.212083ms. No results found.

<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
