### PR TITLE
Add CVE-2026-56350 template

### DIFF
--- a/http/cves/2026/CVE-2026-56350.yaml
+++ b/http/cves/2026/CVE-2026-56350.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-56350
+
+info:
+  name: n8n < 2.8.0 - SSO Enforcement Bypass
+  author: str4k3r
+  severity: medium
+  description: |
+    n8n before 2.8.0 allows an authenticated SSO user to modify an
+    administrator-only self-setting and enable local password login. This
+    bypasses organizational SSO policy and identity-provider-enforced MFA.
+    This template performs a read-only version check against the public editor
+    page.
+  impact: An authenticated SSO user can create a direct local login path that bypasses centralized authentication requirements.
+  remediation: Update n8n to version 2.8.0 or later.
+  reference:
+    - https://github.com/n8n-io/n8n/security/advisories/GHSA-vjf3-2gpj-233v
+    - https://github.com/n8n-io/n8n/releases/tag/n8n@2.8.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-56350
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 6.0
+    cve-id: CVE-2026-56350
+    cwe-id: CWE-285
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: n8n
+    product: n8n
+  tags: cve,cve2026,n8n,sso,authentication-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "n8n.io - Workflow Automation"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.8.0')"
+
+    extractors:
+      - type: regex
+        name: sentry_config
+        part: body
+        group: 1
+        regex:
+          - 'name="n8n:config:sentry"\s+content="([A-Za-z0-9+/=]+)"'
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - "replace_regex(base64_decode(sentry_config), '.*n8n@([0-9.]+).*', '$1')"
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for n8n releases affected by CVE-2026-56350.
- Uses one read-only GET to the public editor page and matches versions below 2.8.0.
- Does not create an account, authenticate through SSO, set a password, or modify user settings.

## Validation

- Official images: `n8nio/n8n:2.7.1` (V, digest `sha256:3ed9f3bc9b77bc79e6e847edf63317381d4f2dc631f8300a0af96385fd944a13`) and `n8nio/n8n:2.8.0` (F, digest `sha256:4854299339aa3b543303e01642ea36e3e411f299c6ad15dc579e8f3d8ef322ff`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires the exact n8n editor title and a valid decoded release below the fixed version. The request is side-effect free and reads only public page metadata.