### PR TITLE
Add symfony-of-damage (Legacy EOL Config Exposure & Awareness)

### DIFF
--- a/http/misconfiguration/symfony-of-damage.yaml
+++ b/http/misconfiguration/symfony-of-damage.yaml
@@ -1,0 +1,34 @@
+id: symfony-of-damage
+
+info:
+  name: symfony publicly exposed configuration file - Detect
+  author: hi-charm
+  severity: critical
+  description: Symfony configuration file was detected and may contain database credentials.
+  reference: https://symfony.com/doc/3.4/configuration/external_parameters.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 9.8
+    cwe-id: CWE-200
+  tags: config,exposure,symfony,lfi
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/app_dev.php/_profiler/open?file=app/config/parameters.yml"
+      - "{{BaseURL}}/app_dev.php/_configurator/final"
+      - "{{BaseURL}}/web/app_dev.php/_profiler/open?file=app/config/parameters.yml"
+      - "{{BaseURL}}/web/app_dev.php/_configurator/final"
+      - "{{BaseURL}}/_profiler/open?file=app/config/parameters.yml"
+    max-redirects: 0
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "parameters:"
+          - "&nbsp;|<textarea"
+        condition: and


### PR DESCRIPTION
## Description

This PR introduces `symfony-of-damage`, a template designed for **Security Awareness and Asset Discovery** targeting heavily legacy, End-of-Life (EOL) Symfony environments (2.x, 3.x, and 4.x). 

Because these frameworks have reached EOL, this template is not intended to prompt framework patching. Instead, it serves organizations maintaining legacy infrastructure for compliance and operational continuity, allowing them to identify critical exposures and implement perimeter-level workarounds (e.g., WAF rules, routing blocks) to avoid architectural collisions.

### The Threat Context & RCE Correlation
While this template detects the exposure of `app/config/parameters.yml` (via legacy front controllers like `app_dev.php` or `_profiler`), the impact extends far beyond database credential theft. 

Symfony 4 environments are known to be vulnerable to **Remote Code Execution (RCE) via the `/_fragment` endpoint** if the framework's `secret` is known. The `parameters.yml` file exposed by this template directly leaks this `secret`, handing attackers the exact cryptographic material required to forge valid HMAC signatures, bypass `/_fragment` protections, and achieve full RCE. 

### Template Details
* **Template ID:** `symfony-of-damage`
* **Target:** EOL Symfony (2.x, 3.x, 4.x)
* **Severity:** Critical (CVSS: 9.8) - *Direct pivot to RCE via secret leakage.*
* **Tags:** `config`, `exposure`, `symfony`, `lfi`, `awareness`
* **Detection Logic:** 
  The template probes classic legacy debug and configurator paths:
  - `app_dev.php` routes
  - `_configurator/final` 
  - `_profiler/open?file=` 
  
  It employs a strict `AND` condition, matching a `200 OK` status with body regex looking for `parameters:` alongside specific HTML elements (`&nbsp;|<textarea`). This confirms the payload is actively rendering and minimizes false positives.

### Checklist
- [x] I have tested this template against a functionally equivalent target within a sanctioned, client-authorized enterprise security assessment.
- [x] - [x] The template follows the [Nuclei template guidelines](https://docs.projectdiscovery.io/templates/introduction).
- [x] I have added relevant tags and severity metrics.
- [x] The detection logic minimizes false positives.