### PR TITLE
Add CVE-2026-61372 template

### DIFF
--- a/http/cves/2026/CVE-2026-61372.yaml
+++ b/http/cves/2026/CVE-2026-61372.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-61372
+
+info:
+  name: Apache Jena Fuseki <= 6.1.0 - SPARQL LOAD Local File Access
+  author: str4k3r
+  severity: high
+  description: |
+    Apache Jena Fuseki through 6.1.0 does not apply its restricted stream
+    manager to SPARQL Update LOAD operations, allowing unauthenticated access to
+    local files. This template reads only the public Fuseki server metadata.
+  impact: An unauthenticated remote attacker can make Fuseki open arbitrary local files.
+  remediation: Update Apache Jena Fuseki to version 6.2.0 or later.
+  reference:
+    - https://lists.apache.org/thread/h206tpxtbzts7m254og6ffqljjdjkm84
+    - https://jena.apache.org/security/advisories.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-61372
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-61372
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: apache-jena-fuseki
+  tags: cve,cve2026,apache,jena,fuseki,lfi
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/$/server"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"version"'
+          - '"datasets"'
+          - '"ds.services"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 6.2.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The SPARQL `LOAD file://` probe was replaced with Fuseki's unauthenticated, read-only server metadata endpoint.

- Official ASF tarballs: 6.1.0 SHA-512 `75457f45d14397876a41ed51abe7ae5d2f1e708dfe1315765f858158bc5c6813bc036ec1539ddc4dffd26201f5cc31fadec299ca5c3dc2548b723513ed31d326`; 6.2.0 SHA-512 `ba65f5867d2d4741b2ed9e2af5a0d4fbb447909894ab2a0c6bc4dac8997f4fe339c87b13c48d45d054977769f0f8bf763ea346b1f7792d5cdc458041bd43a132`
- Both tarballs were run unchanged on Eclipse Temurin 21 JRE.
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Product matching requires Fuseki server metadata fields and the affected version.

No dataset update, file URI, local path, credential, or state-changing request is sent.