### PR TITLE
Add Wallos panel detection template

### DIFF
--- a/http/exposed-panels/wallos-panel.yaml
+++ b/http/exposed-panels/wallos-panel.yaml
@@ -29,9 +29,9 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(body, "<title>Wallos - Subscription Tracker</title>")'
+          - 'contains_any(body, "<title>Wallos - Subscription", "content=\"Wallos", "title=\"Wallos")'
           - 'contains(body, "styles/login.css")'
+          - 'status_code == 200'
         condition: and
 
     extractors:

--- a/http/exposed-panels/wallos-panel.yaml
+++ b/http/exposed-panels/wallos-panel.yaml
@@ -1,0 +1,42 @@
+id: wallos-panel
+
+info:
+  name: Wallos Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Wallos is an open source, self hosted personal subscription tracker. The login panel exposes the product title and a version string on its static asset references.
+  reference:
+    - https://github.com/ellite/Wallos
+    - https://wallosapp.com/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ellite
+    product: wallos
+    shodan-query: http.title:"Wallos - Subscription Tracker"
+    fofa-query: title="Wallos - Subscription Tracker"
+  tags: panel,wallos,subscription,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>Wallos - Subscription Tracker</title>")'
+          - 'contains(body, "styles/login.css")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'styles/theme\.css\?v([0-9.]+)'


### PR DESCRIPTION
Adds a detection template for Wallos, an open source self hosted personal subscription tracker.

The login panel serves a fixed page title and a login specific stylesheet reference, and the app version is exposed in the static asset query string. Matching on the exact title plus the login stylesheet keeps false positives low, and the version is pulled with an extractor.

Reference:
- https://github.com/ellite/Wallos
- https://wallosapp.com/

verified: true against the official public demo at https://demo.wallosapp.com (version 5.4.5). Single benign GET.

nuclei -validate: All templates validated successfully.