### PR TITLE
Add CVE-2026-18050 template

### DIFF
--- a/http/cves/2026/CVE-2026-18050.yaml
+++ b/http/cves/2026/CVE-2026-18050.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-18050
+
+info:
+  name: Events Manager < 7.4 - Unauthenticated File Disclosure
+  author: str4k3r
+  severity: high
+  description: |
+    Events Manager before 7.4 does not enforce authorization when retrieving a
+    temporary upload by identifier. An unauthenticated attacker who knows a
+    live temporary identifier can retrieve the pending file. This template
+    performs a read-only affected-version check against the plugin readme.
+  impact: Unauthenticated attackers can disclose pending uploaded files.
+  remediation: Update Events Manager to version 7.4 or later.
+  reference:
+    - https://wpscan.com/vulnerability/84964951-d25a-4753-bf71-fe00e2492a89/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18050
+    - https://plugins.svn.wordpress.org/events-manager/tags/7.4.0.1/classes/uploads/em-uploads-api.php
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-18050
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: pixelite
+    product: events-manager
+    framework: wordpress
+    publicwww-query: "/plugins/events-manager/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,events-manager,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/events-manager/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Events Manager - Calendar, Bookings, Tickets"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 7.4')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a read-only detector for Events Manager versions affected by CVE-2026-18050.
- Checks the plugin's standard public readme for versions before 7.4.
- Does not guess a temporary upload identifier or retrieve pending file data.

## Validation

- Official WordPress.org packages: 7.3.7.4.2 (V, SHA-256 `be76b1d02fc2e4de6b6e0b74da18a5586589c8427d4bbb1a0ddde0145fb07712`) and 7.4.0.1 (F, SHA-256 `f9e1542922809fa14ffdbc18e99ad72f5672c4e0a264cf74f70c1c72007546ca`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the Events Manager product title, and an affected parsed stable tag. No sensitive upload content is requested.