### PR TITLE
Add CVE-2026-48491 template

### DIFF
--- a/http/cves/2026/CVE-2026-48491.yaml
+++ b/http/cves/2026/CVE-2026-48491.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-48491
+
+info:
+  name: Traefik - Wildcard TLSOptions SNI Check Authentication Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    Traefik can ignore wildcard TLSOptions mappings during SNI checking, which
+    permits domain-fronted requests to bypass mutual TLS. This template safely
+    checks the public API version response without performing a TLS bypass.
+  impact: An unauthenticated remote attacker can reach a backend protected by mutual TLS.
+  remediation: Update to Traefik 2.11.48, 3.7.3, or later.
+  reference:
+    - https://github.com/traefik/traefik/security/advisories/GHSA-5r4w-85f3-pw66
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48491
+  classification:
+    cvss-score: 7.8
+    cve-id: CVE-2026-48491
+    cwe-id: CWE-288
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: traefik
+    product: traefik
+  tags: cve,cve2026,traefik,auth-bypass,mtls
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"Version"'
+          - '"Codename"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 2.11.48') || compare_versions(version, '>= 3.7.0', '< 3.7.3')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9A-Za-z.-]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

This template performs a read-only version check instead of exercising SNI or mutual-TLS policy.

- Official V/F pair: `traefik:3.7.0` (`sha256:eb328e2c806c53aafbbace6c451fa54d268961261a85452fcf0fb752a30c17be`) and `traefik:3.7.3` (`sha256:25cd7b175a493ea66a40329e23a649b59eda38b7e2a570493bf63fc4d74fd1c1`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Matching requires Traefik-specific JSON and the advisory's affected stable release ranges.