### PR TITLE
CVE-2026-0558: fix unclosed string literal in dsl matcher

### DIFF
--- a/http/cves/2026/CVE-2026-0558.yaml
+++ b/http/cves/2026/CVE-2026-0558.yaml
@@ -45,7 +45,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'contains_all(body, "lollms-cve-2026-0558-{{randstr}}", "text_content":")'
+          - 'contains_all(body, "lollms-cve-2026-0558-{{randstr}}", "\"text_content\":")'
           - 'contains(content_type, "application/json")'
           - 'status_code == 200'
         condition: and


### PR DESCRIPTION
### Problem

`http/cves/2026/CVE-2026-0558.yaml` fails to parse. The first DSL matcher expression has an unbalanced quote:

```yaml
- 'contains_all(body, "lollms-cve-2026-0558-{{randstr}}", "text_content":")'
```

The lexer reads the string `"text_content"`, then hits `:` followed by a dangling `"`, so the template is rejected:

```
could not parse "http/cves/2026/CVE-2026-0558.yaml": Unclosed string literal
```

The intent is clearly to match the literal JSON key `"text_content":`, so the inner double quotes need escaping.

### Fix

```yaml
- 'contains_all(body, "lollms-cve-2026-0558-{{randstr}}", "\"text_content\":")'
```

The YAML single-quoted scalar passes `\"` through verbatim, and govaluate unescapes it inside the string literal, so the expression now compiles and matches `"text_content":` as intended. No change in matcher semantics.
