### PR TITLE
Add CVE-2026-33130 template

### DIFF
--- a/http/cves/2026/CVE-2026-33130.yaml
+++ b/http/cves/2026/CVE-2026-33130.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-33130
+
+info:
+  name: Uptime Kuma 1.23.0-2.2.0 - Notification Template File Read
+  author: str4k3r
+  severity: medium
+  description: |
+    Uptime Kuma versions 1.23.0 through 2.2.0 incompletely restrict LiquidJS
+    template file resolution. An authenticated notification editor can use an
+    unquoted absolute path to read server files. This template performs a
+    read-only version check against public frontend assets.
+  impact: An authenticated attacker can disclose files readable by the Uptime Kuma process.
+  remediation: Update Uptime Kuma to version 2.2.1 or later.
+  reference:
+    - https://github.com/louislam/uptime-kuma/security/advisories/GHSA-v832-4r73-wx5j
+    - https://github.com/louislam/uptime-kuma/releases/tag/2.2.1
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33130
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 6.5
+    cve-id: CVE-2026-33130
+    cwe-id: CWE-98,CWE-1336
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: louislam
+    product: uptime-kuma
+  tags: cve,cve2026,uptime-kuma,liquidjs,ssti,lfi
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path: ["{{BaseURL}}/setup-database"]
+    matchers:
+      - type: word
+        part: body
+        words: ["Uptime Kuma"]
+        internal: true
+    extractors:
+      - type: regex
+        name: asset_path
+        part: body
+        group: 1
+        regex: ['src="(/assets/index-[A-Za-z0-9_-]+\.js)"']
+        internal: true
+  - method: GET
+    path: ["{{BaseURL}}{{asset_path}}"]
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: dsl
+        dsl: ["compare_versions(version, '>= 1.23.0', '< 2.2.1')"]
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex: ['frontendVersion\(\)\{return"([0-9.]+)"\}']
+        internal: true

--- a/http/cves/2026/CVE-2026-33130.yaml
+++ b/http/cves/2026/CVE-2026-33130.yaml
@@ -31,31 +31,38 @@ flow: http(1) && http(2)
 
 http:
   - method: GET
-    path: ["{{BaseURL}}/setup-database"]
+    path:
+      - "{{BaseURL}}/setup-database"
     matchers:
       - type: word
         part: body
-        words: ["Uptime Kuma"]
+        words:
+          - "Uptime Kuma"
         internal: true
     extractors:
       - type: regex
         name: asset_path
         part: body
         group: 1
-        regex: ['src="(/assets/index-[A-Za-z0-9_-]+\.js)"']
+        regex:
+          - 'src="(/assets/index-[A-Za-z0-9_-]+\.js)"'
         internal: true
   - method: GET
-    path: ["{{BaseURL}}{{asset_path}}"]
+    path:
+      - "{{BaseURL}}{{asset_path}}"
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: dsl
-        dsl: ["compare_versions(version, '>= 1.23.0', '< 2.2.1')"]
+        dsl:
+          - "compare_versions(version, '>= 1.23.0', '< 2.2.1')"
     extractors:
       - type: regex
         name: version
         part: body
         group: 1
-        regex: ['frontendVersion\(\)\{return"([0-9.]+)"\}']
+        regex:
+          - 'frontendVersion\(\)\{return"([0-9.]+)"\}'
         internal: true


### PR DESCRIPTION
## Summary

Adds a safe Uptime Kuma version detector for CVE-2026-33130. It extracts the hashed public frontend asset and its embedded frontend version; it never logs in, renders a notification template, or reads a file.

## Validation

Official `louislam/uptime-kuma:2.1.3` (V, `sha256:32c352a235fd10f98b3f64a6a4345d3c0c7f4e8be7810d2e1e867f7fe2e48ba2`) versus `:2.2.1` (F, `sha256:7337368a77873f159435de9ef09567f68c31285ed5f951dec36256c4b267ee44`). Native Nuclei v3.11.0: V 3/3, F 0/3.