### PR TITLE
Add OIDC legacy implicit flow enabled template

### DIFF
--- a/http/misconfiguration/oidc-implicit-flow-enabled.yaml
+++ b/http/misconfiguration/oidc-implicit-flow-enabled.yaml
@@ -1,0 +1,58 @@
+id: oidc-implicit-flow-enabled
+
+info:
+  name: OpenID Connect - Legacy Implicit Flow Enabled
+  author: rocky55ayush
+  severity: low
+  description: |
+    The OpenID Connect discovery document advertises a response_type that returns an access token via the front channel (implicit / hybrid flow, e.g. "token" or "id_token token"). Tokens delivered in the URL fragment are exposed to browser history, referrer leakage, and open-redirect / XSS token-theft chains. The implicit grant is removed in OAuth 2.1; the authorization code flow with PKCE should be used instead.
+  reference:
+    - https://openid.net/specs/openid-connect-discovery-1_0.html
+    - https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics
+    - https://oauth.net/2.1/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N
+    cvss-score: 3.7
+    cwe-id: CWE-522
+  metadata:
+    max-request: 3
+  tags: oidc,openid,oauth,keycloak,misconfig,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/openid-configuration"
+      - "{{BaseURL}}/realms/master/.well-known/openid-configuration"
+      - "{{BaseURL}}/auth/realms/master/.well-known/openid-configuration"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"authorization_endpoint"'
+          - '"response_types_supported"'
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - '"response_types_supported"\s*:\s*\[[^\]]*\btoken\b'
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"issuer"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
### Template Added

`http/misconfiguration/oidc-implicit-flow-enabled.yaml`

### What it detects

Flags an OpenID Connect / OAuth 2.0 discovery document (`/.well-known/openid-configuration`) that advertises a `response_type` returning an **access token via the front channel** (implicit / hybrid flow, e.g. `token` or `id_token token`). Tokens delivered in the URL fragment are exposed to browser history, referrer leakage, and open-redirect / XSS token-theft chains. The implicit grant is removed in OAuth 2.1; authorization code flow with PKCE should be used instead.

- **Severity:** low
- **CWE:** CWE-522 (Insufficiently Protected Credentials)
- **Match logic:** requires HTTP 200 + `application/json` + presence of `authorization_endpoint`/`response_types_supported`, then a word-boundary regex that only matches a standalone `token` response type.

### False-positive care

The regex uses a word boundary (`"response_types_supported"\s*:\s*\[[^\]]*\btoken\b`) so the substring `token` inside `id_token` does **not** trigger it. A config that only supports `code`, `id_token`, and `code id_token` (all safe) is correctly ignored.

### Local validation

```
$ nuclei -validate -t http/misconfiguration/oidc-implicit-flow-enabled.yaml
[INF] All templates validated successfully
```

Proof of fire against a local mock discovery doc:

- **Vulnerable doc** (advertises `token` / `id_token token`) → **matches** ✅
- **Hardened doc** (only `code`, `id_token`, `code id_token`) → **no match** ✅ — confirms `id_token` does not false-positive on the `\btoken\b` regex

Tested only against a local, disposable mock — never against third-party infrastructure.
