### PR TITLE
Add CVE-2026-8609 template

### DIFF
--- a/http/cves/2026/CVE-2026-8609.yaml
+++ b/http/cves/2026/CVE-2026-8609.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-8609
+
+info:
+  name: Grafana Multiple Versions - OAuth Metric Cardinality Denial of Service
+  author: str4k3r
+  severity: medium
+  description: |
+    Multiple Grafana release lines use an attacker-controlled unknown OAuth
+    client name as a failed-login metric label. Repeated requests with unique
+    names can create unbounded metric cardinality and exhaust memory. This
+    template performs a read-only version check against Grafana's public
+    health endpoint.
+  impact: An unauthenticated attacker can cause unbounded memory growth and eventually crash the Grafana instance.
+  remediation: Update to Grafana 11.6.15, 12.2.9, 12.3.7, 12.4.4, 13.0.2, or a later version in the corresponding release line.
+  reference:
+    - https://grafana.com/security/security-advisories/cve-2026-8609/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8609
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L
+    cvss-score: 5.3
+    cve-id: CVE-2026-8609
+    cwe-id: CWE-400
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: grafana
+    product: grafana
+  tags: cve,cve2026,grafana,oauth,denial-of-service
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/health"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"database": "ok"'
+          - '"commit":'
+        condition: and
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 11.6.0') && compare_versions(version, '< 11.6.15')) || (compare_versions(version, '>= 12.2.0') && compare_versions(version, '< 12.2.9')) || (compare_versions(version, '>= 12.3.0') && compare_versions(version, '< 12.3.7')) || (compare_versions(version, '>= 12.4.0') && compare_versions(version, '< 12.4.4')) || (compare_versions(version, '>= 13.0.0') && compare_versions(version, '< 13.0.2'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for the five affected Grafana release lines in CVE-2026-8609.
- Uses one read-only GET to the public Grafana health endpoint and applies explicit start and fixed-version boundaries for each line.
- Does not invoke the OAuth callback route, create metric labels, or attempt resource exhaustion.

## Validation

- Official images: `grafana/grafana:11.6.14` (V, digest `sha256:ebe075cd4c4520f9d3af2403a1ddc830651ca7d009cbdfdcf21032db574dc3a7`) and `grafana/grafana:11.6.15` (F, digest `sha256:f739273dfed04760428fcfbfccd1752b3b7fc87ef0a3d5637e2e87cce151e1a2`).
- Native Nuclei v3.11.0 validation passed.
- Exact submitted bytes: V detected 3/3; F not detected 3/3.

## False-positive and safety controls

Detection requires HTTP 200, Grafana health-response fields, and a parsed version inside one of the advisory's explicitly affected ranges. The request returns benign health metadata and is side-effect free.