### PR TITLE
Add CVE-2026-27796: Homarr < 1.54.0 unauthenticated integration config disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-27796.yaml
+++ b/http/cves/2026/CVE-2026-27796.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-27796
+
+info:
+  name: Homarr < 1.54.0 - Unauthenticated Integration Configuration Disclosure
+  author: str4k3r
+  severity: high
+  description: |
+    Homarr before 1.54.0 exposes the tRPC `integration.all` query as a
+    publicProcedure instead of a protectedProcedure. Any unauthenticated
+    remote attacker can call GET /api/trpc/integration.all and receive the
+    full list of configured integrations, including internal service names,
+    kinds and URLs (e.g. package registries, container registries and other
+    self-hosted services wired into the dashboard) without any session.
+    Homarr ships several "Default" integrations out of the box on a fresh
+    install, so the endpoint returns non-empty data with zero setup. Fixed
+    in 1.54.0, which moves `integration.all` (and sibling queries) to
+    protectedProcedure, causing the same request to return an UNAUTHORIZED
+    tRPC error with HTTP 401.
+  reference:
+    - https://github.com/homarr-labs/homarr/security/advisories/GHSA-m4vc-4prp-cvp7
+    - https://github.com/homarr-labs/homarr/commit/91fc5a5c747121475a50f2713d571ceb89e95257
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27796
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-27796
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: homarr-labs
+    product: homarr
+  tags: cve,cve2026,homarr,exposure,unauth,trpc
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/trpc/integration.all"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - '"result":{"data":{"json":'
+          - '"kind":"'
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "UNAUTHORIZED"
+        negative: true

--- a/http/cves/2026/CVE-2026-27796.yaml
+++ b/http/cves/2026/CVE-2026-27796.yaml
@@ -1,36 +1,32 @@
 id: CVE-2026-27796
 
 info:
-  name: Homarr < 1.54.0 - Unauthenticated Integration Configuration Disclosure
+  name: Homarr < 1.54.0 - Information Disclosure
   author: str4k3r
-  severity: high
+  severity: medium
   description: |
-    Homarr before 1.54.0 exposes the tRPC `integration.all` query as a
-    publicProcedure instead of a protectedProcedure. Any unauthenticated
-    remote attacker can call GET /api/trpc/integration.all and receive the
-    full list of configured integrations, including internal service names,
-    kinds and URLs (e.g. package registries, container registries and other
-    self-hosted services wired into the dashboard) without any session.
-    Homarr ships several "Default" integrations out of the box on a fresh
-    install, so the endpoint returns non-empty data with zero setup. Fixed
-    in 1.54.0, which moves `integration.all` (and sibling queries) to
-    protectedProcedure, causing the same request to return an UNAUTHORIZED
-    tRPC error with HTTP 401.
+    Homarr < 1.54.0 contains an information disclosure caused by the integration.all tRPC endpoint being exposed as a publicProcedure, letting unauthenticated users retrieve sensitive integration metadata, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can access sensitive integration metadata, potentially exposing internal service details.
+  remediation: |
+    Update to version 1.54.0 or later.
   reference:
     - https://github.com/homarr-labs/homarr/security/advisories/GHSA-m4vc-4prp-cvp7
     - https://github.com/homarr-labs/homarr/commit/91fc5a5c747121475a50f2713d571ceb89e95257
     - https://nvd.nist.gov/vuln/detail/CVE-2026-27796
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
-    cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
     cve-id: CVE-2026-27796
-    cwe-id: CWE-306
+    cwe-id: CWE-200
   metadata:
     verified: true
     max-request: 1
     vendor: homarr-labs
     product: homarr
-  tags: cve,cve2026,homarr,exposure,unauth,trpc
+    fofa-query: title="Homarr"
+    shodan-query: http.title:"Homarr"
+  tags: cve,cve2026,homarr,exposure,unauth
 
 http:
   - method: GET


### PR DESCRIPTION
## Summary
Homarr before 1.54.0 exposes the tRPC `integration.all` query as a `publicProcedure` instead of `protectedProcedure` (`packages/api/src/router/integration/integration-router.ts`), letting an unauthenticated remote attacker call `GET /api/trpc/integration.all` and receive the full list of configured integrations (name, kind, internal service URL). A default Homarr install ships several pre-seeded "Default" integrations (GitHub, Docker Hub, GitLab, npm, Codeberg, LinuxServer.io, GHCR, Quay), so the endpoint returns real data with zero setup. Fixed in 1.54.0, which switches the query (and sibling queries) to `protectedProcedure`, so the same request now returns an `UNAUTHORIZED` tRPC error with HTTP 401.

- Advisory: https://github.com/homarr-labs/homarr/security/advisories/GHSA-m4vc-4prp-cvp7
- Fix commit: https://github.com/homarr-labs/homarr/commit/91fc5a5c747121475a50f2713d571ceb89e95257
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-27796

## Test plan
- [x] Stood up `ghcr.io/homarr-labs/homarr:v1.53.0` (vulnerable) and `:v1.54.0` (fixed) with only the documented required `SECRET_ENCRYPTION_KEY` env var — no DB, repo, or user setup.
- [x] Confirmed differential with curl: v1.53.0 → `200` + JSON array of default integrations; v1.54.0 → `401` + `{"error":{"json":{"message":"UNAUTHORIZED",...}}}`.
- [x] Validated the template with the native nuclei binary (v3.11.0) directly against both containers, 3/3 runs each: `DETECTED` on v1.53.0, `NOT_DETECTED` on v1.54.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)