### PR TITLE
Add CVE-2026-54314 template

### DIFF
--- a/http/cves/2026/CVE-2026-54314.yaml
+++ b/http/cves/2026/CVE-2026-54314.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-54314
+
+info:
+  name: n8n < 2.24.0 - ZIP Decompression Denial of Service
+  author: str4k3r
+  severity: high
+  description: |
+    n8n before 2.24.0 does not limit decompressed output size or ZIP entry
+    count in the Compression node. A small archive sent to a public webhook
+    workflow can exhaust process memory. This template performs a read-only
+    version check against the public editor page.
+  impact: An unauthenticated attacker can terminate the n8n process and disrupt all workflows when a public webhook processes the crafted archive.
+  remediation: Update n8n to version 2.24.0 or later.
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-jqpw-qww5-cj4c
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54314
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+    cvss-score: 7.5
+    cve-id: CVE-2026-54314
+    cwe-id: CWE-409
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+  tags: cve,cve2026,n8n,zip,decompression,denial-of-service
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "n8n.io - Workflow Automation"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.24.0')"
+
+    extractors:
+      - type: regex
+        name: sentry_config
+        part: body
+        group: 1
+        regex:
+          - 'name="n8n:config:sentry"\s+content="([A-Za-z0-9+/=]+)"'
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - "replace_regex(base64_decode(sentry_config), '.*n8n@([0-9.]+).*', '$1')"
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for n8n releases affected by CVE-2026-54314.
- Uses one read-only GET to the public editor page and matches versions below 2.24.0.
- Does not create a webhook, upload or decompress an archive, allocate attacker-controlled memory, or test denial of service.

## Validation

- Official images: `n8nio/n8n:2.23.4` (V, digest `sha256:1872cce3548bf4dcfe5aceaf3d9293f4499635823fbdea0ee726bd222d2e44b8`) and `n8nio/n8n:2.24.0` (F, digest `sha256:a196f6adc8283ed05bfb44b16bccc0500871297e195c093af7b0bb462e3e3ae4`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires the exact n8n editor title and a valid decoded `n8n@<version>` release. The detector only reads public metadata and never exercises the resource-exhaustion path.