### PR TITLE
Add CVE-2026-0679 template

### DIFF
--- a/http/cves/2026/CVE-2026-0679.yaml
+++ b/http/cves/2026/CVE-2026-0679.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-0679
+
+info:
+  name: Fortis for WooCommerce <= 1.2.0 - Order Status Manipulation
+  author: str4k3r
+  severity: medium
+  description: |
+    Fortis for WooCommerce through 1.2.0 uses an inverted nonce check in its
+    unauthenticated payment notification endpoint and trusts attacker-supplied
+    transaction data. An attacker can mark an order as paid without a verified
+    Fortis transaction. This template uses the public plugin readme for a
+    read-only version check.
+  impact: An unauthenticated attacker can change WooCommerce order status without payment.
+  remediation: Update Fortis for WooCommerce to version 1.3.0 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/9f16c098-3e99-4506-b517-ae4b838a0925?source=cve
+    - https://plugins.trac.wordpress.org/browser/fortis-for-woocommerce/tags/1.2.0/classes/WC_Gateway_Fortis.php#L1674
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0679
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-0679
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: fortispay
+    product: fortis-for-woocommerce
+    framework: wordpress
+    publicwww-query: "/plugins/fortis-for-woocommerce/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,woocommerce,fortis,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/fortis-for-woocommerce/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Fortis"
+          - "WooCommerce"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.2.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Fortis for WooCommerce installations affected by CVE-2026-0679.
- Uses one read-only GET to the standard plugin `readme.txt` path and checks version `<= 1.2.0`.
- Does not call the payment notification endpoint or alter an order.

## Validation

- Official WordPress.org packages: 1.2.0 (V, SHA-256 `48ab69d9a10ee163474bdba6ac779bd45713b85e02df14324187cc48f5858c0c`) and 1.3.0 (F, SHA-256 `a707aea706c4dcae90af4a6bd9347236a0271380d1bc554815a1a06930a573e2`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The response must be HTTP 200 and contain both Fortis and WooCommerce product markers plus an affected stable tag. Only benign public version metadata is read.