### PR TITLE
Add detection of "OpenShift console monitoring plugin" instances.

### DIFF
--- a/http/technologies/openshift-detect.yaml
+++ b/http/technologies/openshift-detect.yaml
@@ -1,7 +1,7 @@
-id: openshift-monitoring-plugin-detect
+id: openshift-detect
 
 info:
-  name: OpenShift Monitoring Plugin
+  name: OpenShift Monitoring Plugin - Detect
   author: righettod
   severity: info
   description: |

--- a/http/technologies/openshift-monitoring-plugin-detect.yaml
+++ b/http/technologies/openshift-monitoring-plugin-detect.yaml
@@ -21,8 +21,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200 && contains(to_lower(body), "openshift console monitoring plugin")'
-        condition: or
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "openshift console monitoring plugin")'
+        condition: and
 
     extractors:
       - type: regex

--- a/http/technologies/openshift-monitoring-plugin-detect.yaml
+++ b/http/technologies/openshift-monitoring-plugin-detect.yaml
@@ -22,7 +22,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200 && contains(to_lower(body), "openshift console monitoring plugin")'
-        condition: or 
+        condition: or
 
     extractors:
       - type: regex

--- a/http/technologies/openshift-monitoring-plugin-detect.yaml
+++ b/http/technologies/openshift-monitoring-plugin-detect.yaml
@@ -1,0 +1,32 @@
+id: openshift-monitoring-plugin-detect
+
+info:
+  name: OpenShift Monitoring Plugin
+  author: righettod
+  severity: info
+  description: |
+     OpenShift Monitoring Plugin was detected - This plugin enables frontend UI based on feature flags passed to the backend
+  reference:
+    - https://github.com/openshift/monitoring-plugin
+  metadata:
+    verified: true
+    max-request: 1
+  tags: tech,openshift,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/plugin-manifest.json"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 && contains(to_lower(body), "openshift console monitoring plugin")'
+        condition: or 
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9\.]+)"'


### PR DESCRIPTION
### PR Information

Hi,

This PR propose a template to detect instance of the **OpenShift console monitoring plugin** software.

Reference: https://github.com/openshift/monitoring-plugin

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

Template was developed and tested against the version **3.11.1** of nuclei.

### Additional Details (leave it blank if not applicable)

I identified such software when running nuclei from a pod into a OpenShift cluster. As nuclei did not identified it then I decided to propose a PR.

### Additional References:

None
