### PR TITLE
Create gpon-router-detect.yaml

### DIFF
--- a/http/iot/gpon-router-detect.yaml
+++ b/http/iot/gpon-router-detect.yaml
@@ -1,0 +1,33 @@
+id: gpon-router-detect
+
+info:
+  name: GPON Router Detection
+  author: K3ysTr0K3R
+  severity: info
+  description: Detects GPON Home Gateway routers based on the web interface title.
+  metadata:
+    verified: true
+    max-request: 1
+  tags: gpon,router,iot,network,tech
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: header
+        words:
+          - "text/html"
+
+      - type: word
+        part: body
+        words:
+          - "<title>GPON Home Gateway</title>"
+        case-insensitive: true


### PR DESCRIPTION
This template detects GPON routers by identifying the `GPON Home Gateway` web interface.