### PR TITLE
fix(false-positive): CVE-2025-29927 add negative matchers for WAF block responses

### DIFF
--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -85,6 +85,16 @@ http:
       - type: status
         status:
           - 200
+          
+      - type: word
+        part: body
+        negative: true
+        words: 
+          - "Request Rejected"
+          - "The requested URL was rejected"
+          - "Your support ID is"
+          - "Access Denied"
+          - "Request Blocked"
 
   - method: GET
     path:
@@ -120,5 +130,5 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - status_code == 200
+          - status_code == 200 && !contains_any(to_lower(body), 'request rejected', 'your support id', 'access denied', 'request blocked')
 # digest: 4a0a00473045022100fda38f0752a965dca528a86a021ae3d794f1caf34c0b479c5002719f1aa5c80002206a161a8c7e7f431141dfa87aac4eefdde58b86d16373eed7ce875339c6922829:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -82,10 +82,6 @@ http:
         X-Middleware-Subrequest: src/middleware:nowaf:src/middleware:src/middleware:src/middleware:src/middleware:middleware:middleware:nowaf:middleware:middleware:middleware:pages/_middleware
 
     matchers:
-      - type: status
-        status:
-          - 200
-          
       - type: word
         part: body
         words: 
@@ -95,6 +91,10 @@ http:
           - "Access Denied"
           - "Request Blocked"
         negative: true
+
+      - type: status
+        status:
+          - 200
 
   - method: GET
     path:

--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -88,13 +88,13 @@ http:
           
       - type: word
         part: body
-        negative: true
         words: 
           - "Request Rejected"
           - "The requested URL was rejected"
           - "Your support ID is"
           - "Access Denied"
           - "Request Blocked"
+        negative: true
 
   - method: GET
     path:
@@ -130,5 +130,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - status_code == 200 && !contains_any(to_lower(body), 'request rejected', 'your support id', 'access denied', 'request blocked')
-# digest: 4a0a00473045022100fda38f0752a965dca528a86a021ae3d794f1caf34c0b479c5002719f1aa5c80002206a161a8c7e7f431141dfa87aac4eefdde58b86d16373eed7ce875339c6922829:922c64590222798bb761d5b6d8e72950
+          - "status_code == 200"
+          - "!contains_any(to_lower(body), 'request rejected', 'your support id', 'access denied', 'request blocked')"
+        condition: and

--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -84,7 +84,7 @@ http:
     matchers:
       - type: word
         part: body
-        words: 
+        words:
           - "Request Rejected"
           - "The requested URL was rejected"
           - "Your support ID is"


### PR DESCRIPTION
### PR Information

- Updated CVE-2025-29927
- References: Fixes #16782

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Added negative word matchers to request 2 and updated DSL matcher in request 5 to ignore WAF block responses returning HTTP 200 (e.g., `"The requested URL was rejected. Your support ID is: ..."`).

Tested successfully against a Mock WAF Server on Google Colab:

```text
[INF] Targets loaded for current scan: 1
[DBG] Dumped HTTP response [http://127.0.0.1:8081](http://127.0.0.1:8081) -> HTTP/1.0 200 OK
<html><body>The requested URL was rejected. Your support ID is: 12345.</body></html>
[INF] No results found. Better luck next time!