### PR TITLE
Add CVE-2026-58208 template

### DIFF
--- a/http/cves/2026/CVE-2026-58208.yaml
+++ b/http/cves/2026/CVE-2026-58208.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-58208
+
+info:
+  name: NATS Server <= 2.12.11 / <= 2.14.2 - MQTT WebSocket Denial of Service
+  author: str4k3r
+  severity: medium
+  description: |
+    NATS Server versions through 2.12.11 and 2.14.2 can crash a WebSocket-only
+    JetStream server when an MQTT-over-WebSocket path is handled before MQTT
+    is enabled. This template reads the public monitoring endpoint and does
+    not perform a WebSocket upgrade or send MQTT data.
+  impact: An unauthenticated remote attacker can crash an affected NATS Server and deny service to clients.
+  remediation: Upgrade NATS Server to version 2.12.12, 2.14.3, or later.
+  reference:
+    - https://github.com/nats-io/nats-server/security/advisories/GHSA-p957-7v2w-g93g
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-58208
+  classification:
+    cve-id: CVE-2026-58208
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: nats-io
+    product: nats-server
+  tags: cve,cve2026,nats,dos,mqtt,websocket
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/varz"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"server_id"'
+          - '"proto"'
+          - '"max_payload"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 2.12.11') || compare_versions(version, '>= 2.13.0', '<= 2.14.2')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The MQTT-over-WebSocket handshake was replaced with NATS Server's read-only monitoring endpoint.

- Official V/F images: `nats:2.12.11` (`sha256:d2e5bde3a006b860c6ec5411d2b0fbdb171dc52a4d4b7513c48ffe4a36caddd0`) and `2.12.12` (`sha256:e0882ab68e01432c3593a20150d681c5c1dd97d50a36a097c6595d05f721fcfa`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/varz` is a public GET endpoint when NATS monitoring is enabled.

No WebSocket upgrade, MQTT frame, credential, publish operation, or state-changing request is sent.