### PR TITLE
Add CVE-2026-50148 template

### DIFF
--- a/http/cves/2026/CVE-2026-50148.yaml
+++ b/http/cves/2026/CVE-2026-50148.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-50148
+
+info:
+  name: Metabase Multiple Versions - Snowflake JDBC Arbitrary File Write
+  author: str4k3r
+  severity: critical
+  description: |
+    Multiple Metabase release lines use a Snowflake JDBC driver that can write
+    attacker-controlled files when connected to a malicious Snowflake server.
+    A user able to configure a database can replace a Metabase driver and gain
+    code execution. This template performs a read-only version check against
+    the public session properties endpoint.
+  impact: A user who can configure a database connection can write files on the Metabase host and execute code in the server process.
+  remediation: Update to Metabase 0.54.24/1.54.24, 0.55.24/1.55.24, 0.56.25/1.56.25, 0.57.19/1.57.19, 0.58.14/1.58.14, 0.59.10/1.59.10, 0.60.4/1.60.4, or later.
+  reference:
+    - https://github.com/metabase/metabase/security/advisories/GHSA-r6x2-rchx-q9g9
+    - https://github.com/metabase/metabase/releases/tag/v0.60.4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50148
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-50148
+    cwe-id: CWE-73
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: metabase
+    product: metabase
+  tags: cve,cve2026,metabase,snowflake,jdbc,file-write,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/session/properties"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"application-name":"Metabase"'
+      - type: dsl
+        dsl:
+          - "(compare_versions(version, '>= 0.54.0') && compare_versions(version, '< 0.54.24')) || (compare_versions(version, '>= 0.55.0') && compare_versions(version, '< 0.55.24')) || (compare_versions(version, '>= 0.56.0') && compare_versions(version, '< 0.56.25')) || (compare_versions(version, '>= 0.57.0') && compare_versions(version, '< 0.57.19')) || (compare_versions(version, '>= 0.58.0') && compare_versions(version, '< 0.58.14')) || (compare_versions(version, '>= 0.59.0') && compare_versions(version, '< 0.59.10')) || (compare_versions(version, '>= 0.60.0') && compare_versions(version, '< 0.60.4')) || (compare_versions(version, '>= 1.54.0') && compare_versions(version, '< 1.54.24')) || (compare_versions(version, '>= 1.55.0') && compare_versions(version, '< 1.55.24')) || (compare_versions(version, '>= 1.56.0') && compare_versions(version, '< 1.56.25')) || (compare_versions(version, '>= 1.57.0') && compare_versions(version, '< 1.57.19')) || (compare_versions(version, '>= 1.58.0') && compare_versions(version, '< 1.58.14')) || (compare_versions(version, '>= 1.59.0') && compare_versions(version, '< 1.59.10')) || (compare_versions(version, '>= 1.60.0') && compare_versions(version, '< 1.60.4'))"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"tag"\s*:\s*"v?([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for affected Metabase Community and Enterprise release lines in CVE-2026-50148.
- Uses one read-only GET to `/api/session/properties` and requires the Metabase application name plus a bounded release tag.
- Does not configure Snowflake, contact a JDBC endpoint, write a file, replace a driver, or execute code.

## Validation

- Official images: `metabase/metabase:v0.60.3` (V, digest `sha256:140678ca9cbb453588047c48a7839db7cbe8bb10d23e7ea4842f2e9a32268fe3`) and `metabase/metabase:v0.60.4` (F, digest `sha256:a2161a720b6f3f774bdf3fb72bda272dae84011bfe76da32f36ea2eb3d3289ce`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

Detection requires HTTP 200, the exact `Metabase` application marker, and a parsed version inside one of fourteen explicitly bounded affected release lines.