### PR TITLE
Add RomM detection template

### DIFF
--- a/http/exposed-panels/romm-panel.yaml
+++ b/http/exposed-panels/romm-panel.yaml
@@ -1,0 +1,40 @@
+id: romm-panel
+
+info:
+  name: RomM Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    RomM (romm.app / github.com/rommapp/romm) is a popular open-source self-hosted ROM manager and player. The unauthenticated /api/heartbeat endpoint returns a JSON config snapshot including the running version, enabled metadata sources, and hosted platforms. Exposed instances leak this configuration and point to a browsable ROM library.
+  reference:
+    - https://github.com/rommapp/romm
+    - https://romm.app/
+    - https://docs.romm.app/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: rommapp
+    product: romm
+    shodan-query: http.title:"RomM"
+    fofa-query: title="RomM"
+  tags: panel,romm,rom,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/heartbeat"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"SHOW_SETUP_WIZARD\"", "\"METADATA_SOURCES\"", "\"IGDB_API_ENABLED\"", "\"FS_PLATFORMS\"")'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"VERSION"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
Adds a detection template for RomM, a popular open-source self-hosted ROM manager and player (github.com/rommapp/romm).

Detection uses the unauthenticated /api/heartbeat endpoint, which returns a JSON config snapshot with the running version, enabled metadata sources, and hosted platforms. Matchers key on RomM-specific JSON fields (SHOW_SETUP_WIZARD, METADATA_SOURCES, IGDB_API_ENABLED, FS_PLATFORMS) plus application/json content type to keep false positives low. Version is extracted from the SYSTEM.VERSION field.

Verified against the official public demo at demo.romm.app (returns version 5.1.0). Validated with nuclei -validate.

References:
- https://github.com/rommapp/romm
- https://romm.app/
- https://docs.romm.app/