### PR TITLE
Add CVE-2026-16041 template

### DIFF
--- a/http/cves/2026/CVE-2026-16041.yaml
+++ b/http/cves/2026/CVE-2026-16041.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-16041
+
+info:
+  name: MStore API < 4.21.0 - Missing Authorization
+  author: str4k3r
+  severity: high
+  description: |
+    MStore API before 4.21.0 exposes its product review creation route without
+    enforcing the required user cookie. An unauthenticated attacker can submit
+    attacker-controlled reviews to WooCommerce products. This template uses the
+    public plugin readme for a non-invasive version check.
+  impact: Unauthenticated attackers can create arbitrary product reviews.
+  remediation: Update MStore API to version 4.21.0 or later.
+  reference:
+    - https://cveawg.mitre.org/api/cve/CVE-2026-16041
+    - https://wpscan.com/vulnerability/0e7d8a17-0901-45b5-959c-2c1ef1316047/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-16041
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-16041
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: inspireui
+    product: mstore-api
+    framework: wordpress
+    publicwww-query: "/plugins/mstore-api/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,mstore-api,woocommerce,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/mstore-api/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "MStore API"
+          - "Native Android & iOS Apps"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 4.21.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for the MStore API missing authorization issue in CVE-2026-16041.
- Checks the standard public plugin readme for versions before 4.21.0.
- Does not reach the review-creation handler or write a WooCommerce review.

## Validation

- Official WordPress.org packages: 4.18.4 (V, SHA-256 `452177438b8cd63ebcf42649a56ba2b7ee373e80854ccec2e9bf16285e8e847d`) and 4.21.1 (F, SHA-256 `673288cfa1557be72b790903f20c1156d53928ef045cbcaf79cf0142d455e0ef`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two MStore-specific title markers, and an affected stable tag. The request is side-effect free and returns only public version metadata.