### PR TITLE
Add CVE-2026-32595 template

### DIFF
--- a/http/cves/2026/CVE-2026-32595.yaml
+++ b/http/cves/2026/CVE-2026-32595.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-32595
+
+info:
+  name: Traefik - BasicAuth Username Enumeration
+  author: str4k3r
+  severity: low
+  description: |
+    A timing difference in Traefik's BasicAuth middleware can disclose whether
+    a supplied username exists. This template safely identifies affected
+    versions through Traefik's read-only API version endpoint.
+  impact: Valid usernames can be enumerated and used in targeted password attacks.
+  remediation: Update to Traefik 2.11.41, 3.6.11, 3.7.0-ea.2, or a later supported release.
+  reference:
+    - https://github.com/traefik/traefik/security/advisories/GHSA-g3hg-j4jv-cwfr
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32595
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 3.7
+    cve-id: CVE-2026-32595
+    cwe-id: CWE-208
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: traefik
+    product: traefik
+  tags: cve,cve2026,traefik,auth,enumeration
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"Version"'
+          - '"Codename"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.7.34') || compare_versions(version, '>= 2.0.0', '< 2.11.41') || compare_versions(version, '>= 3.0.0', '< 3.6.11') || compare_versions(version, '= 3.7.0-ea.1')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9A-Za-z.-]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The prior timing probe was replaced with a side-effect-free detector using Traefik's read-only `/api/version` endpoint.

- Official V/F pair: `traefik:3.6.10` (`sha256:c549d482c55d7a797398562064f35428cc53e748d84d7190997930e7b31bcc32`) and `traefik:3.6.11` (`sha256:acfc80650104f0194a15f73dc1648f517561bc1645391a15705332a064cfc33c`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Matching requires HTTP 200, two Traefik-specific JSON fields, and an advisory-listed affected version range.

No credentials, timing inference, protected route, or state-changing request is used.