### PR TITLE
Add CVE-2026-50160 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -1,0 +1,77 @@
+id: CVE-2026-50160
+
+info:
+  name: Hoppscotch <= 2026.4.1 - Mass Assignment JWT_SECRET Overwrite
+  author: str4k3r
+  severity: critical
+  description: |
+    Hoppscotch self-hosted backend versions through 2026.4.1 accept undeclared
+    onboarding configuration properties without authentication. This probe
+    first checks the onboarding state and then sends a deliberately invalid,
+    non-secret property; the vulnerable validation path reaches the normal
+    configuration schema, while the fixed path rejects the unknown property.
+  impact: |
+    On an incomplete onboarding deployment, the underlying mass-assignment bug
+    can allow authentication secrets to be overwritten and tokens forged.
+  remediation: |
+    Upgrade Hoppscotch to version 2026.5.0 or later and complete onboarding
+    before exposing the service.
+  reference:
+    - https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50160
+    - https://github.com/hoppscotch/hoppscotch/pull/6171
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-50160
+    cwe-id: CWE-915
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: hoppscotch
+    product: hoppscotch
+    shodan-query: http.title:"Hoppscotch"
+    fofa-query: title="Hoppscotch"
+  tags: cve,cve2026,hoppscotch,mass-assignment,jwt,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /v1/onboarding/status HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "canReRunOnboarding")'
+          - 'contains(body, "onboardingCompleted")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /v1/onboarding/config HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"CVE_2026_50160_DETECT":"true"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "VITE_ALLOWED_AUTH_PROVIDERS"
+      - type: word
+        part: body
+        words:
+          - "should not exist"
+        negative: true


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-50160. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.