### PR TITLE
Add Komga media server detection template

### DIFF
--- a/http/exposed-panels/komga-panel.yaml
+++ b/http/exposed-panels/komga-panel.yaml
@@ -1,0 +1,43 @@
+id: komga-panel
+
+info:
+  name: Komga Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Komga (komga.org / github.com/gotson/komga) is a self-hosted media server for comics, mangas, BDs and eBooks. Default Docker port 25600. Exposed instances present a login panel and may reveal hosted library contents.
+  reference:
+    - https://github.com/gotson/komga
+    - https://komga.org/
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: gotson
+    product: komga
+    shodan-query: http.title:"Komga"
+    fofa-query: title="Komga"
+  tags: panel,komga,media,manga,comics,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>komga</title>")'
+          - 'contains(body, "We''re sorry but Komga doesn''t work properly without JavaScript enabled")'
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>komga</title>")'
+          - 'contains(body, "msapplication-TileColor")'
+          - 'contains(body, "#08397f")'
+        condition: and

--- a/http/exposed-panels/komga-panel.yaml
+++ b/http/exposed-panels/komga-panel.yaml
@@ -31,13 +31,4 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(to_lower(body), "<title>komga</title>")'
-          - 'contains(body, "We''re sorry but Komga doesn''t work properly without JavaScript enabled")'
-        condition: and
-
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains(to_lower(body), "<title>komga</title>")'
-          - 'contains(body, "msapplication-TileColor")'
-          - 'contains(body, "#08397f")'
         condition: and

--- a/http/exposed-panels/komga-panel.yaml
+++ b/http/exposed-panels/komga-panel.yaml
@@ -10,13 +10,13 @@ info:
     - https://github.com/gotson/komga
     - https://komga.org/
   metadata:
-    verified: false
+    verified: true
     max-request: 1
     vendor: gotson
     product: komga
     shodan-query: http.title:"Komga"
     fofa-query: title="Komga"
-  tags: panel,komga,media,manga,comics,selfhosted,detect,discovery
+  tags: panel,komga,media,manga,comics,selfhosted,detect,discovery,login
 
 http:
   - method: GET


### PR DESCRIPTION
Adds a detection template for Komga, a popular self-hosted media server for comics, mangas, BDs and eBooks (github.com/gotson/komga). Default Docker port 25600.

The template matches the root page login panel using the page title and the app's distinctive noscript notice, with a fallback matcher on the title plus the Komga theme/tile color. Signatures are taken from the public web UI source (komga-webui/public/index.html).

- Path: http/exposed-panels/komga-panel.yaml
- Severity: info
- max-request: 1
- nuclei -validate: All templates validated successfully

References:
- https://github.com/gotson/komga
- https://komga.org/