### PR TITLE
Add CVE-2026-66664 template

### DIFF
--- a/http/cves/2026/CVE-2026-66664.yaml
+++ b/http/cves/2026/CVE-2026-66664.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-66664
+
+info:
+  name: SEO Plugin by Squirrly SEO <= 14.2.0 - Cross-Site Scripting
+  author: str4k3r
+  severity: high
+  description: |
+    SEO Plugin by Squirrly SEO through 14.2.0 escapes a search canonical URL
+    before URL decoding it. A double-encoded search value can therefore become
+    active markup after escaping and break out of the canonical link attribute.
+    This template safely checks the plugin's public readme version.
+  impact: An unauthenticated attacker can execute script in the browser of a user who opens a crafted search URL.
+  remediation: Update SEO Plugin by Squirrly SEO to version 14.2.1 or later.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/squirrly-seo/vulnerability/wordpress-seo-plugin-by-squirrly-seo-plugin-14-1-1-reflected-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66664
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-66664
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: seo-squirrly
+    product: squirrly-seo
+    framework: wordpress
+    publicwww-query: "/plugins/squirrly-seo/"
+  tags: cve,cve2026,wordpress,wp,wp-plugin,squirrly-seo,xss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/squirrly-seo/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "GEO Plugin by Squirrly SEO"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 14.2.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?i)Stable tag:\s*([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Squirrly SEO versions affected by CVE-2026-66664.
- Uses one read-only GET to the public plugin readme and checks versions through 14.2.0.
- Does not require the optional frontend SEO toggle or send a double-encoded XSS payload.

## Validation

- Official WordPress.org packages: 14.2.0 (V, SHA-256 `37669a2c41a37cea5389105ab0aa87f301eb44c59bab68ced7b4c4bd95fbeb09`) and 14.2.1 (F, SHA-256 `e3be879298a543ada72d0183cd42f50937eec2065b6916e2a0b38f255466cbac`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the official Squirrly package title, and an affected stable tag. Only benign public version data is requested.