### PR TITLE
Add CVE-2026-66613 for JetEngine RCE vulnerability

### DIFF
--- a/http/cves/2026/CVE-2026-66613.yaml
+++ b/http/cves/2026/CVE-2026-66613.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-66613
+
+info:
+  name: JetEngine <= 3.8.14 - Unauthenticated Remote Code Execution
+  author: ouailadel46
+  severity: critical
+  description: |
+    The JetEngine plugin for WordPress is vulnerable to Unauthenticated Remote Code Execution in all versions up to, and including, 3.8.14. This is due to improper neutralization of special elements used in a template engine (CWE-1336), enabling code injection when template input is processed. This makes it possible for unauthenticated attackers to execute arbitrary code on the server.
+  reference:
+    - https://www.ionix.io/threat-center/cve-2026-66613/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66613
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-66613
+    cwe-id: CWE-1336
+  metadata:
+    verified: true
+    max-request: 1
+    public-disclosure: 2026-08-20
+    tags: cve,cve2026,wordpress,wp-plugin,jet-engine,rce,injection
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/jet-engine/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "JetEngine"
+          - "Stable tag: "
+        part: body
+
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 3.8.14')"
+        part: body
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - "(?i)Stable tag: ([0-9.]+)"
+        internal: true


### PR DESCRIPTION
This YAML file describes the CVE-2026-66613 vulnerability in the JetEngine plugin for WordPress, detailing its critical severity and providing necessary metadata and HTTP request information.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
