### PR TITLE
Add CVE-2026-17593 template

### DIFF
--- a/http/cves/2026/CVE-2026-17593.yaml
+++ b/http/cves/2026/CVE-2026-17593.yaml
@@ -29,23 +29,29 @@ info:
 
 http:
   - method: GET
-    path: ["{{BaseURL}}/"]
+    path:
+      - "{{BaseURL}}/"
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: word
         part: body
-        words: ["<title>Sonatype Nexus Repository</title>"]
+        words:
+          - "<title>Sonatype Nexus Repository</title>"
       - type: word
         part: header
-        words: ["Server: Nexus/"]
+        words:
+          - "Server: Nexus/"
       - type: dsl
-        dsl: ["compare_versions(version, '< 3.95.0')"]
+        dsl:
+          - "compare_versions(version, '< 3.95.0')"
     extractors:
       - type: regex
         name: version
         part: header
         group: 1
-        regex: ['(?im)^Server:\s*Nexus/([0-9.]+)-']
+        regex:
+          - '(?im)^Server:\s*Nexus/([0-9.]+)-'
         internal: true

--- a/http/cves/2026/CVE-2026-17593.yaml
+++ b/http/cves/2026/CVE-2026-17593.yaml
@@ -1,0 +1,51 @@
+id: CVE-2026-17593
+
+info:
+  name: Sonatype Nexus Repository < 3.95.0 - Unsafe Realm Configuration
+  author: str4k3r
+  severity: high
+  description: |
+    Nexus Repository before 3.95.0 accepts unregistered realm identifiers
+    through an internal settings API. Persisted invalid entries can trigger
+    unintended code paths or authentication lockout. This template performs a
+    read-only version check using public Nexus response metadata.
+  impact: A settings administrator can persist unsafe realm identifiers, potentially causing code execution or denial of authentication.
+  remediation: Update Sonatype Nexus Repository to version 3.95.0 or later.
+  reference:
+    - https://help.sonatype.com/en/sonatype-nexus-repository-3-95-0-release-notes.html
+    - https://support.sonatype.com/hc/en-us/articles/53849535836179/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-17593
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 7.2
+    cve-id: CVE-2026-17593
+    cwe-id: CWE-470
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: sonatype
+    product: nexus-repository-3
+  tags: cve,cve2026,nexus,realm,code-injection
+
+http:
+  - method: GET
+    path: ["{{BaseURL}}/"]
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: word
+        part: body
+        words: ["<title>Sonatype Nexus Repository</title>"]
+      - type: word
+        part: header
+        words: ["Server: Nexus/"]
+      - type: dsl
+        dsl: ["compare_versions(version, '< 3.95.0')"]
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        group: 1
+        regex: ['(?im)^Server:\s*Nexus/([0-9.]+)-']
+        internal: true


### PR DESCRIPTION
## Summary

Adds a side-effect-free Nexus Repository version detector for CVE-2026-17593. It reads only public product/version metadata and never submits realm configuration.

## Validation

Official `sonatype/nexus3:3.94.1` (V, `sha256:f20aca9b5688b9d1bd9550cc4e2daca2591909b39dc0e7dc240b9e065342c3fe`) versus `:3.95.0` (F, `sha256:c47083c9e77d87cd7f7c1111a68b53e758644deb54aba2235c8de1b40eebb09a`). Native Nuclei v3.11.0: V 3/3, F 0/3.