### PR TITLE
Add CVE-2026-44774 template

### DIFF
--- a/http/cves/2026/CVE-2026-44774.yaml
+++ b/http/cves/2026/CVE-2026-44774.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-44774
+
+info:
+  name: Traefik - Gateway API rest@internal Exposure
+  author: str4k3r
+  severity: medium
+  description: |
+    A Traefik Gateway API route can reference rest@internal and expose the REST
+    provider despite its insecure option being disabled. This template safely
+    identifies affected versions through the read-only API version endpoint.
+  impact: A low-privileged route author can gain access to Traefik dynamic configuration.
+  remediation: Update to Traefik 2.11.46, 3.6.17, 3.7.1, or later.
+  reference:
+    - https://github.com/traefik/traefik/security/advisories/GHSA-96qj-4jj5-wcjc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44774
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:N/SC:L/SI:H/SA:H
+    cvss-score: 6.4
+    cve-id: CVE-2026-44774
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: traefik
+    product: traefik
+  tags: cve,cve2026,traefik,auth-bypass,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"Version"'
+          - '"Codename"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 1.7.34') || compare_versions(version, '>= 2.0.0', '< 2.11.46') || compare_versions(version, '>= 3.0.0', '< 3.6.17') || compare_versions(version, '= 3.7.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9A-Za-z.-]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

This is a side-effect-free version detector; it never submits Gateway API objects or accesses the REST provider.

- Official V/F pair: `traefik:3.7.0` (`sha256:eb328e2c806c53aafbbace6c451fa54d268961261a85452fcf0fb752a30c17be`) and `traefik:3.7.1` (`sha256:6b9cbca6fac42ab0075f5437d8dc1685cfd188626d8d515839ea94f8b6271c42`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- A single `GET /api/version` must expose Traefik-specific fields and an affected release.