### PR TITLE
Add CVE-2026-13448 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-13448.yaml
+++ b/http/cves/2026/CVE-2026-13448.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-13448
+
+info:
+  name: Langflow public flow code-execution component validation bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Detects Langflow releases before 1.10.2 that allow an unauthenticated
+    public-flow build request for a stored flow containing the OpenDsStarAgent
+    code-execution component. Supply the UUID of a public flow containing the
+    component with -V flow_id=<uuid>.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13448
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+  classification:
+    cve-id: CVE-2026-13448
+    cwe-id: CWE-94
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,langflow,rce
+
+variables:
+  flow_id: ""
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/build_public_tmp/{{flow_id}}/flow"
+    headers:
+      Content-Type: application/json
+      Cookie: client_id=nuclei-cve-13448
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"job_id"'


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-13448. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.