### PR TITLE
Fix hp-printer-default-login matching any 200 response as a hit

### DIFF
--- a/http/default-logins/hp/hp-printer-default-login.yaml
+++ b/http/default-logins/hp/hp-printer-default-login.yaml
@@ -45,7 +45,7 @@ http:
     redirects: true
     max-redirects: 2
 
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         part: body
@@ -62,4 +62,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 490a004630440220484631ad9355306f8507d4d65409533b1c2deda36096488dbfe5ab959dedfc8b0220107ae511ee1722b115a73e63ac6adac663266006f4cccd1aeb90a50eabf39c65:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
The last request's matchers-condition is set to `or` across three matchers: a word matcher for admin-session body text, a Set-Cookie regex, and a bare `status: 200`.

Under `or`, any one of them is enough. Status 200 alone will fire on basically every response from this endpoint, including a failed login that just reloads the HP EWS sign-in page (that page is served with 200, not a 401 or similar). So the template reports every HP printer with this login form as a confirmed default-login vulnerability, whether or not the passwordless admin login actually worked.

Changed `matchers-condition` to `and` so a hit now needs the admin-page body evidence, the session cookie, and status 200 all at once, which is what actually indicates a successful login.

Verified locally with `nuclei -validate -t http/default-logins/hp/hp-printer-default-login.yaml` (exit 0, "All templates validated successfully").
