### PR TITLE
Add CVE-2026-44881 template

### DIFF
--- a/http/cves/2026/CVE-2026-44881.yaml
+++ b/http/cves/2026/CVE-2026-44881.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-44881
+
+info:
+  name: Portainer CE Multiple Versions - Git Symlink Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: |
+    Multiple Portainer CE release lines create repository symlinks without
+    validating their targets when deploying Git-backed stacks. Reading the
+    stack entry point then follows the symlink and can disclose arbitrary host
+    files. This template performs a read-only version check against public
+    Portainer endpoints.
+  impact: An authenticated stack author can read arbitrary files accessible to the Portainer process.
+  remediation: Update Portainer CE to version 2.33.8, 2.39.2, 2.41.0, or later in the corresponding release line.
+  reference:
+    - https://github.com/portainer/portainer/security/advisories/GHSA-rpgq-m5fp-32wr
+    - https://github.com/portainer/portainer/releases/tag/2.39.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44881
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:H/SA:H
+    cvss-score: 8.5
+    cve-id: CVE-2026-44881
+    cwe-id: CWE-59
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: portainer
+    product: portainer
+  tags: cve,cve2026,portainer,git,symlink,lfi
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/timeout.html"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Portainer"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/status"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"InstanceID"'
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 2.33.0') && compare_versions(version, '< 2.33.8')) || (compare_versions(version, '>= 2.34.0') && compare_versions(version, '< 2.39.2')) || compare_versions(version, '= 2.40.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for affected Portainer CE release lines in CVE-2026-44881.
- Uses read-only GET requests to a standard Portainer static page and `/api/status`, requiring both the product title and version-bearing instance status.
- Does not authenticate, clone a repository, create a stack, follow a symlink, or read a file.

## Validation

- Official images: `portainer/portainer-ce:2.40.0` (V, digest `sha256:df76590a901e47010977ffe277473908350e13042ac304bbac0798649c63b937`) and `portainer/portainer-ce:2.41.0` (F, digest `sha256:7e859a1d90eaf96b1d934ffd42972cb337747e31ff4e1fac934869d842c10151`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

The first request requires Portainer's own static product marker; the second requires an instance ID and a parsed version in one of the advisory's affected ranges. Both requests are side-effect free.