### PR TITLE
Add CVE-2026-47660 template

### DIFF
--- a/http/cves/2026/CVE-2026-47660.yaml
+++ b/http/cves/2026/CVE-2026-47660.yaml
@@ -28,21 +28,27 @@ info:
 
 http:
   - method: GET
-    path: ["{{BaseURL}}/fhir/metadata"]
+    path:
+      - "{{BaseURL}}/fhir/metadata"
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: word
         part: body
-        words: ['"name":"pathling-fhir-api"', '"publisher":"Australian e-Health Research Centre, CSIRO"']
+        words:
+          - '"name":"pathling-fhir-api"'
+          - '"publisher":"Australian e-Health Research Centre, CSIRO"'
         condition: and
       - type: dsl
-        dsl: ["compare_versions(version, '< 2.0.0')"]
+        dsl:
+          - "compare_versions(version, '< 2.0.0')"
     extractors:
       - type: regex
         name: version
         part: body
         group: 1
-        regex: ['"version"\s*:\s*"([0-9.]+)"']
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
         internal: true

--- a/http/cves/2026/CVE-2026-47660.yaml
+++ b/http/cves/2026/CVE-2026-47660.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-47660
+
+info:
+  name: Pathling Server < 2.0.0 - OAuth Metadata URL Validation Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    Pathling Server before 2.0.0 does not validate a bulk submitter's explicit
+    oauthMetadataUrl against the configured source allowlist. A caller can
+    redirect OAuth discovery and potentially expose submitter credentials. This
+    template performs a read-only version check against the FHIR capability statement.
+  impact: A configured submitter can redirect OAuth metadata and token requests to an unapproved server and expose stored credentials.
+  remediation: Update Pathling Server to version 2.0.0 or later.
+  reference:
+    - https://github.com/aehrc/pathling/security/advisories/GHSA-245h-c573-9vr5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-47660
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 8.7
+    cve-id: CVE-2026-47660
+    cwe-id: CWE-522,CWE-918
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: aehrc
+    product: pathling
+  tags: cve,cve2026,pathling,fhir,oauth,ssrf
+
+http:
+  - method: GET
+    path: ["{{BaseURL}}/fhir/metadata"]
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: word
+        part: body
+        words: ['"name":"pathling-fhir-api"', '"publisher":"Australian e-Health Research Centre, CSIRO"']
+        condition: and
+      - type: dsl
+        dsl: ["compare_versions(version, '< 2.0.0')"]
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex: ['"version"\s*:\s*"([0-9.]+)"']
+        internal: true


### PR DESCRIPTION
## Summary

Adds a safe Pathling Server version detector for CVE-2026-47660. It reads only the public FHIR capability statement and never submits a bulk job or causes an OAuth request.

## Validation

Official `ghcr.io/aehrc/pathling:1.2.0` (V, `sha256:9550acf9b12d882a3fa4bb522bf92bd6dac49bdcb7e43754ffd574190fac65fd`) versus `:2.0.0` (F, `sha256:887f82ff65b0c3ea414adf28bf6da7d24875bf57ffdaa34c43bf3ad7adc8b961`). Native Nuclei v3.11.0: V 3/3, F 0/3.