### PR TITLE
Add CVE-2026-16030 template

### DIFF
--- a/http/cves/2026/CVE-2026-16030.yaml
+++ b/http/cves/2026/CVE-2026-16030.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-16030
+
+info:
+  name: MStore API < 4.21.0 - Firebase Authentication Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    MStore API before 4.21.0 does not cryptographically verify Firebase phone
+    authentication ID tokens. An unauthenticated attacker can forge a token for
+    an arbitrary phone number and sign in as, or create, the corresponding
+    WordPress user. This template safely checks the exposed plugin version.
+  impact: An unauthenticated attacker can take over or create WordPress accounts.
+  remediation: Update MStore API to version 4.21.0 or later.
+  reference:
+    - https://wpscan.com/vulnerability/adf8ffe0-39a2-4d26-af11-1ac807800735/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-16030
+  classification:
+    cve-id: CVE-2026-16030
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: inspireui
+    product: mstore-api
+    framework: wordpress
+    publicwww-query: "/plugins/mstore-api/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,mstore-api,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/mstore-api/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "MStore API"
+          - "Native Android & iOS Apps"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 4.21.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a read-only detector for the MStore API Firebase authentication bypass in CVE-2026-16030.
- Checks the standard public plugin readme for versions before 4.21.0.
- Does not submit a forged Firebase token or create/login a WordPress user.

## Validation

- Official WordPress.org packages: 4.18.4 (V, SHA-256 `452177438b8cd63ebcf42649a56ba2b7ee373e80854ccec2e9bf16285e8e847d`) and 4.21.1 (F, SHA-256 `673288cfa1557be72b790903f20c1156d53928ef045cbcaf79cf0142d455e0ef`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two MStore-specific title markers, and an affected stable tag. The request reads benign public metadata only.