### PR TITLE
Add InvenTree Panel detection template

### DIFF
--- a/http/exposed-panels/inventree-panel.yaml
+++ b/http/exposed-panels/inventree-panel.yaml
@@ -16,7 +16,7 @@ info:
     product: inventree
     shodan-query: http.title:"InvenTree"
     fofa-query: title="InvenTree"
-  tags: panel,inventree,inventory,selfhosted,detect,discovery
+  tags: panel,inventree,inventory,selfhosted,detect,discovery,login
 
 http:
   - method: GET

--- a/http/exposed-panels/inventree-panel.yaml
+++ b/http/exposed-panels/inventree-panel.yaml
@@ -1,0 +1,40 @@
+id: inventree-panel
+
+info:
+  name: InvenTree Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    InvenTree (inventree.org / github.com/inventree/InvenTree) is an open-source inventory management system. Its API root at /api/ is reachable without authentication and returns server metadata including the running version, exposing internet-facing instances.
+  reference:
+    - https://github.com/inventree/InvenTree
+    - https://inventree.org/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: inventree
+    product: inventree
+    shodan-query: http.title:"InvenTree"
+    fofa-query: title="InvenTree"
+  tags: panel,inventree,inventory,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains(body, "InvenTree")'
+          - 'contains_all(body, "\"apiVersion\"", "\"worker_running\"", "\"instance\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'

--- a/http/exposed-panels/inventree-panel.yaml
+++ b/http/exposed-panels/inventree-panel.yaml
@@ -33,8 +33,7 @@ http:
         condition: and
 
     extractors:
-      - type: regex
+      - type: json
         part: body
-        group: 1
-        regex:
-          - '"version"\s*:\s*"([^"]+)"'
+        json:
+          - '.version'


### PR DESCRIPTION
Adds a detection template for InvenTree, an open-source inventory management system (github.com/inventree/InvenTree).

The API root at /api/ is served without authentication and returns server metadata, including the running version. The matcher keys off the JSON response (server value InvenTree plus apiVersion, worker_running and instance fields) and extracts the version.

Tested live against the public demo instance at https://demo.inventree.org (matched /api/, extracted version 1.6.0 dev).

nuclei -validate: All templates validated successfully.