### PR TITLE
Add CVE-2026-35032 template

### DIFF
--- a/http/cves/2026/CVE-2026-35032.yaml
+++ b/http/cves/2026/CVE-2026-35032.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-35032
+
+info:
+  name: Jellyfin < 10.11.7 - Excessive Live TV Management Permission
+  author: str4k3r
+  severity: high
+  description: |
+    Jellyfin before 10.11.7 grants Live TV management permission to newly
+    created non-administrator users by default. Combined with insufficient
+    tuner URL validation, this permits local file access and server-side
+    requests. This template performs a read-only version check against the
+    public system-information endpoint.
+  impact: A low-privileged user can abuse Live TV tuner management to access local files or internal HTTP services and potentially obtain administrative tokens.
+  remediation: Update Jellyfin to version 10.11.7 or later, and disable Live TV management for untrusted users until upgrading.
+  reference:
+    - https://github.com/jellyfin/jellyfin/security/advisories/GHSA-8fw7-f233-ffr8
+    - https://github.com/jellyfin/jellyfin/releases/tag/v10.11.7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35032
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-35032
+    cwe-id: CWE-73,CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: jellyfin
+    product: jellyfin
+  tags: cve,cve2026,jellyfin,authorization,ssrf,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/System/Info/Public"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"ProductName":"Jellyfin Server"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 10.11.7')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Jellyfin installations affected by CVE-2026-35032.
- Uses one read-only GET to `/System/Info/Public` and requires the Jellyfin Server product marker plus a version below 10.11.7.
- Does not complete setup, create a user, configure a tuner, read a file, or issue an SSRF request.

## Validation

- Official images: `jellyfin/jellyfin:10.11.6` (V, digest `sha256:333b647716631443a43c7fabac4b0c46b4e2f036bad19547e00958f10f721b85`) and `jellyfin/jellyfin:10.11.7` (F, digest `sha256:17285f9cce63b3519ccad82b84497fc22482c20f8b8bbe0580d51fec5deaa6fd`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact `Jellyfin Server` product marker, and a parsed affected version. The endpoint is Jellyfin's public system-information API and the request is side-effect free.