### PR TITLE
Add CVE-2026-13596 template

### DIFF
--- a/http/cves/2026/CVE-2026-13596.yaml
+++ b/http/cves/2026/CVE-2026-13596.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-13596
+
+info:
+  name: Participants Database < 2.7.8.4 - SQL Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    Participants Database before 2.7.8.4 fails to escape wildcard list-search
+    input before including it in a SQL LIKE clause. An unauthenticated attacker
+    can inject SQL through a public list-search form. This template safely
+    identifies affected installations through the public plugin readme.
+  impact: An unauthenticated attacker can read or modify data through SQL injection.
+  remediation: Update Participants Database to version 2.7.8.4 or later.
+  reference:
+    - https://wpscan.com/vulnerability/e22227c8-506e-4188-a7a1-1952b41c47f5/
+    - https://patchstack.com/database/wordpress/plugin/participants-database/vulnerability/wordpress-participants-database-plugin-2-7-8-4-unauthenticated-sql-injection-vulnerability
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13596
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-13596
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: xnau
+    product: participants-database
+    framework: wordpress
+    publicwww-query: "/plugins/participants-database/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,participants-database,sqli
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/participants-database/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "=== Participants Database ==="
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.7.8.4')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a non-invasive detector for Participants Database versions affected by CVE-2026-13596.
- Reads the standard plugin `readme.txt` and matches versions before 2.7.8.4.
- Replaces the lab-only timing SQL injection probe with a generic one-request version detector.

## Validation

- Official WordPress.org packages: 2.7.8.3 (V, SHA-256 `4b71ae3b330bf801dfd1e78f5229ece2871d6c9eafc20511915e6297c5573d26`) and 2.7.8.4 (F, SHA-256 `30965bafc95c12f055ec5d91a6f3cb024d3529d6ab892b71a490093a6cdb3a40`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact Participants Database title, and a parsed stable tag below the fixed boundary. No SQL payload or timing oracle is sent.