### PR TITLE
Add CVE-2026-0593 template

### DIFF
--- a/http/cves/2026/CVE-2026-0593.yaml
+++ b/http/cves/2026/CVE-2026-0593.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-0593
+
+info:
+  name: WP Go Maps <= 10.0.04 - Missing Authorization
+  author: str4k3r
+  severity: medium
+  description: |
+    WP Go Maps through 10.0.04 does not perform a capability check in the
+    processBackgroundAction AJAX handler. An authenticated subscriber can use
+    the handler to change global map-engine settings. This template performs a
+    read-only version check against the plugin's public readme file.
+  impact: |
+    Low-privileged users can modify site-wide map configuration without the
+    required administrative capability.
+  remediation: Update WP Go Maps to version 10.0.05 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/7f0741c1-a5d7-41a4-a739-2cb7cb836509?source=cve
+    - https://plugins.trac.wordpress.org/changeset/3439283/wp-google-maps/trunk/includes/class.admin-notices.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0593
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-0593
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpgmaps
+    product: wp-google-maps
+    framework: wordpress
+    publicwww-query: "/plugins/wp-google-maps/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wp-google-maps,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wp-google-maps/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "WP Go Maps (formerly WP Google Maps)"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 10.0.04')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for WP Go Maps installations affected by CVE-2026-0593.
- Uses one read-only GET to the plugin's standard public `readme.txt` path and requires both the product title and an affected version (`<= 10.0.04`).
- Does not invoke the vulnerable AJAX action or change map configuration.

## Validation

- Official WordPress.org packages: 10.0.04 (V, SHA-256 `dca2fcc16d3bc89b5308d1ab9ce2f0ceff5c86a0584a2ee9275a5e6073248219`) and 10.0.05 (F, SHA-256 `b772638be05b3d1872640514a7b607b1727c9110afa760c0b51cf00cd05b223e`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, the exact WP Go Maps product marker, and a parsed WordPress stable tag in the affected range. The response is benign public plugin metadata and the request is side-effect free.