### PR TITLE
Add CVE-2026-72898 - Metabase - SQLi via reset_password

### DIFF
--- a/http/cves/2026/CVE-2026-72898.yaml
+++ b/http/cves/2026/CVE-2026-72898.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-72898
+
+info:
+  name: Metabase - SQLi via reset_password
+  author: 1dayexploit
+  severity: critical
+  description: |
+    Metabase's password-reset endpoint decodes its JSON body against an open schema that keeps unknown keys, and the login pipeline merges that body into the query used to resolve the target user. When the reset fails, an attacker-supplied user-id key survives into a HoneySQL query as an unparameterised value, so a JSON object such as {"raw": "<SQL>"} is spliced directly into the WHERE clause. This lets an unauthenticated remote attacker inject arbitrary SQL, forge an administrator session, and gain full control of the Metabase instance and any connected databases.
+  impact: |
+    Unauthenticated attackers can escalate to full administrator access, read and modify the Metabase application database, and access credentials for every connected data source.
+  remediation: |
+    Update to version 0.58.24, 0.59.21, 0.60.17, 0.61.11, 0.62.9, 0.63.5 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-72898
+    - https://github.com/metabase/metabase/security/advisories/GHSA-vwf4-m7j8-wcjf
+    - https://www.metabase.com/blog/security-update
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-72898
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: metabase
+    product: metabase
+    shodan-query: http.title:"Metabase"
+    fofa-query: title="Metabase"
+  tags: cve,cve2026,metabase,sqli
+
+http:
+  - raw:
+      - |
+        GET /api/session/properties HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - '"tag":"v(\d+\.\d+\.\d+)'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "\"tag\":\"v"
+      - type: dsl
+        dsl:
+          - >-
+            (compare_versions(version, '>= 0.58.0', '< 0.58.24') ||
+            compare_versions(version, '>= 0.59.0', '< 0.59.21') ||
+            compare_versions(version, '>= 0.60.0', '< 0.60.17') ||
+            compare_versions(version, '>= 0.61.0', '< 0.61.11') ||
+            compare_versions(version, '>= 0.62.0', '< 0.62.9') ||
+            compare_versions(version, '>= 0.63.0', '< 0.63.5'))


### PR DESCRIPTION
Detection template for CVE-2026-72898.

Validated against a containerised lab built from the affected and the fixed release: the template matches the vulnerable build and stays quiet on the patched one. Detection is non-invasive - nothing is written to the target.

<details>
<summary>Validation transcript</summary>

# Nuclei template validation - CVE-2026-72898

## Exposure

Default install: yes. The vulnerable endpoint (`POST /api/session/reset_password`)
requires no authentication, no non-default configuration, and no feature flag - it is
part of the stock login flow shipped in every Metabase install. The endpoint the
template itself queries, `GET /api/session/properties`, is the same: it is called by
the unauthenticated login page on every page load to fetch instance settings, and it
is reachable with zero setup.

Normally exposed port: yes. Both the vulnerable endpoint and the fingerprint endpoint
sit on Metabase's single HTTP port (3000 by default, or whatever port the reverse
proxy in front of it forwards to). There is no secondary admin port involved.

Affected range: six minor branches (0.58.x-0.63.x), each vulnerable from its `.0`
release up to a specific patch release. Nothing before 0.58.0 or after the six listed
fixed releases is affected. KEV status: not yet KEV-listed at the time of writing, but
the vendor and independent researchers (Wiz) both report it was exploited in the wild
as a zero-day against Metabase Cloud before the fix shipped, and public PoC code
began circulating within a day of disclosure.

## Detection method

Rank 1 - version fingerprint. `GET /api/session/properties` is unauthenticated and
returns the exact running version as `"version":{"tag":"vX.Y.Z", ...}` in its JSON
body. This is safer than the behavioural alternative (attempting the injection
itself) because it sends nothing but a GET request and never touches the vulnerable
sink, while the version disclosure is precise enough to place a build inside or
outside each of the six affected sub-ranges.

The extracted tag is compared against all six affected ranges with `compare_versions`,
OR'd together, since a single "less than the newest fix" check would misclassify
builds on an earlier branch (e.g. 0.58.23, still vulnerable, is numerically less than
0.63.5 but also less than 0.59.0 so a naive single-range check would need to special
case every branch anyway - the six explicit ranges avoid that class of error
entirely).

## Syntax check

Command: `nuclei -t nuclei-template.yaml -validate -duc`

Output:
```
[INF] All templates validated successfully
```

## Vulnerable build

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:<VULN_PORT> -nc -silent -duc`

Result: MATCHED

```
[CVE-2026-72898] [http] [critical] http://127.0.0.1:<VULN_PORT>/api/session/properties
```

Confirmed running version at match time: `v0.63.2` (inside the `0.63.0 - <0.63.5`
affected range).

## Patched build

Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:<PATCHED_PORT> -nc -silent -duc`

Result: NO MATCH (empty output)

Confirmed running version at match time: `v0.63.5` (the fixed release for the 0.63.x
branch).

## What the detection keys on

The `version.tag` field returned by `/api/session/properties`, which is baked into
the build at compile time and changes on every release regardless of the security
fix itself. It differs between the two builds because they are, by construction,
different point releases (`v0.63.2` vs `v0.63.5`) straddling the vendor's patch. The
template does not infer the fix directly - it relies on the fact that the vendor
fixed all six branches in lockstep with a version bump, so "which release is this"
is equivalent to "is the merge-and-splice bug still present" for every currently
shipped build.

## Limitations

- **New releases beyond the researched ranges are not covered.** Any 0.64.x or later
  branch, or a future point release the vendor has not cut yet, is untested; the
  ranges here reflect the fixed versions known at research time. If the vendor
  backports the fix to a branch not listed above, or a new branch ships before this
  template is updated, the template will not flag it either way until the ranges are
  refreshed.
- **A reverse proxy or CDN that rewrites or strips `/api/session/properties`** would
  produce a false negative (no match, but the target could still be vulnerable),
  though this is not a supported Metabase deployment pattern.
- **Version spoofing is not a realistic concern here** - the field is server-generated
  from the build artifact, not client-influenced, so there is no straightforward way
  for a target to report a false version through normal configuration.
- **False positives:** none expected. The version match is exact and the endpoint is
  not user-configurable, so a report only fires when the queried instance is actually
  running a build inside one of the six affected ranges.

</details>
