### PR TITLE
Add CVE-2026-42878 - FacturaScripts unauthenticated phpinfo() disclosure

### DIFF
--- a/http/cves/2026/CVE-2026-42878.yaml
+++ b/http/cves/2026/CVE-2026-42878.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-42878
+
+info:
+  name: FacturaScripts - Unauthenticated phpinfo() Disclosure
+  author: ChrisJr404
+  severity: medium
+  description: |
+    FacturaScripts exposes a debug branch in the Installer controller that calls phpinfo() when the request carries the phpinfo=TRUE query parameter. On an instance that has not finished installation (config.php without db_name), any unauthenticated user can request the endpoint and read the full PHP configuration, loaded modules, and server environment variables.
+  impact: |
+    The phpinfo() output can leak environment variables such as database credentials, application secrets, and cloud provider keys, along with filesystem paths and the exact PHP build, all without authentication.
+  remediation: |
+    Complete the installation so config.php contains db_name (the Installer controller then refuses to run), or upgrade to a build that removes the phpinfo debug branch from Core/Controller/Installer.php.
+  reference:
+    - https://github.com/advisories/GHSA-vrxf-vrc4-22p7
+    - https://github.com/NeoRazorX/facturascripts/blob/master/Core/Controller/Installer.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42878
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-42878
+    cwe-id: CWE-200
+  metadata:
+    verified: false
+    max-request: 2
+    vendor: facturascripts
+    product: facturascripts
+    shodan-query: html:"FacturaScripts installer"
+    fofa-query: body="FacturaScripts installer"
+  tags: cve,cve2026,facturascripts,phpinfo,exposure,disclosure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/?phpinfo=TRUE"
+
+    stop-at-first-match: false
+    req-condition: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code_1 == 200'
+          - 'contains(body_1, "FacturaScripts installer")'
+          - 'status_code_2 == 200'
+          - 'contains(to_lower(body_2), "<title>phpinfo()")'
+          - 'contains(body_2, "PHP Version")'
+        condition: and

--- a/http/cves/2026/CVE-2026-42878.yaml
+++ b/http/cves/2026/CVE-2026-42878.yaml
@@ -1,15 +1,11 @@
 id: CVE-2026-42878
 
 info:
-  name: FacturaScripts - Unauthenticated phpinfo() Disclosure
+  name: FacturaScripts - Unauthenticated phpinfo Disclosure
   author: ChrisJr404
   severity: medium
   description: |
-    FacturaScripts exposes a debug branch in the Installer controller that calls phpinfo() when the request carries the phpinfo=TRUE query parameter. On an instance that has not finished installation (config.php without db_name), any unauthenticated user can request the endpoint and read the full PHP configuration, loaded modules, and server environment variables.
-  impact: |
-    The phpinfo() output can leak environment variables such as database credentials, application secrets, and cloud provider keys, along with filesystem paths and the exact PHP build, all without authentication.
-  remediation: |
-    Complete the installation so config.php contains db_name (the Installer controller then refuses to run), or upgrade to a build that removes the phpinfo debug branch from Core/Controller/Installer.php.
+   Detected FacturaScripts exposes a debug branch in the Installer controller that calls phpinfo() when the request carries the phpinfo=TRUE query parameter, and on an instance that has not finished installation, this endpoint was reachable without authentication.
   reference:
     - https://github.com/advisories/GHSA-vrxf-vrc4-22p7
     - https://github.com/NeoRazorX/facturascripts/blob/master/Core/Controller/Installer.php
@@ -20,7 +16,7 @@ info:
     cve-id: CVE-2026-42878
     cwe-id: CWE-200
   metadata:
-    verified: false
+    verified: true
     max-request: 2
     vendor: facturascripts
     product: facturascripts
@@ -28,20 +24,28 @@ info:
     fofa-query: body="FacturaScripts installer"
   tags: cve,cve2026,facturascripts,phpinfo,exposure,disclosure,unauth
 
+flow: http(1) && http(2)
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/"
+
+    matchers:
+      - type: dsl
+        internal: true
+        dsl:
+          - "status_code == 200"
+          - "contains(body, \"FacturaScripts installer\")"
+        condition: and
+
+  - method: GET
+    path:
       - "{{BaseURL}}/?phpinfo=TRUE"
 
-    stop-at-first-match: false
-    req-condition: true
     matchers:
       - type: dsl
         dsl:
-          - 'status_code_1 == 200'
-          - 'contains(body_1, "FacturaScripts installer")'
-          - 'status_code_2 == 200'
-          - 'contains(to_lower(body_2), "<title>phpinfo()")'
-          - 'contains(body_2, "PHP Version")'
+          - "status_code == 200"
+          - "contains_all(to_lower(body), \"phpinfo()</title>\", \"php version\")"
         condition: and

--- a/http/cves/2026/CVE-2026-42878.yaml
+++ b/http/cves/2026/CVE-2026-42878.yaml
@@ -29,7 +29,7 @@ flow: http(1) && http(2)
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     matchers:
       - type: dsl


### PR DESCRIPTION
Adds a detection template for CVE-2026-42878.

FacturaScripts leaves a debug branch in the Installer controller (Core/Controller/Installer.php) that calls phpinfo() when the request has the query parameter phpinfo=TRUE. On an instance that has not finished installation (config.php without db_name) the controller is reachable unauthenticated, so a single GET to /?phpinfo=TRUE returns the full PHP configuration, loaded modules, and environment variables (which can include database credentials and secrets).

The template first confirms the FacturaScripts installer on the root path, then sends the phpinfo=TRUE request and matches the phpinfo() output. Two requests, no exploitation, benign GET only.

Source: https://github.com/NeoRazorX/facturascripts/blob/master/Core/Controller/Installer.php (phpinfo branch)
Advisory: https://github.com/advisories/GHSA-vrxf-vrc4-22p7
NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-42878

Validated locally with nuclei -validate: All templates validated successfully.
