### PR TITLE
Add CVE-2026-14364 - TrueBooker <= 1.2.3 - Improper Password Reset Validation

### DIFF
--- a/http/cves/2026/CVE-2026-14364.yaml
+++ b/http/cves/2026/CVE-2026-14364.yaml
@@ -1,0 +1,65 @@
+id: CVE-2026-14364
+
+info:
+  name: TrueBooker <= 1.2.3 - Improper Password Reset Validation
+  author: 1dayexploit
+  severity: critical
+  description: |
+    The TrueBooker - Appointment Booking and Scheduler System plugin for WordPress does not
+    properly validate a user's identity before resetting their password. The AJAX handler
+    for password reset accepts a target user id and skips the reset-key check entirely
+    whenever the target account has no pending reset request, which is the default state
+    for every account. This allows resetting the password of arbitrary user accounts,
+    including administrators.
+  impact: |
+    Allows full takeover of any WordPress user account, including administrators, which is
+    equivalent to complete site compromise.
+  remediation: |
+    Update to version 1.2.4 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14364
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/f441477e-35b8-42ae-b71c-3fdba126021b
+    - https://plugins.trac.wordpress.org/changeset/3595807/truebooker-appointment-booking
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-14364
+    cwe-id: CWE-640
+    epss-score: 0.00285
+    epss-percentile: 0.20696
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: preyantechnosys
+    product: truebooker
+    shodan-query: http.html:"/wp-content/plugins/truebooker-appointment-booking"
+    fofa-query: body="/wp-content/plugins/truebooker-appointment-booking"
+  tags: cve,cve2026,wordpress,wp-plugin,truebooker
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/truebooker-appointment-booking/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "=== TrueBooker - Appointment Booking and Scheduler System ==="
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - compare_versions(version, '<= 1.2.3')
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
Detection template for CVE-2026-14364.

Validated against a containerised lab built from the affected and the fixed release: the template matches the vulnerable build and stays quiet on the patched one. Detection is non-invasive - nothing is written to the target.

<details>
<summary>Validation transcript</summary>

# Nuclei template validation - CVE-2026-14364

## Exposure

Default install: yes. The plugin only needs to be installed and activated (no special mode,
flag or feature toggle) for the vulnerable code path to be reachable - activation alone
registers the `wp_ajax_nopriv_user_front_resetpass` AJAX action and creates the
`tbab-my-account` page. Normally exposed port: yes, the plugin's `readme.txt` sits under
`/wp-content/plugins/<slug>/readme.txt`, served by the site's main HTTP(S) port like any
other WordPress plugin asset - no admin-only or secondary port involved. Affected range:
all versions up to and including 1.2.3, fixed in 1.2.4 - a single point release, so any
`Stable tag` below 1.2.4 is vulnerable. KEV status: not listed (`CVE_INFO.md`: `KEV: No`),
but the flaw is a single unauthenticated POST against a default-active plugin, so reachable
instances exist without requiring KEV to establish that.

## Detection method

Rank 1, version fingerprint. The actual vulnerability (`userresetPassword()` skipping its
reset-key check when the target's `user_activation_key` is empty) only diverges from the
patched behaviour **after** the state-changing `wp_set_password()` call - there is no
observable difference before the write, so probing the AJAX endpoint itself would mean
actually resetting a real account's password to prove the bug, which `exploit.py` itself
flags as inherently destructive with no non-destructive discriminator. `readme.txt` is
served unauthenticated by every WordPress plugin and states `Stable tag: X.Y.Z`, which
matches the installed version because WordPress core enforces that the deployed plugin
version matches the release the site pulled from wordpress.org. This is a purely read-only
GET with no side effects and cleanly separates the vulnerable and patched builds.

## Syntax check

Command: `nuclei -t nuclei-template.yaml -validate -duc`
Result:
```
[INF] All templates validated successfully
```

## Vulnerable build

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:8810 -nc -silent -duc`
Result: MATCHED
```
[CVE-2026-14364] [http] [critical] http://127.0.0.1:8810/wp-content/plugins/truebooker-appointment-booking/readme.txt
```

## Patched build

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:8811 -nc -silent -duc`
Result: NO MATCH (empty output)

## What the detection keys on

The `Stable tag:` line in `/wp-content/plugins/truebooker-appointment-booking/readme.txt`.
The vulnerable lab serves `Stable tag: 1.2.3`, the patched lab serves `Stable tag: 1.2.4` -
confirmed directly:

```
$ curl -s http://127.0.0.1:8810/wp-content/plugins/truebooker-appointment-booking/readme.txt | grep 'Stable tag'
Stable tag: 1.2.3
$ curl -s http://127.0.0.1:8811/wp-content/plugins/truebooker-appointment-booking/readme.txt | grep 'Stable tag'
Stable tag: 1.2.4
```

The template extracts that value and gates on `compare_versions(version, '<= 1.2.3')`. The
word matcher on the readme's `=== TrueBooker - Appointment Booking and Scheduler System ===`
header line guards against matching some unrelated plugin's readme.txt that happens to also
carry an old-looking `Stable tag`.

## Limitations

- False negative if the site owner changes `readme.txt`'s `Stable tag` without actually
  updating the plugin code, or blocks direct access to files under `wp-content/plugins/`
  (some hardening plugins/WAFs do this) - the template would then report not-vulnerable on
  a genuinely vulnerable install.
- False negative if the target has deactivated the plugin after leaving `readme.txt` in
  place (the file persists on disk after deactivation) - the template cannot distinguish
  "installed and active" from "installed but deactivated" from a static asset alone, so on
  a deactivated-but-present install this template overclaims exposure (a soft false
  positive for "vulnerable," though the AJAX endpoint would not actually be routable).
- This template does not confirm exploitability by exercising the AJAX endpoint, by design
  - see Detection method above. It confirms the presence of a vulnerable plugin version,
  which is the standard and accepted signal for this class of WordPress plugin CVE
  template.

</details>
