### PR TITLE
CVE-2024-1708

### DIFF
--- a/http/cves/2024/CVE-2024-1708.yaml
+++ b/http/cves/2024/CVE-2024-1708.yaml
@@ -1,70 +1,46 @@
 id: CVE-2024-1708
 
 info:
-  name: ConnectWise ScreenConnect <=23.9.7 - Path Traversal
+  name: ConnectWise ScreenConnect <= 23.9.7 - Path Traversal
   author: popy21
   severity: high
   description: |
-    ConnectWise ScreenConnect 23.9.7 and prior are affected by path-traversal vulnerability, which
-    may allow an attacker the ability to execute remote code or directly impact confidential data
-    or critical systems.
-
+    ConnectWise ScreenConnect 23.9.7 and prior contain a path traversal caused by improper handling of user input, letting attackers execute remote code or access confidential data, exploit requires network access.
   impact: |
-    An attacker with elevated privileges - including one obtained through the companion authentication bypass CVE-2024-1709 - can write arbitrary .aspx/.ashx files outside the intended extension subdirectory, into the App_Extensions root, yielding remote code execution on the ScreenConnect server.
-
+    Attackers can execute remote code or access sensitive data, potentially leading to full system compromise or data breach.
   remediation: |
-    Update ConnectWise ScreenConnect to version 23.9.8 or later.
-
+    Update to the latest version of ConnectWise ScreenConnect.
   reference:
     - https://www.connectwise.com/company/trust/security-bulletins/connectwise-screenconnect-23.9.8
     - https://www.huntress.com/blog/a-catastrophe-for-control-understanding-the-screenconnect-authentication-bypass
-    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/connectwise_screenconnect_rce_cve_2024_1709.rb
     - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-1708
-    - https://www.microsoft.com/en-us/security/blog/2026/04/06/storm-1175-focuses-gaze-on-vulnerable-web-facing-assets-in-high-tempo-medusa-ransomware-operations/
     - https://nvd.nist.gov/vuln/detail/CVE-2024-1708
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:H/I:H/A:H
     cvss-score: 8.4
     cve-id: CVE-2024-1708
-    cwe-id: cwe-22
-    epss-score: 0.87558
-    epss-percentile: 0.99744
-    cpe: cpe:2.3:a:connectwise:screenconnect:*:*:*:*:*:*:*:*
+    cwe-id: CWE-22
   metadata:
     verified: true
     max-request: 1
     vendor: connectwise
     product: screenconnect
-    shodan-query:
-      - http.favicon.hash:-82958153
-      - "Server: ScreenConnect"
-    fofa-query:
-      - app="ScreenConnect-Remote-Support-Software"
-      - icon_hash=-82958153
+    shodan-query: http.favicon.hash:-82958153
+    fofa-query: icon_hash=-82958153
   tags: cve,cve2024,connectwise,screenconnect,lfi,kev
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/Login"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
 
-    host-redirects: true
-    max-redirects: 2
-
-    matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - "Server: ScreenConnect/"
-
       - type: dsl
         dsl:
-          - "compare_versions(version, '<= 23.9.7')"
-
-      - type: status
-        status:
-          - 200
+          - contains(header, "ScreenConnect/")
+          - compare_versions(version, '<= 23.9.7')
+        condition: and
 
     extractors:
       - type: regex
@@ -75,7 +51,8 @@ http:
           - 'ScreenConnect/([0-9]+\.[0-9]+\.[0-9]+)'
         internal: true
 
-      - type: kval
+      - type: regex
         part: header
-        kval:
-          - Server
+        group: 1
+        regex:
+          - 'ScreenConnect/([0-9]+\.[0-9]+\.[0-9]+)'

--- a/http/cves/2024/CVE-2024-1708.yaml
+++ b/http/cves/2024/CVE-2024-1708.yaml
@@ -1,0 +1,81 @@
+id: CVE-2024-1708
+
+info:
+  name: ConnectWise ScreenConnect <=23.9.7 - Path Traversal
+  author: popy21
+  severity: high
+  description: |
+    ConnectWise ScreenConnect 23.9.7 and prior are affected by path-traversal vulnerability, which
+    may allow an attacker the ability to execute remote code or directly impact confidential data
+    or critical systems.
+
+  impact: |
+    An attacker with elevated privileges - including one obtained through the companion authentication bypass CVE-2024-1709 - can write arbitrary .aspx/.ashx files outside the intended extension subdirectory, into the App_Extensions root, yielding remote code execution on the ScreenConnect server.
+
+  remediation: |
+    Update ConnectWise ScreenConnect to version 23.9.8 or later.
+
+  reference:
+    - https://www.connectwise.com/company/trust/security-bulletins/connectwise-screenconnect-23.9.8
+    - https://www.huntress.com/blog/a-catastrophe-for-control-understanding-the-screenconnect-authentication-bypass
+    - https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/connectwise_screenconnect_rce_cve_2024_1709.rb
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-1708
+    - https://www.microsoft.com/en-us/security/blog/2026/04/06/storm-1175-focuses-gaze-on-vulnerable-web-facing-assets-in-high-tempo-medusa-ransomware-operations/
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-1708
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:H/I:H/A:H
+    cvss-score: 8.4
+    cve-id: CVE-2024-1708
+    cwe-id: cwe-22
+    epss-score: 0.87558
+    epss-percentile: 0.99744
+    cpe: cpe:2.3:a:connectwise:screenconnect:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: connectwise
+    product: screenconnect
+    shodan-query:
+      - http.favicon.hash:-82958153
+      - "Server: ScreenConnect"
+    fofa-query:
+      - app="ScreenConnect-Remote-Support-Software"
+      - icon_hash=-82958153
+  tags: cve,cve2024,connectwise,screenconnect,lfi,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/Login"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "Server: ScreenConnect/"
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 23.9.7')"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        group: 1
+        regex:
+          - 'ScreenConnect/([0-9]+\.[0-9]+\.[0-9]+)'
+        internal: true
+
+      - type: kval
+        part: header
+        kval:
+          - Server


### PR DESCRIPTION
Adds a detection template for **CVE-2024-1708**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.