### PR TITLE
Fix verbose template descriptions from #17027

### DIFF
--- a/http/exposed-panels/chatwoot-super-admin-panel.yaml
+++ b/http/exposed-panels/chatwoot-super-admin-panel.yaml
@@ -5,12 +5,7 @@ info:
   author: RootKaito
   severity: info
   description: |
-    Detects an exposed Chatwoot Super Admin login page (/super_admin/sign_in).
-    Chatwoot is a widely self-hosted customer support / omnichannel platform;
-    an internet-facing super admin panel is a high-value target for credential
-    stuffing / brute-force and reveals the exact installation for further
-    version-based CVE correlation. Confirmed against a live chatwoot/chatwoot
-    instance via official docker-compose.production.yaml.
+    Chatwoot Super Admin login panel was detected.
   reference:
     - https://www.chatwoot.com/
     - https://github.com/chatwoot/chatwoot

--- a/http/exposures/apis/directus-api-exposure.yaml
+++ b/http/exposures/apis/directus-api-exposure.yaml
@@ -5,14 +5,7 @@ info:
   author: RootKaito
   severity: info
   description: |
-    Directus exposes a /server/info endpoint without authentication by
-    design, returning project metadata (name, branding, public registration
-    status) and license entitlement flags (e.g. whether AI translations or
-    production mode are enabled). Confirmed against a live directus/directus
-    instance that the current version no longer includes an exact version
-    string in this unauthenticated response, but the endpoint still reliably
-    fingerprints a live Directus instance and leaks project/tenant naming and
-    licensing configuration that operators sometimes expect to be private.
+    Directus /server/info endpoint is exposed without authentication, leaking project metadata and license configuration.
   reference:
     - https://directus.io/docs/api/server
   classification:

--- a/http/exposures/apis/grafana-loki-api-exposure.yaml
+++ b/http/exposures/apis/grafana-loki-api-exposure.yaml
@@ -5,11 +5,7 @@ info:
   author: RootKaito
   severity: medium
   description: |
-    Grafana Loki ships with authentication disabled by default (auth_enabled
-    must be explicitly turned on, or a reverse-proxy/gateway with auth must be
-    placed in front of it). An internet-facing Loki instance without an auth
-    layer allows anyone to read (and often push) log streams via its HTTP API,
-    which frequently contain sensitive application data.
+    Grafana Loki API is accessible without authentication, allowing unauthorized access to log streams.
   reference:
     - https://grafana.com/docs/loki/latest/operations/authentication/
     - https://grafana.com/docs/loki/latest/reference/loki-http-api/

--- a/http/exposures/apis/victoriametrics-vmagent-api-exposure.yaml
+++ b/http/exposures/apis/victoriametrics-vmagent-api-exposure.yaml
@@ -5,11 +5,7 @@ info:
   author: RootKaito
   severity: low
   description: |
-    VictoriaMetrics' vmagent exposes a /targets (human) and /api/v1/targets
-    (JSON) view of every scrape target it is configured against, with no
-    authentication by default. This leaks internal service inventory
-    (hostnames, ports, labels) and scrape health, which is useful recon data
-    for an attacker mapping an organization's internal infrastructure.
+    VictoriaMetrics vmagent targets endpoint is exposed without authentication, leaking internal service inventory and scrape configuration.
   reference:
     - https://docs.victoriametrics.com/victoriametrics/vmagent/
   classification:
@@ -32,7 +28,7 @@ http:
         part: body
         words:
           - '"activeTargets"'
-      
+
       - type: word
         part: header
         words:


### PR DESCRIPTION
### Summary

Shortens verbose multi-line descriptions added in #17027 to match the repo's standard format (concise 1-2 line descriptions).

Also fixes trailing whitespace in `victoriametrics-vmagent-api-exposure.yaml`.