### PR TITLE
CVE-2026-73570

### DIFF
--- a/http/cves/2026/CVE-2026-73570.yaml
+++ b/http/cves/2026/CVE-2026-73570.yaml
@@ -1,0 +1,81 @@
+id: CVE-2026-73570
+
+info:
+  name: Zimbra Collaboration Suite < 10.1.20 - Remote Code Execution
+  author: popy21
+  severity: high
+  description: |
+    A remote code execution vulnerability exists in Zimbra Collaboration (ZCS) before 10.1.20 when
+    the optional zimbra-snmp package is installed and SNMP notifications are enabled. Due to
+    improper sanitization of untrusted input during SNMP notification processing, an
+    unauthenticated attacker can send specially crafted SMTP requests that may result in execution
+    of arbitrary operating system commands as the Zimbra user. This template is a passive
+    version check: it reads the client version advertised by the unauthenticated web client
+    resource ZmSettings.js and flags builds older than 10.1.20. Exploitability additionally
+    requires the optional zimbra-snmp package to be installed with snmp_notify enabled, which
+    cannot be observed remotely.
+
+  impact: |
+    An unauthenticated remote attacker can execute arbitrary operating system commands as the zimbra
+    user, taking full control of the mail server and the mailbox data it hosts.
+
+  remediation: |
+    Upgrade Zimbra Collaboration to 10.1.20 (released 20 July 2026) or later; until then disable SNMP
+    notifications (snmp_notify), remove the optional zimbra-snmp package, and restrict SMTP exposure
+    to untrusted networks.
+
+  reference:
+    - https://wiki.zimbra.com/wiki/Security_Center
+    - https://wiki.zimbra.com/wiki/Zimbra_Security_Advisories
+    - https://moje.cert.pl/komunikaty/2026/145/aktywnie-wykorzystywana-podatnosc-w-zimbra-collaboration-suite/
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-73570
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73570
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:L
+    cvss-score: 8.9
+    cve-id: CVE-2026-73570
+    cwe-id: cwe-78
+    epss-score: 0.00539
+    epss-percentile: 0.43183
+    cpe: cpe:2.3:a:synacor:zimbra_collaboration_suite:*:*:*:*:*:*:*:*
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: synacor
+    product: zimbra_collaboration_suite
+    shodan-query: http.title:"Zimbra Collaboration Suite"
+    fofa-query: title="Zimbra Collaboration Suite"
+  tags: cve,cve2026,synacor,zimbra-collaboration-suite,rce,kev
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/js/zimbraMail/share/model/ZmSettings.js"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Zimbra Collaboration Suite"
+
+      - type: word
+        part: header
+        words:
+          - "application/x-javascript"
+
+      - type: dsl
+        dsl:
+          - compare_versions(version, '< 10.1.20')
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - CLIENT_VERSION\",\s+{type:ZmSetting\.T_CONFIG, defaultValue:"([0-9.]+)_([A-Z_0-9]+)"\}


### PR DESCRIPTION
Adds a detection template for **CVE-2026-73570**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.