### PR TITLE
CVE-2024-57728

### DIFF
--- a/http/cves/2024/CVE-2024-57728.yaml
+++ b/http/cves/2024/CVE-2024-57728.yaml
@@ -1,0 +1,72 @@
+id: CVE-2024-57728
+
+info:
+  name: SimpleHelp <= 5.5.7 - Arbitrary File Upload
+  author: popy21
+  severity: high
+  description: |
+    SimpleHelp remote support software v5.5.7 and before allows admin users to upload arbitrary
+    files anywhere on the file system by uploading a crafted zip file (i.e. zip slip). This can be
+    exploited to execute arbitrary code on the host in the context of the SimpleHelp server user.
+    This template is a version-based check: it reads the version banner exposed by the vendor's
+    own /allversions page and flags branches that predate the January 2025 fixes.
+
+  impact: |
+    An admin technician (or a low-privileged technician who first escalates via CVE-2024-57726) can write a crafted zip entry to any path on the host - a crontab on Linux, a replaced executable or DLL on Windows - and obtain remote code execution as the SimpleHelp server user, the chain ransomware operators such as Medusa and DragonForce used to take over managed estates.
+
+  remediation: |
+    Upgrade SimpleHelp to 5.5.8 or later (or apply the vendor's 070125 patch to the 5.4.10 and 5.3.9 branches), then rotate all administrator and technician passwords and restrict the source IP addresses allowed to log in.
+
+  reference:
+    - https://simple-help.com/kb---security-vulnerabilities-01-2025#security-vulnerabilities-in-simplehelp-5-5-7-and-earlier
+    - https://www.horizon3.ai/attack-research/disclosures/critical-vulnerabilities-in-simplehelp-remote-support-software/
+    - https://guides.simple-help.com/kb---checking-the-version-and-build-of-your-simplehelp-server
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-57728
+    - https://www.microsoft.com/en-us/security/blog/2026/04/06/storm-1175-focuses-gaze-on-vulnerable-web-facing-assets-in-high-tempo-medusa-ransomware-operations/
+    - https://www.trendmicro.com/vinfo/us/security/news/ransomware-spotlight/ransomware-spotlight-dragonforce
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-57728
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2024-57728
+    cwe-id: CWE-59
+    epss-score: 0.06982
+    epss-percentile: 0.93609
+    cpe: cpe:2.3:a:simple-help:simplehelp:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: simple-help
+    product: simplehelp
+    shodan-query: html:"SimpleHelp"
+  tags: cve,cve2024,simple-help,simplehelp,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/allversions"
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        name: version
+        regex:
+          - 'Visual Version:\s*([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+        internal: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SH Version"
+          - "Visual Version"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 5.3.9') || compare_versions(version, '>= 5.4.0', '< 5.4.10') || compare_versions(version, '>= 5.5.0', '< 5.5.8')"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds a detection template for **CVE-2024-57728**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.