### PR TITLE
Add CVE-2026-65876 template

### DIFF
--- a/http/cves/2026/CVE-2026-65876.yaml
+++ b/http/cves/2026/CVE-2026-65876.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-65876
+
+info:
+  name: SP Page Builder <= 6.7.1 - SQL Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    SP Page Builder for Joomla through 6.7.1 does not normalize the category
+    identifier before using it in the unauthenticated article-loading query.
+    A remote attacker can inject SQL through the catid parameter. This
+    template performs a read-only version check against the component's
+    standard public Joomla manifest.
+  impact: An unauthenticated attacker can inject SQL and disclose database content.
+  remediation: Update SP Page Builder to version 6.8.0 or later.
+  reference:
+    - https://www.joomshaper.com/blog/sp-page-builder-v6-8-0
+    - https://www.joomshaper.com/downloads/extension/sp-page-builder-lite-next
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-65876
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
+    cvss-score: 9.2
+    cve-id: CVE-2026-65876
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: joomshaper
+    product: sp-page-builder
+  tags: cve,cve2026,joomla,joomshaper,sp-page-builder,sqli
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/components/com_sppagebuilder/sppagebuilder.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>SP Page Builder</name>"
+          - "<author>JoomShaper</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 6.7.1')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a non-invasive detector for SP Page Builder installations affected by CVE-2026-65876.
- Uses the component's standard public Joomla manifest and checks versions through 6.7.1.
- Does not send SQL syntax or call the vulnerable article-loading endpoint.

## Validation

- Official JoomShaper packages: 6.7.1 V (SHA-256 `63f96f04a948f3b060f2bc8b8a55676bf628094317330cc0cce5ef84514b1568`) and 6.8.0 F (SHA-256 `8b32f758236c44f06f06c69aa75748caea913e3510ace9511ddea95bd30faab7`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the SP Page Builder name, the JoomShaper author marker, and an affected parsed version. Only public manifest data is requested.