### PR TITLE
Add CVE-2026-66439 template

### DIFF
--- a/http/cves/2026/CVE-2026-66439.yaml
+++ b/http/cves/2026/CVE-2026-66439.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-66439
+
+info:
+  name: Advanced AJAX Product Filters <= 3.2.0.3 - Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    Advanced AJAX Product Filters through 3.2.0.3 includes an attacker-controlled
+    filter string in WPBakery compatibility JavaScript without the required JSON
+    hexadecimal escaping. A crafted URL can inject script-context markup on an
+    affected page. This template performs a read-only plugin version check.
+  impact: An attacker can execute script in the browser of a user who opens a crafted filter URL.
+  remediation: Update Advanced AJAX Product Filters to version 3.2.1 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/woocommerce-ajax-filters/vulnerability/wordpress-advanced-ajax-product-filters-plugin-3-2-0-3-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://plugins.svn.wordpress.org/woocommerce-ajax-filters/tags/3.2.1/includes/compatibility/js_composer.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66439
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-66439
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: berocket
+    product: woocommerce-ajax-filters
+    framework: wordpress
+    publicwww-query: "/plugins/woocommerce-ajax-filters/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,woocommerce,ajax-filters,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-ajax-filters/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "=== Advanced AJAX Product Filters ==="
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 3.2.0.3')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Advanced AJAX Product Filters versions affected by CVE-2026-66439.
- Checks the standard public plugin readme for versions through 3.2.0.3.
- Does not require WPBakery compatibility to be enabled and sends no XSS marker.

## Validation

- Official WordPress.org packages: 3.2.0.3 (V, SHA-256 `0ef32a60cc3f07925f350209684b01cb8ed1a0a1b0ef44f5510c6f01c30bd80e`) and 3.2.1 (F, SHA-256 `afe8f9e0b0280b77511a80a421bf2a263a5b05772bd0f1881d5f837f64f63349`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, the exact Advanced AJAX Product Filters title, and an affected stable tag. The response contains only public plugin metadata.