### PR TITLE
Add CVE-2026-48958 template

### DIFF
--- a/http/cves/2026/CVE-2026-48958.yaml
+++ b/http/cves/2026/CVE-2026-48958.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-48958
+
+info:
+  name: Joomla 4.0.0-5.4.6 and 6.0.0-6.1.1 - Improper Access Control
+  author: str4k3r
+  severity: medium
+  description: |
+    Joomla versions 4.0.0 through 5.4.6 and 6.0.0 through 6.1.1 check custom
+    field creation permission against com_fields instead of the requested
+    component context. An authenticated API user can create a field for a
+    component they are not authorized to modify. This template safely checks
+    the version in Joomla's public core manifest.
+  impact: An authenticated API user can create custom fields outside their authorized component context.
+  remediation: Update Joomla to version 5.4.7, 6.1.2, or later.
+  reference:
+    - https://developer.joomla.org/security-centre/1066-20260712-core-incorrect-access-control-in-com-fields-webservice-endpoints.html
+    - https://github.com/joomla/joomla-cms/releases/tag/6.1.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48958
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:N/VI:L/VA:N/SC:H/SI:H/SA:H
+    cvss-score: 6.4
+    cve-id: CVE-2026-48958
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: joomla
+    product: joomla
+    shodan-query: 'http.html:"content=\"Joomla! CMS\""'
+  tags: cve,cve2026,joomla,cms,access-control
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/manifests/files/joomla.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>files_joomla</name>"
+          - "<author>Joomla! Project</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 4.0.0') && compare_versions(version, '<= 5.4.6')) || (compare_versions(version, '>= 6.0.0') && compare_versions(version, '<= 6.1.1'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Joomla CVE-2026-48958 across the 5.4 and 6.1 release lines.
- Reads the standard public core manifest and does not require an API token.
- Does not create a custom field or change Joomla state.

## Validation

- Official Joomla packages: 5.4.6 V (`6245d4ff736a7fe0f4391bebe6793c038081d09646a113617831f9b8086806a0`) versus 5.4.7 F (`f7340a93d03b2b9d13191ab82cb2e08bfca882315998f55ce56a8ebb4309da8f`).
- Official Joomla packages: 6.1.1 V (`bc27840f38687da105dc5f8a00f94f688b46526379f075fc67020c8d1d8d6e7a`) versus 6.1.2 F (`ec609f1beca6c11d5d8f6d453270843473d6f954efa37c3913cb141bbc4d1c29`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected both V lines 3/3 and remained silent on both F lines 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two Joomla core manifest markers, and an affected release range. Only benign public version metadata is read.