### PR TITLE
Add CVE-2026-8236 template

### DIFF
--- a/http/cves/2026/CVE-2026-8236.yaml
+++ b/http/cves/2026/CVE-2026-8236.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-8236
+
+info:
+  name: Concrete CMS <9.5.1 - Unauthenticated File-Usage Internal Metadata Disclosure
+  author: str4k3r
+  severity: medium
+  description: |
+    Concrete CMS's file-usage dialog controller
+    (concrete/controllers/dialog/file/usage.php, route
+    /ccm/system/dialogs/file/usage/{fID}) renders an internal admin-facing
+    table listing every page (page ID, version, handle, URL location) that
+    references a given file ID, without checking that the requester is
+    authenticated. Fixed in 9.5.1, which adds an authentication check that
+    causes the same request to render a generic "Page Not Found" response
+    for anonymous users instead of the file-usage table.
+  reference:
+    - https://documentation.concretecms.org/9-x/developers/9.5.1-security-releases
+  classification:
+    cve-id: CVE-2026-8236
+    cwe-id: CWE-862
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: concretecms
+    product: concrete_cms
+    technology: PHP, Concrete CMS
+    verification_status: VERIFIED
+    safe_oracle: >-
+      Unauthenticated GET /index.php/ccm/system/dialogs/file/usage/1 on V
+      (ghcr.io/concrete5-community/docker5:9.5.0) returns HTTP 200 with the
+      internal ccm-ui dialog table (headers "Page ID"/"Handle"/"Location"),
+      regardless of whether file ID 1 exists (empty tbody on a fresh
+      install -- the leak is the privileged UI rendering itself, not
+      file-specific content). F (:9.5.1) returns HTTP 404 "Page Not Found"
+      for the identical unauthenticated request.
+  tags: cve,cve2026,concretecms,concrete5,cms,unauth,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.php/ccm/system/dialogs/file/usage/1"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - 'class="ccm-ui"'
+          - "Page ID"
+          - "Handle"
+        condition: and

--- a/http/cves/2026/CVE-2026-8236.yaml
+++ b/http/cves/2026/CVE-2026-8236.yaml
@@ -5,14 +5,11 @@ info:
   author: str4k3r
   severity: medium
   description: |
-    Concrete CMS's file-usage dialog controller
-    (concrete/controllers/dialog/file/usage.php, route
-    /ccm/system/dialogs/file/usage/{fID}) renders an internal admin-facing
-    table listing every page (page ID, version, handle, URL location) that
-    references a given file ID, without checking that the requester is
-    authenticated. Fixed in 9.5.1, which adds an authentication check that
-    causes the same request to render a generic "Page Not Found" response
-    for anonymous users instead of the file-usage table.
+    Concrete CMS 9.5.0 and below is vulnerable to IDOR combined with a missing authentication gate. The endpoint /ccm/system/dialogs/file/usage/{fID} accepts an integer file ID in the URL and returns internal site structure data (page IDs, versions, URL paths) to anyone who sends a GET request.
+  impact: |
+    Remote attackers can access internal site structure data, potentially exposing sensitive information about the site.
+  remediation: |
+    Update to a version later than 9.5.0 or the latest available version.
   reference:
     - https://documentation.concretecms.org/9-x/developers/9.5.1-security-releases
   classification:
@@ -25,16 +22,7 @@ info:
     max-request: 1
     vendor: concretecms
     product: concrete_cms
-    technology: PHP, Concrete CMS
-    verification_status: VERIFIED
-    safe_oracle: >-
-      Unauthenticated GET /index.php/ccm/system/dialogs/file/usage/1 on V
-      (ghcr.io/concrete5-community/docker5:9.5.0) returns HTTP 200 with the
-      internal ccm-ui dialog table (headers "Page ID"/"Handle"/"Location"),
-      regardless of whether file ID 1 exists (empty tbody on a fresh
-      install -- the leak is the privileged UI rendering itself, not
-      file-specific content). F (:9.5.1) returns HTTP 404 "Page Not Found"
-      for the identical unauthenticated request.
+    shodan-query: html:"/index.php/ccm/system/"
   tags: cve,cve2026,concretecms,concrete5,cms,unauth,exposure
 
 http:
@@ -44,13 +32,14 @@ http:
 
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
         part: body
         words:
+          - '<td>Page ID</td>'
           - 'class="ccm-ui"'
-          - "Page ID"
-          - "Handle"
+          - '<td>Handle</td>'
         condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds the Nuclei template for **CVE-2026-8236** as an ecosystem contribution.
The template follows the repository format and references the public advisory.