### PR TITLE
add Fiberhome detection template

### DIFF
--- a/http/iot/fiberhome-router-detect.yaml
+++ b/http/iot/fiberhome-router-detect.yaml
@@ -1,0 +1,35 @@
+id: fiberhome-router-detect
+
+info:
+  name: Fiberhome Router Detection
+  author: K3ysTr0K3R
+  severity: info
+  description: Detects Fiberhome network devices by fingerprinting the Fiberhome web management interface.
+  metadata:
+    max-request: 1
+  tags: fiberhome,router,ont,iot,network
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "<title>Fiberhome</title>"
+        case-insensitive: true
+
+      - type: word
+        part: body
+        words:
+          - "/faviconFH.ico"
+          - "ais_fibre"
+        condition: or
+        case-insensitive: true

--- a/http/technologies/fiberhome-router-detect.yaml
+++ b/http/technologies/fiberhome-router-detect.yaml
@@ -1,18 +1,29 @@
 id: fiberhome-router-detect
 
 info:
-  name: Fiberhome Router Detection
+  name: Fiberhome Router - Detect
   author: K3ysTr0K3R
   severity: info
-  description: Detects Fiberhome network devices by fingerprinting the Fiberhome web management interface.
+  description: |
+    Fiberhome network devices were detected by fingerprinting the web management interface.
+  classification:
+    cpe: cpe:2.3:h:fiberhome:*:*:*:*:*:*:*:*:*
   metadata:
+    verified: true
     max-request: 1
-  tags: fiberhome,router,ont,iot,network
+    vendor: fiberhome
+    product: fiberhome_router
+    shodan-query: title:"Fiberhome"
+    fofa-query: title="Fiberhome"
+  tags: tech,fiberhome,router,iot,detect,discovery
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
This template detects Fiberhome routers by identifying the Fiberhome web interface.