### PR TITLE
Add CVE-2026-4858 template

### DIFF
--- a/http/cves/2026/CVE-2026-4858.yaml
+++ b/http/cves/2026/CVE-2026-4858.yaml
@@ -1,0 +1,62 @@
+id: CVE-2026-4858
+
+info:
+  name: Mattermost Multiple Versions - Integration Action Path Traversal
+  author: str4k3r
+  severity: high
+  description: |
+    Multiple Mattermost release lines do not normalize an integration action
+    URL before deciding whether to attach the current session token. A crafted
+    traversal path can therefore reach an arbitrary internal API route with a
+    privileged token. This template performs a read-only version check against
+    the public system ping endpoint.
+  impact: An authenticated attacker can make an integration action invoke arbitrary Mattermost API routes using a privileged session token.
+  remediation: Update Mattermost to version 10.11.15, 11.4.5, 11.5.4, 11.6.1, or later in the corresponding release line.
+  reference:
+    - https://github.com/advisories/GHSA-c4r7-j7pp-r8mp
+    - https://github.com/mattermost/mattermost/commit/ffee10a61081dcc058f92fe65ba138804c3ca73b
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4858
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H
+    cvss-score: 8.0
+    cve-id: CVE-2026-4858
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: mattermost
+    product: mattermost-server
+  tags: cve,cve2026,mattermost,path-traversal,authorization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v4/system/ping"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"ActiveSearchBackend"'
+          - '"status":"OK"'
+        condition: and
+      - type: word
+        part: header
+        words:
+          - "X-Version-Id:"
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 10.11.0') && compare_versions(version, '< 10.11.15')) || (compare_versions(version, '>= 11.4.0') && compare_versions(version, '< 11.4.5')) || (compare_versions(version, '>= 11.5.0') && compare_versions(version, '< 11.5.4')) || compare_versions(version, '= 11.6.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        group: 1
+        regex:
+          - '(?im)^X-Version-Id:\s*([0-9]+\.[0-9]+\.[0-9]+)\.'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for the four affected Mattermost release lines in CVE-2026-4858.
- Uses one read-only GET to `/api/v4/system/ping` and combines Mattermost-specific response fields with the `X-Version-Id` header.
- Does not authenticate, create an integration action, attach a token, or send a traversal path.

## Validation

- Official images: `mattermost/mattermost-team-edition:11.6.0` (V, digest `sha256:88565cb169f3ca5e6303db3f99c98297763b3fc606fa464f9382393b328ecdb9`) and `mattermost/mattermost-team-edition:11.6.1` (F, digest `sha256:425b1e065a3433f4a7b10d8091fe83b3459c008647cc1e3c3707974832d2ef30`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires HTTP 200, `ActiveSearchBackend`, Mattermost's OK status, the product-specific version header, and an explicitly affected version range.