### PR TITLE
Add CVE-2026-12045 template

### DIFF
--- a/http/cves/2026/CVE-2026-12045.yaml
+++ b/http/cves/2026/CVE-2026-12045.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-12045
+
+info:
+  name: pgAdmin 4 9.13-9.15 - AI Assistant Read-Only Transaction Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    pgAdmin 4 versions 9.13 through 9.15 allow an AI Assistant-generated
+    multi-statement query to terminate its read-only transaction and execute
+    subsequent SQL with the database user's privileges. This template performs
+    a read-only version check against the public login page.
+  impact: Prompt injection through database content can cause unauthorized SQL execution and potentially code execution on the database host.
+  remediation: Update pgAdmin 4 to version 9.16 or later.
+  reference:
+    - https://github.com/pgadmin-org/pgadmin4/issues/10022
+    - https://github.com/pgadmin-org/pgadmin4/commit/bf4792444446f0e7ab721d23cbd6bfe6afaa7a8b
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-12045
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:P/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.4
+    cve-id: CVE-2026-12045
+    cwe-id: CWE-77,CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: pgadmin
+    product: pgadmin_4
+  tags: cve,cve2026,pgadmin,ai,sql-injection
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: word
+        part: body
+        words: ["<title>pgAdmin 4</title>"]
+      - type: dsl
+        dsl:
+          - "to_number(raw_version) >= 91300 && to_number(raw_version) < 91600"
+
+    extractors:
+      - type: regex
+        name: raw_version
+        part: body
+        group: 1
+        regex:
+          - 'favicon\.ico\?ver=([0-9]{5})'
+        internal: true

--- a/http/cves/2026/CVE-2026-12045.yaml
+++ b/http/cves/2026/CVE-2026-12045.yaml
@@ -35,10 +35,12 @@ http:
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: word
         part: body
-        words: ["<title>pgAdmin 4</title>"]
+        words:
+          - "<title>pgAdmin 4</title>"
       - type: dsl
         dsl:
           - "to_number(raw_version) >= 91300 && to_number(raw_version) < 91600"


### PR DESCRIPTION
## Summary

Adds a side-effect-free pgAdmin 4 version detector for CVE-2026-12045. It requires the exact pgAdmin login title and parses the public cache-busting version value; it never contacts a database or invokes the AI Assistant.

## Validation

Official `dpage/pgadmin4:9.13` (V, `sha256:d243a4bcc02d2ee6b447c601692813531d2d0fbca18b583d9f7f9658da835d81`) versus `:9.16` (F, `sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3`). Native Nuclei v3.11.0: V 3/3, F 0/3.