### PR TITLE
Add CVE-2026-40384 template

### DIFF
--- a/http/cves/2026/CVE-2026-40384.yaml
+++ b/http/cves/2026/CVE-2026-40384.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-40384
+
+info:
+  name: Joomla 4.0.0-5.4.5 and 6.0.0-6.1.0 - Path Traversal
+  author: str4k3r
+  severity: medium
+  description: |
+    Joomla versions 4.0.0 through 5.4.5 and 6.0.0 through 6.1.0 build a
+    filesystem glob from the com_media search parameter without rejecting
+    path separators or parent-directory components. An authenticated
+    administrator can search outside the configured media root. This template
+    safely checks the version exposed by Joomla's public core manifest.
+  impact: An authenticated administrator can enumerate files outside the intended media directory.
+  remediation: Update Joomla to version 5.4.6, 6.1.1, or later.
+  reference:
+    - https://developer.joomla.org/security-centre/1042-20260510-core-path-traversal-in-com-media-webservice-endpoint.html
+    - https://github.com/joomla/joomla-cms/pull/47837
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40384
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:H/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 5.9
+    cve-id: CVE-2026-40384
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: joomla
+    product: joomla
+    shodan-query: 'http.html:"content=\"Joomla! CMS\""'
+  tags: cve,cve2026,joomla,cms,path-traversal
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/manifests/files/joomla.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>files_joomla</name>"
+          - "<author>Joomla! Project</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 4.0.0') && compare_versions(version, '<= 5.4.5')) || (compare_versions(version, '>= 6.0.0') && compare_versions(version, '<= 6.1.0'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a non-invasive version detector for Joomla CVE-2026-40384 across both affected core release lines.
- Reads the standard public core manifest and does not require an administrator session or seeded file.
- Does not send a traversal search value or enumerate media files.

## Validation

- Official Joomla packages: 5.4.5 V (`d873c2c0c753036089470551fa9fe958cb289f954afb66ded149a5cf4eaf97bc`) versus 5.4.6 F (`6245d4ff736a7fe0f4391bebe6793c038081d09646a113617831f9b8086806a0`).
- Official Joomla packages: 6.1.0 V (`1442712071ac9db6aef09c46d3c51f6093211114d6145cd7cf8b29c44293807e`) versus 6.1.1 F (`bc27840f38687da105dc5f8a00f94f688b46526379f075fc67020c8d1d8d6e7a`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected both V lines 3/3 and remained silent on both F lines 3/3.

## False-positive and safety controls

Detection requires HTTP 200, Joomla-specific manifest markers, and an explicitly bounded affected version. Only public version metadata is returned.