### PR TITLE
Add Donetick panel detection template

### DIFF
--- a/http/exposed-panels/donetick-panel.yaml
+++ b/http/exposed-panels/donetick-panel.yaml
@@ -31,5 +31,4 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(to_lower(body), "<title>donetick</title>")'
-          - 'contains(body, "/manifest.webmanifest")'
         condition: and

--- a/http/exposed-panels/donetick-panel.yaml
+++ b/http/exposed-panels/donetick-panel.yaml
@@ -1,0 +1,35 @@
+id: donetick-panel
+
+info:
+  name: Donetick Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Donetick (donetick.com / github.com/donetick/donetick) is an open-source self-hosted task and chore manager with a Go backend and a React frontend. Default Docker port 2021. Exposed instances may reveal household task lists, members, and schedules.
+  reference:
+    - https://github.com/donetick/donetick
+    - https://donetick.com/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: donetick
+    product: donetick
+    shodan-query: http.title:"Donetick"
+    fofa-query: title="Donetick"
+  tags: panel,donetick,tasks,selfhosted,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>donetick</title>")'
+          - 'contains(body, "/manifest.webmanifest")'
+        condition: and


### PR DESCRIPTION
Adds a detection template for Donetick, an open-source self-hosted task and chore manager (github.com/donetick/donetick, ~2k stars). Default Docker port 2021.

Detection is a single GET to the root path, matched on the exact `<title>Donetick</title>` and the `/manifest.webmanifest` link served by the frontend. Both conditions must hold to keep false positives low.

Verified against the official live instance at https://app.donetick.com.

```
[donetick-panel] [http] [info] https://app.donetick.com
```

nuclei -validate: All templates validated successfully.
