### PR TITLE
Move 22 invalid/rejected CVE templates to vulnerabilities

### DIFF
--- a/http/vulnerabilities/afterlogic-path-disclosure.yaml
+++ b/http/vulnerabilities/afterlogic-path-disclosure.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-26292
+id: afterlogic-path-disclosure
 
 info:
   name: AfterLogic Aurora and WebMail Pro < 7.7.9 - Full Path Disclosure
@@ -13,8 +13,6 @@ info:
   reference:
     - https://github.com/E3SEC/AfterLogic/blob/main/CVE-2021-26292-full-path-disclosure-vulnerability.md
     - https://nvd.nist.gov/vuln/detail/CVE-2021-26292
-  classification:
-    cve-id: CVE-2021-26292
   metadata:
     verified: true
     max-request: 1
@@ -23,7 +21,7 @@ info:
     fofa-query:
       - "X-Server: AfterlogicDAVServer"
       - "x-server: afterlogicdavserver"
-  tags: cve2021,cve,afterlogic,path,disclosure,AfterLogic,vuln
+  tags: afterlogic,path,disclosure,AfterLogic,vuln
 
 http:
   - raw:

--- a/http/vulnerabilities/bentoml-open-redirect.yaml
+++ b/http/vulnerabilities/bentoml-open-redirect.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-12760
+id: bentoml-open-redirect
 
 info:
   name: BentoML v1.3.9 - Open Redirect
@@ -16,7 +16,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: html:"BentoML"
-  tags: cve,cve2024,gradio,redirect,oss,bentoml,vuln
+  tags: gradio,redirect,oss,bentoml,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/caseaware-xss.yaml
+++ b/http/vulnerabilities/caseaware-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-25669
+id: caseaware-xss
 
 info:
   name: CaseAware a360inc - Cross-Site Scripting
@@ -15,7 +15,6 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cve-id: CVE-2024-25669
     cwe-id: CWE-79
     epss-score: 0.00286
     epss-percentile: 0.65504
@@ -28,7 +27,7 @@ info:
     fofa-query:
       - title="CaseAware"
       - title="caseaware"
-  tags: cve,cve2024,xss,caseaware,a360inc,vuln
+  tags: xss,caseaware,a360inc,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/gestsup-account-takeover.yaml
+++ b/http/vulnerabilities/gestsup-account-takeover.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-23163
+id: gestsup-account-takeover
 
 info:
   name: GestSup - Account Takeover
@@ -15,7 +15,6 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2024-23163
     cwe-id: CWE-287
     cpe: cpe:2.3:a:gestsup:gestsup:*:*:*:*:*:*:*:*
   metadata:
@@ -25,7 +24,7 @@ info:
     fofa-query: title="GestSup"
     shodan-query: http.favicon.hash:-283003760
     product: gestsup
-  tags: cve,cve2024,account-takeover,gestsup,vuln
+  tags: account-takeover,gestsup,vuln
 
 variables:
   email: "{{randstr}}@{{rand_base(5)}}.com"

--- a/http/vulnerabilities/gestsup-xss.yaml
+++ b/http/vulnerabilities/gestsup-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-23167
+id: gestsup-xss
 
 info:
   name: GestSup - Cross-Site Scripting
@@ -17,12 +17,11 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N
     cvss-score: 8.6
-    cve-id: CVE-2024-23167
   metadata:
     max-request: 3
     vendor: gestsup
     product: gestsup
-  tags: cve2024,cve,xss,gestsup,vuln
+  tags: xss,gestsup,vuln
 
 variables:
   formatted_date: "{{date_time('2006/01/02')}}"

--- a/http/vulnerabilities/harman-media-suite-lfi.yaml
+++ b/http/vulnerabilities/harman-media-suite-lfi.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-39024
+id: harman-media-suite-lfi
 
 info:
   name: Harman Media Suite <= 4.2.0 - Local File Disclosure
@@ -20,7 +20,7 @@ info:
     vendor: harman
     product: media-suite
     fofa-query: "Harman Media Suite"
-  tags: cve,cve2023,harman,media-suite,lfi,vuln
+  tags: harman,media-suite,lfi,vuln
 
 flow: http(1) && http(2)
 

--- a/http/vulnerabilities/ibm/websphere-ssrf.yaml
+++ b/http/vulnerabilities/ibm/websphere-ssrf.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-27748
+id: ibm-websphere-ssrf
 
 info:
   name: IBM WebSphere HCL Digital Experience - Server-Side Request Forgery
@@ -15,7 +15,6 @@ info:
     - https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0095665
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27748
   classification:
-    cve-id: CVE-2021-27748
     cpe: cpe:2.3:a:ibm:websphere:*:*:*:*:*:*:*:*
   metadata:
     verified: true
@@ -23,7 +22,7 @@ info:
     shodan-query: http.html:"IBM WebSphere Portal"
     product: websphere
     vendor: ibm
-  tags: cve2021,cve,hcl,ibm,ssrf,websphere,vuln
+  tags: hcl,ibm,ssrf,websphere,vuln
 
 flow: http(1) && http(2)
 

--- a/http/vulnerabilities/lg-nas-rce.yaml
+++ b/http/vulnerabilities/lg-nas-rce.yaml
@@ -1,4 +1,4 @@
-id: CVE-2018-10818
+id: lg-nas-rce
 
 info:
   name: LG NAS Devices - Remote Code Execution
@@ -13,11 +13,9 @@ info:
     - https://www.vpnmentor.com/blog/critical-vulnerability-found-majority-lg-nas-devices/
     - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-10818
-  classification:
-    cve-id: CVE-2018-10818
   metadata:
     max-request: 2
-  tags: cve,cve2018,lg-nas,rce,oast,injection,vuln
+  tags: lg-nas,rce,oast,injection,vuln
 variables:
   useragent: '{{rand_base(6)}}'
 

--- a/http/vulnerabilities/monitorr-file-upload.yaml
+++ b/http/vulnerabilities/monitorr-file-upload.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-0713
+id: monitorr-file-upload
 
 info:
   name: Monitorr Services Configuration - Arbitrary File Upload
@@ -17,7 +17,6 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 8.8
-    cve-id: CVE-2024-0713
     cwe-id: CWE-434
     epss-score: 0.00061
     epss-percentile: 0.2356
@@ -29,7 +28,7 @@ info:
     product: monitorr
     shodan-query: http.favicon.hash:"-211006074"
     fofa-query: "icon_hash=\"-211006074\""
-  tags: cve,cve2024,file-upload,intrusive,monitorr,vuln
+  tags: file-upload,intrusive,monitorr,vuln
 variables:
   file: "{{to_lower(rand_text_alpha(5))}}"
 

--- a/http/vulnerabilities/nodogsplash-lfi.yaml
+++ b/http/vulnerabilities/nodogsplash-lfi.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-39120
+id: nodogsplash-lfi
 
 info:
   name: Nodogsplash - Directory Traversal
@@ -17,13 +17,12 @@ info:
   classification:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
-    cve-id: CVE-2023-39120
     cwe-id: CWE-22
   metadata:
     verified: true
     max-request: 1
     shodan-query: title:"OpenWRT"
-  tags: cve2023,cve,lfi,openwrt,nodogsplash,vuln
+  tags: lfi,openwrt,nodogsplash,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/ntopng-auth-bypass.yaml
+++ b/http/vulnerabilities/ntopng-auth-bypass.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-28073
+id: ntopng-auth-bypass
 
 info:
   name: Ntopng Authentication Bypass
@@ -12,11 +12,9 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-27573
     - http://noahblog.360.cn/ntopng-multiple-vulnerabilities/
     - https://github.com/AndreaOm/docs/blob/c27d2db8dbedb35c9e69109898aaecd0f849186a/wikipoc/PeiQi_Wiki/%E6%9C%8D%E5%8A%A1%E5%99%A8%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/HongKe/HongKe%20ntopng%20%E6%B5%81%E9%87%8F%E5%88%86%E6%9E%90%E7%B3%BB%E7%BB%9F%20%E6%9D%83%E9%99%90%E7%BB%95%E8%BF%87%E6%BC%8F%E6%B4%9E%20CVE-2021-28073.md
-  classification:
-    cve-id: CVE-2021-28073
   metadata:
     max-request: 2
-  tags: cve2021,cve,ntopng,vuln
+  tags: ntopng,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/nuxeo-ssti-rce.yaml
+++ b/http/vulnerabilities/nuxeo-ssti-rce.yaml
@@ -1,4 +1,4 @@
-id: CVE-2018-16341
+id: nuxeo-ssti-rce
 
 info:
   name: Nuxeo <10.3 - Remote Code Execution
@@ -12,11 +12,9 @@ info:
     Upgrade Nuxeo to version 10.3 or later to mitigate this vulnerability.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2018-16299
-  classification:
-    cve-id: CVE-2018-16341
   metadata:
     max-request: 1
-  tags: cve,cve2018,nuxeo,ssti,rce,bypass,vuln
+  tags: nuxeo,ssti,rce,bypass,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/odoo-xss.yaml
+++ b/http/vulnerabilities/odoo-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-1434
+id: odoo-xss
 
 info:
   name: Odoo - Cross-Site Scripting
@@ -14,7 +14,6 @@ info:
     - https://www.sonarsource.com/blog/odoo-get-your-content-type-right-or-else
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1434
   classification:
-    cve-id: CVE-2023-1434
     cwe-id: CWE-79
     cpe: cpe:2.3:a:odoo:odoo:*:*:*:*:*:*:*:*
   metadata:
@@ -23,7 +22,7 @@ info:
     shodan-query: title:"Odoo"
     product: odoo
     vendor: odoo
-  tags: cve2023,cve,odoo,xss,vkev,vuln
+  tags: odoo,xss,vkev,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/solarview-compact-pow-xss.yaml
+++ b/http/vulnerabilities/solarview-compact-pow-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2022-29301
+id: solarview-compact-pow-xss
 
 info:
   name: SolarView Compact 6.00 - 'pow' Cross-Site Scripting
@@ -15,13 +15,11 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29301
     - https://github.com/ARPSyndicate/cvemon
     - https://github.com/ARPSyndicate/kenzer-templates
-  classification:
-    cve-id: CVE-2022-29301
   metadata:
     verified: true
     max-request: 1
     shodan-query: http.favicon.hash:-244067125
-  tags: cve,cve2022,xss,solarview,edb,vuln
+  tags: xss,solarview,edb,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/solarview-compact-time-begin-xss.yaml
+++ b/http/vulnerabilities/solarview-compact-time-begin-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2022-29299
+id: solarview-compact-time-begin-xss
 
 info:
   name: SolarView Compact 6.00 - 'time_begin' Cross-Site Scripting
@@ -16,7 +16,6 @@ info:
     - https://github.com/ARPSyndicate/cvemon
     - https://github.com/ARPSyndicate/kenzer-templates
   classification:
-    cve-id: CVE-2022-29299
     epss-score: 0.00175
     epss-percentile: 0.5456
     cpe: cpe:2.3:o:contec:solarview_compact_firmware:*:*:*:*:*:*:*:*
@@ -26,7 +25,7 @@ info:
     shodan-query: http.favicon.hash:-244067125
     product: solarview_compact_firmware
     vendor: contec
-  tags: cve2022,cve,xss,solarview,edb,vuln
+  tags: xss,solarview,edb,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/springblade-info-leak.yaml
+++ b/http/vulnerabilities/springblade-info-leak.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-44910
+id: springblade-info-leak
 
 info:
   name: SpringBlade - Information Leakage
@@ -14,7 +14,7 @@ info:
     - https://github.com/chillzhuang/blade-tool
   metadata:
     max-request: 3
-  tags: cve,cve2021,springblade,blade,info-leak,vuln
+  tags: springblade,blade,info-leak,vuln
 
 http:
   - raw:

--- a/http/vulnerabilities/temenos-t24-xss.yaml
+++ b/http/vulnerabilities/temenos-t24-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2023-24367
+id: temenos-t24-xss
 
 info:
   name: Temenos T24 R20 - Cross-Site Scripting
@@ -19,7 +19,6 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
     cvss-score: 6.1
-    cve-id: CVE-2023-24367
     cwe-id: CWE-79
     cpe: cpe:2.3:a:temenos:t24:*:*:*:*:*:*:*:*
   metadata:
@@ -28,7 +27,7 @@ info:
     shodan-query: title:"T24 Sign in"
     product: t24
     vendor: temenos
-  tags: cve,cve2023,xss,temenos,vuln
+  tags: xss,temenos,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/temenos-transact-xss.yaml
+++ b/http/vulnerabilities/temenos-transact-xss.yaml
@@ -1,4 +1,4 @@
-id: CVE-2022-38322
+id: temenos-transact-xss
 
 info:
   name: Temenos Transact - Cross-Site Scripting
@@ -16,7 +16,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: http.title:"transact sign in","t24 sign in"
-  tags: cve,cve2022,temenos,transact,xss,vuln
+  tags: temenos,transact,xss,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
+++ b/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
@@ -1,4 +1,4 @@
-id: CVE-2024-57050
+id: tp-link-wr840n-auth-bypass
 
 info:
   name: TP-LINK WR840N v6 up to 0.9.1 4.16 - Improper Authentication
@@ -16,7 +16,6 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2024-57050
     cwe-id: CWE-287
     epss-score: 0.00043
     epss-percentile: 0.1187
@@ -24,7 +23,7 @@ info:
     verified: true
     max-request: 1
     fofa-query: body="WR840N"
-  tags: cve,cve2024,tp-link,auth-bypass,vuln
+  tags: tp-link,auth-bypass,vuln
 
 http:
   - raw:

--- a/http/vulnerabilities/una-cms-rce.yaml
+++ b/http/vulnerabilities/una-cms-rce.yaml
@@ -1,4 +1,4 @@
-id: CVE-2025-32101
+id: una-cms-rce
 
 info:
   name: UNA CMS <= 14.0.0-RC4 - PHP Object Injection
@@ -17,7 +17,7 @@ info:
     verified: true
     max-request: 3
     fofa-query: body="Powered by UNA"
-  tags: cve,cve2025,una-cms,php,rce,vuln
+  tags: una-cms,php,rce,vuln
 
 variables:
   cmd: "echo '{{randstr}}'. system('id') . '{{randstr}}';"

--- a/http/vulnerabilities/vicidial-info-disclosure.yaml
+++ b/http/vulnerabilities/vicidial-info-disclosure.yaml
@@ -1,4 +1,4 @@
-id: CVE-2021-28854
+id: vicidial-info-disclosure
 
 info:
   name: VICIdial Sensitive Information Disclosure
@@ -11,11 +11,9 @@ info:
     Apply the latest security patches and updates provided by VICIdial to fix the vulnerability and ensure sensitive information is properly protected.
   reference:
     - https://github.com/JHHAX/VICIdial
-  classification:
-    cve-id: CVE-2021-28854
   metadata:
     max-request: 1
-  tags: cve2021,cve,sqli,vuln
+  tags: sqli,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/wordpress/simple-file-list-rce.yaml
+++ b/http/vulnerabilities/wordpress/simple-file-list-rce.yaml
@@ -1,4 +1,4 @@
-id: CVE-2025-34085
+id: simple-file-list-rce
 
 info:
   name: WordPress Simple File List <=4.2.2 - Remote Code Execution
@@ -17,13 +17,12 @@ info:
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cve-id: CVE-2025-34085
     cwe-id: CWE-434
   metadata:
     verified: true
     max-request: 3
     fofa-query: body="/wp-content/plugins/simple-file-list/"
-  tags: cve,cve2025,wordpress,wp-plugin,wp,rce,file-upload,intrusive,simple-file-list,vuln
+  tags: wordpress,wp-plugin,wp,rce,file-upload,intrusive,simple-file-list,vuln
 
 variables:
   filepath: '{{rand_base(7, "abcdefghi")}}'


### PR DESCRIPTION
## Summary
- Moved 22 templates with invalid CVE IDs (rejected or not found in NVD) from `http/cves/` to `http/vulnerabilities/`
- Updated template `id`, removed `cve-id` from classification, and cleaned `cve`/`cveYYYY` tags
- Kept 7 templates that are valid in NVD (CVE-2023-42343, CVE-2023-42344, CVE-2024-33288, CVE-2024-33724, CVE-2024-46507, CVE-2026-41640, CVE-2026-41641)

### Rejected in NVD (8)
| CVE | Reason | New Location |
|-----|--------|-------------|
| CVE-2022-29299 | Duplicate of CVE-2021-20660 | `solarview-compact-time-begin-xss.yaml` |
| CVE-2022-29301 | Duplicate of CVE-2021-20660 | `solarview-compact-pow-xss.yaml` |
| CVE-2022-38322 | Withdrawn by CNA | `temenos-transact-xss.yaml` |
| CVE-2023-24367 | Withdrawn by CNA | `temenos-t24-xss.yaml` |
| CVE-2024-0713 | Duplicate of CVE-2020-28871 | `monitorr-file-upload.yaml` |
| CVE-2024-12760 | Duplicate of CVE-2024-4940 | `bentoml-open-redirect.yaml` |
| CVE-2024-57050 | Duplicate of CVE-2018-11714 | `tp-link-wr840n-auth-bypass.yaml` |
| CVE-2025-34085 | Withdrawn by CNA | `wordpress/simple-file-list-rce.yaml` |

### Not Found in NVD (14)
| CVE | New Location |
|-----|-------------|
| CVE-2018-10818 | `lg-nas-rce.yaml` |
| CVE-2018-16341 | `nuxeo-ssti-rce.yaml` |
| CVE-2021-26292 | `afterlogic-path-disclosure.yaml` |
| CVE-2021-27748 | `ibm/websphere-ssrf.yaml` |
| CVE-2021-28073 | `ntopng-auth-bypass.yaml` |
| CVE-2021-28854 | `vicidial-info-disclosure.yaml` |
| CVE-2021-44910 | `springblade-info-leak.yaml` |
| CVE-2023-1434 | `odoo-xss.yaml` |
| CVE-2023-39024 | `harman-media-suite-lfi.yaml` |
| CVE-2023-39120 | `nodogsplash-lfi.yaml` |
| CVE-2024-23163 | `gestsup-account-takeover.yaml` |
| CVE-2024-23167 | `gestsup-xss.yaml` |
| CVE-2024-25669 | `caseaware-xss.yaml` |
| CVE-2025-32101 | `una-cms-rce.yaml` |

Closes #16115