### PR TITLE
CVE-2022-27925

### DIFF
--- a/http/cves/2022/CVE-2022-27925.yaml
+++ b/http/cves/2022/CVE-2022-27925.yaml
@@ -1,0 +1,85 @@
+id: CVE-2022-27925
+
+info:
+  name: Zimbra Collaboration Suite 8.8.15/9.0 - Zip Path Traversal
+  author: popy21
+  severity: high
+  description: |
+    Zimbra Collaboration (aka ZCS) 8.8.15 and 9.0 has mboximport functionality that receives a ZIP
+    archive and extracts files from it. An authenticated user with administrator rights has the
+    ability to upload arbitrary files to the system, leading to directory traversal.
+
+    This template is a passive version check: it reads CLIENT_VERSION from the unauthenticated web
+    client resource /js/zimbraMail/share/model/ZmSettings.js and flags hosts still on the affected
+    8.8.15 and 9.0.0 release branches. Zimbra shipped the fix as 8.8.15 Patch 31 and 9.0.0 Patch 24,
+    and the patch level lives in the zimbra-patch package version (8.8.15.1650529377.p31-2 /
+    9.0.0.1650532159.p24-2), not in CLIENT_VERSION - a patched 8.8.15 host still reports 8.8.15.
+    A match therefore means "vulnerable release branch, patch level unknown" and must be confirmed
+    against the installed patch, not "confirmed exploitable".
+  impact: |
+    An administrator-authenticated attacker uploads a ZIP whose entries traverse out of the
+    extraction directory, dropping a JSP webshell into the Zimbra webroot for remote code execution
+    as the zimbra user - and CVE-2022-37042 removes the authentication requirement entirely, which
+    is how this pair was mass-exploited in the wild.
+  remediation: |
+    Apply Zimbra Collaboration 8.8.15 Patch 31 or 9.0.0 Patch 24 (both released 2022-03-30) or later,
+    which also requires the CVE-2022-37042 fix in 8.8.15 Patch 33 / 9.0.0 Patch 26 to close the
+    authentication bypass on the same mboximport endpoint.
+  reference:
+    - http://packetstormsecurity.com/files/168146/Zimbra-Zip-Path-Traversal.html
+    - https://wiki.zimbra.com/wiki/Security_Center
+    - https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P24
+    - https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P31
+    - https://wiki.zimbra.com/wiki/Zimbra_Security_Advisories
+    - https://www.volexity.com/blog/2022/08/10/mass-exploitation-of-unauthenticated-zimbra-rce-cve-2022-27925/
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-27925
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 7.2
+    cve-id: CVE-2022-27925
+    cwe-id: CWE-22
+    epss-score: 0.98676
+    epss-percentile: 0.99921
+    cpe: cpe:2.3:a:synacor:zimbra_collaboration_suite:8.8.15:-:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: synacor
+    product: zimbra_collaboration_suite
+    shodan-query: http.title:"Zimbra Collaboration Suite"
+    fofa-query: title="Zimbra Collaboration Suite"
+  tags: cve,cve2022,synacor,zimbra,zimbra-collaboration-suite,lfi,rce,kev,vkev,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/js/zimbraMail/share/model/ZmSettings.js"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Zimbra Collaboration Suite Web Client"
+
+      - type: word
+        part: header
+        words:
+          - "application/x-javascript"
+
+      - type: regex
+        part: body
+        regex:
+          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"(?:8\.8\.15|9\.0\.0)_'
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        name: version
+        group: 1
+        regex:
+          - 'CLIENT_VERSION",\s*\{type:ZmSetting\.T_CONFIG,\s*defaultValue:"([^"]+)"'


### PR DESCRIPTION
Adds a detection template for **CVE-2022-27925**.

- Listed in [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) (actively exploited) and had no template.
- Metadata (CVSS, CWE, CPE, EPSS) sourced from NVD.
- `nuclei -validate` passes.

References are in the template.