### PR TITLE
Add CVE-2026-39383 template

### DIFF
--- a/http/cves/2026/CVE-2026-39383.yaml
+++ b/http/cves/2026/CVE-2026-39383.yaml
@@ -1,0 +1,58 @@
+id: CVE-2026-39383
+
+info:
+  name: Gotenberg 8.29.1-8.30.x - Unauthenticated Webhook SSRF
+  author: str4k3r
+  severity: high
+  description: |
+    Gotenberg versions from 8.29.1 before 8.31.0 do not filter webhook URLs,
+    allowing unauthenticated server-side requests to internal resources. This
+    template uses Gotenberg's public version endpoint and sends no webhook.
+  impact: An unauthenticated attacker can access internal network resources through the Gotenberg server.
+  remediation: Update Gotenberg to version 8.31.0 or later.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-5vh4-rgv7-p9g4
+    - https://github.com/gotenberg/gotenberg/releases/tag/v8.31.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-39383
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-39383
+    cwe-id: CWE-918
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: gotenberg
+    product: gotenberg
+  tags: cve,cve2026,gotenberg,ssrf
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Gotenberg has no UI"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 8.29.1', '< 8.31.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '^([0-9.]+)\s*$'
+        internal: true


### PR DESCRIPTION
## Template validation

The webhook request was replaced by Gotenberg's built-in read-only version endpoint.

- Official V/F images: `gotenberg/gotenberg:8.30.1` (`sha256:206a6c708fc6d05257367d9ac902d6c56c50d2e3284d0596ea000814ef97f22c`) and `8.31.0` (`sha256:f0d86e8a1dbc7b33a5a65cb251d02bb271a48ffa989da3feb5ed7d954fe4d4b3`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Product identification and version retrieval are both public GET requests.

No webhook URL, callback, internal address, conversion job, or state-changing request is sent.