### PR TITLE
Fix: CVE-2025-29927 false positive on benign Next.js locale/i18n middleware redirects

### DIFF
--- a/http/cves/2025/CVE-2025-29927.yaml
+++ b/http/cves/2025/CVE-2025-29927.yaml
@@ -59,7 +59,13 @@ http:
       - type: regex
         part: header
         regex:
-          - "(?i)x-nextjs-redirect|x-middleware-rewrite|x-nextjs-rewrite"
+          - "(?i)(x-nextjs-redirect|x-middleware-rewrite|x-nextjs-rewrite):"
+        internal: true
+
+      - type: regex
+        part: header
+        regex:
+          - "(?i)(x-nextjs-redirect|x-middleware-rewrite|x-nextjs-rewrite|location): .*(login|signin|auth|authenticate|unauthorized|admin|dashboard|forbidden)"
         internal: true
 
       - type: status


### PR DESCRIPTION
### Summary

This PR addresses the false positive reported in #17019 for the `CVE-2025-29927` template (`Next.js Middleware Bypass`).

### Root Cause
In `http/cves/2025/CVE-2025-29927.yaml`, `base_check()` executes `http(1) && http(2)`:
- `http(1)` previously passed on ANY request to `/` returning a 307 redirect with `x-nextjs-redirect` / `x-middleware-rewrite` headers.
- When a Next.js application uses standard middleware-based internationalization (i18n locale routing like `/` -> `/en-US` or `/fr`), it returns a 307 redirect with `x-nextjs-redirect`.
- Since root `/` is public on those sites, `http(2)` (which sends `X-Middleware-Subrequest`) returns HTTP 200 regardless of whether any auth bypass occurred.
- This caused `base_check()` to falsely report non-vulnerable Next.js applications as vulnerable.

### Solution
- Refined `http(1)` matchers to verify that the redirect/rewrite target points to an authentication or protected location (e.g. `login`, `signin`, `auth`, `authenticate`, `unauthorized`, `admin`, `dashboard`, `forbidden`), preventing benign locale redirects from satisfying the auth gate condition.
- `endpoint_check()` continues to discover and test protected sub-endpoints found during crawling.

Closes #17019