### PR TITLE
Add CVE-2026-66914 template

### DIFF
--- a/http/cves/2026/CVE-2026-66914.yaml
+++ b/http/cves/2026/CVE-2026-66914.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-66914
+
+info:
+  name: SEBLOD <= 3.29.0 and 5.0.0-6.0.0 - Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    SEBLOD for Joomla does not safely resolve the file parameter in its
+    unauthenticated download task. A path beginning with the allowed tmp
+    directory can contain parent-directory segments and escape the intended
+    root, allowing arbitrary file retrieval. This template performs a
+    read-only version check against the component's public Joomla manifest.
+  impact: An unauthenticated attacker can read sensitive files accessible to the web server, including Joomla configuration data.
+  remediation: Update SEBLOD to version 3.30.0, 4.7.0, 6.0.1, or later in the corresponding release line.
+  reference:
+    - https://www.seblod.com
+    - https://github.com/Octopoos/SEBLOD/compare/3.29.0...3.30.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-66914
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N
+    cvss-score: 9.2
+    cve-id: CVE-2026-66914
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: seblod
+    product: seblod
+  tags: cve,cve2026,joomla,seblod,cck,lfi,path-traversal
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/administrator/components/com_cck/manifest.xml"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<name>com_cck</name>"
+          - "<author>Octopoos</author>"
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 1.0.0') && compare_versions(version, '<= 3.29.0')) || (compare_versions(version, '>= 5.0.0') && compare_versions(version, '<= 6.0.0'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '<version>\s*([0-9.]+)\s*</version>'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for reliably distinguishable SEBLOD release lines affected by CVE-2026-66914.
- Uses the component's standard public Joomla manifest and covers the affected 3.x and 5.x/6.0 lines.
- Does not send a traversal value or retrieve a server file.

## Validation

- Official SEBLOD source tags: 3.29.0 V (`5dd45e1dbdde505a44f822b2a6b59e1218f9160f`) versus 3.30.0 F (`11f1e4788bda098cd9080ec0297c0dbcadca8075`).
- Official SEBLOD source tags: 6.0.0 V (`4925c41d4f4de6a4516a4b790a4278e3c2194d84`) versus 6.0.1 F (`e0ee0fb55af09ed04c7f4406499078cf076391e9`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected both V lines 3/3 and remained silent on both F lines 3/3.

## False-positive and safety controls

Detection requires HTTP 200, two SEBLOD-specific manifest markers, and an explicitly bounded affected version. The 4.x range is intentionally not matched because the vendor's 4.7.0 public component manifest still reports 4.6.0, making safe version-only differentiation impossible for that line.