### PR TITLE
fix: CVE-2026-21858 - add /rest/sentry.js fallback for n8n 1.65.0-1.111.x detection

### DIFF
--- a/http/cves/2026/CVE-2026-21858.yaml
+++ b/http/cves/2026/CVE-2026-21858.yaml
@@ -71,4 +71,32 @@ http:
         name: vulnerable
         dsl:
           - compare_versions(version, '>= 1.65.0', '< 1.121.0')
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/rest/sentry.js"
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - 'release":"([0-9.]+)"'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"release"'
+        case-insensitive: true
+
+      - type: status
+        status:
+          - 200
+
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - compare_versions(version, '>= 1.65.0', '< 1.121.0')
 # digest: 490a0046304402200e5a6c294f1412ff517bce39d5fdf91d55eec160efaa922f56c7bc92f8afbdf302207c308a68498392225fd7f55313fcbae3758ef34e9599cc4cd6347b30e72ba3eb:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Summary
The current template only detects n8n versions 1.112.0+ (which include the `<meta name="n8n:config:sentry">` base64 tag on `/signin`). Versions 1.65.0–1.111.x are missed - they expose version via `/rest/sentry.js` instead.

This creates false negatives for the full vulnerable range the CVE advisory defines (`>= 1.65.0, < 1.121.0`). Notably, vulhub's official lab image (`vulhub/n8n:1.65.0`) is not detected.

## Solution
Add a second HTTP request block targeting `/rest/sentry.js` which returns `{"release":"X.Y.Z"}`. Both blocks check the same vulnerable version range; nuclei matches if either succeeds.

## Testing
- Detects `vulhub/n8n:1.65.0` (via `/rest/sentry.js`)
- Detects `n8nio/n8n:1.112.0` (via `/signin` meta tag)
- Detects `n8nio/n8n:1.119.0` (via `/signin` meta tag)
- No false positives on patched versions (`1.121.0+`)

## Changes
- `http/cves/2026/CVE-2026-21858.yaml`: Added fallback `/rest/sentry.js` HTTP block

## References
- CVE Advisory: https://github.com/n8n-io/n8n/security/advisories/GHSA-v4pr-fm98-w9pg
- Vulhub Lab: https://github.com/vulhub/vulhub/tree/master/n8n/CVE-2026-21858
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-21858