### PR TITLE
Add CVE-2026-48020 template

### DIFF
--- a/http/cves/2026/CVE-2026-48020.yaml
+++ b/http/cves/2026/CVE-2026-48020.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-48020
+
+info:
+  name: Traefik - StripPrefix Route-Level Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Path normalization performed with StripPrefix can route a crafted URL to a
+    protected backend without applying the intended authentication middleware.
+    This template uses the read-only Traefik API version endpoint and does not
+    request a protected route.
+  impact: An unauthenticated attacker can reach protected backend functionality.
+  remediation: Update to Traefik 2.11.48, 3.6.19, 3.7.3, or later.
+  reference:
+    - https://github.com/traefik/traefik/security/advisories/GHSA-xf64-8mw2-4gr2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48020
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-48020
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: traefik
+    product: traefik
+  tags: cve,cve2026,traefik,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"Version"'
+          - '"Codename"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.11.48') || compare_versions(version, '>= 3.0.0', '< 3.6.19') || compare_versions(version, '>= 3.7.0-ea.1', '< 3.7.3')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9A-Za-z.-]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The configuration-dependent route-bypass probe was replaced by a safe release check.

- Official V/F pair: `traefik:3.7.0` (`sha256:eb328e2c806c53aafbbace6c451fa54d268961261a85452fcf0fb752a30c17be`) and `traefik:3.7.3` (`sha256:25cd7b175a493ea66a40329e23a649b59eda38b7e2a570493bf63fc4d74fd1c1`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- One read-only request to `/api/version`; no normalized traversal path or protected backend is touched.