### PR TITLE
Add CVE-2026-15704 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-15704.yaml
+++ b/http/cves/2026/CVE-2026-15704.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-15704
+
+info:
+  name: Eclipse BaSyx Go Components <=1.0.0 ABAC Trailing-Slash Authorization Bypass (CVE-2026-15704)
+  author: str4k3r
+  severity: critical
+  description: >
+    ABAC-enabled deployments of Eclipse BaSyx Go Components up to and
+    including 1.0.0 use Chi's StripSlashes middleware in the shared
+    router, so a request such as GET /shells/ is dispatched to the
+    registered GET /shells handler. The ABAC middleware, however,
+    evaluates the original request path including the trailing slash;
+    when its route lookup finds no matching slash-suffixed rule, the
+    request is passed onward instead of denied, and the router then
+    strips the slash and executes the protected handler without any
+    ABAC authorization decision or query filter applied. An
+    unauthenticated attacker can therefore append a trailing slash to a
+    protected API route (e.g. /shells) to reach data or operations that
+    the deployed ABAC policy would otherwise deny, receiving HTTP 200
+    instead of the 403 Forbidden returned for the un-suffixed path.
+    Fixed in v1.0.1. Requires an ABAC-enabled deployment (the affected
+    and recommended-secure configuration for this framework); ABAC is
+    off by default.
+  reference:
+    - https://github.com/eclipse-basyx/basyx-go-components/pull/442
+    - https://github.com/eclipse-basyx/basyx-go-components/releases/tag/v1.0.1
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-15704
+  classification:
+    cve-id: CVE-2026-15704
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2026,basyx,abac,authorization-bypass,eclipse
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}{{protected_path}}"
+      - "{{BaseURL}}{{protected_path}}/"
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 403"
+          - "status_code_2 == 200"
+        condition: and
+
+variables:
+  protected_path: "/shells"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-15704. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.