### PR TITLE
Add CVE-2026-14919 template

### DIFF
--- a/http/cves/2026/CVE-2026-14919.yaml
+++ b/http/cves/2026/CVE-2026-14919.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-14919
+
+info:
+  name: ShopMonitor.io < 1.2.0 - Worker IP Spoofing
+  author: str4k3r
+  severity: critical
+  description: |
+    ShopMonitor.io versions before 1.2.0 trust client-controlled proxy headers
+    when deciding whether a request originates from an approved worker. An
+    attacker can spoof a loopback worker address and abuse test-mode email
+    routing to redirect security-sensitive mail. This template performs a
+    side-effect-free version check against the plugin's public readme file.
+  impact: An unauthenticated attacker may redirect password-reset email and take over an administrator account.
+  remediation: Upgrade ShopMonitor.io to version 1.2.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14919
+    - https://wpscan.com/vulnerability/6d929535-9757-44ae-8c58-682f1eb89785/
+    - https://plugins.trac.wordpress.org/browser/shopmonitorio/tags/1.1.1/includes/class-shopmonitor-ip-whitelist.php
+    - https://plugins.trac.wordpress.org/browser/shopmonitorio/tags/1.2.0/includes/class-shopmonitor-ip-whitelist.php
+  classification:
+    cve-id: CVE-2026-14919
+    cwe-id: CWE-345
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: shopmonitorio
+    product: shopmonitorio
+  tags: cve,cve2026,wordpress,wp-plugin,shopmonitorio
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/shopmonitorio/readme.txt"
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        internal: true
+        regex:
+          - "(?i)Stable tag:\\s*([0-9.]+)"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "contains(body, 'ShopMonitor')"
+          - "compare_versions(version, '< 1.2.0')"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a side-effect-free version detector for CVE-2026-14919 in the ShopMonitor.io WordPress plugin. Affected versions trust spoofable proxy headers in the worker-IP allowlist path.

## Detection

The template reads the plugin's public `readme.txt`, verifies the product marker, extracts the stable version, and matches versions before 1.2.0. It does not trigger password reset or alter email routing.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-14919
- https://wpscan.com/vulnerability/6d929535-9757-44ae-8c58-682f1eb89785/
- https://plugins.trac.wordpress.org/browser/shopmonitorio/tags/1.2.0/includes/class-shopmonitor-ip-whitelist.php

## Validation

Previously recorded native Nuclei differential: official plugin 1.1.1 detected 3/3 and 1.2.0 not detected 3/3. No new V/F run was performed for this submission.