### PR TITLE
Add CVE-2026-67208 template

### DIFF
--- a/http/cves/2026/CVE-2026-67208.yaml
+++ b/http/cves/2026/CVE-2026-67208.yaml
@@ -21,15 +21,33 @@ info:
     cwe-id: CWE-306
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     product: juggle
     vendor: somta
   tags: cve,cve2026,juggle,h2,exposure,unauth,rce
 
+flow: |
+  http("juggle-detect") && http("h2-console-check")
+
 http:
   - method: GET
+    id: juggle-detect
+    path:
+      - "{{BaseURL}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>Juggle</title>")'
+        condition: and
+        internal: true
+
+  - method: GET
+    id: h2-console-check
     path:
       - "{{BaseURL}}/h2-console/"
+
     matchers-condition: and
     matchers:
       - type: status

--- a/http/cves/2026/CVE-2026-67208.yaml
+++ b/http/cves/2026/CVE-2026-67208.yaml
@@ -1,0 +1,43 @@
+id: CVE-2026-67208
+
+info:
+  name: Juggle <= 1.6.0 - Unauthenticated Exposed H2 Database Console
+  author: str4k3r
+  severity: critical
+  description: |
+    Juggle ships the H2 database web console enabled and reachable from
+    non-localhost by default. No application-level authentication covers
+    the /h2-console path, and the shipped default datasource credentials
+    (sa/juggle) are known. An unauthenticated remote attacker can reach the
+    console and, using the default credentials, achieve OS command
+    execution on the host via the H2 CREATE ALIAS Runtime.exec() technique.
+  reference:
+    - https://github.com/somta/Juggle/issues/86
+    - https://www.vulncheck.com/advisories/juggle-unauthenticated-rce-via-exposed-h2-console
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-67208
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    product: juggle
+    vendor: somta
+  tags: cve,cve2026,juggle,h2,exposure,unauth,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/h2-console/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<title>H2 Console</title>"
+          - "login.jsp?jsessionid="
+        condition: and


### PR DESCRIPTION
## Summary
Adds a detection template for CVE-2026-67208, a critical (CVSS 9.8) unauthenticated exposure of the H2 database web console in Juggle (<= 1.6.0).

- Juggle ships `spring.h2.console.enabled=true` with `web-allow-others=true` by default, and no application-level auth middleware covers the `/h2-console` path.
- The console is reachable unauthenticated on a stock/default deployment, and the shipped default datasource credentials (`sa`/`juggle`) are publicly documented, giving an attacker a direct path to the H2 `CREATE ALIAS` `Runtime.exec()` RCE technique.
- Template detects the exposed console by requesting `/h2-console/` and matching the H2 login page title + redirect marker, which is absent when the console is disabled.

References:
- https://github.com/somta/Juggle/issues/86
- https://www.vulncheck.com/advisories/juggle-unauthenticated-rce-via-exposed-h2-console

## Test plan
- [x] Verified against the official `somta/juggle:latest` Docker image (stock/default config) — template matches (200, H2 Console login page).
- [x] Verified against the same image with `spring.h2.console.enabled=false` as a negative control — template does not match (JSON error response, no H2 markers).
- [x] Ran with the native `nuclei` binary 3x against each side; consistent DETECTED / NOT_DETECTED results.