### PR TITLE
Add CVE-2026-0718 template

### DIFF
--- a/http/cves/2026/CVE-2026-0718.yaml
+++ b/http/cves/2026/CVE-2026-0718.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-0718
+
+info:
+  name: PostX <= 5.0.5 - Unauthenticated Post Metadata Modification
+  author: str4k3r
+  severity: medium
+  description: |
+    PostX versions through 5.0.5 expose the share-count AJAX handler to
+    unauthenticated visitors and update attacker-selected post metadata without
+    checking post visibility or caller capabilities. Version 5.0.6 adds post
+    status and authorization checks. This template performs a side-effect-free
+    version check against the plugin's public readme file.
+  impact: An unauthenticated attacker can modify share-count metadata belonging to arbitrary posts.
+  remediation: Upgrade PostX to version 5.0.6 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0718
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/c4b2cf3b-5d35-4ce6-9453-1538a6f7752f
+    - https://plugins.trac.wordpress.org/changeset?old_path=/ultimate-post/tags/5.0.5/classes/Blocks.php&new_path=/ultimate-post/tags/5.0.6/classes/Blocks.php
+  classification:
+    cve-id: CVE-2026-0718
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpxpo
+    product: ultimate-post
+  tags: cve,cve2026,wordpress,wp-plugin,ultimate-post,postx
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/ultimate-post/readme.txt"
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        internal: true
+        regex:
+          - "(?i)Stable tag:\\s*([0-9.]+)"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "contains_any(body, 'Post Grid', 'PostX', 'Ultimate Post')"
+          - "compare_versions(version, '< 5.0.6')"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a side-effect-free version detector for CVE-2026-0718 in the PostX WordPress plugin. Affected versions expose an unauthenticated share-count handler without the required post-status and capability checks.

## Detection

The template reads the plugin's public `readme.txt`, verifies the product marker, extracts the stable version, and matches versions before 5.0.6. It does not invoke the vulnerable metadata-update action.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-0718
- https://www.wordfence.com/threat-intel/vulnerabilities/id/c4b2cf3b-5d35-4ce6-9453-1538a6f7752f
- https://plugins.trac.wordpress.org/changeset?old_path=/ultimate-post/tags/5.0.5/classes/Blocks.php&new_path=/ultimate-post/tags/5.0.6/classes/Blocks.php

## Validation

Previously recorded native Nuclei v3.11.0 differential: official plugin 5.0.5 detected 3/3 and 5.0.6 not detected 3/3. No new V/F run was performed for this submission.