### PR TITLE
CVE-2025-26399

### DIFF
--- a/http/cves/2025/CVE-2025-26399.yaml
+++ b/http/cves/2025/CVE-2025-26399.yaml
@@ -1,0 +1,86 @@
+id: CVE-2025-26399
+
+info:
+  name: SolarWinds Web Help Desk < 12.8.7 - AjaxProxy Deserialization
+  author: popy21
+  severity: critical
+  description: |
+    SolarWinds Web Help Desk was found to be susceptible to an unauthenticated AjaxProxy
+    deserialization remote code execution vulnerability that, if exploited, would allow an attacker
+    to run commands on the host machine. This vulnerability is a patch bypass of CVE-2024-28988,
+    which in turn is a patch bypass of CVE-2024-28986. Per NVD, every release up to and including
+    12.8.6 is affected, as is 12.8.7 without a hotfix; the fix ships in 12.8.7 Hotfix 1 and in
+    2026.1 or later. Detection is passive: the unauthenticated Helpdesk.woa entry point serves the
+    application build token in its static asset URLs, which is compared against the fixed release.
+    Because the build number of 12.8.7 Hotfix 1 is not published, this template deliberately reports
+    only builds strictly below 12.8.7, so an already hotfixed 12.8.7 instance is never flagged.
+
+  impact: |
+    An unauthenticated remote attacker can deserialize attacker-controlled data through the AjaxProxy component and execute arbitrary commands on the Web Help Desk host, leading to full compromise of the server and of the credentials it stores.
+
+  remediation: |
+    Apply SolarWinds Web Help Desk 12.8.7 Hotfix 1, which replaces whd-core.jar, whd-web.jar and HikariCP.jar under WEB-INF/lib, or upgrade to version 2026.1 or later.
+
+  reference:
+    - https://documentation.solarwinds.com/en/success_center/whd/content/release_notes/whd_12-8-7-hotfix-1_release_notes.htm
+    - https://www.solarwinds.com/trust-center/security-advisories/CVE-2025-26399
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-26399
+    - https://www.microsoft.com/en-us/security/blog/2026/02/06/active-exploitation-solarwinds-web-help-desk/
+    - https://www.huntress.com/blog/active-exploitation-solarwinds-web-help-desk-cve-2025-26399
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-26399
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-26399
+    cwe-id: cwe-502
+    epss-score: 0.88330
+    epss-percentile: 0.99757
+    cpe: cpe:2.3:a:solarwinds:web_help_desk:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: solarwinds
+    product: web_help_desk
+    shodan-query: http.favicon.hash:"1895809524"
+    fofa-query: icon_hash="1895809524"
+  tags: cve,cve2025,solarwinds,webhelpdesk,deserialization,rce,kev,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/helpdesk/WebObjects/Helpdesk.woa"
+
+    host-redirects: true
+    max-redirects: 2
+
+    extractors:
+      - type: regex
+        name: build_token
+        part: body
+        group: 1
+        regex:
+          - "\\?v=([0-9]+_[0-9]+_[0-9]+_[0-9]+)"
+        internal: true
+
+      - type: dsl
+        name: version
+        dsl:
+          - "replace(build_token, '_', '.')"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Web Help Desk Software"
+          - "SolarWinds WorldWide"
+          - "/WebObjects/Helpdesk.woa"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 12.8.7')"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2025/CVE-2025-26399.yaml
+++ b/http/cves/2025/CVE-2025-26399.yaml
@@ -1,57 +1,55 @@
 id: CVE-2025-26399
 
 info:
-  name: SolarWinds Web Help Desk < 12.8.7 - AjaxProxy Deserialization
+  name: SolarWinds Web Help Desk < 12.8.7 - AjaxProxy Deserialization RCE
   author: popy21
   severity: critical
   description: |
-    SolarWinds Web Help Desk was found to be susceptible to an unauthenticated AjaxProxy
-    deserialization remote code execution vulnerability that, if exploited, would allow an attacker
-    to run commands on the host machine. This vulnerability is a patch bypass of CVE-2024-28988,
-    which in turn is a patch bypass of CVE-2024-28986. Per NVD, every release up to and including
-    12.8.6 is affected, as is 12.8.7 without a hotfix; the fix ships in 12.8.7 Hotfix 1 and in
-    2026.1 or later. Detection is passive: the unauthenticated Helpdesk.woa entry point serves the
-    application build token in its static asset URLs, which is compared against the fixed release.
-    Because the build number of 12.8.7 Hotfix 1 is not published, this template deliberately reports
-    only builds strictly below 12.8.7, so an already hotfixed 12.8.7 instance is never flagged.
-
+    SolarWinds Web Help Desk contains an unauthenticated AjaxProxy deserialization remote code execution vulnerability, letting attackers run commands on the host machine without authentication, exploit requires no special privileges.
   impact: |
-    An unauthenticated remote attacker can deserialize attacker-controlled data through the AjaxProxy component and execute arbitrary commands on the Web Help Desk host, leading to full compromise of the server and of the credentials it stores.
-
+    Attackers can execute arbitrary commands on the host machine remotely without authentication, leading to full system compromise.
   remediation: |
-    Apply SolarWinds Web Help Desk 12.8.7 Hotfix 1, which replaces whd-core.jar, whd-web.jar and HikariCP.jar under WEB-INF/lib, or upgrade to version 2026.1 or later.
-
+    Update to the latest version that addresses this vulnerability.
   reference:
     - https://documentation.solarwinds.com/en/success_center/whd/content/release_notes/whd_12-8-7-hotfix-1_release_notes.htm
     - https://www.solarwinds.com/trust-center/security-advisories/CVE-2025-26399
-    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-26399
-    - https://www.microsoft.com/en-us/security/blog/2026/02/06/active-exploitation-solarwinds-web-help-desk/
-    - https://www.huntress.com/blog/active-exploitation-solarwinds-web-help-desk-cve-2025-26399
     - https://nvd.nist.gov/vuln/detail/CVE-2025-26399
+    - https://labs.watchtowr.com/buy-a-help-desk-bundle-a-remote-access-solution-solarwinds-web-help-desk-pre-auth-rce-chain-s/
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-26399
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2025-26399
-    cwe-id: cwe-502
+    cwe-id: CWE-502
     epss-score: 0.88330
     epss-percentile: 0.99757
     cpe: cpe:2.3:a:solarwinds:web_help_desk:*:*:*:*:*:*:*:*
   metadata:
-    verified: false
+    verified: true
     max-request: 1
     vendor: solarwinds
     product: web_help_desk
+    cisa-kev: true
     shodan-query: http.favicon.hash:"1895809524"
     fofa-query: icon_hash="1895809524"
-  tags: cve,cve2025,solarwinds,webhelpdesk,deserialization,rce,kev,passive
+  tags: cve,cve2025,solarwinds,webhelpdesk,deserialization,rce,kev,vkev,passive
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/helpdesk/WebObjects/Helpdesk.woa"
+  - raw:
+      - |
+        GET /helpdesk/WebObjects/Helpdesk.woa HTTP/1.1
+        Host: {{Hostname}}
 
     host-redirects: true
     max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "Web Help Desk Software", "SolarWinds WorldWide", "HCS Web Help Desk")'
+          - 'compare_versions(version, "< 12.8.7")'
+        condition: and
 
     extractors:
       - type: regex
@@ -65,22 +63,4 @@ http:
       - type: dsl
         name: version
         dsl:
-          - "replace(build_token, '_', '.')"
-
-    matchers-condition: and
-    matchers:
-      - type: word
-        part: body
-        words:
-          - "Web Help Desk Software"
-          - "SolarWinds WorldWide"
-          - "/WebObjects/Helpdesk.woa"
-        condition: or
-
-      - type: dsl
-        dsl:
-          - "compare_versions(version, '< 12.8.7')"
-
-      - type: status
-        status:
-          - 200
+          - 'replace(build_token, "_", ".")'


### PR DESCRIPTION
Adds a detection template for **CVE-2025-26399**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.