### PR TITLE
Add template for Johnson Controls Frick Quantum HD Compressor web interface default login

### DIFF
--- a/http/default-logins/johnson-controls-frick-quantum-hd-compressor-default-login.yaml
+++ b/http/default-logins/johnson-controls-frick-quantum-hd-compressor-default-login.yaml
@@ -1,0 +1,45 @@
+id: johnson-controls-frick-quantum-hd-compressor-default-login
+info:
+  name: Johnson Controls Frick Quantum HD Compressors Default Login
+  author: mister-joe
+  severity: high
+  description: |
+    Test for default credentials on Johnson Controls Frick Quantum HD Compressors.
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: Johnson Controls
+  tags: default-login
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        {"pin":"{{password}}"}
+
+    attack: pitchfork
+    payloads:
+      password:
+        - 1
+        - 2
+        - 3
+        - 10
+        - 20
+        - 30
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "Authorized"
+      - type: regex
+        part: header
+        regex:
+          - "Set-Cookie:\\sPrimeUnity=.*;"


### PR DESCRIPTION
### Template / PR Information

This template identifies Johnson Controls Frick Quantum HD Compressor web interfaces with default credentials.

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Sample Output

<img width="1188" height="904" alt="image" src="https://github.com/user-attachments/assets/3feef1a6-9856-44c4-b06b-199fe8e79f12" />

<img width="1016" height="721" alt="image" src="https://github.com/user-attachments/assets/10f3cd91-34f4-4057-85fb-1165cee71cbc" />

### Additional References:

- [Johnson Controls Frick Quantum HD Operation](https://www.manualslib.com/manual/2951516/Johnson-Controls-Frick-Quantum-Hd.html?page=12) (mentions factory default passwords for basic, operator, and service levels)