### PR TITLE
Add CVE-2026-49465 template

### DIFF
--- a/http/cves/2026/CVE-2026-49465.yaml
+++ b/http/cves/2026/CVE-2026-49465.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-49465
+
+info:
+  name: n8n Multiple Versions - Git Node File Sandbox Bypass
+  author: str4k3r
+  severity: medium
+  description: |
+    Multiple n8n release lines permit an authenticated workflow author to use
+    local filesystem paths in Git node clone or push operations, bypassing the
+    configured file-access sandbox. This template performs a read-only version
+    check against the public editor page.
+  impact: An authenticated workflow author can clone local repositories into an allowed path and read files that should be blocked by the sandbox.
+  remediation: Update n8n to version 1.123.48, 2.21.8, 2.22.4, or later in the corresponding release line.
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-5xp3-2w67-427v
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-49465
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:L/SI:N/SA:N
+    cvss-score: 6.0
+    cve-id: CVE-2026-49465
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+  tags: cve,cve2026,n8n,git,sandbox,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "n8n.io - Workflow Automation"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.123.48') || (compare_versions(version, '>= 2.0.0') && compare_versions(version, '< 2.21.8')) || (compare_versions(version, '>= 2.22.0') && compare_versions(version, '< 2.22.4'))"
+
+    extractors:
+      - type: regex
+        name: sentry_config
+        part: body
+        group: 1
+        regex:
+          - 'name="n8n:config:sentry"\s+content="([A-Za-z0-9+/=]+)"'
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - "replace_regex(base64_decode(sentry_config), '.*n8n@([0-9.]+).*', '$1')"
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for n8n releases affected by CVE-2026-49465.
- Uses one read-only GET to the public editor page and a product-bound decoded release value.
- Does not authenticate, execute a workflow, invoke Git, reference a local repository, or read a file.

## Validation

- Official images: `n8nio/n8n:1.123.47` (V, digest `sha256:b4f2caf56d0ed73b007b4d569c6753f6c7eab80ec287ecdd0defcbfb648b7744`) and `n8nio/n8n:1.123.48` (F, digest `sha256:93f599ab0c5980d8e4267809c4bf398b032ce7ee4d68cd52bc9202ff4b3dcb32`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires the exact n8n editor title and a decoded semantic version inside one of the vendor's affected release lines. The request is side-effect free.