### PR TITLE
Add CVE-2026-0481 template

### DIFF
--- a/network/cves/2026/CVE-2026-0481.yaml
+++ b/network/cves/2026/CVE-2026-0481.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-0481
+
+info:
+  name: AMD Device Metrics Exporter gpuagent - Unrestricted IP Binding
+  author: str4k3r
+  severity: critical
+  description: |
+    The AMD Device Metrics Exporter (ROCm ecosystem) ships an internal
+    `gpuagent` gRPC control service is intended to be reachable only through
+    a loopback interface. Prior to the fix, gpuagent bound its gRPC listener
+    to all interfaces instead of a loopback-only address, allowing an
+    unauthenticated remote user to reach the internal control port and
+    perform unauthorized GPU configuration changes. The listener returns a
+    valid HTTP/2 SETTINGS frame to an off-host connection on vulnerable
+    installations; the fixed listener refuses the same connection.
+  reference:
+    - https://www.amd.com/en/resources/product-security/bulletin/amd-sb-6031.html
+    - https://github.com/advisories/GHSA-g7c7-634v-gp3r
+    - https://github.com/ROCm/device-metrics-exporter/blob/main/docs/releasenotes.md
+  classification:
+    cve-id: CVE-2026-0481
+    cwe-id: CWE-1327
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 9.2
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: amd
+    product: device-metrics-exporter
+  tags: cve,cve2026,amd,rocm,gpuagent,grpc,exposure,network,tcp
+
+tcp:
+  - inputs:
+      - data: "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a000000040000000000" # HTTP/2 client preface + empty SETTINGS frame
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+
+    port: 50061
+    read-size: 1024
+
+    matchers:
+      - type: binary
+        binary:
+          - "000018040000000000" # HTTP/2 SETTINGS frame (len=24,type=4,flags=0,stream=0) returned by the internal gpuagent gRPC server


### PR DESCRIPTION
## Summary

Adds a Nuclei template for CVE-2026-0481 in AMD Device Metrics Exporter.

## Detection

The template sends the HTTP/2 client preface and an empty SETTINGS frame to
the `gpuagent` service on TCP port 50061. Vulnerable Debian-package
deployments expose the internal listener off-host and return a valid SETTINGS
frame. Fixed deployments keep the listener on a loopback interface and refuse
the same remote connection. The probe does not send a configuration operation
or modify GPU state.

## References

- https://www.amd.com/en/resources/product-security/bulletin/amd-sb-6031.html
- https://github.com/advisories/GHSA-g7c7-634v-gp3r
- https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/releasenotes.html

## Validation

- Vulnerable: official `mirror.gcr.io/rocm/device-metrics-exporter` v1.4.0
- Fixed: official `mirror.gcr.io/rocm/device-metrics-exporter` v1.4.0.1
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3