### PR TITLE
Add CVE-2026-35579 template

### DIFF
--- a/http/cves/2026/CVE-2026-35579.yaml
+++ b/http/cves/2026/CVE-2026-35579.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-35579
+
+info:
+  name: CoreDNS < 1.14.3 - Multi-Transport TSIG Authentication Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    CoreDNS versions before 1.14.3 can bypass TSIG authentication on gRPC,
+    QUIC, DoH, and DoH3 transports. This template reads the public Prometheus
+    build metric and does not send a DNS query or attempt authentication.
+  impact: An unauthenticated client may access DNS data protected by TSIG authorization.
+  remediation: Upgrade CoreDNS to version 1.14.3 or later.
+  reference:
+    - https://github.com/coredns/coredns/security/advisories/GHSA-vp29-5652-4fw9
+    - https://github.com/coredns/coredns/releases/tag/v1.14.3
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-35579
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-35579
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: coredns
+    product: coredns
+  tags: cve,cve2026,coredns,tsig,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/metrics"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "coredns_build_info"
+          - "coredns_panics_total"
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '< 1.14.3')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - 'coredns_build_info\{[^\r\n]*version="([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The transport-specific TSIG probe was replaced with CoreDNS's read-only Prometheus build metric.

- Official V/F images: `coredns/coredns:1.14.2` (`sha256:e7e6440cfd1e919280958f5b5a6ab2b184d385bba774c12ad2a9e1e4183f90d9`) and `1.14.3` (`sha256:b21d26b915e10acb5bc78715c1e8b6047ab2675389b2bcc18b3a6499d90e74c0`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/metrics` is a public GET endpoint when the Prometheus plugin is enabled.

No DNS request, TSIG record, credential, zone transfer, or state-changing request is sent.