### PR TITLE
Add CVE-2026-7872 template

### DIFF
--- a/http/cves/2026/CVE-2026-7872.yaml
+++ b/http/cves/2026/CVE-2026-7872.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-7872
+
+info:
+  name: Langflow 1.0.0-1.9.1 - TAR Symlink Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: |
+    Langflow versions 1.0.0 through 1.9.1 follow symbolic links while
+    extracting TAR uploads for the File component. An authenticated attacker
+    can use a crafted archive to read files accessible to the Langflow
+    process. This template performs a read-only version check against the
+    public Langflow version endpoint and uses the observed fixed boundary.
+  impact: An authenticated attacker can disclose sensitive server files, including material that may permit authentication-token forgery.
+  remediation: Update Langflow to version 1.9.2 or later.
+  reference:
+    - https://www.ibm.com/support/pages/node/7278934
+    - https://github.com/langflow-ai/langflow/releases/tag/v1.9.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-7872
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-7872
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflow
+    product: langflow
+  tags: cve,cve2026,langflow,tar,symlink,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"package":"Langflow"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.0.0', '<= 1.9.1')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe detector for the independently observed vulnerable Langflow range for CVE-2026-7872.
- Uses one read-only GET to the public version endpoint and requires the Langflow package marker plus the measured 1.0.0-1.9.1 range.
- Does not authenticate, upload a TAR file, create a symbolic link, or access a server file.

## Validation

- Official images: `langflowai/langflow:1.9.1` (V, digest `sha256:3783ccaf4849215a9661bc756d69f503d27fbf8c6b087f11b4bd4a31ce2c7feb`) and `langflowai/langflow:1.10.0` (F, digest `sha256:3ec67ddf344b3f2393b4961aa4f87e8928798f33772fdfdc6d348bfd54f58bf0`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

The upper bound is intentionally 1.9.1: the official 1.10.0 artifact rejects the symlink member, while the upstream 1.9.2 release identifies the relevant extraction fix. Detection requires HTTP 200, the exact `Langflow` package marker, and a version in this measured range.