### PR TITLE
Add CVE-2026-61982 template

### DIFF
--- a/http/cves/2026/CVE-2026-61982.yaml
+++ b/http/cves/2026/CVE-2026-61982.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-61982
+
+info:
+  name: SiteGuard WP Plugin <= 1.8.6 - Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    SiteGuard WP Plugin through 1.8.6 does not safely preserve URL encoding
+    while rebuilding a renamed-login logout URL. An attacker-controlled
+    redirect value can therefore escape an HTML attribute on the logout nonce
+    confirmation page. This template identifies affected installations using
+    the plugin's public readme.
+  impact: A remote attacker can execute script in a user browser through a crafted logout URL.
+  remediation: Update SiteGuard WP Plugin to version 1.8.7 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/siteguard/vulnerability/wordpress-siteguard-wp-plugin-plugin-1-8-6-cross-site-scripting-xss-vulnerability
+    - https://plugins.svn.wordpress.org/siteguard/tags/1.8.7/classes/siteguard-rename-login.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-61982
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-61982
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: jp-secure
+    product: siteguard
+    framework: wordpress
+    publicwww-query: "/plugins/siteguard/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,siteguard,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/siteguard/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "=== SiteGuard WP Plugin ==="
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.8.6')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for SiteGuard WP Plugin versions affected by CVE-2026-61982.
- Uses one read-only request to the standard plugin readme and checks versions through 1.8.6.
- Does not depend on a configured renamed-login slug or send an XSS payload.

## Validation

- Official WordPress.org packages: 1.8.6 (V, SHA-256 `f088a837db7d57e8e5c4dccc755864b17913d580a5c22d76d9d7368df98f073a`) and 1.8.7 (F, SHA-256 `c445120be8793e5f3830288966a6a2f281945dcacfa9e09cf287cf72162b9829`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, the exact SiteGuard product title, and an affected stable tag. It reads benign public metadata only.