### PR TITLE
Add Planka panel detection template

### DIFF
--- a/http/exposed-panels/planka-panel.yaml
+++ b/http/exposed-panels/planka-panel.yaml
@@ -1,0 +1,39 @@
+id: planka-panel
+
+info:
+  name: Planka Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Planka is an open source kanban-style project management board. The login panel was detected.
+  reference:
+    - https://planka.app/
+    - https://github.com/plankanban/planka
+  classification:
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:planka:planka:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: planka
+    product: planka
+    shodan-query: http.html:"PLANKA is the kanban-style project mastering tool"
+  tags: panel,planka,kanban,login,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<meta name="description" content="PLANKA is the kanban-style project mastering tool for everyone" />'
+          - '<title>PLANKA'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds a detection template for the Planka login panel.

Planka is an open source kanban-style project management board (self-hosted Trello alternative). This template flags an exposed instance with a single benign GET to the base URL.

Matcher is anchored on the stable meta description shipped in the client index.html plus the title prefix, with a 200 status check to keep false positives down.

Source of the fingerprint:
- https://github.com/plankanban/planka/blob/master/client/index.html

Verified against the official public demo at https://pro.demo.planka.cloud (matched). Set verified: true.

nuclei -validate: All templates validated successfully.
