### PR TITLE
Add Karakeep detection template

### DIFF
--- a/http/exposed-panels/karakeep-panel.yaml
+++ b/http/exposed-panels/karakeep-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: karakeep
     shodan-query: http.title:"Karakeep"
     fofa-query: title="Karakeep"
-  tags: panel,karakeep,hoarder,bookmark,selfhosted,detect,discovery
+  tags: panel,login,karakeep,hoarder,bookmark,selfhosted,detect,discovery
 
 flow: http(1) && http(2) && http(3)
 

--- a/http/exposed-panels/karakeep-panel.yaml
+++ b/http/exposed-panels/karakeep-panel.yaml
@@ -1,0 +1,69 @@
+id: karakeep-panel
+
+info:
+  name: Karakeep Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Detected Karakeep (formerly Hoarder) was a self-hosted bookmark-everything app for links, notes and images with AI-based tagging and full text search, usually served on TCP 3000.
+  reference:
+    - https://github.com/karakeep-app/karakeep
+    - https://docs.karakeep.app/api/karakeep-api/
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: karakeep-app
+    product: karakeep
+    shodan-query: http.title:"Karakeep"
+    fofa-query: title="Karakeep"
+  tags: panel,karakeep,hoarder,bookmark,selfhosted,detect,discovery
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>karakeep</title>")'
+        internal: true
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"status\":\"ok\"")'
+          - 'contains(body, "\"message\":\"Web app is working\"")'
+          - 'contains(content_type, "application/json")'
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "\"version\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
[Karakeep](https://github.com/karakeep-app/karakeep) (formerly Hoarder) is a popular self-hosted bookmark-everything app for links, notes and images with AI-based tagging and full text search, usually run in Docker on TCP 3000. Exposed instances may reveal a user's saved bookmarks, notes and archived pages.

No existing karakeep template in the repo.

### Detection signatures
- `<title>Karakeep</title>` on the root page
- `/api/health` returning JSON `{"status":"ok","message":"Web app is working"}` (the canonical health route used by the Docker healthcheck)
- `/api/version` returning JSON with a `version` field

All three requests are chained with `flow` so every signal must match, and a regex extractor pulls the version. Validated with `nuclei -validate`.

References:
- https://github.com/karakeep-app/karakeep
- https://docs.karakeep.app/api/karakeep-api/
