### PR TITLE
Add Docmost detection template

### DIFF
--- a/http/exposed-panels/docmost-panel.yaml
+++ b/http/exposed-panels/docmost-panel.yaml
@@ -5,7 +5,7 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    Docmost (docmost.com / github.com/docmost/docmost) is an open-source self-hosted wiki and documentation collaboration platform. Default Docker port 3000. Exposed instances may reveal internal spaces, pages and workspace member details.
+    Detected Docmost (docmost.com / github.com/docmost/docmost) was an open-source self-hosted wiki and documentation collaboration platform. Default Docker port 3000. Exposed instances may reveal internal spaces, pages and workspace member details.
   reference:
     - https://github.com/docmost/docmost
     - https://docmost.com/
@@ -29,7 +29,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(to_lower(body), "<title>docmost</title>")'
-          - 'contains(body, "apple-mobile-web-app-title\" content=\"Docmost\"")'
+          - "status_code == 200"
+          - "contains_all(to_lower(body), \"<title>docmost</title>\", \"apple-mobile-web-app-title\")"
         condition: and

--- a/http/exposed-panels/docmost-panel.yaml
+++ b/http/exposed-panels/docmost-panel.yaml
@@ -1,0 +1,35 @@
+id: docmost-panel
+
+info:
+  name: Docmost Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Docmost (docmost.com / github.com/docmost/docmost) is an open-source self-hosted wiki and documentation collaboration platform. Default Docker port 3000. Exposed instances may reveal internal spaces, pages and workspace member details.
+  reference:
+    - https://github.com/docmost/docmost
+    - https://docmost.com/
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: docmost
+    product: docmost
+    shodan-query: http.title:"Docmost"
+    fofa-query: title="Docmost"
+  tags: panel,docmost,wiki,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>docmost</title>")'
+          - 'contains(body, "apple-mobile-web-app-title\" content=\"Docmost\"")'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added Docmost exposed-panel detection template.
- Docmost is an open-source self-hosted wiki and documentation collaboration platform. This template fingerprints exposed instances on the default root path using the served `index.html` title and the app-specific `apple-mobile-web-app-title` meta tag.
- References:
  - https://github.com/docmost/docmost
  - https://docmost.com/

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

Signature is based on the published client `index.html` in the upstream repo (https://github.com/docmost/docmost/blob/main/apps/client/index.html). Not run against a live instance, so metadata verified is set to false. Matcher requires status 200 plus two independent Docmost markers to keep false positives low.

`nuclei -validate` passes: All templates validated successfully.

### Additional References:

- https://docs.projectdiscovery.io/templates/introduction
