### PR TITLE
Add CVE-2026-61808 - LightRAG unauthenticated default exposure

### DIFF
--- a/http/cves/2026/CVE-2026-61808.yaml
+++ b/http/cves/2026/CVE-2026-61808.yaml
@@ -26,13 +26,13 @@ info:
   tags: lightrag,lfi,path-traversal,ai
 
 flow: http(1) && http(2)
- 
+
 http:
   - raw:
       - |
         GET /health HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2026/CVE-2026-61808.yaml
+++ b/http/cves/2026/CVE-2026-61808.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-61808
 
 info:
-  name: LightRAG <= 1.5.4 - Missing Authentication for Critical API Functions
+  name: LightRAG <= 1.5.4 - Missing Authentication
   author: str4k3r
   severity: high
   description: |
@@ -12,6 +12,7 @@ info:
     Update to version 1.5.5rc1 or later.
   reference:
     - https://github.com/HKUDS/LightRAG/security/advisories/GHSA-mmg5-8x8q-v934
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-61808
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -23,7 +24,7 @@ info:
     product: lightrag
     shodan-query: http.html:"LightRAG"
     fofa-query: body="LightRAG"
-  tags: lightrag,lfi,path-traversal,ai
+  tags: lightrag,lfi,traversal,ai
 
 flow: http(1) && http(2)
 
@@ -37,7 +38,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(body, "healthy", "lightrag", "LightRAG", "status")'
+          - 'contains_any(tolower(body), "healthy", "lightrag", "status")'
         condition: and
         internal: true
 

--- a/http/cves/2026/CVE-2026-61808.yaml
+++ b/http/cves/2026/CVE-2026-61808.yaml
@@ -24,7 +24,7 @@ info:
     product: lightrag
     shodan-query: http.html:"LightRAG"
     fofa-query: body="LightRAG"
-  tags: lightrag,lfi,traversal,ai
+  tags: cve,cve2026,lightrag,lfi,traversal,ai
 
 flow: http(1) && http(2)
 

--- a/http/cves/2026/CVE-2026-61808.yaml
+++ b/http/cves/2026/CVE-2026-61808.yaml
@@ -1,0 +1,40 @@
+id: CVE-2026-61808
+
+info:
+  name: LightRAG <= 1.5.4 - Missing Authentication for Critical API Functions in Default Configuration
+  author: str4k3r
+  severity: critical
+  description: >
+    LightRAG's API server binds to 0.0.0.0 (all interfaces) with authentication
+    disabled by default. Operators who follow the documented quickstart
+    (cp env.example .env; docker compose up) without setting LIGHTRAG_API_KEY
+    or AUTH_ACCOUNTS expose every administrative and data endpoint - including
+    document upload/delete, knowledge-graph mutation, cache clearing, and
+    knowledge-base query - to any unauthenticated network attacker.
+  reference:
+    - https://github.com/HKUDS/LightRAG/security/advisories/GHSA-mmg5-8x8q-v934
+    - https://github.com/HKUDS/LightRAG/commit/0bd102401b4b28a02664e5b6af476bf7a4470292
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-61808
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: title:"LightRAG"
+  tags: cve,cve2026,lightrag,exposure,unauth,default-login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/documents"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "\"statuses\""

--- a/http/cves/2026/CVE-2026-61808.yaml
+++ b/http/cves/2026/CVE-2026-61808.yaml
@@ -1,40 +1,55 @@
 id: CVE-2026-61808
 
 info:
-  name: LightRAG <= 1.5.4 - Missing Authentication for Critical API Functions in Default Configuration
+  name: LightRAG <= 1.5.4 - Missing Authentication for Critical API Functions
   author: str4k3r
-  severity: critical
-  description: >
-    LightRAG's API server binds to 0.0.0.0 (all interfaces) with authentication
-    disabled by default. Operators who follow the documented quickstart
-    (cp env.example .env; docker compose up) without setting LIGHTRAG_API_KEY
-    or AUTH_ACCOUNTS expose every administrative and data endpoint - including
-    document upload/delete, knowledge-graph mutation, cache clearing, and
-    knowledge-base query - to any unauthenticated network attacker.
+  severity: high
+  description: |
+    LightRAG through version 1.5.4 contains a broken access control vulnerability caused by the API server binding to all network interfaces with authentication disabled, letting unauthenticated network attackers fully control indexed documents and resources, exploit requires network access.
+  impact: |
+    Unauthenticated attackers can read, modify, delete documents, and consume resources, leading to full system compromise and denial of service.
+  remediation: |
+    Update to version 1.5.5rc1 or later.
   reference:
     - https://github.com/HKUDS/LightRAG/security/advisories/GHSA-mmg5-8x8q-v934
-    - https://github.com/HKUDS/LightRAG/commit/0bd102401b4b28a02664e5b6af476bf7a4470292
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
-    cve-id: CVE-2026-61808
-    cwe-id: CWE-306
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-22
   metadata:
     verified: true
-    max-request: 1
-    shodan-query: title:"LightRAG"
-  tags: cve,cve2026,lightrag,exposure,unauth,default-login
+    max-request: 2
+    vendor: hkuds
+    product: lightrag
+    shodan-query: http.html:"LightRAG"
+    fofa-query: body="LightRAG"
+  tags: lightrag,lfi,path-traversal,ai
 
+flow: http(1) && http(2)
+ 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/documents"
-    matchers-condition: and
+  - raw:
+      - |
+        GET /health HTTP/1.1
+        Host: {{Hostname}}
+ 
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "\"statuses\""
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "healthy", "lightrag", "LightRAG", "status")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /documents HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "statuses", "content_summary", "file_path")'
+        condition: and


### PR DESCRIPTION
## Description

LightRAG (HKUDS/LightRAG, ~38k GitHub stars) ships its API server bound to `0.0.0.0` with authentication disabled by default. Operators following the documented quickstart (`cp env.example .env` then `docker compose up`, or the published `ghcr.io/hkuds/lightrag` image with no additional env vars) get a fully open server: every administrative and data endpoint — document upload/delete, knowledge-graph mutation, cache clearing, and knowledge-base query — is reachable without credentials.

Confirmed against the official image:
- Default config (no `LIGHTRAG_API_KEY` / `AUTH_ACCOUNTS` set): `GET /documents` → `200` with `{"statuses": {...}}`.
- Recommended secure config (`LIGHTRAG_API_KEY` set): the same unauthenticated request → `403 {"detail":"API Key required"}`.

Reference: [GHSA-mmg5-8x8q-v934](https://github.com/HKUDS/LightRAG/security/advisories/GHSA-mmg5-8x8q-v934), which documents `/documents` (GET) as one of the affected endpoints, alongside the fix commit.

## Template validation

- [x] Template triggers with `nuclei -validate`
- [x] Template only contains information about the specific vulnerability
- [x] Template is well-formatted
- [x] Real nuclei run: `DETECTED` 3/3 against the default (no-auth) configuration, `NOT_DETECTED` 3/3 against the same configuration with `LIGHTRAG_API_KEY` set.