### PR TITLE
Add Miniflux login panel detection template

### DIFF
--- a/http/exposed-panels/miniflux-login-panel.yaml
+++ b/http/exposed-panels/miniflux-login-panel.yaml
@@ -1,0 +1,43 @@
+id: miniflux-login-panel
+
+info:
+  name: Miniflux - Login Panel
+  author: ashish-cybersec
+  severity: info
+  description: |
+    Miniflux is a minimalist and opinionated self-hosted feed reader written in Go. The login panel was detected.
+  reference:
+    - https://miniflux.app/docs/index.html
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: miniflux
+    product: miniflux
+    shodan-query: http.title:"Sign In - Miniflux"
+  tags: panel,miniflux,rss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Sign In - Miniflux</title>"
+
+      - type: word
+        part: body
+        words:
+          - 'data-add-subscription-url="/subscribe"'
+          - 'data-refresh-all-feeds-url="/feeds/refresh"'
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/exposed-panels/miniflux-panel.yaml
+++ b/http/exposed-panels/miniflux-panel.yaml
@@ -1,4 +1,4 @@
-id: miniflux-login-panel
+id: miniflux-panel
 
 info:
   name: Miniflux - Login Panel
@@ -14,7 +14,7 @@ info:
     vendor: miniflux
     product: miniflux
     shodan-query: http.title:"Sign In - Miniflux"
-  tags: panel,miniflux,rss
+  tags: panel,miniflux,rss,login,signin
 
 http:
   - method: GET


### PR DESCRIPTION
### PR Information

- Added `miniflux-login-panel` - Miniflux login panel detection
- References:
  - https://miniflux.app/docs/index.html

Miniflux is a self-hosted minimalist feed reader written in Go (Apache 2.0). No existing template covers it.

Detection uses three matchers on a single unauthenticated request to `{{BaseURL}}`: the exact login page title, two application-specific `data-*` attributes that Miniflux renders on the body tag, and status 200. The `data-*` attributes are part of the application's own JS contract and contain no version hashes, unlike the stylesheet and script paths on the same page.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested against the official image `miniflux/miniflux:latest` with a PostgreSQL backend.

True positive:

```
[miniflux-login-panel] [http] [info] http://127.0.0.1:8091
[INF] Scan completed in 14.367944ms. 1 matches found.
```

Negative control against an unrelated self-hosted app on the same host:

```
[INF] Scan completed in 4.633491ms. No results found.
```

Honeypot check against honey.scanme.sh:

```
[INF] Scan completed in 923.730233ms. No results found.
```

`nuclei -validate` passes and the file lints clean against `.yamllint`.

Note: the Shodan query is derived from the page title observed on the running instance rather than tested against Shodan.