### PR TITLE
Add CVE-2026-34976 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-34976.yaml
+++ b/http/cves/2026/CVE-2026-34976.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-34976
+
+info:
+  name: Dgraph - restoreTenant Admin Mutation Missing Authorization
+  author: str4k3r
+  severity: critical
+  description: |
+    Every Dgraph admin GraphQL mutation is wired to authorization middleware
+    in adminMutationMWConfig (admin.go) except restoreTenant. The similar
+    restore mutation is protected by gogMutMWs (Guardian-of-Galaxy auth + IP
+    whitelist + audit logging); restoreTenant is absent from that map, so its
+    middleware lookup returns nil and the resolver executes with zero access
+    control. restoreTenant accepts an attacker-controlled backup location
+    (including file:// for local filesystem access, or an S3/MinIO endpoint),
+    letting an unauthenticated caller overwrite the database, read
+    server-side files, or trigger SSRF. Fixed by adding "restoreTenant":
+    gogMutMWs to adminMutationMWConfig, giving it the same protection as
+    restore. This template is self-contained and does not touch any real
+    data: it points both restore and restoreTenant at a guaranteed-
+    nonexistent local path so neither mutation can succeed even if reached,
+    then compares their responses. It only flags a target where restore is
+    demonstrably protected (blocked by IP whitelist or Guardian-of-Galaxy
+    auth) yet restoreTenant on the same target is not - the specific
+    marginal exposure this CVE introduces - so it does not false-positive on
+    a target with no admin protection configured at all, and does not
+    require any operator-supplied target-specific value.
+  reference:
+    - https://github.com/hypermodeinc/dgraph/security/advisories/GHSA-p5rh-vmhp-gvcw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-34976
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: hypermodeinc
+    product: dgraph
+  tags: cve,cve2026,dgraph,authbypass,unauth,ssrf
+
+http:
+  - raw:
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restore(input: { location: \"file:///nonexistent-cve-34976-probe/\" }) { code message } }"}
+
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restoreTenant(input: { restoreInput: { location: \"file:///nonexistent-cve-34976-probe/\" }, fromNamespace: 0 }) { code message } }"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "unauthorized ip address"
+      - type: word
+        part: body_2
+        words:
+          - "unauthorized ip address"
+        negative: true
+      - type: word
+        part: body_2
+        words:
+          - "restoreTenant"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-34976. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.