### PR TITLE
Add CVE-2026-17603 template

### DIFF
--- a/http/cves/2026/CVE-2026-17603.yaml
+++ b/http/cves/2026/CVE-2026-17603.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-17603
+
+info:
+  name: Sonatype Nexus Repository < 3.95.0 - HikariCP Connection Initialization SQL Injection
+  author: str4k3r
+  severity: high
+  description: |
+    Nexus Repository versions 3.20.0 through 3.94.x allow a user with datastore
+    update permission to configure the HikariCP connectionInitSql property. This
+    can execute attacker-controlled SQL when a database connection is created.
+    This template performs a read-only version check using public Nexus response
+    metadata and does not submit a datastore configuration.
+  impact: An authenticated datastore manager can execute arbitrary SQL and potentially compromise the repository host.
+  remediation: Update Sonatype Nexus Repository to version 3.95.0 or later.
+  reference:
+    - https://support.sonatype.com/hc/en-us/articles/53890127489427
+    - https://help.sonatype.com/en/sonatype-nexus-repository-3-95-0-release-notes.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-17603
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+    cvss-score: 8.7
+    cve-id: CVE-2026-17603
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: sonatype
+    product: nexus-repository-3
+  tags: cve,cve2026,nexus,sqli,rce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<title>Sonatype Nexus Repository</title>"
+      - type: word
+        part: header
+        words:
+          - "Server: Nexus/"
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 3.20.0', '< 3.95.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        group: 1
+        regex:
+          - '(?im)^Server:\s*Nexus/([0-9.]+)-'
+        internal: true


### PR DESCRIPTION
## Template validation

This contribution detects affected Sonatype Nexus Repository versions without exercising the authenticated datastore API or sending SQL.

- Official vulnerable image: `sonatype/nexus3:3.94.1` (`sha256:f20aca9b5688b9d1bd9550cc4e2daca2591909b39dc0e7dc240b9e065342c3fe`)
- Official fixed image: `sonatype/nexus3:3.95.0` (`sha256:c47083c9e77d87cd7f7c1111a68b53e758644deb54aba2235c8de1b40eebb09a`)
- Native Nuclei v3.11.0: vulnerable detected 3/3; fixed not detected 3/3
- The request is a single unauthenticated `GET /`; matching requires the Nexus title, Nexus server header, and an affected semantic version.

The prior LAB_ONLY exploit probe was replaced with this side-effect-free public version detector.