### PR TITLE
fix(CVE-2025-29927): add missing matchers-condition to the bypass request

### DIFF
--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -81,6 +81,7 @@ http:
         X-Nextjs-Data: 1
         X-Middleware-Subrequest: src/middleware:nowaf:src/middleware:src/middleware:src/middleware:src/middleware:middleware:middleware:nowaf:middleware:middleware:middleware:pages/_middleware
 
+    matchers-condition: and
     matchers:
       - type: word
         part: body
@@ -133,4 +134,3 @@ http:
           - "status_code == 200"
           - "!contains_any(to_lower(body), 'request rejected', 'your support id', 'access denied', 'request blocked')"
         condition: and
-# digest: 4a0a00473045022100fc40a90e9ee2944ed04f94a174f6080d10ffe575e03235d8ff60ebaf7bb466a3022006e24b9ba8c310babfc4635754c69e21688a397dc28af048504abc01107916d4:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Fixed CVE-2025-29927

The second http block (the `X-Middleware-Subrequest` bypass request) has two matchers, a negative
matcher for WAF block pages and a `status: 200` check. It sets no `matchers-condition`, so nuclei falls
back to `or`, and either matcher alone is enough to satisfy the block:

- On a **patched** host the bypass header is ignored and `/` still answers `307`. The status matcher is
  false, but the body has no WAF strings so the negative matcher is true → block matches.
- On a **WAF block page** the body *is* a block page so the negative matcher is false, but the page is
  served with `200` → block matches.

`base_check()` is `http(1) && http(2)`, so it returns true in both cases and the template reports
critical. The negative matcher added in #16870 never actually constrained anything, because the
`status: 200` matcher can satisfy the `or` on its own.

Block 5 of the same template already expresses these exact two conditions as a single dsl matcher with
`condition: and`, so the intended semantics are unambiguous:

```yaml
      - type: dsl
        dsl:
          - "status_code == 200"
          - "!contains_any(to_lower(body), 'request rejected', 'your support id', 'access denied', 'request blocked')"
        condition: and
```

This restores the pre-#16870 behaviour of block 2 while keeping the WAF negative matcher effective.
The change only tightens the matcher, so it cannot introduce false negatives on a host that was
previously detected through this block.

Closes #17019. Also fixes #16782, which was closed as completed but still reproduces on current main.

- References:
  - https://github.com/projectdiscovery/nuclei-templates/issues/17019
  - https://github.com/projectdiscovery/nuclei-templates/issues/16782
  - https://github.com/projectdiscovery/nuclei-templates/pull/16870
  - https://zhero-web-sec.github.io/research-and-things/nextjs-and-the-corrupt-middleware
  - https://github.com/vercel/next.js/security/advisories/GHSA-f82v-jwr5-mffw

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Four local `http.server` targets on 127.0.0.1, nuclei v3.8.0. All four answer `/` with
`307` + `x-nextjs-redirect` so `http(1)` passes on every one of them:

| port | scenario | bypass request returns |
|--|--|--|
| 19401 | patched, middleware used for i18n locale redirect (#17019) | `307`, header ignored |
| 19402 | vulnerable, middleware used as an auth gate | `200` + admin page |
| 19403 | patched, behind a WAF returning a block page (#16782) | `200` + "Request Rejected" |
| 19404 | vulnerable, middleware used for i18n locale redirect | `200` + home page |

Current template on the patched i18n host. Note that the bypass request answers `307`, and the match
is attributed to `word-1`, the negative matcher, firing on its own:

```
$ nuclei -t http/cves/2025/CVE-2025-29927.yaml -u http://127.0.0.1:19401 -debug-resp -ms
[DBG] [CVE-2025-29927] Dumped HTTP response http://127.0.0.1:19401
HTTP/1.1 307 Temporary Redirect
Content-Type: text/html
Location: /en-US/
X-Nextjs-Redirect: /en-US/
Content-Length: 0

[CVE-2025-29927:word-1] [http] [critical] http://127.0.0.1:19401
[INF] Scan completed in 8.379558ms. 1 matches found.
```

Current template on the WAF host. This is the mirror image: `status-2` fires on its own even though
the body is the block page the negative matcher was added to catch:

```
$ nuclei -t http/cves/2025/CVE-2025-29927.yaml -u http://127.0.0.1:19403 -debug-resp -ms
[DBG] [CVE-2025-29927] Dumped HTTP response http://127.0.0.1:19403
HTTP/1.1 200 OK
Content-Length: 190
Content-Type: text/html

<html>
<head>
<title>Request Rejected</title>
</head>
<body>
The requested URL was rejected.
Please consult with your administrator.
Your support ID is: <redacted>
</body>
</html>

[CVE-2025-29927:status-2] [http] [critical] http://127.0.0.1:19403
[INF] Scan completed in 2.180756ms. 1 matches found.
```

Before and after, all four targets:

```
                                          before      after
patched, i18n redirect      (19401)       MATCH       no match
vulnerable, auth gate       (19402)       MATCH       MATCH
patched, WAF block page     (19403)       MATCH       no match
vulnerable, i18n redirect   (19404)       MATCH       MATCH
```

```
$ nuclei -t http/cves/2025/CVE-2025-29927.yaml -u http://127.0.0.1:19401
[INF] Scan completed in 5.714047ms. 0 matches found.

$ nuclei -t http/cves/2025/CVE-2025-29927.yaml -u http://127.0.0.1:19403
[INF] Scan completed in 5.889357ms. 0 matches found.

$ nuclei -t http/cves/2025/CVE-2025-29927.yaml -u http://127.0.0.1:19402
[CVE-2025-29927] [http] [critical] http://127.0.0.1:19402
[INF] Scan completed in 2.817774ms. 1 matches found.
```

Honeypot check, matching the CI weak-matcher job. No results before or after:

```
$ nuclei -duc -silent -u http://honey.scanme.sh -t http/cves/2025/CVE-2025-29927.yaml
$
```

`nuclei -validate` passes, and `yamllint -c .yamllint` on the changed file is clean.

One note on #17019: the reporter also suggested restricting `http(1)` to redirect targets matching
`login|signin|auth|unauthorized`. I deliberately did not do that. Target 19404 above is a genuinely
vulnerable host whose middleware only does locale routing. The bypass really works there, so it
should still be reported, and an auth-keyword filter would suppress it. The `or`/`and` bug is the part
that produces findings on hosts that are not vulnerable at all, and it is what this PR fixes.

The `# digest` line is dropped so the template is re-signed on merge.
