### PR TITLE
Add CVE-2026-18051 - W3 Total Cache < 2.10.5 - Path Traversal via Page Cache

### DIFF
--- a/http/cves/2026/CVE-2026-18051.yaml
+++ b/http/cves/2026/CVE-2026-18051.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-18051
+
+info:
+  name: W3 Total Cache < 2.10.5 - Path Traversal via Page Cache
+  author: 1dayexploit
+  severity: critical
+  description: |
+    W3 Total Cache before 2.10.5 builds the Disk Enhanced page-cache file path directly
+    from the request URI without validating it, allowing an unauthenticated attacker to
+    write a cache file into any already-existing directory on the server, inside or
+    outside the web root, overwriting whatever occupies that name.
+  impact: |
+    Unauthenticated attackers can write attacker-influenced content into arbitrary
+    existing directories on the server, overwriting files such as the site's .htaccess
+    and disrupting site availability.
+  remediation: |
+    Update to version 2.10.5 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18051
+    - https://wpscan.com/vulnerability/dc56cdd2-419b-4a64-9d2a-29dc7e79cb6d/
+    - https://github.com/BoldGrid/w3-total-cache/commit/10f60af0bbc2fabaabed0c0ad02d179a2605a997
+    - https://github.com/advisories/GHSA-3qrw-968g-4hqv
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-18051
+    cwe-id: CWE-22
+    epss-score: 0.0018
+    epss-percentile: 0.07797
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: boldgrid
+    product: w3_total_cache
+    shodan-query: html:"w3-total-cache"
+    fofa-query: body="w3-total-cache"
+  tags: cve,cve2026,wordpress,wp-plugin,w3-total-cache
+
+http:
+  - raw:
+      - |
+        GET /wp-content/plugins/w3-total-cache/readme.txt HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'Stable tag:\s*([0-9.]+)'
+        internal: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "W3 Total Cache"
+      - type: word
+        part: header
+        words:
+          - "text/plain"
+      - type: dsl
+        dsl:
+          - compare_versions(version, '< 2.10.5')


### PR DESCRIPTION
Detection template for CVE-2026-18051.

Validated against a containerised lab built from the affected and the fixed release: the template matches the vulnerable build and stays quiet on the patched one. Detection is non-invasive - nothing is written to the target.

<details>
<summary>Validation transcript</summary>

# Nuclei template validation - CVE-2026-18051

## Exposure
Default install: partial. The vulnerable code path (`Cache_File_Generic::set()` building
the Disk Enhanced page-cache filename straight from the request URI) ships in every
version before 2.10.5 and requires no special flag to compile in. Page Cache itself is
disabled out of the box (`pgcache.enabled` defaults false), but it is W3 Total Cache's
headline feature - RESEARCH.md notes it is "on wherever the plugin is actually used" - and
the engine it defaults to when enabled, `file_generic` ("Disk: Enhanced"), is exactly the
vulnerable one. The plugin itself, and the version-disclosing `readme.txt` this template
reads, is present regardless of that toggle. Normally exposed port: yes, plain HTTP/HTTPS
on the site's main port, no admin or secondary port involved. Affected range: all versions
before 2.10.5, a single-digit point-release gap. KEV: no, but CVSS 10.0 and a WPScan-verified
advisory (published 2026-08-19); this plugin is one of the most widely installed WordPress
performance plugins, so the population is large even accounting for the cache-enabled
caveat.

## Detection method
Rank 1, version fingerprint. `wp-content/plugins/<slug>/readme.txt` is served as a plain
static file by WordPress's own plugin structure - not through a special endpoint W3TC
adds - and every WordPress.org plugin release exposes a `Stable tag:` header on it. This
avoids depending on `pgcache.enabled`/`pgcache.engine` at all, unlike the behavioural
traversal probe in `exploit.py`, and avoids writing anything to the target. The behavioural
probe was not used because it performs the same file write `exploit.py` performs (a real
file lands in the document root, overwriting whatever occupied that name) - exactly the
kind of damage this template must not do.

## Syntax check
```
$ nuclei -t nuclei-template.yaml -validate -duc
[INF] All templates validated successfully
```

## Vulnerable build
Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:8051 -nc -silent -duc`
Result: MATCHED
```
[CVE-2026-18051] [http] [critical] http://127.0.0.1:8051/wp-content/plugins/w3-total-cache/readme.txt
```
(`readme.txt` on this build carries `Stable tag: 2.10.4`.)

## Patched build
Command: `nuclei -t nuclei-template.yaml -u http://127.0.0.1:8052 -nc -silent -duc`
Result: NO MATCH (empty output, exit 0)
(`readme.txt` on this build carries `Stable tag: 2.10.5`.)

## What the detection keys on
The `Stable tag:` line in the plugin's own `readme.txt`. The vendor's 2.10.5 release bumped
this from `2.10.4` to `2.10.5` as part of the same release that shipped the fix (new
`_resolve_path()` containment in `Cache_File_Generic.php`, tightened `_get_page_key_urlpart()`
in `PgCache_ContentGrabber.php`). `compare_versions(version, '< 2.10.5')` is true only for
the pre-fix build, so the template matches exactly the vulnerable population and nothing
else.

## Limitations
- Version-only fingerprint: it cannot tell a 2.10.4 install with Page Cache left disabled
  (not actually reachable right now) from one where it is on. It also cannot detect a
  self-patched fork that keeps the `2.10.4` string in `readme.txt` while backporting the
  fix, or a hardened deployment that blocks direct access to plugin `readme.txt` files
  (a fairly common WAF/hardening rule), which would produce a false negative rather than a
  false positive.
- No false positives observed: the `Stable tag:` comparison is exact-version, not a range
  guess, and the `text/plain` + `"W3 Total Cache"` matchers guard against a generic 200 from
  a custom 404 page being mistaken for the readme.

</details>
