### PR TITLE
Add detection of "mGuard" appliances.

### DIFF
--- a/http/exposed-panels/mguard-security-appliance-login.yaml
+++ b/http/exposed-panels/mguard-security-appliance-login.yaml
@@ -1,0 +1,33 @@
+id: mguard-security-appliance-login
+
+info:
+  name: mGuard Security Appliance Login Panel
+  author: righettod
+  severity: info
+  description: |
+    mGuard Security Appliance was detected - A industrial firewalls/secure routers designed to protect machines, PLCs, HMIs, and industrial networks.
+  reference:
+    - https://www.phoenixcontact.com/
+  metadata:
+    max-request: 1
+    shodan-query: http.title:"mGuard"
+  tags: panel,phoenixcontact,login,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: or
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_any(to_lower(body), '<title>mguard</title>', '<span id="hostname">mguard</span>')
+          - status_code == 200
+        condition: and
+        
+      - type: dsl
+        dsl:
+          - contains(header, 'mGuard')
+          - status_code == 200
+        condition: and

--- a/http/exposed-panels/mguard-security-appliance-login.yaml
+++ b/http/exposed-panels/mguard-security-appliance-login.yaml
@@ -25,7 +25,7 @@ http:
           - contains_any(to_lower(body), '<title>mguard</title>', '<span id="hostname">mguard</span>')
           - status_code == 200
         condition: and
-        
+
       - type: dsl
         dsl:
           - contains(header, 'mGuard')

--- a/http/exposed-panels/mguard-security-appliance-panel.yaml
+++ b/http/exposed-panels/mguard-security-appliance-panel.yaml
@@ -1,7 +1,7 @@
-id: mguard-security-appliance-login
+id: mguard-security-appliance-panel
 
 info:
-  name: mGuard Security Appliance Login Panel
+  name: mGuard Security Appliance - Panel
   author: righettod
   severity: info
   description: |


### PR DESCRIPTION
### PR Information

Hi,

This PR propose a template to detect instances of the security appliance **mGuard**: An industrial firewalls/secure routers designed to protect machines, PLCs, HMIs, and industrial networks.

- References: https://www.phoenixcontact.com/

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

The template was developed and tested against the version **3.11.1** of nuclei.

### Additional Details (leave it blank if not applicable)

### Additional References:

None