### PR TITLE
Add CVE-2026-1470 template

### DIFF
--- a/http/cves/2026/CVE-2026-1470.yaml
+++ b/http/cves/2026/CVE-2026-1470.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-1470
+
+info:
+  name: n8n Multiple Versions - Expression Sandbox Escape
+  author: str4k3r
+  severity: critical
+  description: |
+    Multiple n8n release lines do not sufficiently isolate workflow expression
+    evaluation. An authenticated workflow author can escape the JavaScript
+    sandbox and execute code with the privileges of the n8n process. This
+    template performs a read-only version check against the public editor page.
+  impact: An authenticated workflow author can execute arbitrary code, access stored secrets, and compromise the n8n host process.
+  remediation: Update n8n to version 1.123.17, 2.4.5, 2.5.1, or later in the corresponding release line.
+  reference:
+    - https://research.jfrog.com/vulnerabilities/n8n-expression-node-rce/
+    - https://github.com/n8n-io/n8n/commit/aa4d1e5825829182afa0ad5b81f602638f55fa04
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1470
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2026-1470
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+  tags: cve,cve2026,n8n,rce,sandbox
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "n8n.io - Workflow Automation"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.123.17') || (compare_versions(version, '>= 2.0.0') && compare_versions(version, '< 2.4.5')) || compare_versions(version, '= 2.5.0')"
+
+    extractors:
+      - type: regex
+        name: sentry_config
+        part: body
+        group: 1
+        regex:
+          - 'name="n8n:config:sentry"\s+content="([A-Za-z0-9+/=]+)"'
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - "replace_regex(base64_decode(sentry_config), '.*n8n@([0-9.]+).*', '$1')"
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for n8n releases affected by CVE-2026-1470.
- Uses one read-only GET to the public editor page, requires the n8n product title, and decodes the public Sentry release value for bounded version comparison.
- Does not authenticate, create or execute a workflow, evaluate an expression, or run a command.

## Validation

- Official images: `n8nio/n8n:1.123.14` (V, digest `sha256:681e9a04270818a8e2abc1100b33bd6a47f6011a9275d5653420c06864506f77`) and `n8nio/n8n:1.123.17` (F, digest `sha256:d8479cb641b95412593bb37763980a28bb32df88c514b3ef0229a89a7298542d`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact n8n editor title, a valid decoded `n8n@<version>` release, and one of the advisory's affected version ranges. The request is side-effect free.