### PR TITLE
Add CVE-2026-65513 template

### DIFF
--- a/http/cves/2026/CVE-2026-65513.yaml
+++ b/http/cves/2026/CVE-2026-65513.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-65513
+
+info:
+  name: Simply Schedule Appointments <= 1.6.12.10 - Stored Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    Simply Schedule Appointments through 1.6.12.10 sanitizes several URL-valued
+    appointment metadata fields with esc_attr instead of esc_url_raw. An
+    unauthenticated booking user can store a javascript URI that is later shown
+    as an administrative link. This template safely checks the public plugin
+    version without creating an appointment.
+  impact: An attacker can store a script-capable link that executes when an administrator clicks it.
+  remediation: Update Simply Schedule Appointments to version 1.6.12.11 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/simply-schedule-appointments/vulnerability/wordpress-simply-schedule-appointments-plugin-1-6-12-10-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-65513
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-65513
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: nsquared
+    product: simply-schedule-appointments
+    framework: wordpress
+    publicwww-query: "/plugins/simply-schedule-appointments/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,simply-schedule-appointments,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/simply-schedule-appointments/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Simply Schedule Appointments"
+          - "Appointment Booking Calendar"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.6.12.10')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a non-invasive detector for Simply Schedule Appointments versions affected by CVE-2026-65513.
- Uses one GET to the standard public plugin readme and checks versions through 1.6.12.10.
- Does not create an appointment, write metadata, or send a `javascript:` URI.

## Validation

- Official WordPress.org packages: 1.6.12.10 (V, SHA-256 `8f8167fa8efd66c94b581d28723d80a12c6155b510c153e7e787b74908e11043`) and 1.6.12.11 (F, SHA-256 `a2bec468e0814b153dec91c7a4c2c30b486224592a34400b1fa15cc29e66ff39`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two product-title markers, and an affected stable tag. The generic request reads public metadata and cannot alter booking state.