### PR TITLE
Add Homebox detection template

### DIFF
--- a/http/technologies/homebox-detect.yaml
+++ b/http/technologies/homebox-detect.yaml
@@ -1,0 +1,49 @@
+id: homebox-detect
+
+info:
+  name: Homebox Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Homebox, a self-hosted home inventory and organization system, was detected via its unauthenticated /api/v1/status endpoint.
+  reference:
+    - https://github.com/sysadminsmedia/homebox
+    - https://homebox.software
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: sysadminsmedia
+    product: homebox
+    shodan-query: http.html:"Track, Manage, and Organize your Things"
+  tags: tech,homebox,inventory,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/status"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"title":"Homebox"'
+          - '"message":"Track, Manage, and Organize your Things"'
+          - '"build":'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"build":\{"version":"([^"]+)"'

--- a/http/technologies/homebox-detect.yaml
+++ b/http/technologies/homebox-detect.yaml
@@ -1,7 +1,7 @@
 id: homebox-detect
 
 info:
-  name: Homebox Detect
+  name: Homebox - Detect
   author: ChrisJr404
   severity: info
   description: |
@@ -14,7 +14,8 @@ info:
     max-request: 1
     vendor: sysadminsmedia
     product: homebox
-    shodan-query: http.html:"Track, Manage, and Organize your Things"
+    shodan-query: html:"homebox-frontend"
+    fofa-query: body="homebox-frontend"
   tags: tech,homebox,inventory,detect,discovery
 
 http:
@@ -28,7 +29,6 @@ http:
         part: body
         words:
           - '"title":"Homebox"'
-          - '"message":"Track, Manage, and Organize your Things"'
           - '"build":'
         condition: and
 


### PR DESCRIPTION
Adds a detection template for Homebox, a self-hosted home inventory and organization system (sysadminsmedia/homebox).

Detection is based on the unauthenticated /api/v1/status endpoint, which returns a JSON body with a fixed title and message plus the running build version. Matching both the title and message strings keeps false positives low, and the build version is extracted.

Source:
- https://github.com/sysadminsmedia/homebox/blob/main/backend/app/api/handlers/v1/controller.go (APISummary / HandleBase)
- Route registered at /api/v1/status in backend/app/api/routes.go

Verified against the official public demo at https://demo.homebox.software/api/v1/status which returns:
"title":"Homebox","message":"Track, Manage, and Organize your Things","build":{"version":"v0.26.2", ...}

nuclei -validate: All templates validated successfully.
Live run against the demo matches and extracts version v0.26.2.