### PR TITLE
Add CVE-2026-42238 template

### DIFF
--- a/http/cves/2026/CVE-2026-42238.yaml
+++ b/http/cves/2026/CVE-2026-42238.yaml
@@ -1,0 +1,41 @@
+id: cve-2026-42238-nginx-ui-restore-auth-bypass
+
+info:
+  name: nginx-ui Unauthenticated Backup Restore (CVE-2026-42238)
+  author: str4k3r
+  severity: critical
+  description: >
+    Fresh nginx-ui versions before 2.3.8 expose POST /api/restore without
+    authentication during the installation window. A malformed multipart request
+    reaches the handler and returns its backup-file error; patched versions reject
+    the same request at authentication middleware.
+  reference:
+    - https://github.com/0xJacky/nginx-ui/security/advisories/GHSA-4pvg-prr3-9cxr
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42238
+  classification:
+    cve-id: CVE-2026-42238
+  metadata:
+    verified: true
+  tags: cve,cve2026,nginx-ui,auth-bypass,rce
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/restore"
+    headers:
+      Content-Type: multipart/form-data; boundary=forge
+    body: |-
+      --forge
+      Content-Disposition: form-data; name="security_token"
+
+      invalid
+      --forge--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 500
+      - type: word
+        part: body
+        words:
+          - "Backup file not found"


### PR DESCRIPTION
Adds the Nuclei template for this CVE based on public advisory references. The template includes an HTTP proof-of-concept request and response matchers for maintainer review.