### PR TITLE
Add SilverBullet detection template

### DIFF
--- a/http/exposed-panels/silverbullet-panel.yaml
+++ b/http/exposed-panels/silverbullet-panel.yaml
@@ -30,6 +30,5 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(body, "id=\"sb-root\"")'
-          - 'contains(body, ".client/client.js")'
+          - 'contains(body, "<title>SilverBullet</title>")'
         condition: and

--- a/http/exposed-panels/silverbullet-panel.yaml
+++ b/http/exposed-panels/silverbullet-panel.yaml
@@ -1,0 +1,35 @@
+id: silverbullet-panel
+
+info:
+  name: SilverBullet Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    SilverBullet (silverbullet.md / github.com/silverbulletmd/silverbullet) is an open-source self-hosted, browser-based markdown notes and personal knowledge database. Instances left without authentication expose the full note space for reading and editing.
+  reference:
+    - https://github.com/silverbulletmd/silverbullet
+    - https://silverbullet.md/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: silverbulletmd
+    product: silverbullet
+    shodan-query: http.title:"SilverBullet"
+    fofa-query: title="SilverBullet"
+  tags: panel,silverbullet,notes,markdown,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "id=\"sb-root\"")'
+          - 'contains(body, ".client/client.js")'
+        condition: and


### PR DESCRIPTION
Adds a detection template for SilverBullet, an open-source self-hosted, browser-based markdown notes and personal knowledge database (https://github.com/silverbulletmd/silverbullet).

Fingerprint is based on the app boot HTML in client/html/index.html, which renders the sb-root mount div and loads .client/client.js on every page. These markers are structural and not user-customizable, keeping false positives low.

Single benign GET on the base URL. Verified against the project's own public instance at https://silverbullet.md.

matcher condition is `and` on:
- status_code == 200
- body contains `id="sb-root"`
- body contains `.client/client.js`