### PR TITLE
Add CVE-2026-54762 template

### DIFF
--- a/http/cves/2026/CVE-2026-54762.yaml
+++ b/http/cves/2026/CVE-2026-54762.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-54762
+
+info:
+  name: Traefik 3.7.0-3.7.4 - Missing Auth Secret Fails Open
+  author: str4k3r
+  severity: high
+  description: |
+    Traefik's Kubernetes Ingress NGINX provider can expose a route when its
+    configured authentication Secret is missing or invalid. This template
+    checks the read-only version endpoint and does not access protected routes.
+  impact: A route intended to require authentication can become publicly accessible.
+  remediation: Update Traefik to version 3.7.5 or later.
+  reference:
+    - https://github.com/traefik/traefik/security/advisories/GHSA-4mr2-fg2p-w63c
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54762
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-54762
+    cwe-id: CWE-636
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: traefik
+    product: traefik
+  tags: cve,cve2026,traefik,auth-bypass,kubernetes
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"Version"'
+          - '"Codename"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 3.7.0-ea.1', '< 3.7.5')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"Version"\s*:\s*"([0-9A-Za-z.-]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The Kubernetes configuration-specific authorization probe was replaced with a side-effect-free release check.

- Official V/F pair: `traefik:3.7.4` (`sha256:fcdef599e6259359833dd2e1d49f9e964f66825d69bd3dd468f51102ce013d03`) and `traefik:3.7.5` (`sha256:e4d98158c01ad752fc1071d4e9573788747230d902cdde00a772516e692d07c9`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- One `GET /api/version`; no Kubernetes object, Secret, credential, or protected route is accessed.