### PR TITLE
Add outsystems platform server detection

### DIFF
--- a/http/miscellaneous/outsystems-platform-server-detect.yaml
+++ b/http/miscellaneous/outsystems-platform-server-detect.yaml
@@ -1,4 +1,4 @@
-id: outsystems-platform-server
+id: outsystems-platform-server-detect
 info:
   name: Outsystems Platform Server Version Detector
   author: Bruno Pincho

--- a/http/miscellaneous/outsystems-platform-server-detect.yaml
+++ b/http/miscellaneous/outsystems-platform-server-detect.yaml
@@ -1,0 +1,26 @@
+id: outsystems-platform-server
+info:
+  name: Outsystems Platform Server Version Detector
+  author: Bruno Pincho
+  severity: info
+  description: This template detects if the provided host is an Outsystems Platform Server, if so it returns the version. The objective is to facilitate enumeration.
+  tags: outsystems,detect,discovery
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ServiceCenter/_osjs.js"
+
+    matchers:
+      - type: word
+        name: 'version'
+        words:
+          - 'OutSystems Platform Server'
+        part: body
+
+    extractors:
+     - type: regex
+       name: outsystems-server-version
+       regex:
+          - 'OutSystems Platform Server (\d+.?)+'
+       group: 0


### PR DESCRIPTION
### PR Information

Adds a detection template for Outsystems Platform Server, printing the version after a match.
Works by searching for a specific javascript file which has the platform server's version listed on the 2nd line. Simple version detection template, no complicated logic.

### Template validation

- [x] `nuclei -validate` (version 3.9.0) passes without any trouble.
- [x] Validated against a real server with succcess.

#### Additional Details

```
└─$ nuclei -t outsystems-platform-server-detect.yaml -u https://targetserver/

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

                projectdiscovery.io

[INF] Current nuclei version: v3.9.0 (outdated)
[INF] Current nuclei-templates version: v10.4.8 (latest)
[INF] New templates added in latest release: 112
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[outsystems-platform-server-detect:version] [http] [info] https://targetserver/ServiceCenter/_osjs.js ["OutSystems Platform Server 11.18.1.37828"]
[INF] Scan completed in 1.40323245s. 1 matches found.
```