### PR TITLE
Add CVE-2026-2628 template

### DIFF
--- a/http/cves/2026/CVE-2026-2628.yaml
+++ b/http/cves/2026/CVE-2026-2628.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-2628
+
+info:
+  name: All-in-One Microsoft 365 & Entra ID SSO <= 2.2.5 - Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    All-in-One Microsoft 365 & Entra ID / Azure AD SSO Login through 2.2.5
+    accepts an ID token from the callback request and decodes its claims without
+    verifying the JWT signature. An unauthenticated attacker can forge a token
+    for an existing user and obtain that user's session. This template performs
+    a read-only version check against the plugin readme.
+  impact: An unauthenticated attacker can take over arbitrary WordPress accounts, including administrators.
+  remediation: Update the plugin to version 2.2.7 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/5e15e36e-55f9-4095-a0ba-48ef9434606a?source=cve
+    - https://plugins.svn.wordpress.org/login-with-azure/tags/2.2.7/class-moazure-widget.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2628
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-2628
+    cwe-id: CWE-288
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: cyberlord92
+    product: login-with-azure
+    framework: wordpress
+    publicwww-query: "/plugins/login-with-azure/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,login-with-azure,auth-bypass,jwt
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/login-with-azure/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "All-in-One Microsoft 365"
+          - "Azure AD SSO Login"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 2.2.5')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for the login-with-azure authentication bypass in CVE-2026-2628.
- Reads the standard public plugin readme and checks versions through 2.2.5.
- Does not send a forged JWT or attempt to obtain an authenticated session.

## Validation

- Official WordPress.org packages: 2.2.5 (V, SHA-256 `ba75ea6cbfd2abf81155ea61d955974681ec590d467f252a5aba5b58b8f2fd0b`) and 2.2.7 (F, SHA-256 `cced0939eb0a819f278a595f6f2ae18374bb0264667035728c58ec3d99a80362`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, two product-specific SSO title markers, and an affected stable tag. Only public version metadata is returned.