### PR TITLE
Add CVE-2026-17566 template

### DIFF
--- a/http/cves/2026/CVE-2026-17566.yaml
+++ b/http/cves/2026/CVE-2026-17566.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-17566
+
+info:
+  name: pgAdmin 4 9.16 - Import/Export Data Tool Command Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    pgAdmin 4 version 9.16 contains a command-injection vulnerability in the
+    Import/Export Data tool's query parenthesis validation. An authenticated
+    user with access to a registered PostgreSQL server can craft a query that
+    reaches psql's TO PROGRAM functionality. This template performs a read-only
+    public version check and does not authenticate, create a job, or send SQL.
+  impact: An authenticated pgAdmin user can execute operating-system commands with the privileges of the pgAdmin service account.
+  remediation: Update pgAdmin 4 to version 9.17 or later.
+  reference:
+    - https://github.com/pgadmin-org/pgadmin4/commit/1496fabe28c9f825f6bac0f0d000d9d3276322c3
+    - https://github.com/pgadmin-org/pgadmin4/issues/10213
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-17566
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H
+    cvss-score: 9.4
+    cve-id: CVE-2026-17566
+    cwe-id: CWE-78
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: pgadmin
+    product: pgadmin_4
+  tags: cve,cve2026,pgadmin,rce,cmdi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<title>pgAdmin 4</title>"
+      - type: dsl
+        dsl:
+          - "to_number(raw_version) == 91600"
+
+    extractors:
+      - type: regex
+        name: raw_version
+        part: body
+        group: 1
+        regex:
+          - 'favicon\.ico\?ver=([0-9]{5})'
+        internal: true


### PR DESCRIPTION
## Template validation

This contribution replaces the credentialed command-injection workflow with a side-effect-free pgAdmin version detector.

- Official vulnerable image: `dpage/pgadmin4:9.16` (`sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3`)
- Official fixed image: `dpage/pgadmin4:9.17` (`sha256:2f4ce946ddf8360680d7eff4eaba1d91859eb6b4003e6623bad5c63a322c2f4d`)
- Native Nuclei v3.11.0: vulnerable detected 3/3; fixed not detected 3/3
- The only request is `GET /login`; matching requires the pgAdmin title and the release-specific public favicon version marker.

No login, PostgreSQL connection, import/export job, SQL statement, or command payload is used.