### PR TITLE
Add CVE-2026-50160 Hoppscotch onboarding mass-assignment

### DIFF
--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -1,0 +1,77 @@
+id: CVE-2026-50160
+
+info:
+  name: Hoppscotch <= 2026.4.1 - Mass Assignment JWT_SECRET Overwrite
+  author: str4k3r
+  severity: critical
+  description: |
+    Hoppscotch self-hosted backend versions through 2026.4.1 accept undeclared
+    onboarding configuration properties without authentication. This probe
+    first checks the onboarding state and then sends a deliberately invalid,
+    non-secret property; the vulnerable validation path reaches the normal
+    configuration schema, while the fixed path rejects the unknown property.
+  impact: |
+    On an incomplete onboarding deployment, the underlying mass-assignment bug
+    can allow authentication secrets to be overwritten and tokens forged.
+  remediation: |
+    Upgrade Hoppscotch to version 2026.5.0 or later and complete onboarding
+    before exposing the service.
+  reference:
+    - https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50160
+    - https://github.com/hoppscotch/hoppscotch/pull/6171
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-50160
+    cwe-id: CWE-915
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: hoppscotch
+    product: hoppscotch
+    shodan-query: http.title:"Hoppscotch"
+    fofa-query: title="Hoppscotch"
+  tags: cve,cve2026,hoppscotch,mass-assignment,jwt,unauth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /v1/onboarding/status HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "canReRunOnboarding")'
+          - 'contains(body, "onboardingCompleted")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /v1/onboarding/config HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"CVE_2026_50160_DETECT":"true"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "VITE_ALLOWED_AUTH_PROVIDERS"
+      - type: word
+        part: body
+        words:
+          - "should not exist"
+        negative: true


### PR DESCRIPTION
## Vulnerability
Hoppscotch 2026.4.1 accepts undeclared properties in the onboarding configuration payload. The 2026.5.0 fix rejects unknown fields and limits the accepted configuration schema.

## Template behavior
The template checks that onboarding is incomplete, submits a harmless unknown property to `/v1/onboarding/config`, and matches the vulnerable schema response. It does not submit secrets or attempt to complete onboarding.

## Required configuration
The target must be a fresh Hoppscotch deployment with onboarding still incomplete. No variables are required; reset the test instance if onboarding has already been completed.

## Impact
Mass-assignment can let an unauthenticated caller alter onboarding state or inject configuration that should be server-controlled.

## Usage
```bash
nuclei -u <authorized-fresh-install> -t http/cves/2026/CVE-2026-50160.yaml
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
