### PR TITLE
fix: CVE-2025-30220 XXE detector should rely on OOB interaction, not version-dependent NPE

### DIFF
--- a/http/cves/2025/CVE-2025-30220.yaml
+++ b/http/cves/2025/CVE-2025-30220.yaml
@@ -12,11 +12,11 @@ info:
     Upgrade to the latest GeoServer version that properly disables external entity processing in WFS requests.
   reference:
     - https://github.com/geoserver/geoserver/security/advisories/GHSA-jj54-8f66-c5pc
+    - https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html
     - https://docs.geoserver.org/latest/en/user/production/config.html#production-config-external-entities
     - https://github.com/geonetwork/core-geonetwork/pull/8757
     - https://github.com/geonetwork/core-geonetwork/pull/8803
     - https://github.com/geonetwork/core-geonetwork/pull/8812
-    - https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:L
     cvss-score: 9.9
@@ -92,8 +92,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains(interactsh_protocol, "dns")'
-          - 'contains(body, "java.lang.NullPointerException")'
           - "status_code == 200"
+          - 'contains(interactsh_protocol, "dns") || contains(interactsh_protocol, "http")'
         condition: and
-# digest: 4a0a00473045022100871d02531dd335179c09d614919260d0ff798cf58d504158476147929210845c02203f061856d581ddb2f0a56a4de38988446d58cd092e81dcddf51e8816917a3789:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The current CVE-2025-30220 matcher requires java.lang.NullPointerException in the WFS GetFeature response body. That signal is version-dependent: on docker.osgeo.org/geoserver:2.26.2 (in the affected range per GHSA-jj54-8f66-c5pc (https://github.com/geoserver/geoserver/security/advisories/GHSA-jj54-8f66-c5pc)) the response returns valid feature data instead of an error, so the template false-negatives even though GeoServer clearly performs the Out-of-Band DNS lookup to the Interactsh callback (the actual XXE external-entity fetch).

This PR keys detection on the OOB interaction itself, which is the definitive proof — a patched version never dereferences the external schema and therefore never triggers a callback. Verified against docker.osgeo.org/geoserver:2.26.2 (in-range) producing a confirmed interactsh_protocol == "dns" interaction.

Cross-version validation

| Version | Status | Expected | Result |
|---------|--------|----------|--------|
| 2.25.6 | vulnerable | match | MATCH |
| 2.26.2 | vulnerable | match | MATCH |
| 2.27.0 | vulnerable | match | MATCH |
| 2.25.7 | patched | no match | NO MATCH |
| 2.26.3 | patched | no match | NO MATCH |
| 2.27.1 | patched | no match | NO MATCH |

Reproducer

docker run --rm -d -p 8080:8080 --platform linux/amd64 docker.osgeo.org/geoserver:2.26.2
# wait for boot (~60s), then:
nuclei -u http://localhost:8080 -t CVE-2025-30220.yaml -duc

References

- GeoServer GHSA-jj54-8f66-c5pc (https://github.com/geoserver/geoserver/security/advisories/GHSA-jj54-8f66-c5pc)
- NVD CVE-2025-30220 (https://nvd.nist.gov/vuln/detail/CVE-2025-30220)
- GeoServer vulnerability disclosure (https://geoserver.org/vulnerability/2025/06/10/cve-disclosure.html)