### PR TITLE
Add CVE-2026-20706 template

### DIFF
--- a/http/cves/2026/CVE-2026-20706.yaml
+++ b/http/cves/2026/CVE-2026-20706.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-20706
+
+info:
+  name: Gitea <= 1.26.1 - Repository Archive Token-Scope Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Gitea through 1.26.1 does not enforce repository token scopes on the web
+    archive-download route. A token without repository scope can therefore
+    download an archive when its owner can otherwise read the repository.
+    This template performs a read-only version check against Gitea's public
+    Swagger document.
+  impact: An attacker holding an under-scoped token can download private repository archives accessible to the token owner.
+  remediation: Update Gitea to version 1.26.2 or later.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-cr4g-f395-h25h
+    - https://github.com/go-gitea/gitea/pull/37735
+    - https://github.com/go-gitea/gitea/releases/tag/v1.26.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20706
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-20706
+    cwe-id: CWE-284
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: gitea
+    product: gitea
+  tags: cve,cve2026,gitea,authorization,token-scope
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/swagger.v1.json"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "Gitea API"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.26.1')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Gitea installations affected by CVE-2026-20706.
- Uses one read-only GET to the public Swagger document and requires the Gitea API title plus an affected version (`<= 1.26.1`).
- Does not authenticate, access a repository, or request an archive.

## Validation

- Official images: `gitea/gitea:1.26.1` (V, digest `sha256:d8667667b4ccbd1f67b86a376bffcc0a17b16cf71309ed04e3918231776d47dd`) and `gitea/gitea:1.26.2` (F, digest `sha256:7d13848af12645600a5f9d93ee2560daa9c6fa6b5b859b7bff3a5e1c0b661031`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the product-specific `Gitea API` Swagger marker, and a parsed version in the affected range. The response contains only public API metadata and the request is side-effect free.