### PR TITLE
Add CVE-2026-64638 (WordPress Core XSS2Shell reflected XSS) template

### DIFF
--- a/http/cves/2026/CVE-2026-64638.yaml
+++ b/http/cves/2026/CVE-2026-64638.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-64638
+
+info:
+  name: WordPress Core < 7.0.3 - Reflected Cross-Site Scripting (XSS2Shell)
+  author: Boreas37
+  severity: high
+  description: |
+    WordPress Core versions prior to 7.0.3 are vulnerable to a reflected cross-site
+    scripting (XSS) vulnerability in wp-login.php. A crafted username containing a
+    parser differential payload (whitespace between '<' and the tag name, e.g.
+    "< area id=test>") survives PHP strip_tags() and is re-parsed by KSES into a
+    live DOM element on the login page. This is the first stage of the XSS2Shell
+    chain which can escalate to remote code execution against a logged-in
+    administrator.
+  impact: |
+    An unauthenticated attacker can execute arbitrary JavaScript in the context
+    of the login page. Against a logged-in administrator this chains into full
+    remote code execution via OAuth application password abuse and plugin upload.
+  remediation: |
+    Update WordPress Core to version 7.0.3 or later. The fix was backported to
+    all maintained branches going back to WordPress 4.7.
+  reference:
+    - https://pwn.ai/blog/xss2shell
+    - https://thehackernews.com/2026/08/new-wordpress-pre-auth-xss-could-lead.html
+    - https://digital.nhs.uk/cyber-alerts/2026/cc-4827
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-64638
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:N/SA:N
+    cvss-score: 8.9
+    cve-id: CVE-2026-64638
+    cwe-id: CWE-79
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,wordpress,wp-login,xss,rce,chain
+
+http:
+  - raw:
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        log={{url_encode(payload)}}&pwd=x&wp-submit=Log+In
+
+    payloads:
+      payload:
+        - '< area id=ajaxurl href=/?rest_route=/>'
+        - '< area id=test>'
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'id="ajaxurl"'
+          - '<area'
+          - 'Error:'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - 'text/html'


### PR DESCRIPTION
## Summary
Adds a nuclei template for **CVE-2026-64638** — the WordPress Core reflected XSS on `wp-login.php` (dubbed **XSS2Shell** by PWN.AI), affecting WordPress 4.7 through 7.0.2 (patched in 7.0.3).

## Detection logic
The template exploits the parser differential at the heart of the chain: a username containing `< area id=...>` (whitespace between `<` and the tag name) survives PHP `strip_tags()` and is re-parsed by KSES into a live DOM `<area>` element. Matches on the reflected `<area id="ajaxurl"` element plus the login error message.

## Verification
- ✅ Template validates (`nuclei -validate`)
- ✅ **Positive:** Detected on local vulnerable WordPress 6.9.4 lab instance
- ✅ **Negative:** No match on patched WordPress (7.0.3+) — wordpress.org clean

## References
- https://pwn.ai/blog/xss2shell
- https://thehackernews.com/2026/08/new-wordpress-pre-auth-xss-could-lead.html
- https://nvd.nist.gov/vuln/detail/CVE-2026-64638