### PR TITLE
Add CVE-2026-8452: Citrix NetScaler ADC and Gateway Pre-Auth RCE

### DIFF
--- a/http/cves/2026/CVE-2026-8452.yaml
+++ b/http/cves/2026/CVE-2026-8452.yaml
@@ -1,0 +1,92 @@
+id: CVE-2026-8452
+
+info:
+  name: Citrix NetScaler ADC and Gateway < 14.1-72.61 / < 13.1-63.18 - Pre-Auth RCE
+  author: Nick Vidovic
+  severity: critical
+  description: |
+    A heap overflow vulnerability in Citrix NetScaler ADC and Gateway's SAML
+    signature canonicalization allows unauthenticated remote attackers to
+    achieve code execution by sending a crafted SAML message with an oversized
+    PrefixList in the InclusiveNamespaces element of the SignedInfo.
+    The vulnerability is only reachable when SAML is configured as SP or IdP.
+    This template performs passive version mbased detection only the exploit
+    is destructive (crashes nsppe, triggers pitboss reboot) so no active probe
+    is sent.
+  impact: |
+    Remote code execution as root on the NetScaler appliance leading to
+    full compromise of the VPN gateway and all connected networks.
+    The nsppe packet engine crashes and pitboss reboots the appliance.
+  remediation: |
+    Upgrade to fixed versions:
+      - NetScaler ADC/Gateway 14.1 to 14.1-72.61 or later
+      - NetScaler ADC/Gateway 13.1 to 13.1-63.18 or later
+  reference:
+    - https://labs.watchtowr.com/youre-back-in-the-room-citrix-netscaler-pre-auth-rce-cve-2026-8452/
+    - https://support.citrix.com/support-home/kbsearch/article?articleNumber=CTX696604
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8452
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-8452
+    cwe-id: CWE-122
+  metadata:
+    verified: false
+    max-request: 3
+    vendor: citrix
+    product: netscaler
+    shodan-query: http.title:"Citrix Gateway" || http.title:"NetScaler Gateway" || http.title:"NetScaler AAA"
+    fofa-query: title="Citrix Gateway" || title="NetScaler Gateway" || title="NetScaler AAA"
+  tags: cve,cve2026,citrix,netscaler,saml,rce,heap-overflow
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/vpn/index.html"
+      - "{{BaseURL}}/logon/LogonPoint/tmindex.html"
+    stop-at-first-match: true
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "NSC_AAAC"
+        internal: true
+      - type: word
+        part: body
+        words:
+          - "NetScaler AAA</title>"
+          - "Netscaler Gateway</title>"
+          - "_ctxstxt_NetscalerAAA"
+        condition: or
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        part: all
+        group: 1
+        regex:
+          - '(?:NetScaler|Build|Version)[:\s]*(\d+\.\d+-\d+\.\d+)'
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, ">= 14.1") && compare_versions(version, "< 14.1-72.61")'
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, ">= 13.1") && compare_versions(version, "< 13.1-63.18")'
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Version: " + version'


### PR DESCRIPTION
### PR Information

CVE-2026-8452: Citrix NetScaler ADC and Gateway before 14.1-72.61 and 13.1 before 13.1-63.18 are vulnerable to an unauthenticated remote code execution via a heap overflow in the SAML signature canonicalization. Sending a crafted SAML message with an oversized PrefixList in the InclusiveNamespaces element overflows a fixed size buffer, corrupting packet engine state and leading to code execution as root.

- Added CVE-2026-8452
- References:
  - https://labs.watchtowr.com/youre-back-in-the-room-citrix-netscaler-pre-auth-rce-cve-2026-8452/
  - https://support.citrix.com/support-home/kbsearch/article?articleNumber=CTX696604

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Passive version detection template. The vulnerability is destructive  exploitation crashes the nsppe packet engine and triggers a pitboss reboot  so no active probe is sent. The template fingerprints NetScaler via the NSC_AAAC cookie and login page markers, then compares the extracted build version against the vulnerable ranges (14.1 < 14.1-72.61, 13.1 < 13.1-63.18) using compare_versions(). Only two GET requests are made, zero impact on the target.

It got shooted against a big base of Clients to exclude False positives, couldnt verify a TP.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
