### PR TITLE
Add CVE-2026-16734 template

### DIFF
--- a/http/cves/2026/CVE-2026-16734.yaml
+++ b/http/cves/2026/CVE-2026-16734.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-16734
+
+info:
+  name: WP Full Pay < 8.5.2 - Missing Authorization
+  author: str4k3r
+  severity: high
+  description: |
+    WP Full Pay before 8.5.2 accepts an attacker-selected Stripe PaymentIntent
+    identifier in its public pricing flow without verifying the corresponding
+    client secret. An unauthenticated caller can reach server-side processing
+    for a PaymentIntent they do not own. This template checks the public plugin
+    readme without interacting with Stripe or a payment flow.
+  impact: Attackers can access server-side payment processing for another user's PaymentIntent.
+  remediation: Update WP Full Pay to version 8.5.2 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wp-full-stripe-free/stripe-payment-forms-by-wp-full-pay-851-missing-authorization
+    - https://wpscan.com/vulnerability/5fcb5b11-3ebd-4821-aa6f-c6be70bac395/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-16734
+  classification:
+    cve-id: CVE-2026-16734
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: themeisle
+    product: wp-full-stripe-free
+    framework: wordpress
+    publicwww-query: "/plugins/wp-full-stripe-free/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,wp-full-pay,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/wp-full-stripe-free/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Stripe Payment Forms by WP Full Pay"
+          - "Accept Credit Card Payments"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 8.5.2')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for WP Full Pay installations affected by CVE-2026-16734.
- Uses one GET to the standard public plugin readme and matches versions before 8.5.2.
- Does not contact Stripe, supply a PaymentIntent, or invoke a payment endpoint.

## Validation

- Official WordPress.org packages: 8.5.1 (V, SHA-256 `1cc4a23251679e03f3ce2a6aa5a2f51e9bf39bc4ecfe58ed7883b0e14a4a5a74`) and 8.5.2 (F, SHA-256 `91fe0bf9c1665eae1081bdc044c259ba3f37f7302fec3d239871029318363a7d`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, two exact WP Full Pay title fragments, and an affected stable tag. The request reads public metadata and cannot mutate payment state.