### PR TITLE
Add CVE-2026-35223 template

### DIFF
--- a/http/cves/2026/CVE-2026-35223.yaml
+++ b/http/cves/2026/CVE-2026-35223.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-35223
+
+info:
+  name: Joomla 4.0.0-5.4.5 and 6.0.0-6.1.0 - Improper Access Control
+  author: str4k3r
+  severity: high
+  description: |
+    Joomla versions 4.0.0 through 5.4.5 and 6.0.0 through 6.1.0 do not
+    perform the required authorization check in the com_config webservice
+    component controller. An authenticated API user can access component
+    configuration without the corresponding administrative permission. This
+    template performs a read-only version check against Joomla's public core
+    manifest.
+  impact: An authenticated API user can access configuration data for components they are not authorized to administer.
+  remediation: Update Joomla to version 5.4.6, 6.1.1, or later.
+  reference:
+    - https://developer.joomla.org/security-centre/1040-20260508-core-improper-access-check-in-com-config-webservice-endpoints.html
+    - https://github.com/joomla/joomla-cms/compare/5.4.5...5.4.6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35223
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-35223
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: joomla
+    product: joomla
+    shodan-query: 'http.html:"content=\"Joomla! CMS\""'
+  tags: cve,cve2026,joomla,cms,access-control
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/manifests/files/joomla.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>files_joomla</name>"
+          - "<author>Joomla! Project</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 4.0.0') && compare_versions(version, '<= 5.4.5')) || (compare_versions(version, '>= 6.0.0') && compare_versions(version, '<= 6.1.0'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Joomla CVE-2026-35223 across both affected core release lines.
- Reads Joomla's standard public core manifest and does not require or use API credentials.
- Does not request component configuration or exercise the vulnerable authorization path.

## Validation

- Official Joomla packages: 5.4.5 V (`d873c2c0c753036089470551fa9fe958cb289f954afb66ded149a5cf4eaf97bc`) versus 5.4.6 F (`6245d4ff736a7fe0f4391bebe6793c038081d09646a113617831f9b8086806a0`).
- Official Joomla packages: 6.1.0 V (`1442712071ac9db6aef09c46d3c51f6093211114d6145cd7cf8b29c44293807e`) versus 6.1.1 F (`bc27840f38687da105dc5f8a00f94f688b46526379f075fc67020c8d1d8d6e7a`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected both V lines 3/3 and remained silent on both F lines 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two Joomla core manifest markers, and an explicitly bounded affected version in either release line. The request reads benign public XML only.