### PR TITLE
Add CVE-2026-45347 template

### DIFF
--- a/http/cves/2026/CVE-2026-45347.yaml
+++ b/http/cves/2026/CVE-2026-45347.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-45347
+
+info:
+  name: Open WebUI < 0.5.11 - PDF Generation SSRF
+  author: str4k3r
+  severity: medium
+  description: |
+    Open WebUI before 0.5.11 interprets user-controlled PDF export fields as
+    HTML. An embedded image element can cause the server to request an
+    attacker-selected URL during PDF generation. This template performs a
+    read-only version check against the public application configuration
+    endpoint.
+  impact: An authenticated attacker can induce server-side requests to internal or external resources during PDF generation.
+  remediation: Update Open WebUI to version 0.5.11 or later.
+  reference:
+    - https://github.com/open-webui/open-webui/security/advisories/GHSA-f776-fp4w-266c
+    - https://github.com/open-webui/open-webui/commit/167c8bf00d165af523acfc3b870749f6be6d3e57
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-45347
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
+    cvss-score: 4.3
+    cve-id: CVE-2026-45347
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: openwebui
+    product: open_webui
+  tags: cve,cve2026,open-webui,pdf,ssrf
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/config"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"name":"Open WebUI"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 0.5.11')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Open WebUI installations affected by CVE-2026-45347.
- Uses one read-only GET to the public application configuration endpoint and requires the Open WebUI product name plus a version below 0.5.11.
- Does not generate a PDF, submit HTML, or cause a server-side request.

## Validation

- Official images: `ghcr.io/open-webui/open-webui:0.5.10` (V, digest `sha256:d1946178c44ac314bf8764bf4b28ac64e372668be5e8c9d233e32ded9c8c10c7`) and `ghcr.io/open-webui/open-webui:0.5.11` (F, digest `sha256:f4396ddb52979a87ca0626f100a8b51f1318b9b8e95544329ba095d1e1860018`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact `Open WebUI` product marker, and a parsed affected version. The response is public application metadata and the request is side-effect free.