### PR TITLE
Add OIDC unsigned (alg none) ID token supported template

### DIFF
--- a/http/misconfiguration/oidc-signing-alg-none-supported.yaml
+++ b/http/misconfiguration/oidc-signing-alg-none-supported.yaml
@@ -1,0 +1,52 @@
+id: oidc-signing-alg-none-supported
+
+info:
+  name: OpenID Connect - Unsigned (alg none) ID Token Supported
+  author: rocky55ayush
+  severity: medium
+  description: |
+    The OpenID Connect discovery document advertises "none" among its id_token_signing_alg_values_supported, meaning the authorization server is willing to issue ID tokens with no signature. A relying party that accepts such a token cannot verify its integrity, enabling JWT "alg:none" forgery and authentication bypass. The "none" algorithm should never be offered for ID tokens in production.
+  reference:
+    - https://openid.net/specs/openid-connect-discovery-1_0.html
+    - https://datatracker.ietf.org/doc/html/rfc7518#section-3.6
+    - https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 5.9
+    cwe-id: CWE-347
+  metadata:
+    max-request: 3
+  tags: oidc,openid,oauth,jwt,keycloak,misconfig
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.well-known/openid-configuration"
+      - "{{BaseURL}}/realms/master/.well-known/openid-configuration"
+      - "{{BaseURL}}/auth/realms/master/.well-known/openid-configuration"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+      - type: word
+        part: body
+        words:
+          - '"id_token_signing_alg_values_supported"'
+      - type: regex
+        part: body
+        regex:
+          - '"id_token_signing_alg_values_supported"\s*:\s*\[[^\]]*"none"'
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"issuer"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
### Template Added

`http/misconfiguration/oidc-signing-alg-none-supported.yaml`

### What it detects

Flags an OpenID Connect discovery document (`/.well-known/openid-configuration`) that lists `"none"` among `id_token_signing_alg_values_supported` — i.e. the authorization server is willing to issue **unsigned** ID tokens. A relying party accepting such a token cannot verify integrity, enabling classic JWT `alg:none` forgery / authentication bypass. `none` should never be offered for ID tokens in production.

- **Severity:** medium
- **CWE:** CWE-347 (Improper Verification of Cryptographic Signature)
- **Match logic:** HTTP 200 + `application/json` + presence of `id_token_signing_alg_values_supported`, then a regex anchored to that array (`"id_token_signing_alg_values_supported"\s*:\s*\[[^\]]*"none"`) so `"none"` elsewhere in the JSON cannot trigger it.

### Local validation

```
$ nuclei -validate -t http/misconfiguration/oidc-signing-alg-none-supported.yaml
[INF] All templates validated successfully
```

Proof of fire against a local mock discovery doc:

- **Vulnerable doc** (`["RS256","none","HS256"]`) → **matches** ✅
- **Hardened doc** (`["RS256","ES256"]`) → **no match** ✅ (no false positive)

Tested only against a local, disposable mock — never against third-party infrastructure.
