### PR TITLE
Add CVE-2026-40281 template

### DIFF
--- a/http/cves/2026/CVE-2026-40281.yaml
+++ b/http/cves/2026/CVE-2026-40281.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-40281
+
+info:
+  name: Gotenberg <= 8.30.1 - ExifTool Argument Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    Gotenberg through 8.30.1 does not reject control characters in metadata
+    values passed to ExifTool. A newline can inject pseudo-tags and move,
+    overwrite, or link files in the container. This template performs a
+    read-only version check against Gotenberg's public version endpoint.
+  impact: An unauthenticated attacker can write or move files and create links in the Gotenberg container.
+  remediation: Update Gotenberg to version 8.31.0 or later.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-q7r4-hc83-hf2q
+    - https://github.com/gotenberg/gotenberg/commit/405f1069c026bb08f319fb5a44e5c67c33208318
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40281
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-40281
+    cwe-id: CWE-88
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: gotenberg
+    product: gotenberg
+  tags: cve,cve2026,gotenberg,exiftool,argument-injection
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path: ["{{BaseURL}}/"]
+    matchers:
+      - type: word
+        part: body
+        words: ["Gotenberg has no UI"]
+        internal: true
+  - method: GET
+    path: ["{{BaseURL}}/version"]
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: dsl
+        dsl: ["compare_versions(version, '< 8.31.0')"]
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex: ['^([0-9.]+)\s*$']
+        internal: true

--- a/http/cves/2026/CVE-2026-40281.yaml
+++ b/http/cves/2026/CVE-2026-40281.yaml
@@ -31,24 +31,30 @@ flow: http(1) && http(2)
 
 http:
   - method: GET
-    path: ["{{BaseURL}}/"]
+    path:
+      - "{{BaseURL}}/"
     matchers:
       - type: word
         part: body
-        words: ["Gotenberg has no UI"]
+        words:
+          - "Gotenberg has no UI"
         internal: true
   - method: GET
-    path: ["{{BaseURL}}/version"]
+    path:
+      - "{{BaseURL}}/version"
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: dsl
-        dsl: ["compare_versions(version, '< 8.31.0')"]
+        dsl:
+          - "compare_versions(version, '< 8.31.0')"
     extractors:
       - type: regex
         name: version
         part: body
         group: 1
-        regex: ['^([0-9.]+)\s*$']
+        regex:
+          - '^([0-9.]+)\s*$'
         internal: true


### PR DESCRIPTION
## Summary

Adds a safe Gotenberg version detector for CVE-2026-40281. It checks the product landing marker and public `/version` endpoint; it never uploads a PDF or sends ExifTool metadata.

## Validation

Official `gotenberg/gotenberg:8.30.1` (V, `sha256:206a6c708fc6d05257367d9ac902d6c56c50d2e3284d0596ea000814ef97f22c`) versus `:8.31.0` (F, `sha256:f0d86e8a1dbc7b33a5a65cb251d02bb271a48ffa989da3feb5ed7d954fe4d4b3`). Native Nuclei v3.11.0: V 3/3, F 0/3.