### PR TITLE
Add wallabag detection template

### DIFF
--- a/http/exposed-panels/wallabag-panel.yaml
+++ b/http/exposed-panels/wallabag-panel.yaml
@@ -1,7 +1,7 @@
 id: wallabag-panel
 
 info:
-  name: wallabag Panel - Detect
+  name: Wallabag Panel - Detect
   author: ChrisJr404
   severity: info
   description: |
@@ -19,35 +19,29 @@ info:
     fofa-query: title="wallabag"
   tags: panel,wallabag,readlater,selfhosted,detect,discovery
 
-flow: http(1) && http(2)
-
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
+      - "{{BaseURL}}/api/info.json"
 
+    stop-at-first-match: true
     host-redirects: true
     max-redirects: 2
 
+    matchers-condition: or
     matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "wallabag</title>")'
-          - 'contains(to_lower(body), "wallabag logo")'
-        internal: true
+          - 'contains_all(to_lower(body), "wallabag</title>", "wallabag logo")'
         condition: and
 
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/info.json"
-
-    matchers:
       - type: dsl
         dsl:
           - 'status_code == 200'
           - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"appname\"", "\"wallabag\"", "\"version\"", "\"allowed_registration\"")'
+          - 'contains_all(body, "\"appname\"", "\"wallabag\"", "\"version")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/wallabag-panel.yaml
+++ b/http/exposed-panels/wallabag-panel.yaml
@@ -1,0 +1,58 @@
+id: wallabag-panel
+
+info:
+  name: wallabag Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    wallabag (wallabag.org / github.com/wallabag/wallabag) is a popular open-source self-hosted read-it-later application built on Symfony. The login page and the anonymous /api/info.json endpoint expose the running instance and its version.
+  reference:
+    - https://github.com/wallabag/wallabag
+    - https://wallabag.org/
+    - https://doc.wallabag.org/developer/api/methods.html
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: wallabag
+    product: wallabag
+    shodan-query: http.title:"wallabag"
+    fofa-query: title="wallabag"
+  tags: panel,wallabag,readlater,selfhosted,detect,discovery
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "wallabag</title>")'
+          - 'contains(to_lower(body), "wallabag logo")'
+        internal: true
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/info.json"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"appname\"", "\"wallabag\"", "\"version\"", "\"allowed_registration\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
[wallabag](https://github.com/wallabag/wallabag) is a popular open-source self-hosted read-it-later application built on Symfony. Default Docker port 80. Exposed instances reveal the login panel and the running version.

No existing `wallabag` template in the repo.

### Detection signatures
- login page: `<title>` ends with `wallabag</title>` and body contains the `wallabag logo` image alt text
- `/api/info.json` is an anonymous endpoint (whitelisted `IS_AUTHENTICATED_ANONYMOUSLY` in the firewall) returning `{"appname":"wallabag","version":"...","allowed_registration":...}`, so the version is extracted from it

Source for the anonymous route: https://github.com/wallabag/wallabag/blob/master/app/config/security.yml

Validated with `nuclei -validate`. Signatures derived from the wallabag source, not tested against a live instance.
