### PR TITLE
Add CVE-2026-39999 template

### DIFF
--- a/http/cves/2026/CVE-2026-39999.yaml
+++ b/http/cves/2026/CVE-2026-39999.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-39999
+
+info:
+  name: Apache APISIX 2.2-3.16.0 - JWT Algorithm Confusion
+  author: str4k3r
+  severity: critical
+  description: |
+    Apache APISIX versions 2.2 through 3.16.0 do not require a JWT header
+    algorithm to match the algorithm configured for a consumer. This can
+    allow forged tokens to bypass jwt-auth. This template performs only a
+    read-only version check against APISIX response metadata.
+  impact: An unauthenticated attacker can forge a token and access routes protected by jwt-auth.
+  remediation: Upgrade Apache APISIX to version 3.17.0 or later.
+  reference:
+    - https://lists.apache.org/thread/nfopt8cnxd3k0rs1oxtr7lzxrdw4mojq
+    - https://apisix.apache.org/blog/2026/06/15/release-apache-apisix-3.17.0/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-39999
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-39999
+    cwe-id: CWE-290
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: apisix
+  tags: cve,cve2026,apache,apisix,jwt,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 404
+      - type: word
+        part: body
+        words:
+          - '"error_msg":"404 Route Not Found"'
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 2.2.0', '< 3.17.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: header
+        group: 1
+        regex:
+          - '(?im)^Server:\s*APISIX/([0-9.]+)'
+        internal: true


### PR DESCRIPTION
## Template validation

The forged JWT request was replaced with APISIX's public response metadata.

- Official V/F images: `apache/apisix:3.16.0-debian` (`sha256:b921bdef3cfb2ca72e483d643f40e7843683ff8e188984489c2020f17654ee88`) and `3.17.0-debian` (`sha256:0e5377839f4ff5e322a5686ab6ce6797ba768008aca1bfc9b71149c3b326c4df`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- Matching requires APISIX's standard route-not-found body and versioned server header.

No JWT, credential, protected route, configuration update, or state-changing request is sent.