### PR TITLE
New CVE-2026-15748 - WordPress Forminator Forms Unauth Arbitrary File Upload

### DIFF
--- a/http/cves/2026/CVE-2026-15748.yaml
+++ b/http/cves/2026/CVE-2026-15748.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-15748
+
+info:
+  name: WordPress Forminator Forms <= 1.56.1 - Unauthenticated Arbitrary File Upload
+  author: ouailadel46
+  severity: critical
+  description: |
+    The Forminator Forms plugin for WordPress is vulnerable to Arbitrary File Upload in all versions up to, and including, 1.56.1 via the handle_file_upload function. This is due to insufficient file type validation and trust in attacker-controlled upload field configuration injected via a forged Select field value. This makes it possible for unauthenticated attackers to upload executable files, leading to remote code execution.
+  reference:
+    - https://www.wordfence.com/blog/2026/08/600000-wordpress-sites-affected-by-arbitrary-file-upload-vulnerability-in-forminator-forms-wordpress-plugin/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-15748
+    - https://www.ionix.io/threat-center/cve-2026-15748/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-15748
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 1
+    public-disclosure: 2026-08-17
+  tags: cve,cve2026,wordpress,wp-plugin,forminator,rce,fileupload,intrusive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/forminator/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Forminator"
+          - "Stable tag: "
+        part: body
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.56.1')"
+        part: body
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "(?i)Stable tag: ([0-9.]+)"
+        internal: true


### PR DESCRIPTION
### PR Information

- Added CVE-2026-15748 nuclei template for WordPress Forminator Forms Unauthenticated Arbitrary File Upload.
- References:
  - https://www.wordfence.com/blog/2026/08/600000-wordpress-sites-affected-by-arbitrary-file-upload-vulnerability-in-forminator-forms-wordpress-plugin/
  - https://nvd.nist.gov/vuln/detail/CVE-2026-15748

### Template validation

- Validated detection logic against plugin version in readme files.