### PR TITLE
Add Documenso detection template

### DIFF
--- a/http/exposed-panels/documenso-panel.yaml
+++ b/http/exposed-panels/documenso-panel.yaml
@@ -1,0 +1,50 @@
+id: documenso-panel
+
+info:
+  name: Documenso Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Detected Documenso, an open source document signing platform and self-hosted DocuSign alternative built with React Router and a Prisma backend.
+  reference:
+    - https://github.com/documenso/documenso
+    - https://documenso.com/
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: documenso
+    product: documenso
+    shodan-query: http.title:"Documenso"
+    fofa-query: title="Documenso"
+  tags: panel,documenso,docusign,signing,selfhosted,detect,discovery
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Documenso - The Open Source DocuSign Alternative")'
+          - 'contains(body, "content=\"@documenso\"")'
+        internal: true
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"status\"", "\"checks\"", "\"database\"", "\"certificate\"")'
+        condition: and

--- a/http/exposed-panels/documenso-panel.yaml
+++ b/http/exposed-panels/documenso-panel.yaml
@@ -5,20 +5,18 @@ info:
   author: ChrisJr404
   severity: info
   description: |
-    Detected Documenso, an open source document signing platform and self-hosted DocuSign alternative built with React Router and a Prisma backend.
+    Documenso, an open source document signing platform and self-hosted DocuSign alternative built with React Router and a Prisma backend, was identified.
   reference:
     - https://github.com/documenso/documenso
     - https://documenso.com/
   metadata:
     verified: true
-    max-request: 2
+    max-request: 1
     vendor: documenso
     product: documenso
     shodan-query: http.title:"Documenso"
     fofa-query: title="Documenso"
-  tags: panel,documenso,docusign,signing,selfhosted,detect,discovery
-
-flow: http(1) && http(2)
+  tags: panel,documenso,docusign,signing,selfhosted,detect
 
 http:
   - method: GET
@@ -31,20 +29,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(body, "Documenso - The Open Source DocuSign Alternative")'
-          - 'contains(body, "content=\"@documenso\"")'
-        internal: true
-        condition: and
-
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/health"
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"status\"", "\"checks\"", "\"database\"", "\"certificate\"")'
+          - "status_code == 200"
+          - "contains_all(body, \"Documenso - The Open Source DocuSign Alternative\", \"@documenso\")"
         condition: and


### PR DESCRIPTION
[Documenso](https://github.com/documenso/documenso) is a popular open source document signing platform (self-hosted DocuSign alternative, AGPL-3.0) built on React Router with a Prisma/Postgres backend. Self-hosted instances are commonly exposed on the public internet and the signin panel plus health endpoint can be reached without authentication.

No existing `documenso` template in the repo.

### Detection signatures
- Root page (redirects to `/signin`) carries the default meta tags from `apps/remix/app/utils/meta.ts`: `og:title` of `Documenso - The Open Source DocuSign Alternative` and `twitter:site` of `@documenso`
- `/api/health` (route `apps/remix/app/routes/api+/health.ts`) returns JSON with `status`, `checks`, `database`, and `certificate` fields

Flow requires both signals to reduce false positives. Verified against the official hosted instance at https://app.documenso.com with `nuclei -validate` passing and the template firing on a live run.
