### PR TITLE
Add linkding detection template

### DIFF
--- a/http/exposed-panels/linkding-panel.yaml
+++ b/http/exposed-panels/linkding-panel.yaml
@@ -1,0 +1,58 @@
+id: linkding-panel
+
+info:
+  name: linkding Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    linkding (github.com/sissbruecker/linkding) is a popular open-source self-hosted bookmark manager built on Django. Default Docker port 9090. Exposed instances may reveal users' saved bookmarks, tags, and archived pages.
+  reference:
+    - https://github.com/sissbruecker/linkding
+    - https://linkding.link/
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: sissbruecker
+    product: linkding
+    shodan-query: http.title:"Linkding"
+    fofa-query: title="Linkding"
+  tags: panel,linkding,bookmarks,selfhosted,detect,discovery
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "self-hosted bookmark service")'
+          - 'contains(to_lower(body), "linkding")'
+        internal: true
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"status\"", "\"version\"")'
+          - 'contains(to_lower(body), "healthy")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'

--- a/http/exposed-panels/linkding-panel.yaml
+++ b/http/exposed-panels/linkding-panel.yaml
@@ -32,8 +32,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(to_lower(body), "self-hosted bookmark service")'
-          - 'contains(to_lower(body), "linkding")'
+          - 'contains_all(to_lower(body), "self-hosted bookmark service", "linkding")'
         internal: true
         condition: and
 
@@ -46,8 +45,7 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"status\"", "\"version\"")'
-          - 'contains(to_lower(body), "healthy")'
+          - 'contains_all(body, "\"status\"", "\"version\"", "healthy")'
         condition: and
 
     extractors:

--- a/http/exposed-panels/linkding-panel.yaml
+++ b/http/exposed-panels/linkding-panel.yaml
@@ -1,7 +1,7 @@
 id: linkding-panel
 
 info:
-  name: linkding Panel - Detect
+  name: Linkding Panel - Detect
   author: ChrisJr404
   severity: info
   description: |
@@ -18,8 +18,6 @@ info:
     fofa-query: title="Linkding"
   tags: panel,linkding,bookmarks,selfhosted,detect,discovery
 
-flow: http(1) && http(2)
-
 http:
   - method: GET
     path:
@@ -33,24 +31,4 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains_all(to_lower(body), "self-hosted bookmark service", "linkding")'
-        internal: true
         condition: and
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/health"
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"status\"", "\"version\"", "healthy")'
-        condition: and
-
-    extractors:
-      - type: regex
-        part: body
-        group: 1
-        regex:
-          - '"version"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
### PR Information

Added `linkding-panel` detection template. linkding (github.com/sissbruecker/linkding) is a popular self-hosted bookmark manager built on Django, default Docker port 9090. No existing `linkding` template in the repo.

- References:
  - https://github.com/sissbruecker/linkding
  - https://linkding.link/

### Detection signatures

Two-step flow for near-zero false positives:
1. Root page (redirects to login when unauthenticated) carries the linkding branding: `<meta name="description" content="Self-hosted bookmark service">` and the `linkding` name/title.
2. Public `/health` endpoint (used by the Docker healthcheck) returns JSON `{"version": "...", "status": "healthy"}`. The `version` value is extracted.

Both are derived from the product source:
- health view: https://github.com/sissbruecker/linkding/blob/master/bookmarks/views/health.py
- head/meta: https://github.com/sissbruecker/linkding/blob/master/bookmarks/templates/shared/head.html

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

Validated with `nuclei -validate` (All templates validated successfully). Signatures were derived from the documented public source above, not confirmed against a live instance, so metadata `verified` is set to `false`.
