### PR TITLE
Add CVE-2026-18577 - N-able N-central < 2026.3.1.10 Authentication Bypass (KEV)

### DIFF
--- a/http/cves/2026/CVE-2026-18577.yaml
+++ b/http/cves/2026/CVE-2026-18577.yaml
@@ -5,25 +5,11 @@ info:
   author: patrick-threatmate
   severity: critical
   description: |
-    N-able N-central versions through 2026.3.1 contain an authentication bypass that lets a remote
-    unauthenticated attacker take over an administrator account and gain full control of the
-    N-central server. CVE-2026-18577 is a bypass of the incomplete fix for CVE-2026-18556, so the
-    2026.3.1 Hotfix 1 build (2026.3.1.7) does not fully remediate it. Hotfix 2 (2026.3.1.10)
-    supersedes Hotfix 1 and is the first fully fixed 2026.3 build.
-
-    Severity is set to critical to reflect real-world risk: this is a CISA KEV, unauthenticated,
-    actively-exploited bypass against an RMM, where a single compromised server exposes every
-    downstream managed endpoint. The NVD CVSS 3.1 base score (8.1, retained below) is held under
-    9.0 only by Attack Complexity: High, which prices the one-time effort of defeating the Hotfix 1
-    mitigation and does not account for the exploit already circulating at scale.
+    N-able N-central versions through 2026.3.1 contain an authentication bypass that lets a remote unauthenticated attacker take over an administrator account and gain full control of the N-central server. CVE-2026-18577 is a bypass of the incomplete fix for CVE-2026-18556, so the 2026.3.1 Hotfix 1 build (2026.3.1.7) does not fully remediate it. Hotfix 2 (2026.3.1.10) supersedes Hotfix 1 and is the first fully fixed 2026.3 build.
   impact: |
-    Unauthenticated attackers gain administrative access to the RMM console and can reach every
-    managed endpoint through Take Control. Exploited in the wild and added to the CISA Known
-    Exploited Vulnerabilities catalog on 2026-08-03.
+    Unauthenticated attackers gain administrative access to the RMM console and can reach every managed endpoint through Take Control. Exploited in the wild and added to the CISA Known
   remediation: |
-    Upgrade on-premises N-central to 2026.3.1.10 (2026.3 Hotfix 2) or to a later release line
-    (2026.4 or newer). Applying Hotfix 1 (2026.3.1.7) alone is not sufficient. N-able hosted
-    environments were mitigated by the vendor and need no customer action.
+    Upgrade on-premises N-central to 2026.3.1.10 (2026.3 Hotfix 2) or to a later release line (2026.4 or newer). Applying Hotfix 1 (2026.3.1.7) alone is not sufficient. N-able hosted environments were mitigated by the vendor and need no customer action.
   reference:
     - https://www.n-able.com/blog/n-central-security-update-august-6-2026
     - https://status.n-able.com/2026/08/06/n-central-2026-3-hotfix-2-additional-mitigation-for-cve-2026-18577/
@@ -43,7 +29,7 @@ info:
     product: n-central
     shodan-query: http.title:"N-central Login"
     fofa-query: title="N-central Login"
-  tags: cve,cve2026,n-able,ncentral,auth-bypass,kev,passive,vuln
+  tags: cve,cve2026,n-able,ncentral,auth-bypass,kev,passive
 
 http:
   - method: GET
@@ -58,9 +44,6 @@ http:
           - 'class="ncentral"'
           - 'ncentralVersion'
 
-      # Version segments compare numerically, so this one constraint covers the whole matrix:
-      # every older line (2025.4, 2026.1, 2026.2, 2026.3.0.x) is below it, Hotfix 1 (2026.3.1.7)
-      # is below it, and 2026.4 and later sort above it. An unextractable version yields no match.
       - type: dsl
         dsl:
           - compare_versions(version, '< 2026.3.1.10')

--- a/http/cves/2026/CVE-2026-18577.yaml
+++ b/http/cves/2026/CVE-2026-18577.yaml
@@ -1,0 +1,74 @@
+id: CVE-2026-18577
+
+info:
+  name: N-able N-central < 2026.3.1.10 - Authentication Bypass
+  author: patrick-threatmate
+  severity: high
+  description: |
+    N-able N-central versions through 2026.3.1 contain an authentication bypass that lets a remote
+    unauthenticated attacker take over an administrator account and gain full control of the
+    N-central server. CVE-2026-18577 is a bypass of the incomplete fix for CVE-2026-18556, so the
+    2026.3.1 Hotfix 1 build (2026.3.1.7) does not fully remediate it. Hotfix 2 (2026.3.1.10)
+    supersedes Hotfix 1 and is the first fully fixed 2026.3 build.
+  impact: |
+    Unauthenticated attackers gain administrative access to the RMM console and can reach every
+    managed endpoint through Take Control. Exploited in the wild and added to the CISA Known
+    Exploited Vulnerabilities catalog on 2026-08-03.
+  remediation: |
+    Upgrade on-premises N-central to 2026.3.1.10 (2026.3 Hotfix 2) or to a later release line
+    (2026.4 or newer). Applying Hotfix 1 (2026.3.1.7) alone is not sufficient. N-able hosted
+    environments were mitigated by the vendor and need no customer action.
+  reference:
+    - https://www.n-able.com/blog/n-central-security-update-august-6-2026
+    - https://status.n-able.com/2026/08/06/n-central-2026-3-hotfix-2-additional-mitigation-for-cve-2026-18577/
+    - https://www.rapid7.com/blog/post/etr-cve-2026-18577-n-able-n-central-authentication-bypass-exploited-in-the-wild/
+    - https://www.huntress.com/blog/n-able-vulnerability-exploitation
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18577
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18556
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cve-id: CVE-2026-18577
+    cwe-id: CWE-288
+    cpe: cpe:2.3:a:n-able:n-central:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: n-able
+    product: n-central
+    shodan-query: http.title:"N-central Login"
+    fofa-query: title="N-central Login"
+  tags: cve,cve2026,n-able,ncentral,auth-bypass,kev,passive,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        condition: or
+        words:
+          - 'class="ncentral"'
+          - 'ncentralVersion'
+
+      # Version segments compare numerically, so this one constraint covers the whole matrix:
+      # every older line (2025.4, 2026.1, 2026.2, 2026.3.0.x) is below it, Hotfix 1 (2026.3.1.7)
+      # is below it, and 2026.4 and later sort above it. An unextractable version yields no match.
+      - type: dsl
+        dsl:
+          - compare_versions(version, '< 2026.3.1.10')
+
+    extractors:
+      - type: regex
+        name: version
+        internal: true
+        group: 1
+        regex:
+          - 'ncentralVersion:\s*"(202\d+\.\d+\.\d+\.\d+)"'
+
+      - type: regex
+        name: ncentral_version
+        group: 1
+        regex:
+          - 'ncentralVersion:\s*"(202\d+\.\d+\.\d+\.\d+)"'

--- a/http/cves/2026/CVE-2026-18577.yaml
+++ b/http/cves/2026/CVE-2026-18577.yaml
@@ -3,13 +3,19 @@ id: CVE-2026-18577
 info:
   name: N-able N-central < 2026.3.1.10 - Authentication Bypass
   author: patrick-threatmate
-  severity: high
+  severity: critical
   description: |
     N-able N-central versions through 2026.3.1 contain an authentication bypass that lets a remote
     unauthenticated attacker take over an administrator account and gain full control of the
     N-central server. CVE-2026-18577 is a bypass of the incomplete fix for CVE-2026-18556, so the
     2026.3.1 Hotfix 1 build (2026.3.1.7) does not fully remediate it. Hotfix 2 (2026.3.1.10)
     supersedes Hotfix 1 and is the first fully fixed 2026.3 build.
+
+    Severity is set to critical to reflect real-world risk: this is a CISA KEV, unauthenticated,
+    actively-exploited bypass against an RMM, where a single compromised server exposes every
+    downstream managed endpoint. The NVD CVSS 3.1 base score (8.1, retained below) is held under
+    9.0 only by Attack Complexity: High, which prices the one-time effort of defeating the Hotfix 1
+    mitigation and does not account for the exploit already circulating at scale.
   impact: |
     Unauthenticated attackers gain administrative access to the RMM console and can reach every
     managed endpoint through Take Control. Exploited in the wild and added to the CISA Known


### PR DESCRIPTION
### Template: `http/cves/2026/CVE-2026-18577.yaml`

Detects **N-able N-central** instances vulnerable to **CVE-2026-18577**, an unauthenticated authentication bypass / account takeover that is **actively exploited in the wild** and was added to the **CISA KEV catalog on 2026-08-03**.

CVE-2026-18577 is a bypass of the incomplete fix for CVE-2026-18556, so 2026.3.1 **Hotfix 1 (2026.3.1.7) is still vulnerable**. The first fully fixed build is **Hotfix 2 (2026.3.1.10)**; the 2026.4 line and later are also fixed. The template reads the `ncentralVersion` string embedded in `/login` and flags anything `< 2026.3.1.10` — numeric segment comparison covers every older line and lets 2026.4+ pass.

### On the severity rating
Set to **critical**, while the classification block retains the authoritative **NVD CVSS 3.1 = 8.1 (High)**. The base score is held under 9.0 solely by **Attack Complexity: High**, which prices the one-time effort of defeating the Hotfix 1 mitigation — it does not account for a weaponized exploit already circulating at scale. Given CISA KEV listing, confirmed in-the-wild exploitation, no authentication requirement, and the RMM blast radius (one compromised server reaches every downstream managed endpoint), the operational risk is critical. Notably, CISA assigned an **accelerated 3-day federal remediation deadline** rather than the standard BOD 22-01 window, underscoring that the response urgency far exceeds a routine "High." Happy to move it back to `high` if the maintainers prefer strict CVSS-band alignment.

### Detection method
- Passive: single `GET /login`, no exploitation.
- Fingerprint: `class="ncentral"` OR the `ncentralVersion` JS variable.
- Version gate: `compare_versions(version, '< 2026.3.1.10')`. Fails closed if the version cannot be extracted.

### Testing (nuclei v3.11.0)
`nuclei -validate` passes. Validated against live N-central instances reporting the following builds:

| Build under test | Result | Expected |
|------------------|--------|----------|
| 2026.4.0.14 | no match | ✓ patched line |
| 2026.3.1.7 (Hotfix 1) | **match — vulnerable** | ✓ Hotfix 1 does not remediate |
| 2026.3.1.10 (Hotfix 2) | no match | ✓ fixed build, boundary case |

The Hotfix-1 case is the important one: `2026.3.1.10` must sort **above** `2026.3.1.7`, which `compare_versions` (hashicorp/go-version) handles correctly where a string compare would not.

### References
- https://www.n-able.com/blog/n-central-security-update-august-6-2026
- https://status.n-able.com/2026/08/06/n-central-2026-3-hotfix-2-additional-mitigation-for-cve-2026-18577/
- https://www.rapid7.com/blog/post/etr-cve-2026-18577-n-able-n-central-authentication-bypass-exploited-in-the-wild/
- https://www.theregister.com/security/2026/08/04/feds-get-3-days-to-patch-n-able-god-mode-flaw-under-active-exploit/
- https://nvd.nist.gov/vuln/detail/CVE-2026-18577
