### PR TITLE
Add CVE-2026-69085 template

### DIFF
--- a/http/cves/2026/CVE-2026-69085.yaml
+++ b/http/cves/2026/CVE-2026-69085.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-69085
+
+info:
+  name: SiYuan <= 3.7.2 - Unauthenticated SQL Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    SiYuan through 3.7.2 contains an unauthenticated SQL injection in the
+    publish search interface. This template queries the public read-only system
+    version endpoint and does not submit a search or SQL expression.
+  impact: An unauthenticated attacker can read or modify cleartext notebook data.
+  remediation: Update SiYuan to version 3.7.3 or later, or disable the publish service.
+  reference:
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-33jq-p8c2-q3q4
+    - https://github.com/siyuan-note/siyuan/releases/tag/v3.7.3
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-69085
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-69085
+    cwe-id: CWE-89
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: b3log
+    product: siyuan
+  tags: cve,cve2026,siyuan,sqli
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/system/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"code":0'
+          - '"msg":""'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 3.7.3')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"data"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The SQL-injection workflow was replaced with SiYuan's public read-only system-version endpoint.

- Official V/F images: `b3log/siyuan:v3.7.2` (`sha256:534d7f0aedb022224813fb41be56b3b52160a2988869070ad482c702c7b8e2c6`) and `v3.7.3` (`sha256:908faf8ec55d391d95244982c081edabbaec118552d01fc3dc189d098cc0ffc8`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- The endpoint remains public even when workspace access authentication is enabled.

No notebook, search query, SQL fragment, credential, or state-changing request is used.