### PR TITLE
fix: update max-request counter for CVE-2021-40822

### DIFF
--- a/http/cves/2021/CVE-2021-40822.yaml
+++ b/http/cves/2021/CVE-2021-40822.yaml
@@ -25,7 +25,7 @@ info:
     cpe: cpe:2.3:a:osgeo:geoserver:*:*:*:*:*:*:*:*
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: osgeo
     product: geoserver
     shodan-query:


### PR DESCRIPTION
Fixes `max-request` metadata for `http/cves/2021/CVE-2021-40822.yaml`.

The template uses `flow: http(1) && http(2)` and sends 2 sequential requests (GET `/geoserver/` + POST `/geoserver/TestWfsPost`), but `metadata.max-request` was set to `1`. This corrects it to `2`.

Prior art: #7656 fixed the Host-header/interactsh-url mismatch for the same template. This is a follow-up metadata correction.