### PR TITLE
Add CVE-2026-44790 template

### DIFF
--- a/http/cves/2026/CVE-2026-44790.yaml
+++ b/http/cves/2026/CVE-2026-44790.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-44790
+
+info:
+  name: n8n Multiple Versions - Git Node Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    Multiple n8n release lines allow an authenticated workflow author to inject
+    command-line flags into the Git node's push operation. The injected options
+    can expose arbitrary server files and may lead to broader compromise. This
+    template performs a read-only version check against the public editor page.
+  impact: An authenticated workflow author can read files accessible to the n8n process and potentially fully compromise the instance.
+  remediation: Update n8n to version 1.123.43, 2.20.7, 2.22.1, or later in the corresponding release line.
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-57g9-58c2-xjg3
+    - https://github.com/n8n-io/n8n/commit/f4f066c7dbb332a990a9a4bbcf4d3f8abe1316a8
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44790
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.4
+    cve-id: CVE-2026-44790
+    cwe-id: CWE-88
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+  tags: cve,cve2026,n8n,git,lfi,authenticated
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "n8n.io - Workflow Automation"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.123.43') || (compare_versions(version, '>= 2.0.0') && compare_versions(version, '< 2.20.7')) || (compare_versions(version, '>= 2.21.0') && compare_versions(version, '< 2.22.1'))"
+
+    extractors:
+      - type: regex
+        name: sentry_config
+        part: body
+        group: 1
+        regex:
+          - 'name="n8n:config:sentry"\s+content="([A-Za-z0-9+/=]+)"'
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - "replace_regex(base64_decode(sentry_config), '.*n8n@([0-9.]+).*', '$1')"
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for n8n releases affected by CVE-2026-44790.
- Uses one read-only GET to the public editor page and a product-bound decoded release value.
- Does not authenticate, create a workflow, invoke the Git node, pass CLI flags, or read a file.

## Validation

- Official images: `n8nio/n8n:1.123.42` (V, digest `sha256:3ff4bdb2f12810dda3eb0c14a82df9969e7dde2bc581728a228503135a615f39`) and `n8nio/n8n:1.123.43` (F, digest `sha256:417270816354b73ca75588fb7f698ab844de9cfeae2e9b54c06f1ee6dbe7ddd4`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires the exact n8n editor title and a decoded semantic version inside one of the vendor's affected release lines. Only benign public page metadata is read.