### PR TITLE
Add CVE-2026-48084 template

### DIFF
--- a/http/cves/2026/CVE-2026-48084.yaml
+++ b/http/cves/2026/CVE-2026-48084.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-48084
+
+info:
+  name: OpenReception < 1.0.2 - Missing Passphrase Login Rate Limit
+  author: str4k3r
+  severity: high
+  description: |
+    OpenReception before 1.0.2 does not rate-limit passphrase authentication,
+    allowing repeated password guesses. This template performs a read-only
+    version check using the public OpenReception page footer.
+  impact: An unauthenticated attacker can conduct unrestricted passphrase guessing attacks.
+  remediation: Update OpenReception to version 1.0.2 or later.
+  reference:
+    - https://github.com/open-reception/appointment-booking-software/security/advisories/GHSA-hhg5-xmjg-3m93
+    - https://github.com/open-reception/appointment-booking-software/commit/b283dbb670e09112299fb0cf89f3cb054ecc1700
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48084
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 7.4
+    cve-id: CVE-2026-48084
+    cwe-id: CWE-307
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: open-reception
+    product: appointment-booking-software
+  tags: cve,cve2026,openreception,bruteforce
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    redirects: true
+    max-redirects: 3
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "OpenReception"
+          - "Powered by"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.0.2')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'title="v([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The repeated login-attempt probe was replaced with a side-effect-free public version detector.

- Official V/F images: `openreception/open-reception:v1.0.1` (`sha256:79b47bd2c13049f8c9ad4bc9a32e0cac37a18bb283bbeb05edf5dd99b66443e9`) and `v1.0.2` (`sha256:33aec80ec661c4e1fff8526f12de8ed3f0ea95fb6149aa2ba79efb6b305f32b8`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- One public GET; no email address, passphrase, login attempt, or throttle counter is consumed.