### PR TITLE
Add CVE-2026-45338 template

### DIFF
--- a/http/cves/2026/CVE-2026-45338.yaml
+++ b/http/cves/2026/CVE-2026-45338.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-45338
+
+info:
+  name: Open WebUI < 0.9.0 - OAuth Profile Picture SSRF
+  author: str4k3r
+  severity: high
+  description: |
+    Open WebUI before 0.9.0 fetches URLs supplied in OAuth profile-picture
+    claims without applying its URL validation routine. A malicious identity
+    provider can make the server request internal resources and expose their
+    responses as profile images. This template performs a read-only version
+    check against the public application configuration endpoint.
+  impact: An attacker controlling an OAuth profile can access internal HTTP resources and retrieve their responses through the application.
+  remediation: Update Open WebUI to version 0.9.0 or later.
+  reference:
+    - https://github.com/open-webui/open-webui/security/advisories/GHSA-24c9-2m8q-qhmh
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-45338
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 7.7
+    cve-id: CVE-2026-45338
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: openwebui
+    product: open_webui
+  tags: cve,cve2026,open-webui,oauth,ssrf
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/config"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"name":"Open WebUI"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 0.9.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Open WebUI installations affected by CVE-2026-45338.
- Uses one read-only GET to the public application configuration endpoint and requires the Open WebUI product name plus a version below 0.9.0.
- Does not initiate OAuth, control a profile-picture URL, or issue a server-side request.

## Validation

- Official images: `ghcr.io/open-webui/open-webui:0.8.12` (V, digest `sha256:8113fa5510020ef05a44afc0c42d33eabeeb2524a996e3e3fb8c437c00f0d792`) and `ghcr.io/open-webui/open-webui:0.9.0` (F, digest `sha256:eb874c0530209dd5ca21a4d0a7cc42e69f2ee85f0e7b90ae94659cd415c27c6d`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact `Open WebUI` product marker, and a parsed affected version. The response is public application metadata and the request is side-effect free.