### PR TITLE
Add DocuSeal detection template

### DIFF
--- a/http/technologies/docuseal-detect.yaml
+++ b/http/technologies/docuseal-detect.yaml
@@ -1,0 +1,36 @@
+id: docuseal-detect
+
+info:
+  name: DocuSeal Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    DocuSeal, an open source document filling and signing platform, was detected via the application theme attribute and site metadata exposed on the root page.
+  reference:
+    - https://github.com/docusealco/docuseal
+    - https://www.docuseal.com
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: docusealco
+    product: docuseal
+    shodan-query: http.html:"data-theme=\"docuseal\""
+  tags: tech,docuseal,signing,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'data-theme="docuseal"'
+          - 'og:site_name" content="DocuSeal"'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Adds an info-level detection template for DocuSeal, an open source document filling and signing platform.

Detection is based on the application theme attribute (data-theme="docuseal") and the og:site_name metadata on the root page. Both are required (AND) to keep false positives low.

Reference:
- https://github.com/docusealco/docuseal
- https://www.docuseal.com

Validated with nuclei -validate (All templates validated successfully) and matched against the official public demo at https://demo.docuseal.tech.