### PR TITLE
Add CVE-2026-47661 template

### DIFF
--- a/http/cves/2026/CVE-2026-47661.yaml
+++ b/http/cves/2026/CVE-2026-47661.yaml
@@ -28,21 +28,27 @@ info:
 
 http:
   - method: GET
-    path: ["{{BaseURL}}/fhir/metadata"]
+    path:
+      - "{{BaseURL}}/fhir/metadata"
     matchers-condition: and
     matchers:
       - type: status
-        status: [200]
+        status:
+          - 200
       - type: word
         part: body
-        words: ['"name":"pathling-fhir-api"', '"publisher":"Australian e-Health Research Centre, CSIRO"']
+        words:
+          - '"name":"pathling-fhir-api"'
+          - '"publisher":"Australian e-Health Research Centre, CSIRO"'
         condition: and
       - type: dsl
-        dsl: ["compare_versions(version, '< 2.0.0')"]
+        dsl:
+          - "compare_versions(version, '< 2.0.0')"
     extractors:
       - type: regex
         name: version
         part: body
         group: 1
-        regex: ['"version"\s*:\s*"([0-9.]+)"']
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
         internal: true

--- a/http/cves/2026/CVE-2026-47661.yaml
+++ b/http/cves/2026/CVE-2026-47661.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-47661
+
+info:
+  name: Pathling Server < 2.0.0 - Export Result Path Traversal
+  author: str4k3r
+  severity: high
+  description: |
+    Pathling Server before 2.0.0 concatenates the file parameter of its export
+    result endpoint without canonicalization or containment validation. A
+    caller with an export job identifier can read files outside the job
+    directory. This template performs a read-only version check against the FHIR capability statement.
+  impact: An unauthenticated attacker can disclose warehouse data and other files accessible to the Pathling process.
+  remediation: Update Pathling Server to version 2.0.0 or later.
+  reference:
+    - https://github.com/aehrc/pathling/security/advisories/GHSA-8w85-f63v-3wh6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-47661
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N
+    cvss-score: 8.7
+    cve-id: CVE-2026-47661
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: aehrc
+    product: pathling
+  tags: cve,cve2026,pathling,fhir,path-traversal,lfi
+
+http:
+  - method: GET
+    path: ["{{BaseURL}}/fhir/metadata"]
+    matchers-condition: and
+    matchers:
+      - type: status
+        status: [200]
+      - type: word
+        part: body
+        words: ['"name":"pathling-fhir-api"', '"publisher":"Australian e-Health Research Centre, CSIRO"']
+        condition: and
+      - type: dsl
+        dsl: ["compare_versions(version, '< 2.0.0')"]
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex: ['"version"\s*:\s*"([0-9.]+)"']
+        internal: true


### PR DESCRIPTION
## Summary

Adds a safe Pathling Server version detector for CVE-2026-47661. It reads only the public FHIR capability statement and never creates a job or attempts path traversal.

## Validation

Official `ghcr.io/aehrc/pathling:1.2.0` (V, `sha256:9550acf9b12d882a3fa4bb522bf92bd6dac49bdcb7e43754ffd574190fac65fd`) versus `:2.0.0` (F, `sha256:887f82ff65b0c3ea414adf28bf6da7d24875bf57ffdaa34c43bf3ad7adc8b961`). Native Nuclei v3.11.0: V 3/3, F 0/3.