### PR TITLE
Add CVE-2026-48957 template

### DIFF
--- a/http/cves/2026/CVE-2026-48957.yaml
+++ b/http/cves/2026/CVE-2026-48957.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-48957
+
+info:
+  name: Joomla 4.0.0-5.4.6 and 6.0.0-6.1.1 - Improper Access Control
+  author: str4k3r
+  severity: medium
+  description: |
+    Joomla versions 4.0.0 through 5.4.6 and 6.0.0 through 6.1.1 do not
+    enforce the required core.admin permission on com_privacy webservice
+    request endpoints. An authenticated API user can access privacy-request
+    data without Super User authorization. This template performs a read-only
+    version check against Joomla's public core manifest.
+  impact: An authenticated API user can access privacy-request information outside their authorization level.
+  remediation: Update Joomla to version 5.4.7, 6.1.2, or later.
+  reference:
+    - https://developer.joomla.org/security-centre/1065-20260711-core-incorrect-access-control-in-com-privacy-webservice-endpoints.html
+    - https://github.com/joomla/joomla-cms/compare/5.4.6...5.4.7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48957
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:N/VA:N/SC:H/SI:H/SA:H
+    cvss-score: 6.4
+    cve-id: CVE-2026-48957
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: joomla
+    product: joomla
+    shodan-query: 'http.html:"content=\"Joomla! CMS\""'
+  tags: cve,cve2026,joomla,cms,access-control
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/manifests/files/joomla.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>files_joomla</name>"
+          - "<author>Joomla! Project</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 4.0.0') && compare_versions(version, '<= 5.4.6')) || (compare_versions(version, '>= 6.0.0') && compare_versions(version, '<= 6.1.1'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Joomla CVE-2026-48957 across the 5.4 and 6.1 release lines.
- Reads Joomla's public core manifest without an API token.
- Does not query privacy requests or return sensitive application data.

## Validation

- Official Joomla packages: 5.4.6 V (`6245d4ff736a7fe0f4391bebe6793c038081d09646a113617831f9b8086806a0`) versus 5.4.7 F (`f7340a93d03b2b9d13191ab82cb2e08bfca882315998f55ce56a8ebb4309da8f`).
- Official Joomla packages: 6.1.1 V (`bc27840f38687da105dc5f8a00f94f688b46526379f075fc67020c8d1d8d6e7a`) versus 6.1.2 F (`ec609f1beca6c11d5d8f6d453270843473d6f954efa37c3913cb141bbc4d1c29`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected both V lines 3/3 and remained silent on both F lines 3/3.

## False-positive and safety controls

The matcher combines HTTP status, two Joomla core product markers, and exact affected ranges. The request is side-effect free and reads only public XML.