### PR TITLE
Add CVE-2026-41268 template

### DIFF
--- a/http/cves/2026/CVE-2026-41268.yaml
+++ b/http/cves/2026/CVE-2026-41268.yaml
@@ -1,0 +1,63 @@
+id: CVE-2026-41268
+
+info:
+  name: Flowise < 3.1.0 - Parameter Override Remote Code Execution
+  author: str4k3r
+  severity: critical
+  description: |
+    Flowise before 3.1.0 permits a public chatflow parameter override to bypass
+    enablement checks and inject NODE_OPTIONS into a Custom MCP child process.
+    An unauthenticated attacker can use this path to execute code. This template
+    performs a read-only version check against public Flowise endpoints.
+  impact: An unauthenticated attacker can execute arbitrary commands when an affected public chatflow exposes the vulnerable configuration.
+  remediation: Update Flowise to version 3.1.0 or later.
+  reference:
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cvrr-qhgw-2mm6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41268
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-41268
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: flowiseai
+    product: flowise
+  tags: cve,cve2026,flowise,rce,parameter-injection
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Flowise - Build AI Agents, Visually"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 3.1.0')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Flowise installations affected by CVE-2026-41268.
- Uses two read-only GET requests: one product-title check and one public version API check.
- Does not require a chatflow ID, submit a parameter override, set `NODE_OPTIONS`, launch MCP, write a marker, or execute code.

## Validation

- Official images: `flowiseai/flowise:3.0.13` (V, digest `sha256:5fa98cd5bd14ac6da3471a06d9b41c9166e7e2d09e960ca0182b58c4173dbd23`) and `flowiseai/flowise:3.1.0` (F, digest `sha256:d4da3ffa539f397a1b0f20d384198ba0999cf348f702680950b2f73a243c80de`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

The flow requires the exact Flowise page title before accepting a semantic version from `/api/v1/version`; only versions below 3.1.0 match.