### PR TITLE
Add CVE-2026-42238 nginx-ui unauthenticated restore during first-run setup

### DIFF
--- a/http/cves/2026/CVE-2026-42238.yaml
+++ b/http/cves/2026/CVE-2026-42238.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-42238
+
+info:
+  name: nginx-ui Unauthenticated Backup Restore (CVE-2026-42238)
+  author: str4k3r
+  severity: critical
+  description: >
+    Fresh nginx-ui versions before 2.3.8 expose POST /api/restore without
+    authentication during the installation window. A deliberately malformed
+    multipart request reaches the handler and returns its backup-file error;
+    patched versions reject the same request at authentication middleware.
+  reference:
+    - https://github.com/0xJacky/nginx-ui/security/advisories/GHSA-4pvg-prr3-9cxr
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42238
+  classification:
+    cve-id: CVE-2026-42238
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,nginx-ui,auth-bypass,rce
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/restore"
+    headers:
+      Content-Type: multipart/form-data; boundary=forge
+    body: |-
+      --forge
+      Content-Disposition: form-data; name="security_token"
+
+      invalid
+      --forge--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 500
+      - type: word
+        part: body
+        words:
+          - "Backup file not found"


### PR DESCRIPTION
## Vulnerability
nginx-ui 2.3.7 exposes the restore handler while the installation is still uninitialized. A malformed multipart request reaches the handler without authentication; 2.3.8 requires the setup authorization first.

## Template behavior
The template sends a minimal malformed multipart restore request and matches the vulnerable “Backup file not found” response. A normal authenticated installation is not reported.

## Required configuration
Use only a fresh nginx-ui installation that is still in its initial setup window. No template variables are required; do not run this against an initialized production instance.

## Impact
An attacker may abuse the first-run restore endpoint to replace configuration or bootstrap administrative access.

## Usage
```bash
nuclei -u <authorized-fresh-install> -t http/cves/2026/CVE-2026-42238.yaml
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
