### PR TITLE
Add CVE-2026-33267 Apache Traffic Server @ header internal metadata spoof detection

### DIFF
--- a/http/cves/2026/CVE-2026-33267.yaml
+++ b/http/cves/2026/CVE-2026-33267.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-33267
+
+info:
+  name: Apache Traffic Server 9.2.0-9.2.14 / 10.1.0-10.1.3 - Internal Metadata Header Spoofing
+  author: Boreas37
+  severity: critical
+  description: |
+    Apache Traffic Server (ATS) reserves '@'-prefixed headers (e.g. @Ats-Internal,
+    @ICAP-Status, @TCPInfo) as internal metadata: they live in the in-memory header
+    structure and are not serialized on the wire. In vulnerable versions
+    (9.2.0 through 9.2.14, 10.1.0 through 10.1.3) '@' headers supplied by a client
+    request or by an origin response are not stripped before plugin hooks
+    (TS_HTTP_READ_REQUEST_HDR_HOOK, TS_HTTP_READ_RESPONSE_HDR_HOOK, remap plugins)
+    run. A remote attacker can therefore spoof ATS internal metadata and plugins
+    (cache, ACL, header_rewrite, ...) may trust attacker-controlled internal state.
+  impact: |
+    An unauthenticated attacker can spoof ATS internal metadata. Depending on the
+    plugins in use on the target deployment this can lead to cache poisoning, ACL
+    bypass, request/response tampering or remote code execution.
+  remediation: |
+    Upgrade Apache Traffic Server to 9.2.15 or 10.1.4 (or later). The fix adds
+    HttpTransact::strip_at_headers(), which strips externally-supplied '@' headers
+    before plugin hooks run (commits a9aee837db / 4ab63dbd93).
+  reference:
+    - https://lists.apache.org/thread/5prl9glcm9g2swnq9hqxvnokylm1gr6d
+    - https://github.com/advisories/GHSA-jrh6-9hgv-mqm7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33267
+  classification:
+    cve-id: CVE-2026-33267
+    cwe-id: CWE-20
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    epss-score: 0.00335
+    epss-percentile: 0.26287
+  metadata:
+    max-request: 1
+    verified: true
+    shodan-query: http.component:"traffic server"
+  tags: cve,cve2026,apache,trafficserver,ats,metadata,spoofing
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+
+    stop-at-first-match: true
+    matchers:
+      - type: regex
+        part: header
+        regex:
+          - 'Server: ATS/(?:9\.2\.(?:0|[1-9]|1[0-4])|10\.1\.[0-3])\b'


### PR DESCRIPTION
## Template for CVE-2026-33267 — Apache Traffic Server untrusted `@` header → internal metadata spoof

### Vulnerability
ATS reserves `@`-prefixed headers (`@Ats-Internal`, `@ICAP-Status`, `@TCPInfo`, ...) as **internal metadata**: they live in the in-memory header structure and are never serialized on the wire. In affected versions (**9.2.0–9.2.14, 10.1.0–10.1.3**) `@` headers supplied by the client request / origin response are **not stripped before plugin hooks** run (`TS_HTTP_READ_REQUEST_HDR_HOOK`, `TS_HTTP_READ_RESPONSE_HDR_HOOK`, remap plugins), so a remote attacker can spoof ATS internal metadata that plugins (cache, ACL, header_rewrite, …) may trust. CVSS 10.0 (GHSA-jrh6-9hgv-mqm7).

Fix: 9.2.15 / 10.1.4 — `HttpTransact::strip_at_headers()` strips external `@` headers before plugin hooks (commits `a9aee837db` / `4ab63dbd93`).

### Detection design (why version fingerprint)
Verified in a Docker lab with a custom `at_probe` plugin on both builds:
- **ATS 10.1.2 (vulnerable)**: plugin observes client-supplied `@Ats-Internal` / `@Another-At` at the read-request hook (`VULN: plugin observed client-supplied @ header` in diags.log).
- **ATS 10.1.4 (fixed, built from source)**: same probe → `stripped internal @ header from client request` — the plugin never sees them.

The HTTP responses of both builds are **byte-identical except the `Server:` version** (`ATS/10.1.2` vs `ATS/10.1.4`) — the `@`-header leak is only observable server-side (plugin hooks / logs), not in the response. Additionally, nuclei's HTTP engine (Go `net/http`) rejects `@`-prefixed header names (`invalid header field name "@Another-At"`), so the trigger itself cannot be transmitted via a standard template. Detection therefore uses the `Server: ATS/<version>` fingerprint restricted to the affected ranges (`9.2.0–9.2.14`, `10.1.0–10.1.3`); `\b` anchoring prevents false matches on e.g. `10.1.10`.

### Verification (Raspberry Pi 5 / ARM64 Docker lab)
| Test | Target | Result |
|---|---|---|
| `nuclei -validate` | — | ✅ All templates validated successfully |
| **Positive** | ATS **10.1.2** (vulnerable, `http://127.0.0.1:18080`) | ✅ `[CVE-2026-33267] [http] [critical]` matched (`Server: ATS/10.1.2`) |
| **Negative** | ATS **10.1.4** (fixed, `http://172.17.0.4:8081`) | ✅ No results — response received (`HTTP/1.1 200 OK`, `Server: ATS/10.1.4`), no match |
| False-positive check | non-ATS hosts (api-gateway, NiFi) | ✅ No results |

### References
- Apache advisory: https://lists.apache.org/thread/5prl9glcm9g2swnq9hqxvnokylm1gr6d
- GHSA: https://github.com/advisories/GHSA-jrh6-9hgv-mqm7
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-33267
