### PR TITLE
Add CVE-2026-14943 template

### DIFF
--- a/http/cves/2026/CVE-2026-14943.yaml
+++ b/http/cves/2026/CVE-2026-14943.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-14943
+
+info:
+  name: Password Protected >= 2.6.8 < 2.8.4 - REST API Access Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    Password Protected versions from 2.6.8 through 2.8.3 do not correctly
+    restrict unauthenticated REST API access when the REST API option is
+    enabled. An attacker can bypass the site-wide password gate and read
+    protected REST content. This template performs a read-only version check.
+  impact: Unauthenticated users can access protected WordPress content through the REST API.
+  remediation: Update Password Protected to version 2.8.4 or later.
+  reference:
+    - https://wpscan.com/vulnerability/874ada86-f13b-44f9-85e6-f2ec16e82f85/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-14943
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-14943
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpexpertsio
+    product: password-protected
+    framework: wordpress
+    publicwww-query: "/plugins/password-protected/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,password-protected,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/password-protected/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Password Protected"
+          - "Lock Entire Site"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 2.6.8') && compare_versions(version, '< 2.8.4')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for the Password Protected REST API bypass in CVE-2026-14943.
- Restricts the affected range to the documented regression window `>= 2.6.8` and `< 2.8.4`.
- Does not request protected REST content or depend on a site configuration toggle.

## Validation

- Official WordPress.org packages: 2.8.3 (V, SHA-256 `553a1e9620e5dc2421f47cd71a1a879e5e45c21531468599d11bf10feb61e5a2`) and 2.8.4 (F, SHA-256 `baec2e7314220f421260c50b2e699b0bb537f0b5844cd42e7298aa0310b7d6fa`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, two product-title markers, and both lower and upper version bounds. The only returned data is the public plugin readme.