### PR TITLE
Add CVE-2026-42863 template

### DIFF
--- a/http/cves/2026/CVE-2026-42863.yaml
+++ b/http/cves/2026/CVE-2026-42863.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-42863
+
+info:
+  name: Flowise < 3.1.2 - Chatflow Mass Assignment
+  author: str4k3r
+  severity: high
+  description: |
+    Flowise before 3.1.2 assigns unfiltered chatflow update fields directly to
+    the database entity. An authenticated user can modify protected attributes,
+    including the owning workspace, and reassign resources across tenants. This
+    template performs a read-only version check against public Flowise endpoints.
+  impact: An authenticated attacker can alter protected chatflow fields and move a chatflow into another workspace.
+  remediation: Update Flowise to version 3.1.2 or later.
+  reference:
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-5wxp-qjgq-fx6m
+    - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.1.2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42863
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 8.1
+    cve-id: CVE-2026-42863
+    cwe-id: CWE-915
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: flowiseai
+    product: flowise
+  tags: cve,cve2026,flowise,mass-assignment,authorization
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Flowise - Build AI Agents, Visually"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 3.1.2')"
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Summary

- Adds a safe version detector for Flowise installations affected by CVE-2026-42863.
- Uses two read-only GET requests: one product-title check and one public version API check.
- Does not authenticate, create or update a chatflow, alter a workspace, or write database state.

## Validation

- Official images: `flowiseai/flowise:3.1.0` (V, digest `sha256:d4da3ffa539f397a1b0f20d384198ba0999cf348f702680950b2f73a243c80de`) and `flowiseai/flowise:3.1.2` (F, digest `sha256:3f96eb1fe88ba038a028b024f98d9f9cf7c62bdbe170ea190d90698936165f94`).
- Native Nuclei v3.11.0 validation passed; exact submitted bytes detected V 3/3 and remained silent on F 3/3.

## False-positive and safety controls

The flow requires the exact Flowise page title before accepting a semantic version from `/api/v1/version`; only versions below 3.1.2 match.