### PR TITLE
feat(templates): add CVE-2025-53690 Sitecore Experience Platform template

### DIFF
--- a/http/cves/2025/CVE-2025-53690.yaml
+++ b/http/cves/2025/CVE-2025-53690.yaml
@@ -1,0 +1,120 @@
+id: CVE-2025-53690
+
+info:
+  name: Sitecore XM/XP/XC - Deserialization RCE via Known Machine Keys
+  author: BountyGrid
+  severity: critical
+  description: |
+    Sitecore Experience Manager (XM), Experience Platform (XP), and Experience Commerce (XC) are vulnerable to unauthenticated remote code execution due to the use of publicly documented, static ASP.NET machineKey values in production deployments. Legacy Sitecore installation guides (pre-2017) shipped sample machineKey entries that many organizations deployed without replacing. An attacker who knows these well-known keys can craft a malicious ViewState payload, sign it with the leaked key, and send it to any Sitecore endpoint that processes ViewState (such as /sitecore/blocked.aspx), resulting in arbitrary code execution on the server via .NET deserialization.
+  impact: |
+    Unauthenticated attackers can achieve full remote code execution on the Sitecore web server by exploiting ViewState deserialization with publicly known machineKey values, potentially compromising the entire web application, content management system, and underlying infrastructure.
+  remediation: |
+    Immediately rotate ASP.NET machineKey values in web.config to unique, cryptographically strong keys. Upgrade to a supported Sitecore version where deployment processes automatically generate unique keys. Refer to Sitecore Security Bulletin SC2025-005 for detailed remediation steps.
+  reference:
+    - https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002578
+    - https://cloud.google.com/blog/topics/threat-intelligence/sitecore-rce-machine-key
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-53690
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 9.0
+    cve-id: CVE-2025-53690
+    cwe-id: CWE-502
+    epss-score: 0.87544
+    epss-percentile: 0.99472
+  metadata:
+    verified: false
+    max-request: 3
+    vendor: sitecore
+    product: experience_manager
+    shodan-query:
+      - http.title:"Welcome to Sitecore"
+      - http.title:"Sitecore"
+    fofa-query:
+      - title="Welcome to Sitecore"
+      - body="Sitecore.NET"
+  tags: cve,cve2025,sitecore,deserialization,rce,viewstate,machinekey,kev,vkev,vuln
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - raw:
+      - |
+        GET /sitecore/shell/sitecore.version.xml HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'Sitecore Corporation')"
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: sc_major
+        part: body
+        group: 1
+        regex:
+          - "<major>([0-9]+)</major>"
+        internal: true
+
+      - type: regex
+        name: sc_minor
+        part: body
+        group: 1
+        regex:
+          - "<minor>([0-9]+)</minor>"
+        internal: true
+
+  - raw:
+      - |
+        GET /-/media/doo-doo.ashx HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 302 || status_code == 301"
+          - "contains(tolower(header), 'sitecore')"
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /sitecore/blocked.aspx HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200 || status_code == 302"
+
+      - type: word
+        part: body
+        words:
+          - "__VIEWSTATE"
+          - "__VIEWSTATEGENERATOR"
+        condition: and
+
+      - type: word
+        part: body
+        words:
+          - "Sitecore"
+
+      - type: dsl
+        dsl:
+          - "sc_major != '' && sc_minor != ''"
+
+    extractors:
+      - type: dsl
+        dsl:
+          - "'Sitecore Version: ' + sc_major + '.' + sc_minor"
+
+      - type: regex
+        name: viewstate_generator
+        part: body
+        group: 1
+        regex:
+          - '__VIEWSTATEGENERATOR[^>]*value="([^"]*)"'


### PR DESCRIPTION
## Description
Adds a non-intrusive vulnerability detection template for Sitecore Experience Platform (CVE-2025-53690).

Fixes #<ISSUE_NUMBER>
/claim #<ISSUE_NUMBER>

## Template Details
- **Severity**: Critical (CVSS 9.0)
- **CWE**: CWE-502 (Deserialization of Untrusted Data)
- **Detection Method**: Non-intrusive HTTP version signature and ViewState evaluation.

## Verification
- Validated via `nuclei -validate` with 0 warnings/errors.
- Schema verified with PyYAML validator.