### PR TITLE
Add CVE-2026-57828 template

### DIFF
--- a/http/cves/2026/CVE-2026-57828.yaml
+++ b/http/cves/2026/CVE-2026-57828.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-57828
+
+info:
+  name: Phoca Download <= 6.1.2 - Unrestricted File Upload
+  author: str4k3r
+  severity: critical
+  description: |
+    Phoca Download for Joomla through 6.1.2 does not enforce the configured
+    extension allow list on the frontend member-upload path. An authenticated
+    user with upload permission can upload a dangerous file type. This
+    template performs a read-only version check against the component's
+    standard public Joomla manifest.
+  impact: An authenticated user can upload a dangerous file type, potentially leading to remote code execution.
+  remediation: Update Phoca Download to version 6.1.3 or later.
+  reference:
+    - https://www.phoca.cz/news/1481-phoca-download-version-6-1-3-released-security-release
+    - https://github.com/PhocaCz/PhocaDownload/releases/tag/6.1.3
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-57828
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.0
+    cve-id: CVE-2026-57828
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: phoca
+    product: phoca-download
+  tags: cve,cve2026,joomla,phoca,phoca-download,file-upload
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/components/com_phocadownload/phocadownload.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>com_phocadownload</name>"
+          - "<projectName>PhocaDownload</projectName>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 6.1.2')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a read-only detector for Phoca Download installations affected by CVE-2026-57828.
- Uses the component's standard public Joomla manifest and checks versions through 6.1.2.
- Does not log in, upload a file, or change component state.

## Validation

- Official Phoca release packages: 6.1.2 V (SHA-256 `95f51e448d47ebee322b7b4e37de31acf72cb047240d3d4e91afb28c91e171c9`) and 6.1.3 F (SHA-256 `e90feb0fa55006be8bbd70144cf0d5cf87c41d1aefdaf8de7cd4639a66a3beac`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, both Phoca Download manifest identifiers, and an affected parsed version. The response is benign public XML.