### PR TITLE
Add CVE-2026-18325 template

### DIFF
--- a/http/cves/2026/CVE-2026-18325.yaml
+++ b/http/cves/2026/CVE-2026-18325.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-18325
+
+info:
+  name: Forminator Forms <= 1.56.1 - Stored Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    Forminator Forms through 1.56.1 trusts a client-supplied return flag in
+    select-field data and can store an attacker-controlled upload URL without
+    the normal field validation. The resulting value is rendered without
+    sufficient escaping in an administrative submission view. This template
+    safely identifies the affected version from the public plugin changelog.
+  impact: An unauthenticated attacker can store script-capable markup that executes for an administrator reviewing submissions.
+  remediation: Update Forminator Forms to version 1.56.2 or later.
+  reference:
+    - https://plugins.trac.wordpress.org/browser/forminator/tags/1.55.1/library/modules/custom-forms/front/front-action.php#L1091
+    - https://plugins.trac.wordpress.org/browser/forminator/tags/1.55.1/library/model/class-form-entry-model.php#L1569
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18325
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2026-18325
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpmudev
+    product: forminator
+    framework: wordpress
+    publicwww-query: "/plugins/forminator/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,forminator,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/forminator/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Forminator Forms"
+          - "Contact Form"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.56.1')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?s)== Changelog ==.*?\n=\s*([0-9.]+)\s+\([0-9-]+\)\s*='
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Forminator versions affected by CVE-2026-18325.
- Uses one GET to the public plugin readme and extracts the first release under `Changelog`, because these official packages retain an older `Stable tag` value.
- Does not submit a form, create an entry, or store an XSS payload.

## Validation

- Official WordPress.org packages: 1.56.1 (V, SHA-256 `9fc3ec887bba4bcd90be28a82717b04be25dc67bad63222ca35781cf382a603d`) and 1.56.2 (F, SHA-256 `60807f24444d24c458e8e12561bc6dc9b65d2f6d282f93eda83746a2c655defa`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, two Forminator title markers, and an affected first changelog release. The detector reads only benign public package metadata.