### PR TITLE
Add CVE-2026-66491 template

### DIFF
--- a/http/cves/2026/CVE-2026-66491.yaml
+++ b/http/cves/2026/CVE-2026-66491.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-66491
+
+info:
+  name: Phoca Commander <= 6.1.3 - Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: |
+    Phoca Commander for Joomla through 6.1.3 passes an attacker-controlled,
+    base64-decoded filename to file_get_contents without enforcing path
+    containment. An authenticated Joomla administrator can read files outside
+    the web root. This template performs a safe version check against the
+    component's standard public Joomla manifest.
+  impact: An authenticated administrator can read arbitrary files accessible to the web server process.
+  remediation: Update Phoca Commander to version 6.1.4 or later.
+  reference:
+    - https://www.phoca.cz/news/1498-phoca-commander-version-6-1-4-released-security-release
+    - https://github.com/PhocaCz/PhocaCommander/releases/tag/6.1.4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66491
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
+    cvss-score: 8.2
+    cve-id: CVE-2026-66491
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: phoca
+    product: phoca-commander
+  tags: cve,cve2026,joomla,phoca,phoca-commander,lfi,path-traversal
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/components/com_phocacommander/phocacommander.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>com_phocacommander</name>"
+          - "<projectName>PhocaCommander</projectName>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 6.1.3')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Phoca Commander installations affected by CVE-2026-66491.
- Reads the standard public component manifest and checks versions through 6.1.3.
- Does not authenticate to Joomla, submit a traversal path, or read a filesystem file.

## Validation

- Official Phoca release packages: 6.1.3 V (SHA-256 `47bb352f59ad3160ba5c7835ba33c51c2cefa825c06aca390acf6395b1ef098e`) and 6.1.4 F (SHA-256 `f6880b40f6cbb658d92ab19c16e642dd18100544e773bbfaa6fa08c323cc697d`).
- The 6.1.4 package source was additionally inspected to confirm `getSource()` uses `getContainedRealPath()` before `file_get_contents()`.
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

The matcher requires HTTP 200, both Phoca Commander manifest identifiers, and an affected parsed version. It reads only benign public XML.