### PR TITLE
Add CVE-2024-42327 - Zabbix user.get SQL injection version detection

### DIFF
--- a/http/cves/2024/CVE-2024-42327.yaml
+++ b/http/cves/2024/CVE-2024-42327.yaml
@@ -1,0 +1,59 @@
+id: CVE-2024-42327
+
+info:
+  name: Zabbix < 6.0.32 / 6.4.17 / 7.0.1 - SQL Injection
+  author: ChrisJr404
+  severity: critical
+  description: |
+    Zabbix frontend versions 6.0.0 to 6.0.31, 6.4.0 to 6.4.16 and 7.0.0 contain an SQL injection in the CUser class addRelatedObjects function, which is reached through the user.get API method. A non-admin user account with the default User role, or any role that grants API access, can inject SQL and dump the database. This template does not exploit the flaw. It calls the unauthenticated apiinfo.version JSON-RPC method exposed at api_jsonrpc.php and flags instances whose reported version falls in the affected ranges.
+  impact: |
+    An authenticated low-privileged user can run arbitrary SQL against the Zabbix database, leading to full database compromise.
+  remediation: |
+    Upgrade to Zabbix 6.0.32, 6.4.17, 7.0.1 or later.
+  reference:
+    - https://support.zabbix.com/browse/ZBX-25623
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-42327
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2024-42327
+    cwe-id: CWE-89
+    epss-score: 0.78831
+    epss-percentile: 0.99559
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: zabbix
+    product: zabbix
+    shodan-query: http.title:"Zabbix"
+    fofa-query: title="Zabbix"
+  tags: cve,cve2024,zabbix,sqli,vuln
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api_jsonrpc.php"
+      - "{{BaseURL}}/zabbix/api_jsonrpc.php"
+
+    headers:
+      Content-Type: application/json-rpc
+
+    body: |
+      {"jsonrpc":"2.0","method":"apiinfo.version","params":[],"id":1}
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, '"result"')
+          - "compare_versions(version, '>= 6.0.0', '< 6.0.32') || compare_versions(version, '>= 6.4.0', '< 6.4.17') || compare_versions(version, '>= 7.0.0', '< 7.0.1')"
+        condition: and
+
+    extractors:
+      - type: json
+        name: version
+        json:
+          - ".result"
+        internal: true


### PR DESCRIPTION
Adds a detection template for CVE-2024-42327, an SQL injection in the Zabbix frontend CUser class reachable via the user.get API method.

The template is version based and does not exploit the flaw. It sends an unauthenticated apiinfo.version JSON-RPC request to api_jsonrpc.php (root and /zabbix/ paths) and compares the returned version against the affected ranges: 6.0.0 to 6.0.31, 6.4.0 to 6.4.16, and 7.0.0. Fixed in 6.0.32, 6.4.17 and 7.0.1.

apiinfo.version is callable without authentication, so this stays a safe fingerprint with low false positives.

References:
- https://support.zabbix.com/browse/ZBX-25623
- https://nvd.nist.gov/vuln/detail/CVE-2024-42327

Validated with nuclei -validate (All templates validated successfully). Not run against a live instance, so metadata verified is false.