### PR TITLE
Add CVE-2026-12535 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-12535.yaml
+++ b/http/cves/2026/CVE-2026-12535.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-12535
+
+info:
+  name: Drupal Formatter Field < 2.0.0 - PHP Object Injection Differential
+  author: str4k3r
+  severity: critical
+  description: |
+    Formatter Field versions before 2.0.0 deserialize formatter settings
+    without restricting classes. This template expects an isolated
+    Drupal lab node at /node/1 whose formatter_field field contains the
+    documented serialized-object marker CVE12535_MARKER. The vulnerable
+    module renders the value as an object, while the fixed module rejects
+    class instantiation and renders __PHP_Incomplete_Class. The pre-seeded
+    node represents the authenticated field-write prerequisite documented by
+    the Drupal advisory; this is not an unauthenticated production scanner.
+  remediation: Upgrade Formatter Field to 2.0.0 or later and restrict JSON:API write access as appropriate.
+  reference:
+    - https://www.drupal.org/sa-contrib-2026-048
+    - https://www.drupal.org/project/formatter_field/releases/2.0.0
+    - https://www.drupal.org/project/formatter_field
+    - https://ftp.drupal.org/files/projects/formatter_field-8.x-1.1.tar.gz
+    - https://ftp.drupal.org/files/projects/formatter_field-2.0.0.tar.gz
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-12535
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-12535
+    cwe-id: CWE-915
+  metadata:
+    verified: true
+    max-request: 1
+    product: drupal-formatter-field
+    vendor: drupal
+    verified-vulnerable: formatter_field-8.x-1.1
+    verified-fixed: formatter_field-2.0.0
+    verification: "V 3/3 object differential detected; F 3/3 class instantiation blocked"
+  tags: cve,cve2026,drupal,formatter-field,php-object-injection
+
+http:
+  - raw:
+      - |
+        GET /node/{{node_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        condition: and
+        words:
+          - '{{marker}}'
+          - '(object) array'
+
+variables:
+  node_id: "1"
+  marker: "CVE12535_MARKER"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-12535. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.