### PR TITLE
Add Dawarich detection template

### DIFF
--- a/http/technologies/dawarich-detect.yaml
+++ b/http/technologies/dawarich-detect.yaml
@@ -28,8 +28,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains(header, "X-Dawarich-Version")'
-          - 'contains(header, "X-Dawarich-Response")'
+          - 'contains_any(header, "X-Dawarich-Version", "X-Dawarich-Response")'
           - 'contains(body, "\"status\":\"ok\"")'
         condition: and
 

--- a/http/technologies/dawarich-detect.yaml
+++ b/http/technologies/dawarich-detect.yaml
@@ -28,7 +28,7 @@ http:
       - type: dsl
         dsl:
           - 'status_code == 200'
-          - 'contains_any(header, "X-Dawarich-Version", "X-Dawarich-Response")'
+          - 'contains(header, "X-Dawarich-Version")'
           - 'contains(body, "\"status\":\"ok\"")'
         condition: and
 

--- a/http/technologies/dawarich-detect.yaml
+++ b/http/technologies/dawarich-detect.yaml
@@ -1,0 +1,39 @@
+id: dawarich-detect
+
+info:
+  name: Dawarich - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Dawarich is a self-hosted location history and timeline application (Google Timeline alternative). The unauthenticated /api/v1/health endpoint returns a status payload together with the X-Dawarich-Response and X-Dawarich-Version headers, which identify the instance and disclose its version.
+  reference:
+    - https://github.com/Freika/dawarich
+    - https://dawarich.app/
+    - https://github.com/Freika/dawarich/blob/master/app/controllers/api/v1/health_controller.rb
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: freika
+    product: dawarich
+    shodan-query: http.title:"Dawarich"
+    fofa-query: title="Dawarich"
+  tags: tech,dawarich,location,selfhosted,detect
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/health"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(header, "X-Dawarich-Version")'
+          - 'contains(header, "X-Dawarich-Response")'
+          - 'contains(body, "\"status\":\"ok\"")'
+        condition: and
+
+    extractors:
+      - type: kval
+        kval:
+          - x_dawarich_version


### PR DESCRIPTION
Adds a detection template for Dawarich, a self-hosted location history and timeline application.

Detection uses the unauthenticated GET /api/v1/health endpoint. On a Dawarich instance this returns HTTP 200 with a {"status":"ok"} body and two identifying response headers: X-Dawarich-Response ("Hey, I'm alive!") and X-Dawarich-Version. The template matches on the presence of both headers plus the status body and extracts the running version from X-Dawarich-Version.

Source of the signature:
- https://github.com/Freika/dawarich/blob/master/app/controllers/api/v1/health_controller.rb (endpoint, skips auth)
- app_controller before_action set_version_header sets X-Dawarich-Version / X-Dawarich-Response on API responses

Verified against the vendor hosted instance https://my.dawarich.app/api/v1/health (version 1.13.1) with a single benign GET.

nuclei -validate: All templates validated successfully.