### PR TITLE
Add CVE-2026-78003 template

### DIFF
--- a/http/cves/2026/CVE-2026-78003.yaml
+++ b/http/cves/2026/CVE-2026-78003.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-78003
+
+info:
+  name: WordPress Mailgun <= 2.2.0 - Unauthenticated Server-Side Request Forgery
+  author: kocaemre
+  severity: critical
+  description: |
+    The Mailgun for WordPress plugin <= 2.2.0 is vulnerable to unauthenticated server-side request forgery via path traversal in the add_list() function. User-controlled addresses array keys are used in Mailgun API paths, allowing unauthenticated attackers to make authenticated POST requests to arbitrary Mailgun API endpoints with the configured site API key.
+  impact: |
+    An unauthenticated attacker can abuse the WordPress site's Mailgun API key to perform Mailgun API actions, including creating inbound email-forwarding routes that may intercept password reset emails and lead to administrator account takeover.
+  remediation: |
+    Upgrade the Mailgun for WordPress plugin to version 2.2.1 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/110e888d-69fc-4682-b908-2b62288c5227
+    - https://plugins.trac.wordpress.org/browser/mailgun/tags/2.1.10/mailgun.php#L319
+    - https://plugins.trac.wordpress.org/browser/mailgun/tags/2.1.10/mailgun.php#L557
+    - https://plugins.trac.wordpress.org/browser/mailgun/trunk/mailgun.php#L319
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-78003
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-78003
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    publicwww-query: "/wp-content/plugins/mailgun/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,mailgun,ssrf,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/mailgun/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Mailgun for WordPress"
+          - "Stable tag:"
+        condition: and
+
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "<= 2.2.0")'
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Template / CVE

Adds a detector for CVE-2026-78003 affecting the Mailgun for WordPress plugin.

## Summary

- Detects exposed Mailgun for WordPress `readme.txt`
- Extracts the plugin stable tag
- Matches affected versions `<= 2.2.0`
- Uses a single non-intrusive GET request; no exploit payload or state-changing request is sent

## References

- https://www.wordfence.com/threat-intel/vulnerabilities/id/110e888d-69fc-4682-b908-2b62288c5227
- https://nvd.nist.gov/vuln/detail/CVE-2026-78003
- https://plugins.trac.wordpress.org/browser/mailgun/tags/2.1.10/mailgun.php#L319
- https://plugins.trac.wordpress.org/browser/mailgun/tags/2.1.10/mailgun.php#L557

## Validation

- [x] `nuclei -validate -t http/cves/2026/CVE-2026-78003.yaml -duc -silent`
- [x] `git diff --check -- http/cves/2026/CVE-2026-78003.yaml`
- [x] Positive test against an affected live instance (`Stable tag: 2.1.9`) returned a match
- [x] Negative control against a patched live instance (`Stable tag: 2.2.2`) returned no match
