### PR TITLE
Printers: add intrusive tag to vuln, misconfig, CVE and default-login templates

### DIFF
--- a/http/cves/2018/CVE-2018-7282.yaml
+++ b/http/cves/2018/CVE-2018-7282.yaml
@@ -33,7 +33,7 @@ info:
     fofa-query: title="printmonitor"
     google-query: intitle:"printmonitor"
     product": printmonitor
-  tags: time-based-sqli,cve2018,cve,sqli,printmonitor,unauth,titool,vkev,vuln
+  tags: time-based-sqli,cve2018,cve,sqli,printmonitor,unauth,titool,vkev,intrusive,vuln
 variables:
   username: "{{rand_base(6)}}"
   password: "{{rand_base(8)}}"

--- a/http/cves/2020/CVE-2020-23575.yaml
+++ b/http/cves/2020/CVE-2020-23575.yaml
@@ -28,7 +28,7 @@ info:
     product: d-copia253mf_plus_firmware
     shodan-query: http.favicon.hash:-50306417
     fofa-query: icon_hash=-50306417
-  tags: cve2020,cve,printer,iot,lfi,edb,kyocera,vkev,vuln
+  tags: cve2020,cve,printer,iot,lfi,edb,kyocera,vkev,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2021/CVE-2021-38154.yaml
+++ b/http/cves/2021/CVE-2021-38154.yaml
@@ -27,7 +27,7 @@ info:
     max-request: 2
     vendor: canon
     shodan-query: title:"imageRUNNER"
-  tags: cve,cve2021,canon,auth-bypass,vkev,vuln
+  tags: cve,cve2021,canon,auth-bypass,vkev,intrusive,vuln
 
 flow: http(1) || http(2)
 

--- a/http/cves/2022/CVE-2022-1026.yaml
+++ b/http/cves/2022/CVE-2022-1026.yaml
@@ -26,7 +26,7 @@ info:
     product: net_viewer
     shodan-query: product:"Kyocera Printer Panel"
     max-request: 1
-  tags: cve,cve2022,kyocera,exposure,vkev,vuln
+  tags: cve,cve2022,kyocera,exposure,vkev,intrusive,vuln
 
 http:
   - raw:

--- a/http/cves/2023/CVE-2023-26067.yaml
+++ b/http/cves/2023/CVE-2023-26067.yaml
@@ -32,7 +32,7 @@ info:
     shodan-query:
       - "Server: Lexmark_Web_Server"
       - "server: lexmark_web_server"
-  tags: cve2023,cve,printer,iot,lexmark,vkev,vuln
+  tags: cve2023,cve,printer,iot,lexmark,vkev,intrusive,vuln
 variables:
   cmd: 'nslookup {{interactsh-url}}'
 

--- a/http/cves/2023/CVE-2023-27350.yaml
+++ b/http/cves/2023/CVE-2023-27350.yaml
@@ -37,7 +37,7 @@ info:
     fofa-query:
       - body="papercut"
       - body="content=\"papercut\""
-  tags: cve2023,cve,packetstorm,papercut,rce,oast,unauth,kev,vkev,vuln
+  tags: cve2023,cve,packetstorm,papercut,rce,oast,unauth,kev,vkev,intrusive,vuln
 variables:
   cmd: "nslookup {{interactsh-url}}"
 

--- a/http/cves/2023/CVE-2023-27351.yaml
+++ b/http/cves/2023/CVE-2023-27351.yaml
@@ -35,7 +35,7 @@ info:
     fofa-query:
       - body="papercut"
       - body="content=\"papercut\""
-  tags: cve2023,cve,papercut,auth-bypass,vkev,kev
+  tags: cve2023,cve,papercut,auth-bypass,vkev,kev,intrusive
 
 flow: http(1) && http(2)
 

--- a/http/cves/2023/CVE-2023-31059.yaml
+++ b/http/cves/2023/CVE-2023-31059.yaml
@@ -33,7 +33,7 @@ info:
       - title="Repetier-Server"
       - title="repetier-server"
     google-query: intitle:"repetier-server"
-  tags: cve2023,cve,repetier,lfi,repetier-server,vkev,vuln
+  tags: cve2023,cve,repetier,lfi,repetier-server,vkev,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2023/CVE-2023-34259.yaml
+++ b/http/cves/2023/CVE-2023-34259.yaml
@@ -31,7 +31,7 @@ info:
     product: d-copia253mf_plus_firmware
     shodan-query: http.favicon.hash:-50306417
     fofa-query: icon_hash=-50306417
-  tags: cve,cve2023,packetstorm,seclists,kyocera,lfi,printer,vuln
+  tags: cve,cve2023,packetstorm,seclists,kyocera,lfi,printer,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2023/CVE-2023-3710.yaml
+++ b/http/cves/2023/CVE-2023-3710.yaml
@@ -31,7 +31,7 @@ info:
     product: pm43_firmware
     shodan-query: http.html:"/main/login.lua?pageid="
     fofa-query: body="/main/login.lua?pageid="
-  tags: cve2023,cve,honeywell,pm43,printer,iot,rce,vkev,vuln
+  tags: cve2023,cve,honeywell,pm43,printer,iot,rce,vkev,intrusive,vuln
 
 http:
   - raw:

--- a/http/cves/2023/CVE-2023-39143.yaml
+++ b/http/cves/2023/CVE-2023-39143.yaml
@@ -36,7 +36,7 @@ info:
     fofa-query:
       - body="papercut"
       - body="content=\"papercut\""
-  tags: cve2023,cve,lfi,papercut,vkev,vuln
+  tags: cve2023,cve,lfi,papercut,vkev,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2023/CVE-2023-4568.yaml
+++ b/http/cves/2023/CVE-2023-4568.yaml
@@ -35,7 +35,7 @@ info:
       - body='content="papercut'
       - body="content=\"papercut\""
     google-query: html:'content="papercut'
-  tags: cve2023,cve,unauth,papercut,vuln
+  tags: cve2023,cve,unauth,papercut,intrusive,vuln
 
 http:
   - raw:

--- a/http/cves/2024/CVE-2024-33605.yaml
+++ b/http/cves/2024/CVE-2024-33605.yaml
@@ -28,7 +28,7 @@ info:
     shodan-query: "Set-Cookie: MFPSESSIONID="
     product: mx-3550v_firmware
     vendor: sharp
-  tags: cve,cve2024,sharp,printer,traversal,vuln
+  tags: cve,cve2024,sharp,printer,traversal,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2024/CVE-2024-33610.yaml
+++ b/http/cves/2024/CVE-2024-33610.yaml
@@ -24,7 +24,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: "Set-Cookie: MFPSESSIONID="
-  tags: cve,cve2024,sharp,printer,exposure,vuln
+  tags: cve,cve2024,sharp,printer,exposure,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2024/CVE-2024-51977.yaml
+++ b/http/cves/2024/CVE-2024-51977.yaml
@@ -23,7 +23,7 @@ info:
       - app="brother-Printer"
     zoomeye-query:
       - device="brother-Printer" || app="brother-Printer"
-  tags: cve,cve2024,brother,mfc,printer,exposure,vkev,vuln
+  tags: cve,cve2024,brother,mfc,printer,exposure,vkev,intrusive,vuln
 
 http:
   - method: GET

--- a/http/cves/2024/CVE-2024-51978.yaml
+++ b/http/cves/2024/CVE-2024-51978.yaml
@@ -25,7 +25,7 @@ info:
   metadata:
     fofa-query: app="brother-Printer"
     zoomeye-query: device="brother-Printer" || app="brother-Printer"
-  tags: cve,cve2024,brother,authenticated,default-login,vkev,vuln
+  tags: cve,cve2024,brother,authenticated,default-login,vkev,intrusive,vuln
 
 # Flow: Extract serial → Generate password → Login attempt
 flow: |

--- a/http/cves/2025/CVE-2025-41393.yaml
+++ b/http/cves/2025/CVE-2025-41393.yaml
@@ -24,7 +24,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: http.html:"Web Image Monitor"
-  tags: cve,cve2025,ricoh,xss,web,vuln
+  tags: cve,cve2025,ricoh,xss,web,intrusive,vuln
 
 http:
   - method: GET

--- a/http/default-logins/canon/canon-c3325-default-login.yaml
+++ b/http/default-logins/canon/canon-c3325-default-login.yaml
@@ -10,7 +10,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: title:"c3325"
-  tags: canon,c3325,default-login,misconfig,vuln
+  tags: canon,c3325,default-login,misconfig,intrusive,vuln
 
 variables:
   username: "Administrator"

--- a/http/default-logins/fuji-xerox/fuji-xerox-default-login.yaml
+++ b/http/default-logins/fuji-xerox/fuji-xerox-default-login.yaml
@@ -16,7 +16,7 @@ info:
     vendor: fujixerox
     product: apeosport-v_c3375
     fofa-query: '"prop.htm" && "docucentre"'
-  tags: default-login,fuji,fuji-xerox,printer,vuln
+  tags: default-login,fuji,fuji-xerox,printer,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/hp/hp-printer-default-login.yaml
+++ b/http/default-logins/hp/hp-printer-default-login.yaml
@@ -12,7 +12,7 @@ info:
     verified: true
     shodan-query: html:"hp/device/SignIn/Index"
     max-request: 2
-  tags: hp,printer,default-login,vuln
+  tags: hp,printer,default-login,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -13,7 +13,7 @@ info:
     cwe-id: CWE-522
   metadata:
     max-request: 1
-  tags: ricoh,default-login,vuln
+  tags: ricoh,default-login,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/samsung/samsung-printer-default-login.yaml
+++ b/http/default-logins/samsung/samsung-printer-default-login.yaml
@@ -19,7 +19,7 @@ info:
     shodan-query: title:"SyncThru Web Service"
     product: scx-6555n
     vendor: samsung
-  tags: default-login,iot,samsung,printer,vuln
+  tags: default-login,iot,samsung,printer,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/sato/sato-default-login.yaml
+++ b/http/default-logins/sato/sato-default-login.yaml
@@ -10,7 +10,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: title:"Sato"
-  tags: sato,default-login,printer,vuln
+  tags: sato,default-login,printer,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/topaccess/topaccess-default-login.yaml
+++ b/http/default-logins/topaccess/topaccess-default-login.yaml
@@ -10,7 +10,7 @@ info:
     verified: true
     max-request: 2
     shodan-query: title:"topaccess"
-  tags: topaccess,default-login,misconfig,vuln
+  tags: topaccess,default-login,misconfig,intrusive,vuln
 
 variables:
   username: "admin"

--- a/http/default-logins/xerox/xerox-default-login.yaml
+++ b/http/default-logins/xerox/xerox-default-login.yaml
@@ -11,7 +11,7 @@ info:
   metadata:
     verified: true
     max-request: 1
-  tags: xerox,versalink,fuji,default-login
+  tags: xerox,versalink,fuji,default-login,intrusive
 
 variables:
   username: admin

--- a/http/default-logins/xerox/xerox7-default-login.yaml
+++ b/http/default-logins/xerox/xerox7-default-login.yaml
@@ -13,7 +13,7 @@ info:
     cwe-id: CWE-522
   metadata:
     max-request: 1
-  tags: xerox,default-login,vuln
+  tags: xerox,default-login,intrusive,vuln
 
 http:
   - raw:

--- a/http/default-logins/zebra/zebra-printer-default-login.yaml
+++ b/http/default-logins/zebra/zebra-printer-default-login.yaml
@@ -10,7 +10,7 @@ info:
     verified: true
     max-request: 4
     shodan-query: title:"Zebra"
-  tags: zebra,default-login,misconfig,printer,vuln
+  tags: zebra,default-login,misconfig,printer,intrusive,vuln
 
 http:
   - raw:

--- a/http/exposures/configs/hp-laserjet-config.yaml
+++ b/http/exposures/configs/hp-laserjet-config.yaml
@@ -22,7 +22,7 @@ info:
     shodan-query: http.title:"HP LaserJet"
     fofa-query: title="HP LaserJet"
     google-query: intitle:"HP LaserJet" inurl:info_configuration
-  tags: hp,laserjet,printer,iot,config,exposure,misconfig
+  tags: hp,laserjet,printer,iot,config,exposure,misconfig,intrusive
 
 http:
   - method: GET

--- a/http/iot/brother-unauthorized-access.yaml
+++ b/http/iot/brother-unauthorized-access.yaml
@@ -9,7 +9,7 @@ info:
     - https://www.exploit-db.com/ghdb/6889
   metadata:
     max-request: 1
-  tags: iot,printer,unauth,vuln,discovery
+  tags: iot,printer,unauth,intrusive,vuln,discovery
 
 http:
   - method: GET

--- a/http/iot/dell-laser-printer-unauth.yaml
+++ b/http/iot/dell-laser-printer-unauth.yaml
@@ -10,7 +10,7 @@ info:
     max-request: 1
     shodan-query: title="Laser Printer"
     verified: true
-  tags: dell,iot,unauth,misconfig,printer,vuln,discovery
+  tags: dell,iot,unauth,misconfig,printer,intrusive,vuln,discovery
 
 flow: http(1) && http(2)
 

--- a/http/misconfiguration/amr-printer-management-unauth.yaml
+++ b/http/misconfiguration/amr-printer-management-unauth.yaml
@@ -11,7 +11,7 @@ info:
     verified: true
     shodan-query: title:"AMR Printer Management"
     fofa-query: title="AMR Printer Management"
-  tags: network,iot,printer,misconfig,unauth,vuln
+  tags: network,iot,printer,misconfig,unauth,intrusive,vuln
 
 http:
   - method: GET

--- a/http/misconfiguration/hp/unauthorized-hp-printer.yaml
+++ b/http/misconfiguration/hp/unauthorized-hp-printer.yaml
@@ -7,7 +7,7 @@ info:
   description: HP Printer is exposed.
   metadata:
     max-request: 1
-  tags: hp,iot,unauth,misconfig,vuln
+  tags: hp,iot,unauth,misconfig,intrusive,vuln
 
 http:
   - method: GET

--- a/http/misconfiguration/hp/unauthorized-printer-hp.yaml
+++ b/http/misconfiguration/hp/unauthorized-printer-hp.yaml
@@ -12,7 +12,7 @@ info:
     vendor: hp
     product: officejet_pro_8730_m9l80a
     shodan-query: http.title:"Hp Officejet pro"
-  tags: hp,iot,unauth,misconfig,vuln
+  tags: hp,iot,unauth,misconfig,intrusive,vuln
 
 http:
   - method: GET

--- a/http/misconfiguration/installer/octoprint-installer.yaml
+++ b/http/misconfiguration/installer/octoprint-installer.yaml
@@ -14,7 +14,7 @@ info:
     vendor: octoprint
     product: octoprint
     fofa-query: body="Thank you for installing OctoPrint"
-  tags: install,octoprint,misconfig,vuln
+  tags: install,octoprint,misconfig,intrusive,vuln
 
 http:
   - method: GET

--- a/http/misconfiguration/mfp-unauth-exposure.yaml
+++ b/http/misconfiguration/mfp-unauth-exposure.yaml
@@ -14,7 +14,7 @@ info:
   metadata:
     max-request: 1
     verified: true
-  tags: network,iot,printer,misconfig,escl,vuln
+  tags: network,iot,printer,misconfig,escl,intrusive,vuln
 
 http:
   - method: GET

--- a/http/misconfiguration/repetier-unauth.yaml
+++ b/http/misconfiguration/repetier-unauth.yaml
@@ -15,7 +15,7 @@ info:
     product: repetier-server
     shodan-query: title:"Repetier-Server"
     fofa-query: title="repetier-server"
-  tags: repetier,dashboard,unauth,misconfig,vuln
+  tags: repetier,dashboard,unauth,misconfig,intrusive,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/ibm/ibm-infoprint-lfi.yaml
+++ b/http/vulnerabilities/ibm/ibm-infoprint-lfi.yaml
@@ -13,7 +13,7 @@ info:
     cwe-id: CWE-23
   metadata:
     max-request: 1
-  tags: matrix,printer,edb,ibm,lfi,vuln
+  tags: matrix,printer,edb,ibm,lfi,intrusive,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/other/clodop-printer-lfi.yaml
+++ b/http/vulnerabilities/other/clodop-printer-lfi.yaml
@@ -15,7 +15,7 @@ info:
     max-request: 1
     shodan-query: title:"Welcome to C-Lodop"
     fofa-query: title="C-Lodop"
-  tags: c-lodop,lfi,printer,iot,vuln
+  tags: c-lodop,lfi,printer,iot,intrusive,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/other/kyocera-m2035dn-lfi.yaml
+++ b/http/vulnerabilities/other/kyocera-m2035dn-lfi.yaml
@@ -14,7 +14,7 @@ info:
     cwe-id: CWE-22
   metadata:
     max-request: 1
-  tags: edb,printer,iot,kyocera,lfi,vuln
+  tags: edb,printer,iot,kyocera,lfi,intrusive,vuln
 
 http:
   - method: GET

--- a/http/vulnerabilities/other/papercut-log4j-rce.yaml
+++ b/http/vulnerabilities/other/papercut-log4j-rce.yaml
@@ -19,7 +19,7 @@ info:
     shodan-query: title:"Papercut"
     product: papercut_mf
     vendor: papercut
-  tags: cve,cve2021,rce,jndi,log4j,papercut,oast,kev,vuln
+  tags: cve,cve2021,rce,jndi,log4j,papercut,oast,kev,intrusive,vuln
 variables:
   rand1: '{{rand_int(111, 999)}}'
   rand2: '{{rand_int(111, 999)}}'

--- a/http/vulnerabilities/other/sharp-printers-lfi.yaml
+++ b/http/vulnerabilities/other/sharp-printers-lfi.yaml
@@ -20,7 +20,7 @@ info:
     vendor: sharp
     product: mx-3050v_firmware
     shodan-query: "Set-Cookie: MFPSESSIONID="
-  tags: sharp,printer,lfi,vuln
+  tags: sharp,printer,lfi,intrusive,vuln
 
 http:
   - method: GET

--- a/javascript/cves/2024/CVE-2024-47176.yaml
+++ b/javascript/cves/2024/CVE-2024-47176.yaml
@@ -27,7 +27,7 @@ info:
   metadata:
     verified: true
     shodan-query: "product:cups"
-  tags: cve,cve2024,cups,udp,printer,oast,rce,vkev,vuln
+  tags: cve,cve2024,cups,udp,printer,oast,rce,vkev,intrusive,vuln
 
 javascript:
   - pre-condition: |

--- a/network/misconfig/printers-info-leak.yaml
+++ b/network/misconfig/printers-info-leak.yaml
@@ -18,7 +18,7 @@ info:
     vendor: generic
     product: printer
     shodan-query: port:9100
-  tags: network,iot,printer,misconfig,tcp,pjl,vuln
+  tags: network,iot,printer,misconfig,tcp,pjl,intrusive,vuln
 
 tcp:
   - inputs:


### PR DESCRIPTION
## Summary

Adds the `intrusive` tag to **43 printer templates** that actively exploit or authenticate, so they can be filtered out of non-invasive scans with `-etags intrusive`. Detection-only printer templates are deliberately left alone.

Every change is a single line — the `tags:` line. No logic, matchers, or requests were touched:

```
43 files changed, 43 insertions(+), 43 deletions(-)
```

## What was tagged

| Category | Count | Templates |
|---|---|---|
| CVEs | 18 | Kyocera (d-COPIA, TASKalfa, Net View, M2035dn), Lexmark, PaperCut ×4, Sharp MFP ×2, Brother ×2, Honeywell PM43, Ricoh, Canon Catwalk, Repetier, TITool PrintMonitor, CUPS |
| Misconfiguration / exposure | 10 | AMR printer mgmt, HP unauthorized ×2, OctoPrint installer, MFP eSCL, Repetier dashboard, HP LaserJet config, Brother unauth, Dell laser printer, PJL info leak |
| Vulnerabilities | 5 | IBM InfoPrint LFI, C-Lodop LFI, Kyocera M2035dn LFI, PaperCut log4j RCE, Sharp MFP LFI |
| Default-logins | 10 | Canon C3325, Fuji Xerox, HP, Ricoh, Samsung, Sato, Toshiba TopAccess, Xerox ×2, Zebra |

The default-logins are the strongest case in the set — all 10 POST credentials to the device (4 use `pitchfork` payload sets), so they can trigger account lockout on an MFP. There is existing precedent for tagging these: `empirec2-default-login` and `panabit-default-login` already carry `intrusive`.

## Tag placement

`intrusive` is inserted before the trailing `vuln` tag to match the dominant existing convention:

```diff
-  tags: cve2023,cve,honeywell,pm43,printer,iot,rce,vkev,vuln
+  tags: cve2023,cve,honeywell,pm43,printer,iot,rce,vkev,intrusive,vuln
```

Two templates had no `vuln` tag (`CVE-2023-27351`, `hp-laserjet-config`), so the tag is appended at the end there.

## Deliberately NOT tagged

- **All `exposed-panels/`** printer templates (brother, ecosys, epson ×2, fuji-xerox, samsung, syncthru, xerox, safeq, octoprint-login, papercut-ng, repetier-server, myq)
- **All `technologies/`** printer templates (lexmark-detect, xerox-workcentre-detect)
- **Detect-only `iot/`** templates (brother-printer-detect, hp-laserjet-detect, hp-color-laserjet-detect, epson-wf-series, kyocera-printer-panel, octoprint-3dprinter-detect, zebra-printer-detect)
- **`CVE-2026-4480`** (Samba printing subsystem RCE) — it is tagged `passive` and only performs an SMB banner check via `ConnectSMBInfoMode`, with no exploitation. Tagging it `intrusive` would contradict `passive` on the same template.
- **`3d-print-lite-xss`** — a WordPress plugin, not a printer device.

## Validation

```
nuclei -validate -t <all 43 templates>
[INF] All templates validated successfully
```

Verified the diff contains only `tags:` lines, and that all 43 files parse as valid YAML.

Note: the trailing `# digest:` signature lines are now stale for these files and will need regeneration by the signing bot on merge.