### PR TITLE
Add CVE-2025-68273 Signal K Server info disclosure detection

### DIFF
--- a/http/cves/2025/CVE-2025-68273.yaml
+++ b/http/cves/2025/CVE-2025-68273.yaml
@@ -1,0 +1,69 @@
+id: CVE-2025-68273
+
+info:
+  name: Signal K Server <= 2.18.0 - Unauthenticated Information Disclosure
+  author: ChrisJr404
+  severity: medium
+  description: |
+    Signal K Server versions up to and including 2.18.0 expose the /skServer/serialports, /skServer/availablePaths, and /skServer/hasAnalyzer endpoints without authentication. These routes were missing from the authentication middleware configuration, letting any unauthenticated user retrieve the full Signal K data schema, the list of connected serial devices, and whether traffic analyzer tools are installed. This template fingerprints the server via the public /signalk discovery endpoint and flags builds older than the fixed 2.19.0 release.
+  impact: |
+    An unauthenticated attacker can enumerate the vessel data schema, connected hardware serial ports, and installed analyzer tooling, aiding reconnaissance for further attacks against the marine data server.
+  remediation: |
+    Upgrade to Signal K Server 2.19.0 or later, which adds the missing endpoints to the authentication middleware.
+  reference:
+    - https://github.com/SignalK/signalk-server/security/advisories/GHSA-fpf5-w967-rr2m
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-68273
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2025-68273
+    cwe-id: CWE-200
+    epss-score: 0.00359
+    epss-percentile: 0.28563
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: signalk
+    product: signalk-server
+    shodan-query: http.html:"signalk-http"
+    fofa-query: body="signalk-http"
+  tags: cve,cve2025,signalk,exposure,unauth,iot
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/signalk"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"signalk-http"'
+          - '"server"'
+          - '"version"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "< 2.19.0")'
+
+    extractors:
+      - type: regex
+        name: version
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"server"\s*:\s*\{[^}]*?"version"\s*:\s*"([^"]+)"'
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"server"\s*:\s*\{[^}]*?"version"\s*:\s*"([^"]+)"'


### PR DESCRIPTION
Adds a detection template for CVE-2025-68273.

Signal K Server up to and including 2.18.0 exposes the /skServer/serialports, /skServer/availablePaths, and /skServer/hasAnalyzer endpoints without authentication, leaking the vessel data schema, connected serial devices, and installed analyzer tooling. Fixed in 2.19.0.

The template fingerprints the server via the public /signalk discovery endpoint and flags builds older than 2.19.0 by comparing the reported server.version. Single benign GET, no exploitation.

Details:
- id: CVE-2025-68273
- severity: medium (CVSS 5.3, CWE-200)
- max-request: 1

Fingerprint and version extraction confirmed against the official public demo at demo.signalk.org (running patched 2.31.1, so it correctly does not match the < 2.19.0 gate).

References:
- https://github.com/SignalK/signalk-server/security/advisories/GHSA-fpf5-w967-rr2m
- https://nvd.nist.gov/vuln/detail/CVE-2025-68273

nuclei -validate: All templates validated successfully.