### PR TITLE
Add CVE-2026-0656 template

### DIFF
--- a/http/cves/2026/CVE-2026-0656.yaml
+++ b/http/cves/2026/CVE-2026-0656.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-0656
+
+info:
+  name: iPaymu Payment Gateway for WooCommerce <= 2.0.2 - Unauthenticated Webhook Handler
+  author: str4k3r
+  severity: high
+  description: >
+    The iPaymu Payment Gateway for WooCommerce plugin <= 2.0.2 exposes its
+    `check_ipaymu_response()` webhook handler without signature or origin
+    verification. An unauthenticated POST reaches the order lookup before
+    validation. Version 2.0.3 requires `reference_id` and an HMAC
+    `X-Signature` header before the lookup. This detector uses order ID `0`,
+    which cannot identify an order, and matches the vulnerable handler's
+    `Invalid order ID` response without changing an order.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/7e639aed-ec67-4212-9051-1f7465bbfde2?source=cve
+    - https://plugins.trac.wordpress.org/browser/ipaymu-for-woocommerce/tags/2.0.2/gateway.php?marks=316-336,370-380#L316
+    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3429657%40ipaymu-for-woocommerce&new=3429657%40ipaymu-for-woocommerce
+  classification:
+    cve-id: CVE-2026-0656
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,wordpress,woocommerce,ipaymu,auth-bypass,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/?wc-api=Ipaymu_WC_Gateway"
+    headers:
+      Content-Type: application/json
+    body: '{"id_order":0,"status":"berhasil","trx_id":"nuclei-poc"}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "Invalid order ID"


### PR DESCRIPTION
## Summary

Adds a Nuclei template for CVE-2026-0656 in iPaymu Payment Gateway for
WooCommerce.

## Detection

The template sends one unauthenticated JSON POST to the generic WooCommerce
API callback. Versions through 2.0.2 reach the webhook handler and return
`Invalid order ID` for the non-existent order ID `0`. Version 2.0.3 rejects
the same unsigned payload before the vulnerable lookup with `Missing
reference_id`. The probe uses an impossible order ID and does not change an
order or payment state.

## References

- https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/ipaymu-for-woocommerce/ipaymu-payment-gateway-for-woocommerce-202-missing-authentication-to-unauthenticated-payment-bypass-and-order-information-disclosure
- https://plugins.trac.wordpress.org/browser/ipaymu-for-woocommerce/tags/2.0.2/gateway.php
- https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=ipaymu-for-woocommerce&old=3429657%40ipaymu-for-woocommerce&new=3429657%40ipaymu-for-woocommerce

## Validation

- Vulnerable: iPaymu Payment Gateway 2.0.2 with WooCommerce 11.0.1
- Fixed: iPaymu Payment Gateway 2.0.3 with WooCommerce 11.0.1
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3