### PR TITLE
Add CVE-2026-48085 template

### DIFF
--- a/http/cves/2026/CVE-2026-48085.yaml
+++ b/http/cves/2026/CVE-2026-48085.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-48085
+
+info:
+  name: OpenReception < 1.0.1 - Unauthenticated Global Administrator Creation
+  author: str4k3r
+  severity: critical
+  description: |
+    OpenReception before 1.0.1 permits an unauthenticated caller to create an
+    additional global administrator after initial setup. This template safely
+    detects affected releases from the public OpenReception page footer.
+  impact: An unauthenticated attacker can gain global administrative access.
+  remediation: Update OpenReception to version 1.0.1 or later.
+  reference:
+    - https://github.com/open-reception/appointment-booking-software/security/advisories/GHSA-qvvq-hhpj-64rp
+    - https://github.com/open-reception/appointment-booking-software/commit/222408af6fd4bd85554a25ec8de8131bd0733797
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-48085
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-48085
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: open-reception
+    product: appointment-booking-software
+  tags: cve,cve2026,openreception,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    redirects: true
+    max-redirects: 3
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "OpenReception"
+          - "Powered by"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.0.1')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'title="v([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The administrator-creation request was removed and replaced with a public version check.

- Official V/F images: `openreception/open-reception:v1.0.0` (`sha256:4471260b58f4efb9e2394a8e29ccdf4a4caa98aac226c83bab184ee7fdcb4e74`) and `v1.0.1` (`sha256:79b47bd2c13049f8c9ad4bc9a32e0cac37a18bb283bbeb05edf5dd99b66443e9`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Matching uses the OpenReception footer version after normal same-host redirects.

No setup form, account data, credential, or state-changing request is sent.