### PR TITLE
Add CVE-2026-7663 template

### DIFF
--- a/http/cves/2026/CVE-2026-7663.yaml
+++ b/http/cves/2026/CVE-2026-7663.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-7663
+
+info:
+  name: Langflow 1.0.0-1.9.6 - MCP Project Authorization Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Langflow versions 1.0.0 through 1.9.6 do not correctly enforce project
+    authorization on the Streamable MCP transport endpoint. An unauthenticated
+    attacker can access protected MCP resources and invoke project operations.
+    This template performs a read-only version check against the public
+    Langflow version endpoint.
+  impact: An unauthenticated attacker can access another user's protected MCP project resources and execute exposed MCP operations.
+  remediation: Update Langflow to version 1.10.0 or later.
+  reference:
+    - https://www.ibm.com/support/pages/node/7277570
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-7663
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-7663
+    cwe-id: CWE-285,CWE-863
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflow
+    product: langflow
+  tags: cve,cve2026,langflow,mcp,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"package":"Langflow"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.0.0', '<= 1.9.6')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for Langflow installations affected by CVE-2026-7663.
- Uses one read-only GET to the public version endpoint and requires the Langflow package marker plus the bounded 1.0.0-1.9.6 affected range.
- Does not access a project or initialize an MCP session.

## Validation

- Official images: `langflowai/langflow:1.9.6` (V, digest `sha256:bc004d30ec7ffb64b55323ee3f87d76e9b50d114cb7a959608535420417abd2a`) and `langflowai/langflow:1.10.0` (F, digest `sha256:3ec67ddf344b3f2393b4961aa4f87e8928798f33772fdfdc6d348bfd54f58bf0`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact `Langflow` package marker, and a parsed version inside the advisory's affected range. The endpoint returns benign public version metadata and the request is side-effect free.