### PR TITLE
CVE-2022-41040

### DIFF
--- a/http/cves/2022/CVE-2022-41040.yaml
+++ b/http/cves/2022/CVE-2022-41040.yaml
@@ -1,0 +1,79 @@
+id: CVE-2022-41040
+
+info:
+  name: Exchange Server - SSRF
+  author: popy21
+  severity: high
+  description: |
+    Microsoft Exchange Server is vulnerable to a server-side request forgery (ProxyNotShell) that lets an attacker holding standard user credentials reach internal back-end endpoints, including Remote PowerShell, through the Autodiscover front end. This template performs a passive version check: it reads the build number disclosed by the unauthenticated OWA logon page and flags builds older than the November 8, 2022 security update. It confirms an unpatched build, not exploitability.
+
+  impact: |
+    An attacker with standard user credentials can make the Exchange front end proxy authenticated requests to internal back-end endpoints such as Remote PowerShell, which chained with CVE-2022-41082 yields remote code execution on the mailbox server.
+
+  remediation: |
+    Apply the November 8, 2022 Exchange Server security update (KB5019758) or later - Exchange 2013 CU23 15.0.1497.44, Exchange 2016 CU22 15.1.2375.37 / CU23 15.1.2507.16, Exchange 2019 CU11 15.2.986.36 / CU12 15.2.1118.20.
+
+  reference:
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-41040
+    - http://packetstormsecurity.com/files/170066/Microsoft-Exchange-ProxyNotShell-Remote-Code-Execution.html
+    - https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41040
+    - https://support.microsoft.com/help/5019758
+    - https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates
+    - https://unit42.paloaltonetworks.com/proxynotshell-cve-2022-41040-cve-2022-41082/
+    - https://www.kb.cert.org/vuls/id/915563
+    - https://www.secpod.com/blog/microsoft-november-2022-patch-tuesday-patches-65-vulnerabilities-including-6-zero-days/
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2022-41040
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-41040
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2022-41040
+    cwe-id: cwe-918
+    epss-score: 0.99956
+    epss-percentile: 0.99975
+    cpe: cpe:2.3:a:microsoft:exchange_server:2013:cumulative_update_23:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: microsoft
+    product: exchange_server
+    shodan-query:
+      - http.favicon.hash:1768726119
+      - http.title:"outlook"
+      - cpe:"cpe:2.3:a:microsoft:exchange_server"
+    fofa-query:
+      - icon_hash=1768726119
+      - title="outlook"
+  tags: cve,cve2022,microsoft,exchange-server,ssrf,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/owa/auth/logon.aspx"
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '/owa/auth/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/'
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 15.0', '< 15.0.1497.44')"
+          - "compare_versions(version, '>= 15.1', '< 15.1.2375.37')"
+          - "compare_versions(version, '>= 15.1.2376', '< 15.1.2507.16')"
+          - "compare_versions(version, '>= 15.2', '< 15.2.986.36')"
+          - "compare_versions(version, '>= 15.2.987', '< 15.2.1118.20')"
+        condition: or
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - '/owa/auth/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/'

--- a/http/cves/2022/CVE-2022-41040.yaml
+++ b/http/cves/2022/CVE-2022-41040.yaml
@@ -33,6 +33,7 @@ info:
     epss-percentile: 0.99975
     cpe: cpe:2.3:a:microsoft:exchange_server:2013:cumulative_update_23:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
     vendor: microsoft
     product: exchange_server
@@ -43,7 +44,7 @@ info:
     fofa-query:
       - icon_hash=1768726119
       - title="outlook"
-  tags: cve,cve2022,microsoft,exchange-server,ssrf,kev
+  tags: cve,cve2022,microsoft,exchange-server,ssrf,kev,passive
 
 http:
   - method: GET
@@ -52,6 +53,15 @@ http:
 
     matchers-condition: and
     matchers:
+      - type: word
+        part: response
+        words:
+          - "X-OWA-Version"
+          - "owa/auth.owa"
+          - "flogon.js"
+          - "logon.aspx"
+        condition: or
+
       - type: regex
         part: body
         regex:


### PR DESCRIPTION
Adds a detection template for **CVE-2022-41040**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.