### PR TITLE
Add CVE-2025-53887 Directus version disclosure

### DIFF
--- a/http/cves/2025/CVE-2025-53887.yaml
+++ b/http/cves/2025/CVE-2025-53887.yaml
@@ -1,0 +1,57 @@
+id: CVE-2025-53887
+
+info:
+  name: Directus < 11.9.0 - Version Disclosure
+  author: ChrisJr404
+  severity: medium
+  description: |
+    Directus versions from 9.0.0 before 11.9.0 expose the exact running version through the OpenAPI specification returned by the unauthenticated /server/specs/oas endpoint. The version is placed in the OpenAPI info.version field, letting an unauthenticated attacker fingerprint the precise Directus release. The fix replaces the exact version in that field with a hashed value.
+  impact: |
+    An unauthenticated attacker can read the exact Directus version and use it to look up known vulnerabilities in that release or its bundled dependencies.
+  remediation: |
+    Upgrade to Directus 11.9.0 or later, where the OpenAPI info.version field no longer contains the exact version.
+  reference:
+    - https://github.com/directus/directus/security/advisories/GHSA-rmjh-cf9q-pv7q
+    - https://github.com/directus/directus/pull/25353
+    - https://github.com/directus/directus/commit/e74f3e4e92edc33b5f83eefb001a3d2a85af17a3
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-53887
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-53887
+    cwe-id: CWE-200
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: monospace
+    product: directus
+    shodan-query: 'X-Powered-By: Directus'
+    fofa-query: 'header="X-Powered-By: Directus"'
+  tags: cve,cve2025,directus,exposure,disclosure,vuln
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/server/specs/oas"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Dynamic API Specification"
+          - "This is a dynamically generated API specification"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'compare_versions(version, ">= 9.0.0", "< 11.9.0")'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - 'dynamically generated API specification for all endpoints existing on the current project\.",\s*"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'


### PR DESCRIPTION
### PR Information

Added CVE-2025-53887 (Directus version disclosure).

Directus 9.0.0 before 11.9.0 exposes the exact running version in the OpenAPI info.version field returned by the unauthenticated /server/specs/oas endpoint. The template does a single GET to that endpoint, confirms the Directus OpenAPI spec, extracts the semver from info.version, and flags versions in the affected range with compare_versions. Patched builds (>= 11.9.0) put a hashed value in that field, so the semver extraction does not match and there is no result.

- References:
  - https://github.com/directus/directus/security/advisories/GHSA-rmjh-cf9q-pv7q
  - https://github.com/directus/directus/pull/25353
  - https://github.com/directus/directus/commit/e74f3e4e92edc33b5f83eefb001a3d2a85af17a3
  - https://nvd.nist.gov/vuln/detail/CVE-2025-53887

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

Passed `nuclei -validate`. The matcher/version logic is derived from the advisory and the fix commit (info.version changed from the exact version to a hashed value in 11.9.0). Not run against a live host, so metadata verified is set to false.
