### PR TITLE
Fix wp-vr-view-xss and vrview-xss firing on hosts that escape the payload

### DIFF
--- a/http/vulnerabilities/wordpress/vrview-xss.yaml
+++ b/http/vulnerabilities/wordpress/vrview-xss.yaml
@@ -33,6 +33,7 @@ http:
         GET /wp-content/plugins/vrview/vrview/?image=<img%20src=x%20onerror=alert(document.domain)> HTTP/1.1
         Host: {{Hostname}}
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
@@ -47,4 +48,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100a11ca2f3657ecbf5079819e3557a27596e2a313d07c8e541d3b04d6c8e636f61022037de044e1037819e9200e8f1fe1119f720f4254cbd42d677f3669ddbd62b2bf0:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/wordpress/wp-vr-view-xss.yaml
+++ b/http/vulnerabilities/wordpress/wp-vr-view-xss.yaml
@@ -33,6 +33,7 @@ http:
         GET /wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)> HTTP/1.1
         Host: {{Hostname}}
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
@@ -47,4 +48,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4b0a0048304602210097322accd35bf12a8524f090bdbbad41494a8114c4d1b780d56ff8577c3a3baf022100bcec46ec2336fc5a723be6b0cb9bce18e4cb3d7b14a3eb709e88a4f04f0f152a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Fixed wp-vr-view-xss and vrview-xss

The second request in both templates has three matchers. One looks for the payload reflected in the body. The other two check `content_type` for `text/html` and status `200`. Neither block sets `matchers-condition` so nuclei falls back to `or`. Two of the three hold for almost any HTML page. Both templates end up reporting high severity XSS on hosts that escape the payload correctly. Same author and same shape in both files so they are fixed together.

- References: https://blog.mindedsecurity.com/2018/04/dom-based-cross-site-scripting-in.html

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Two local `http.server` targets on 127.0.0.1. Both serve the plugin path on `/` so the `flow` gate passes. Port 8801 HTML escapes the reflected `image` parameter and is not vulnerable. Port 8802 echoes it back raw and is. nuclei v3.11.0.

Current template against the escaping host:

```
$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8801 -ms -debug-resp
[DBG] [wp-vr-view-xss] Dumped HTTP response http://127.0.0.1:8801/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
HTTP/1.1 200 OK
Content-Length: 83
Content-Type: text/html; charset=utf-8
Server: BaseHTTP/0.6 Python/3.14.6
<html><body>VR view: &lt;img src=x onerror=alert(document.domain)&gt;</body></html>
[wp-vr-view-xss:word-2] [matched] [http] [high] http://127.0.0.1:8801/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
[wp-vr-view-xss:status-3] [matched] [http] [high] http://127.0.0.1:8801/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 43.869536ms. 2 matches found.
```

`word-1` is the payload matcher and it never fires. The finding comes from `word-2` and `status-3`, and either alone is enough.

Current template against the raw echo host:

```
$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8802
[wp-vr-view-xss] [http] [high] http://127.0.0.1:8802/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 44.2162ms. 1 matches found.
```

With `matchers-condition: and`:

```
$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8801
[INF] Scan completed in 43.686843ms. 0 matches found.

$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8802
[wp-vr-view-xss] [http] [high] http://127.0.0.1:8802/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 44.286523ms. 1 matches found.
```

Same four runs for `vrview-xss`:

```
$ nuclei -t vrview-xss.yaml -u http://127.0.0.1:8801
[vrview-xss] [http] [high] http://127.0.0.1:8801/wp-content/plugins/vrview/vrview/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 43.798803ms. 1 matches found.

$ nuclei -t vrview-xss.yaml -u http://127.0.0.1:8802
[vrview-xss] [http] [high] http://127.0.0.1:8802/wp-content/plugins/vrview/vrview/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 44.319885ms. 1 matches found.
```

```
$ nuclei -t vrview-xss.yaml -u http://127.0.0.1:8801   # with matchers-condition: and
[INF] Scan completed in 43.813771ms. 0 matches found.

$ nuclei -t vrview-xss.yaml -u http://127.0.0.1:8802   # with matchers-condition: and
[vrview-xss] [http] [high] http://127.0.0.1:8802/wp-content/plugins/vrview/vrview/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 43.833889ms. 1 matches found.
```

The status matcher is not gating anything either. A 404 that comes back as `text/html` still reports, on the content type alone:

```
$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8803 -ms -debug-resp
[DBG] [wp-vr-view-xss] Dumped HTTP response http://127.0.0.1:8803/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
HTTP/1.1 404 Not Found
Content-Length: 85
Content-Type: text/html; charset=utf-8
Server: BaseHTTP/0.6 Python/3.14.6
<html><body>Not Found: &lt;img src=x onerror=alert(document.domain)&gt;</body></html>
[wp-vr-view-xss:word-2] [matched] [http] [high] http://127.0.0.1:8803/wp-content/plugins/wp-vr-view/asset/?image=<img%20src=x%20onerror=alert(document.domain)>
[INF] Scan completed in 44.438548ms. 1 matches found.

$ nuclei -t wp-vr-view-xss.yaml -u http://127.0.0.1:8803   # with matchers-condition: and
[INF] Scan completed in 43.002763ms. 0 matches found.
```

Validation passes on both:

```
$ nuclei -validate -t http/vulnerabilities/wordpress/wp-vr-view-xss.yaml -t http/vulnerabilities/wordpress/vrview-xss.yaml
[INF] All templates validated successfully
```

I left the first request block alone. It has one matcher so a condition there would do nothing. I also dropped the stale `# digest` lines so the signing workflow re-signs them on merge.

Both files are the same plugin family so I grouped them. Happy to split them into two PRs if you would rather review them separately.
