### PR TITLE
Add exposure templates for Terraform state, Terraform CLI credentials, and Serverless Framework config

### DIFF
--- a/http/exposures/configs/serverless-framework-config-exposure.yaml
+++ b/http/exposures/configs/serverless-framework-config-exposure.yaml
@@ -1,0 +1,53 @@
+id: serverless-framework-config-exposure
+
+info:
+  name: Serverless Framework Configuration Exposure
+  author: ChrisJr404
+  severity: medium
+  description: |
+    A Serverless Framework configuration file (serverless.yml) was found exposed on the web server. The file describes the service, cloud provider, functions and often provider level environment variables, IAM statements and plugin settings, which can disclose the application architecture and occasionally hardcoded secrets to an unauthenticated visitor.
+  reference:
+    - https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml
+    - https://www.serverless.com/framework/docs/providers/aws/guide/functions
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cwe-id: CWE-200
+  metadata:
+    max-request: 2
+    google-query: intitle:"index of" "serverless.yml"
+  tags: exposure,config,serverless,iac,aws
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/serverless.yml"
+      - "{{BaseURL}}/serverless.yaml"
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "service:"
+          - "provider:"
+          - "functions:"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+        negative: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'service:\s*([a-zA-Z0-9_-]+)'

--- a/http/exposures/configs/terraformrc-credentials-exposure.yaml
+++ b/http/exposures/configs/terraformrc-credentials-exposure.yaml
@@ -1,0 +1,52 @@
+id: terraformrc-credentials-exposure
+
+info:
+  name: Terraform CLI Configuration Credentials Exposure
+  author: ChrisJr404
+  severity: high
+  description: |
+    A Terraform CLI configuration file (.terraformrc or terraform.rc) containing a credentials block was found exposed. This file stores API tokens used to authenticate the Terraform CLI to remote backends such as Terraform Cloud or Terraform Enterprise, so exposure can leak a valid token that grants access to remote state and workspaces.
+  reference:
+    - https://developer.hashicorp.com/terraform/cli/config/config-file
+    - https://developer.hashicorp.com/terraform/cli/config/config-file#credentials
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-522
+  metadata:
+    max-request: 2
+    google-query: intitle:"index of" ".terraformrc"
+  tags: exposure,config,terraform,iac,token
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.terraformrc"
+      - "{{BaseURL}}/terraform.rc"
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'credentials\s+"[^"]+"\s*\{'
+          - 'token\s*=\s*"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+        negative: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'credentials\s+"([^"]+)"'

--- a/http/exposures/files/terraform-tfstate-exposure.yaml
+++ b/http/exposures/files/terraform-tfstate-exposure.yaml
@@ -1,0 +1,53 @@
+id: terraform-tfstate-exposure
+
+info:
+  name: Terraform State File Exposure
+  author: ChrisJr404
+  severity: high
+  description: |
+    A Terraform state file was found exposed on the web server. State files map real world infrastructure to configuration and frequently store resource attributes such as passwords, private keys, database connection strings and access tokens in clear text, so public exposure can leak sensitive credentials for the managed infrastructure.
+  reference:
+    - https://developer.hashicorp.com/terraform/language/state
+    - https://developer.hashicorp.com/terraform/language/state/sensitive-data
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cwe-id: CWE-538
+  metadata:
+    max-request: 2
+    google-query: intitle:"index of" "terraform.tfstate"
+  tags: exposure,config,terraform,iac,files
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/terraform.tfstate"
+      - "{{BaseURL}}/terraform.tfstate.backup"
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"terraform_version"'
+          - '"lineage"'
+          - '"serial"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+        negative: true
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"terraform_version"\s*:\s*"([0-9.]+)"'


### PR DESCRIPTION
### PR Information

Adds three new exposure templates for Infrastructure-as-Code state and config files that are commonly left reachable in web roots and can leak infrastructure secrets.

- `terraform-tfstate-exposure` (high): detects an exposed `terraform.tfstate` / `terraform.tfstate.backup`. State files store resource attributes such as passwords, private keys and tokens in clear text. Matches on the `terraform_version`, `lineage` and `serial` JSON keys and extracts the Terraform version.
  - Ref: https://developer.hashicorp.com/terraform/language/state/sensitive-data
- `terraformrc-credentials-exposure` (high): detects an exposed `.terraformrc` / `terraform.rc` containing a `credentials` block with an API token for a remote backend (Terraform Cloud / Enterprise). Matches the `credentials "<host>" {` block plus a `token = "..."` assignment and extracts the credentials host.
  - Ref: https://developer.hashicorp.com/terraform/cli/config/config-file#credentials
- `serverless-framework-config-exposure` (medium): detects an exposed `serverless.yml` / `serverless.yaml`. Discloses service, provider, functions and provider level environment/IAM settings. Matches on the `service:`, `provider:` and `functions:` keys and extracts the service name.
  - Ref: https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml

Each template uses an AND matcher combining status 200, multiple content keywords/regex, and a negative `text/html` content-type check to avoid SPA catch-all false positives. Extractors pull version/host/service evidence.

### Template validation

- [x] Validated with a host running a vulnerable configuration (True Positive) — fired against local sample files for all three, extractors returned expected evidence.
- [x] `nuclei -validate` passes with no errors or warnings for all three templates.

No third-party or real-world targets were used.
