### PR TITLE
CVE-2026-25231 - FileRise - Unauthenticated Arbitrary File Read

### DIFF
--- a/http/cves/2026/CVE-2026-25231.yaml
+++ b/http/cves/2026/CVE-2026-25231.yaml
@@ -1,47 +1,74 @@
 id: CVE-2026-25231
 
 info:
-  name: FileRise < 3.3.0 - Unauthenticated Arbitrary File Read (Unprotected /uploads Directory)
+  name: FileRise <= 3.3.0 - Unauthenticated File Read via Unprotected /uploads Directory
   author: str4k3r
   severity: high
-  description: >
-    FileRise before 3.3.0 stores uploaded files under /var/www/uploads and the
-    web server serves that directory directly, with no authentication or
-    access-control check in front of it. Any file that exists in the uploads
-    directory can be fetched by an unauthenticated remote attacker who knows or
-    guesses its path, exposing user-uploaded data. Fixed in 3.3.0, which adds a
-    web-server-level access-control rule that blocks all direct /uploads/
-    requests with 403 Forbidden regardless of whether the requested file
-    exists, forcing retrieval through the authenticated API instead.
+  description: |
+    FileRise <= 3.3.0 contains an unauthenticated file read vulnerability caused by lack of access control on the /uploads directory, letting unauthenticated attackers access uploaded files directly, exploit requires knowledge or guessing of file paths.
+  impact: |
+    Unauthenticated attackers can access sensitive uploaded files, leading to data exposure and privacy breaches.
+  remediation: |
+    Upgrade to version 3.3.0 or later.
   reference:
     - https://github.com/error311/FileRise/security/advisories/GHSA-hv99-77cw-hvpr
-    - https://github.com/error311/FileRise/releases/tag/v3.3.0
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-25231
+    - https://github.com/error311/FileRise
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cve-id: CVE-2026-25231
     cwe-id: CWE-284
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: error311
     product: filerise
-    shodan-query: title:"FileRise"
-  tags: cve,cve2026,filerise,exposure,unauth
+    shodan-query: 'http.title:"FileRise"'
+    fofa-query: 'title="FileRise"'
+    google-query: 'intitle:"FileRise"'
+  tags: filerise,error311,ghsa,exposure,unauth,fileread
 
+flow: http(1) && (http(2) || http(3))
+ 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/"
-      - "{{BaseURL}}/uploads/{{randstr}}.txt"
-    redirects: true
-    req-condition: true
-    matchers-condition: and
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+ 
+    host-redirects: true
+    max-redirects: 2
     matchers:
       - type: dsl
         dsl:
-          - "status_code_1 == 200"
-          - "contains(body_1, 'FileRise')"
-          - "status_code_2 == 404"
+          - "status_code == 200"
+          - "contains(to_lower(body), '<title>filerise')"
+          - "contains_any(body, 'api/auth/login_basic.php', 'js/main.js')"
+        condition: and
+        internal: true
+ 
+  - raw:
+      - |
+        GET /uploads/README.md HTTP/1.1
+        Host: {{Hostname}}
+ 
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "len(body) > 0"
+          - "!contains(to_lower(content_type), 'text/html')"
+          - "!contains(to_lower(body), '<title')"
+        condition: and
+ 
+  - raw:
+      - |
+        GET /uploads HTTP/1.1
+        Host: {{Hostname}}
+ 
+    redirects: false
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 301"
+          - "contains(header, '/uploads/')"
         condition: and

--- a/http/cves/2026/CVE-2026-25231.yaml
+++ b/http/cves/2026/CVE-2026-25231.yaml
@@ -1,11 +1,11 @@
 id: CVE-2026-25231
 
 info:
-  name: FileRise <= 3.3.0 - Unauthenticated File Read via Unprotected /uploads Directory
+  name: FileRise <= 3.3.0 - Unauthenticated File Read
   author: str4k3r
   severity: high
   description: |
-    FileRise <= 3.3.0 contains an unauthenticated file read vulnerability caused by lack of access control on the /uploads directory, letting unauthenticated attackers access uploaded files directly, exploit requires knowledge or guessing of file paths.
+    FileRise <= 3.3.0 contains an unauthenticated file read vulnerability caused by a lack of access control on the /uploads directory, letting unauthenticated attackers access uploaded files directly, exploit requires knowledge or guessing of file paths.
   impact: |
     Unauthenticated attackers can access sensitive uploaded files, leading to data exposure and privacy breaches.
   remediation: |
@@ -25,7 +25,7 @@ info:
     shodan-query: 'http.title:"FileRise"'
     fofa-query: 'title="FileRise"'
     google-query: 'intitle:"FileRise"'
-  tags: filerise,error311,ghsa,exposure,unauth,fileread
+  tags: cve,cve2026,filerise,exposure,file-read
 
 flow: http(1) && (http(2) || http(3))
 

--- a/http/cves/2026/CVE-2026-25231.yaml
+++ b/http/cves/2026/CVE-2026-25231.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-25231
+
+info:
+  name: FileRise < 3.3.0 - Unauthenticated Arbitrary File Read (Unprotected /uploads Directory)
+  author: str4k3r
+  severity: high
+  description: >
+    FileRise before 3.3.0 stores uploaded files under /var/www/uploads and the
+    web server serves that directory directly, with no authentication or
+    access-control check in front of it. Any file that exists in the uploads
+    directory can be fetched by an unauthenticated remote attacker who knows or
+    guesses its path, exposing user-uploaded data. Fixed in 3.3.0, which adds a
+    web-server-level access-control rule that blocks all direct /uploads/
+    requests with 403 Forbidden regardless of whether the requested file
+    exists, forcing retrieval through the authenticated API instead.
+  reference:
+    - https://github.com/error311/FileRise/security/advisories/GHSA-hv99-77cw-hvpr
+    - https://github.com/error311/FileRise/releases/tag/v3.3.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25231
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-25231
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: error311
+    product: filerise
+    shodan-query: title:"FileRise"
+  tags: cve,cve2026,filerise,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/uploads/{{randstr}}.txt"
+    redirects: true
+    req-condition: true
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "contains(body_1, 'FileRise')"
+          - "status_code_2 == 404"
+        condition: and

--- a/http/cves/2026/CVE-2026-25231.yaml
+++ b/http/cves/2026/CVE-2026-25231.yaml
@@ -28,13 +28,13 @@ info:
   tags: filerise,error311,ghsa,exposure,unauth,fileread
 
 flow: http(1) && (http(2) || http(3))
- 
+
 http:
   - raw:
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
- 
+
     host-redirects: true
     max-redirects: 2
     matchers:
@@ -45,12 +45,12 @@ http:
           - "contains_any(body, 'api/auth/login_basic.php', 'js/main.js')"
         condition: and
         internal: true
- 
+
   - raw:
       - |
         GET /uploads/README.md HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -59,12 +59,12 @@ http:
           - "!contains(to_lower(content_type), 'text/html')"
           - "!contains(to_lower(body), '<title')"
         condition: and
- 
+
   - raw:
       - |
         GET /uploads HTTP/1.1
         Host: {{Hostname}}
- 
+
     redirects: false
     matchers:
       - type: dsl


### PR DESCRIPTION
FileRise before 3.3.0 serves the `/uploads` directory directly from the web
server with no authentication or access-control check. Any unauthenticated
remote attacker who knows or guesses a file's path under `/uploads/` can
retrieve it. Fixed in 3.3.0, which adds a web-server-level access-control rule
that returns 403 for *any* direct `/uploads/` request regardless of whether
the file exists, forcing retrieval through the authenticated API.

**Detection logic:** request `/` to fingerprint the app (200 + body contains
`FileRise`), then request a random nonexistent path under `/uploads/`.
Vulnerable instances return 404 (Apache serves the path directly, unauthenticated,
proving no access-control gate is in front of the directory). Patched instances
return 403 for every request under `/uploads/`, authenticated or not.

- Advisory / PoC: https://github.com/error311/FileRise/security/advisories/GHSA-hv99-77cw-hvpr
- Fix: https://github.com/error311/FileRise/releases/tag/v3.3.0
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-25231

Verified against official `error311/filerise-docker` images: `v3.2.4`
(vulnerable) and `v3.3.0` (fixed), 3x each, with a clean nuclei binary.