### PR TITLE
[nuclei-template] AI coding-agent config exposures (CLAUDE.md, AGENTS.md, Cursor rules)

### DIFF
--- a/http/exposures/configs/agents-md-exposure.yaml
+++ b/http/exposures/configs/agents-md-exposure.yaml
@@ -1,0 +1,54 @@
+id: agents-md-exposure
+
+info:
+  name: AGENTS.md Agent Instructions Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected an exposed AGENTS.md (or nested agents instruction) file. AGENTS.md
+    is used by coding agents and multi-agent tooling (for example Codex, Cursor
+    workflows, and custom agent harnesses) to describe repository conventions,
+    commands, architecture, and operational rules. Exposure can leak internal
+    process details, service names, and sensitive operational guidance.
+  reference:
+    - https://agents.md/
+    - https://docs.claude.com/en/docs/claude-code/memory
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 4
+    shodan-query: html:"AGENTS.md"
+  tags: config,exposure,agents,ai,markdown,cursor,codex
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/AGENTS.md"
+      - "{{BaseURL}}/agents.md"
+      - "{{BaseURL}}/.agents/AGENTS.md"
+      - "{{BaseURL}}/.github/AGENTS.md"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 40'
+          - 'regex("(?m)^\\s*#\\s+", body)'
+          - 'contains_any(to_lower(body), "agent", "codebase", "repository", "prefer ", "always ", "never ", "do not ", "must ", "build", "test", "pull request", "workflow")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/claude-md-exposure.yaml
+++ b/http/exposures/configs/claude-md-exposure.yaml
@@ -1,0 +1,54 @@
+id: claude-md-exposure
+
+info:
+  name: Claude Code CLAUDE.md Project Instructions Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected an exposed Claude Code project instruction file (CLAUDE.md). These
+    markdown files define project-specific guidance for Claude Code agents,
+    including coding conventions, architecture notes, internal service names,
+    workflow rules, and sometimes environment or secret-handling instructions.
+    Public exposure can leak proprietary process detail and aid targeted attacks
+    against the application or its infrastructure.
+  reference:
+    - https://docs.claude.com/en/docs/claude-code/memory
+    - https://docs.claude.com/en/docs/claude-code/overview
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 3
+    shodan-query: html:"CLAUDE.md"
+  tags: config,exposure,claude,claude-code,anthropic,ai,markdown
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/CLAUDE.md"
+      - "{{BaseURL}}/.claude/CLAUDE.md"
+      - "{{BaseURL}}/claude.md"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 40'
+          - 'regex("(?m)^\\s*#\\s+", body)'
+          - 'contains_any(to_lower(body), "claude", "codebase", "prefer ", "always ", "never ", "do not ", "must ", "when working", "this project", "pull request")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/cursor-rules-exposure.yaml
+++ b/http/exposures/configs/cursor-rules-exposure.yaml
@@ -1,0 +1,58 @@
+id: cursor-rules-exposure
+
+info:
+  name: Cursor AI Rules Configuration Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected exposed Cursor AI rule configuration files (.cursorrules,
+    .cursor/rules, or related Cursor project config). These files instruct the
+    Cursor coding agent on project conventions, architecture constraints, and
+    sometimes environment-specific guidance. Public exposure can leak
+    proprietary development process detail and internal system hints useful for
+    attackers.
+  reference:
+    - https://docs.cursor.com/context/rules
+    - https://docs.cursor.com/context/rules-for-ai
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 5
+    shodan-query: html:".cursorrules"
+  tags: config,exposure,cursor,ai,markdown
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.cursorrules"
+      - "{{BaseURL}}/.cursor/rules"
+      - "{{BaseURL}}/.cursor/rules.md"
+      - "{{BaseURL}}/.cursor/rules/index.mdc"
+      - "{{BaseURL}}/.cursor/mcp.json"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/json"
+          - "application/octet-stream"
+          - "text/yaml"
+          - "application/yaml"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 30'
+          - 'contains_any(to_lower(body), "you are", "always ", "never ", "prefer ", "do not ", "must ", "globs:", "alwaysapply", "\"mcpservers\"", "description:", "cursor", "rules for")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype html", "page not found", "404 not found")'


### PR DESCRIPTION
### Template / PR Information

| Key | Value |
|-----|-------|
| Type | New templates (exposure / config disclosure) |
| Templates | `claude-md-exposure`, `agents-md-exposure`, `cursor-rules-exposure` |
| Severity | medium |
| Protocol | HTTP |

### Summary

Adds three complementary exposure templates for AI coding-agent project files that are often committed into repositories and occasionally served from misconfigured web roots:

1. **`claude-md-exposure`** — `CLAUDE.md` / `.claude/CLAUDE.md` (Claude Code project memory/instructions)
2. **`agents-md-exposure`** — `AGENTS.md` and common nested paths (multi-agent tooling instructions)
3. **`cursor-rules-exposure`** — `.cursorrules`, `.cursor/rules*`, `.cursor/mcp.json` (Cursor rules/config)

These follow the same class as the existing `claude-settings-exposure` and `vscode-mcp-json` templates.

### Why this is useful

Exposed agent instruction files frequently contain:
- Internal architecture and service naming
- Preferred commands, deploy steps, and review workflows
- Tool/MCP configuration hints
- Process rules that aid targeted recon

### Matchers

- HTTP 200
- Content-Type limited to text/markdown, text/plain, JSON/YAML/octet-stream (template-dependent)
- Markdown heading or instruction-like keywords
- Negative matchers for HTML soft-404 pages

### Local validation

```text
nuclei -validate -t http/exposures/configs/claude-md-exposure.yaml \
  -t http/exposures/configs/agents-md-exposure.yaml \
  -t http/exposures/configs/cursor-rules-exposure.yaml
# All templates validated successfully

# Fixture server smoke test (all three matched expected paths):
# [claude-md-exposure]  .../CLAUDE.md
# [agents-md-exposure]  .../AGENTS.md
# [cursor-rules-exposure] .../.cursorrules
```

### References

- https://docs.claude.com/en/docs/claude-code/memory
- https://agents.md/
- https://docs.cursor.com/context/rules

### Checklist

- [x] Templates placed under `http/exposures/configs/`
- [x] Multi-matcher FP reduction (content-type + keywords + HTML negative)
- [x] `max-request` documented
- [x] No real-world target URLs shared
- [x] Validated with `nuclei -validate`