### PR TITLE
[nuclei-template] More AI coding agent config exposures (Copilot, Gemini, OpenCode, Cline/Roo, CodeRabbit, Repomix)

### DIFF
--- a/http/exposures/configs/cline-roo-rules-exposure.yaml
+++ b/http/exposures/configs/cline-roo-rules-exposure.yaml
@@ -1,0 +1,55 @@
+id: cline-roo-rules-exposure
+
+info:
+  name: Cline and Roo Code Rules Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected exposed Cline or Roo Code agent rule files. These files steer VS
+    Code coding agents with project conventions, tool permissions, and
+    workflow instructions. Public exposure can leak proprietary process detail
+    and internal operational guidance.
+  reference:
+    - https://docs.cline.bot/
+    - https://docs.roocode.com/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 6
+    shodan-query: html:".clinerules"
+  tags: config,exposure,cline,roo,vscode,ai,markdown
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.clinerules"
+      - "{{BaseURL}}/.clinerules/default.md"
+      - "{{BaseURL}}/.cline/rules.md"
+      - "{{BaseURL}}/.roo/rules"
+      - "{{BaseURL}}/.roo/rules.md"
+      - "{{BaseURL}}/.roomodes"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/json"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 30'
+          - 'contains_any(to_lower(body), "cline", "roo", "you are", "always ", "never ", "prefer ", "do not ", "must ", "mode", "tools", "codebase", "workflow")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/coderabbit-config-exposure.yaml
+++ b/http/exposures/configs/coderabbit-config-exposure.yaml
@@ -1,0 +1,53 @@
+id: coderabbit-config-exposure
+
+info:
+  name: CodeRabbit Configuration Exposure
+  author: 686f6c61
+  severity: low
+  description: |
+    Detected an exposed CodeRabbit configuration file. CodeRabbit config can
+    reveal review preferences, path filters, knowledge base settings, and
+    automation behavior for pull request review bots. Exposure is usually low
+    risk but can aid recon of internal process and tooling.
+  reference:
+    - https://docs.coderabbit.ai/guides/configure-coderabbit
+    - https://github.com/coderabbitai
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  metadata:
+    max-request: 3
+    shodan-query: html:"coderabbit"
+  tags: config,exposure,coderabbit,ai,yaml
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.coderabbit.yaml"
+      - "{{BaseURL}}/.coderabbit.yml"
+      - "{{BaseURL}}/coderabbit.yaml"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/yaml"
+          - "application/yaml"
+          - "application/x-yaml"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 15'
+          - 'contains_any(to_lower(body), "language:", "reviews:", "chat:", "knowledge_base:", "path_filters:", "path_instructions:", "coderabbit", "early_access:", "enable_free_tier:")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/copilot-instructions-exposure.yaml
+++ b/http/exposures/configs/copilot-instructions-exposure.yaml
@@ -1,0 +1,53 @@
+id: copilot-instructions-exposure
+
+info:
+  name: GitHub Copilot Instructions Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected exposed GitHub Copilot custom instructions used to steer Copilot
+    in a repository. These markdown files often describe architecture,
+    coding conventions, internal services, and operational workflow. Public
+    exposure can leak proprietary process detail useful for attackers.
+  reference:
+    - https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot
+    - https://docs.github.com/en/copilot/how-tos/configure-custom-instructions
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 4
+    shodan-query: html:"copilot-instructions"
+  tags: config,exposure,copilot,github,ai,markdown
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.github/copilot-instructions.md"
+      - "{{BaseURL}}/.github/instructions/copilot.instructions.md"
+      - "{{BaseURL}}/.github/instructions/copilot-instructions.md"
+      - "{{BaseURL}}/copilot-instructions.md"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 40'
+          - 'regex("(?m)^\\s*#\\s+", body) || contains_any(to_lower(body), "copilot", "prefer ", "always ", "never ", "do not ", "must ", "this repository", "this project")'
+          - 'contains_any(to_lower(body), "copilot", "codebase", "prefer ", "always ", "never ", "do not ", "must ", "pull request", "commit", "test", "build")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/gemini-md-exposure.yaml
+++ b/http/exposures/configs/gemini-md-exposure.yaml
@@ -1,0 +1,52 @@
+id: gemini-md-exposure
+
+info:
+  name: Gemini GEMINI.md Project Instructions Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected an exposed Gemini project instruction file (GEMINI.md). These
+    markdown files provide project specific guidance for Gemini based coding
+    agents, including conventions, architecture notes, and operational rules.
+    Public exposure can leak proprietary process detail.
+  reference:
+    - https://github.com/google-gemini/gemini-cli
+    - https://ai.google.dev/gemini-api/docs
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 3
+    shodan-query: html:"GEMINI.md"
+  tags: config,exposure,gemini,google,ai,markdown
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/GEMINI.md"
+      - "{{BaseURL}}/.gemini/GEMINI.md"
+      - "{{BaseURL}}/gemini.md"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 40'
+          - 'regex("(?m)^\\s*#\\s+", body)'
+          - 'contains_any(to_lower(body), "gemini", "codebase", "prefer ", "always ", "never ", "do not ", "must ", "when working", "this project", "pull request")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/opencode-config-exposure.yaml
+++ b/http/exposures/configs/opencode-config-exposure.yaml
@@ -1,0 +1,55 @@
+id: opencode-config-exposure
+
+info:
+  name: OpenCode Configuration Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected exposed OpenCode configuration files. OpenCode project config can
+    describe models, providers, permissions, MCP servers, and agent behavior.
+    Public exposure may leak internal tooling setup and sensitive configuration
+    hints.
+  reference:
+    - https://opencode.ai/docs
+    - https://github.com/sst/opencode
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 5
+    shodan-query: html:"opencode"
+  tags: config,exposure,opencode,ai,json
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/opencode.json"
+      - "{{BaseURL}}/.opencode.json"
+      - "{{BaseURL}}/.opencode/config.json"
+      - "{{BaseURL}}/.config/opencode/config.json"
+      - "{{BaseURL}}/opencode.jsonc"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+          - "text/plain"
+          - "text/json"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 20'
+          - 'contains_any(to_lower(body), "\"provider\"", "\"model\"", "\"mcp\"", "\"agent\"", "\"permission\"", "\"opencode\"", "\"autoshare\"", "\"autoupdate\"", "\"username\"")'
+          - 'contains_any(body, "{", "}")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype", "page not found", "404 not found")'

--- a/http/exposures/configs/repomix-output-exposure.yaml
+++ b/http/exposures/configs/repomix-output-exposure.yaml
@@ -1,0 +1,56 @@
+id: repomix-output-exposure
+
+info:
+  name: Repomix Output or Config Exposure
+  author: 686f6c61
+  severity: medium
+  description: |
+    Detected exposed Repomix configuration or packed repository output.
+    Repomix packs source trees into a single file for LLM consumption. If
+    served publicly, this can disclose large portions of private source code,
+    secrets accidentally included in the pack, and project structure.
+  reference:
+    - https://github.com/yamadashy/repomix
+    - https://repomix.com/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-200,CWE-538
+  metadata:
+    max-request: 5
+    shodan-query: html:"repomix"
+  tags: config,exposure,repomix,ai,source-code
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/repomix-output.xml"
+      - "{{BaseURL}}/repomix-output.md"
+      - "{{BaseURL}}/repomix.config.json"
+      - "{{BaseURL}}/.repomixignore"
+      - "{{BaseURL}}/repomix.json"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+          - "text/markdown"
+          - "text/xml"
+          - "application/xml"
+          - "application/json"
+          - "application/octet-stream"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - 'len(body) > 20'
+          - 'contains_any(to_lower(body), "repomix", "<file path=", "<repository", "\"output\"", "\"include\"", "\"ignore\"", "packed", "this file is a merged representation")'
+          - '!contains_any(to_lower(body), "<html", "<!doctype html", "page not found", "404 not found")'


### PR DESCRIPTION
### Template / PR Information

Six new HTTP exposure templates for AI coding agent project files that are commonly committed and sometimes served from misconfigured web roots.

Templates:
1. copilot-instructions-exposure
2. gemini-md-exposure
3. opencode-config-exposure
4. cline-roo-rules-exposure
5. coderabbit-config-exposure
6. repomix-output-exposure

Severity is medium for instruction/source leakage candidates and low for CodeRabbit config only process disclosure.

### Local validation

nuclei -validate on all six templates passed.

Fixture smoke test matched expected paths for every template.

### Checklist

Templates under http/exposures/configs/
Multi matcher FP reduction with content type and HTML negative checks
max-request documented
No real world targets shared