### PR TITLE
Add CVE-2026-42221 template

### DIFF
--- a/http/cves/2026/CVE-2026-42221.yaml
+++ b/http/cves/2026/CVE-2026-42221.yaml
@@ -1,0 +1,43 @@
+id: CVE-2026-42221
+
+info:
+  name: Nginx UI < 2.3.8 - Unauthenticated First-Run Installer Exposure
+  author: str4k3r
+  severity: critical
+  description: |
+    Nginx UI 2.0.0 through 2.3.7 exposes the pre-authentication installer at
+    `/api/install`. The endpoint is removed in 2.3.8, which moves installation
+    behind the authenticated setup route. This non-mutating probe submits an
+    intentionally invalid encrypted payload and detects the vulnerable route
+    from its decryption error without setting any installation values.
+  remediation: Upgrade Nginx UI to 2.3.8 or later.
+  reference:
+    - https://github.com/0xJacky/nginx-ui/security/advisories/GHSA-h27v-ph7w-m9fp
+    - https://github.com/0xJacky/nginx-ui/releases/tag/v2.3.8
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42221
+  classification:
+    cve-id: CVE-2026-42221
+    cwe-id: CWE-306
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,nginx-ui,unauth,takeover,cwe-306
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/install"
+    headers:
+      Content-Type: application/json
+    body: '{"encrypted_params":"not-a-real-encrypted-payload"}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "decryption failed"

--- a/http/cves/2026/CVE-2026-42221.yaml
+++ b/http/cves/2026/CVE-2026-42221.yaml
@@ -1,16 +1,15 @@
 id: CVE-2026-42221
 
 info:
-  name: Nginx UI < 2.3.8 - Unauthenticated First-Run Installer Exposure
+  name: Nginx UI <= 2.3.7 - Unauthenticated Installer Exposure
   author: str4k3r
-  severity: critical
+  severity: high
   description: |
-    Nginx UI 2.0.0 through 2.3.7 exposes the pre-authentication installer at
-    `/api/install`. The endpoint is removed in 2.3.8, which moves installation
-    behind the authenticated setup route. This non-mutating probe submits an
-    intentionally invalid encrypted payload and detects the vulnerable route
-    from its decryption error without setting any installation values.
-  remediation: Upgrade Nginx UI to 2.3.8 or later.
+    Nginx UI 2.0.0 to 2.3.8 contains an authentication bypass caused by unauthenticated access to /api/install during first-run setup, letting remote attackers claim the initial admin account, exploit requires attacker to access the service before legitimate operator.
+  impact: |
+    Remote attackers can permanently take over the initial administrator account, leading to full control of the instance.
+  remediation: |
+    Upgrade to version 2.3.8 or later.
   reference:
     - https://github.com/0xJacky/nginx-ui/security/advisories/GHSA-h27v-ph7w-m9fp
     - https://github.com/0xJacky/nginx-ui/releases/tag/v2.3.8
@@ -18,26 +17,54 @@ info:
   classification:
     cve-id: CVE-2026-42221
     cwe-id: CWE-306
-    cvss-score: 9.8
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 8.1
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
+    vendor: 0xjacky
+    product: nginx-ui
+    shodan-query: http.title:"Nginx UI"
+    fofa-query: app="Nginx-UI"
   tags: cve,cve2026,nginx-ui,unauth,takeover,cwe-306
 
+flow: http(1) && http(2)
+
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/api/install"
-    headers:
-      Content-Type: application/json
-    body: '{"encrypted_params":"not-a-real-encrypted-payload"}'
-    matchers-condition: and
+  - raw:
+      - |
+        GET /api/install HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+
     matchers:
-      - type: status
-        status:
-          - 400
-      - type: word
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "lock")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
         part: body
-        words:
-          - "decryption failed"
+        name: lock_state
+        group: 1
+        regex:
+          - '("lock":\s*(?:true|false)(?:,\s*"timeout":\s*(?:true|false))?)'
+        internal: true
+
+  - raw:
+      - |
+        POST /api/install HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"encrypted_params":"aW52YWxpZA=="}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains_all(body, "decryption failed", "40001")'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-42221 in Nginx UI. Versions before 2.3.8 expose the pre-authentication installer route; 2.3.8 removes `/api/install` and moves installation behind the setup-authentication path.

## Detection

The template sends an intentionally invalid encrypted payload to the generic installer route. A vulnerable instance reaches the decryption layer and returns `decryption failed`; the fixed route returns a missing-route response. No installation values are submitted or changed.

## References

- https://github.com/0xJacky/nginx-ui/security/advisories/GHSA-h27v-ph7w-m9fp
- https://github.com/0xJacky/nginx-ui/releases/tag/v2.3.8
- https://nvd.nist.gov/vuln/detail/CVE-2026-42221

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 2.3.7 detected 3/3; fixed 2.3.8 not detected 3/3. The final template was syntax-validated and quality-checked before submission.