### PR TITLE
Add Net Vision UPS Default Credentials

### DIFF
--- a/http/default-logins/net-vision-default-login.yaml
+++ b/http/default-logins/net-vision-default-login.yaml
@@ -1,7 +1,7 @@
 id: net-vision-default-login
 
 info:
-  name: Net Vision UPS Monitor Default Login
+  name: Net Vision UPS Monitor - Default Login
   author: Th3l0newolf
   severity: high
   description: |
@@ -12,14 +12,28 @@ info:
   metadata:
     max-request: 2
     verified: true
+    shodan-query: title:"Net Vision UPS"
     product: net-vision
     vendor: socomec
-  tags: socomec,net-vision,ups,default-login,default-credentials
+  tags: socomec,net-vision,ups,default-login
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(body, "Net Vision UPS Monitor")'
+          - 'contains_any(body, ".input_username", "Login</span>"")'
+        condition: and
+        internal: true
+
+  - method: GET
+    path:
       - "{{BaseURL}}/PageAEventlog.asp"
 
     headers:
@@ -30,14 +44,11 @@ http:
 
     matchers-condition: and
     matchers:
+      - type: dsl
+        dsl:
+          - 'contains_all(body, "USHA Events Log", "Events Log", "Event Level")'
+        condition: and
+
       - type: status
         status:
           - 200
-
-      - type: dsl
-        dsl:
-          - 'contains(body_1, "Net Vision UPS Monitor")'
-          - 'contains(body_2, "USHA Events Log")'
-          - 'contains(body_2, "Events Log")'
-          - 'contains(body_2, "Event Level")'
-        condition: and

--- a/http/default-logins/net-vision-default-login.yaml
+++ b/http/default-logins/net-vision-default-login.yaml
@@ -1,0 +1,43 @@
+id: net-vision-default-login
+
+info:
+  name: Net Vision UPS Monitor Default Login
+  author: Th3l0newolf
+  severity: high
+  description: |
+    Net Vision UPS Monitor default credentials were detected.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cwe-id: CWE-798
+  metadata:
+    max-request: 2
+    verified: true
+    product: net-vision
+    vendor: socomec
+  tags: socomec,net-vision,ups,default-login,default-credentials
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/PageAEventlog.asp"
+
+    headers:
+      Authorization: "Basic YWRtaW46cHVibGlj"
+
+    redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - 'contains(body_1, "Net Vision UPS Monitor")'
+          - 'contains(body_2, "USHA Events Log")'
+          - 'contains(body_2, "Events Log")'
+          - 'contains(body_2, "Event Level")'
+        condition: and

--- a/http/default-logins/net-vision/net-vision-default-login.yaml
+++ b/http/default-logins/net-vision/net-vision-default-login.yaml
@@ -28,7 +28,7 @@ http:
       - type: dsl
         dsl:
           - 'contains(body, "Net Vision UPS Monitor")'
-          - 'contains_any(body, ".input_username", "Login</span>"")'
+          - 'contains_any(body, ".input_username", "Login</span>")'
         condition: and
         internal: true
 


### PR DESCRIPTION
Added a new YAML file for Net Vision UPS Monitor default login credentials detection.

### PR Information

This templates check for presence of default credentials used for  Socomec (NET VISION) UPS via Ethernet SMART CARD  

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- References: 
- https://scalelogic.freshdesk.com/support/solutions/articles/62000230977-how-to-configure-socomec-net-vision-ups-via-ethernet-smart-card-www-socomec-ch-
- https://www.socomec.ch/sites/default/files/2025-04/NET-VISION-SW-TOOL_PRODUCT-SOFTWARE_2015-02_QUICKSTART-PDF_ZH.pdf

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)

I have validated template 

<img width="827" height="311" alt="image" src="https://github.com/user-attachments/assets/331ff356-fab1-4099-8211-6e1983840bcc" />

<img width="930" height="259" alt="image" src="https://github.com/user-attachments/assets/05d042e2-19f8-4cfa-8958-9cbc489af124" />






#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
