### PR TITLE
Add CVE-2026-48080 template

### DIFF
--- a/http/cves/2026/CVE-2026-48080.yaml
+++ b/http/cves/2026/CVE-2026-48080.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-48080
+
+info:
+  name: OpenReception < 1.0.2 - Tenant Database URL Disclosure
+  author: str4k3r
+  severity: high
+  description: |
+    OpenReception before 1.0.2 exposes a tenant database URL, including
+    connection credentials, to a tenant administrator. This template performs
+    a read-only version check using the public OpenReception page footer.
+  impact: A tenant administrator can obtain PostgreSQL connection details and credentials.
+  remediation: Update OpenReception to version 1.0.2 or later.
+  reference:
+    - https://github.com/open-reception/appointment-booking-software/security/advisories/GHSA-v7fw-6xpm-7gj9
+    - https://github.com/open-reception/appointment-booking-software/commit/ad9e49e3cf66b0cc9a327f6d8a895b23bbd6fea9
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48080
+  classification:
+    cve-id: CVE-2026-48080
+    cwe-id: CWE-200
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: open-reception
+    product: appointment-booking-software
+  tags: cve,cve2026,openreception,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    redirects: true
+    max-redirects: 3
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "OpenReception"
+          - "Powered by"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.0.2')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'title="v([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The authenticated data-disclosure probe was replaced with a single read-only public version check.

- Official V/F images: `openreception/open-reception:v1.0.1` (`sha256:79b47bd2c13049f8c9ad4bc9a32e0cac37a18bb283bbeb05edf5dd99b66443e9`) and `v1.0.2` (`sha256:33aec80ec661c4e1fff8526f12de8ed3f0ea95fb6149aa2ba79efb6b305f32b8`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Matching requires OpenReception branding, its footer marker, and the public footer version.

No login, tenant identifier, API token, database URL, or sensitive response is requested.