### PR TITLE
Add Shiori Bookmarks Manager panel detection template

### DIFF
--- a/http/exposed-panels/shiori-panel.yaml
+++ b/http/exposed-panels/shiori-panel.yaml
@@ -1,0 +1,43 @@
+id: shiori-panel
+
+info:
+  name: Shiori Bookmarks Manager Panel - Detect
+  author: ashish-cybersec
+  severity: info
+  description: |
+    Shiori bookmarks manager panel was detected.
+  reference:
+    - https://github.com/go-shiori/shiori
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: go-shiori
+    product: shiori
+    shodan-query: http.title:"Shiori - Bookmarks Manager"
+    fofa-query: title="Shiori - Bookmarks Manager"
+    google-query: intitle:"Shiori - Bookmarks Manager"
+  tags: panel,shiori,bookmarks,oss,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Shiori - Bookmarks Manager</title>"
+
+      - type: word
+        part: header
+        words:
+          - "X-Shiori-Response-Format"
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/shiori-panel.yaml
+++ b/http/exposed-panels/shiori-panel.yaml
@@ -1,7 +1,7 @@
 id: shiori-panel
 
 info:
-  name: Shiori Bookmark Manager - Panel Detect
+  name: Shiori Bookmark Manager - Detect
   author: johnk3r
   severity: info
   description: |

--- a/http/exposed-panels/shiori-panel.yaml
+++ b/http/exposed-panels/shiori-panel.yaml
@@ -1,43 +1,34 @@
 id: shiori-panel
 
 info:
-  name: Shiori Bookmarks Manager Panel - Detect
-  author: ashish-cybersec
+  name: Shiori Bookmark Manager - Panel Detect
+  author: johnk3r
   severity: info
   description: |
-    Shiori bookmarks manager panel was detected.
+    Detected A Shiori bookmark manager panel.
   reference:
-    - https://github.com/go-shiori/shiori
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cwe-id: CWE-200
+    - https://github.com/nicholasgasior/goshiori
   metadata:
     verified: true
     max-request: 1
-    vendor: go-shiori
+    vendor: shiori
     product: shiori
-    shodan-query: http.title:"Shiori - Bookmarks Manager"
+    shodan-query: title:"Shiori - Bookmarks Manager"
     fofa-query: title="Shiori - Bookmarks Manager"
-    google-query: intitle:"Shiori - Bookmarks Manager"
-  tags: panel,shiori,bookmarks,oss,discovery
+  tags: panel,shiori,detect,discovery
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
+    host-redirects: true
+    max-redirects: 2
+
     matchers:
-      - type: word
-        part: body
-        words:
-          - "<title>Shiori - Bookmarks Manager</title>"
-
-      - type: word
-        part: header
-        words:
-          - "X-Shiori-Response-Format"
-
-      - type: status
-        status:
-          - 200
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "shiori-token", "<title>Shiori - Bookmarks Manager</title>")'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added `shiori-panel` - Shiori Bookmarks Manager panel detection
- References:
  - https://github.com/go-shiori/shiori

Shiori is an open-source self-hosted bookmarks manager (MIT, ~11.6k stars) distributed as a single Go binary. No existing template covers it.

Detection uses three matchers on a single unauthenticated request: the exact page title, the application-specific `X-Shiori-Response-Format` header advertised in `Access-Control-Allow-Headers`, and status 200. The custom header is part of Shiori's own API contract, so it does not appear on unrelated services.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested against the official image `ghcr.io/go-shiori/shiori:latest` (single container, SQLite backend).

True positive:

```
[shiori-panel] [http] [info] http://127.0.0.1:8090
[INF] Scan completed in 5.475001ms. 1 matches found.
```

Negative control against an unrelated nginx instance:

```
[INF] Scan completed in 16.095491ms. No results found.
```

Honeypot check against honey.scanme.sh:

```
[INF] Scan completed in 824.245345ms. No results found.
```

`nuclei -validate` passes and the file lints clean against `.yamllint`.

Note: the Shodan, FOFA, and Google queries are derived from the page title observed on the running instance rather than tested against those services.