### PR TITLE
Add CVE-2026-61963 template

### DIFF
--- a/http/cves/2026/CVE-2026-61963.yaml
+++ b/http/cves/2026/CVE-2026-61963.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-61963
+
+info:
+  name: Media Library Assistant <= 3.38 - Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    Media Library Assistant through 3.38 does not recursively validate nested
+    request keys before adding them to shortcode pagination links. A crafted
+    nested key can break out of an HTML attribute and inject script markup on a
+    page using an affected shortcode. This template performs a safe public
+    readme version check.
+  impact: An attacker can execute script in the browser of a user who follows a crafted link.
+  remediation: Update Media Library Assistant to version 3.39 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/media-library-assistant/vulnerability/wordpress-media-library-assistant-plugin-3-38-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-61963
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-61963
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dglingren
+    product: media-library-assistant
+    framework: wordpress
+    publicwww-query: "/plugins/media-library-assistant/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,media-library-assistant,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/media-library-assistant/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Media Library Assistant"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 3.38')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Media Library Assistant versions affected by CVE-2026-61963.
- Uses one GET to the standard public readme and checks versions through 3.38.
- Does not require a shortcode page or send an XSS payload.

## Validation

- Official WordPress.org packages: 3.38 (V, SHA-256 `f385bd29294a235e00a1a786387a90ea7f6d04376fd39509357c39e31bca5396`) and 3.39 (F, SHA-256 `415f2092d73c7fc0246a78babd77f2a49068e057c7713e2257ca433364b74c1a`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact Media Library Assistant title, and an affected stable tag. The request is independent of site content and side-effect free.