### PR TITLE
Add CVE-2026-13448 Langflow public flow code execution

### DIFF
--- a/http/cves/2026/CVE-2026-13448.yaml
+++ b/http/cves/2026/CVE-2026-13448.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-13448
+
+info:
+  name: Langflow public flow code-execution component validation bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Detects Langflow releases before 1.10.2 that allow an unauthenticated
+    public-flow build request for a stored flow containing the OpenDsStarAgent
+    code-execution component. Supply the UUID of a public flow containing the
+    component with -V flow_id=<uuid>.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13448
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+  classification:
+    cve-id: CVE-2026-13448
+    cwe-id: CWE-94
+  metadata:
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,langflow,rce
+
+variables:
+  flow_id: ""
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/build_public_tmp/{{flow_id}}/flow"
+    headers:
+      Content-Type: application/json
+      Cookie: client_id=nuclei-cve-13448
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"job_id"'


### PR DESCRIPTION
## Vulnerability
Langflow 1.10.1 allows a public flow build to include the OpenData/OpenAI-style agent component that executes attacker-controlled code. Langflow 1.10.2 rejects the unsafe component in public builds.

## Template behavior
The template posts to `/api/v1/build_public_tmp/<flow_id>/flow` and matches the returned build job identifier and success response. It exercises the public build API used by an unauthenticated caller.

## Required configuration
Set `flow_id` to an existing public Langflow flow on the target. The flow must be configured so the public build endpoint can process the component used by this template.

## Impact
Unauthenticated users can execute code with the privileges of the Langflow service.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-13448.yaml -var flow_id=<public-flow-uuid>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
