### PR TITLE
Add CVE-2026-63637 template

### DIFF
--- a/http/cves/2026/CVE-2026-63637.yaml
+++ b/http/cves/2026/CVE-2026-63637.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-63637
+
+info:
+  name: Dgraph <= 25.3.7 - GraphQL Regexp Filter Injection
+  author: str4k3r
+  severity: high
+  description: |
+    Dgraph versions through 25.3.7 fail to sanitize a GraphQL regexp filter
+    argument before rewriting it into DQL. This can allow an unauthenticated
+    caller to alter the intended filter and disclose additional nodes. This
+    template performs only a read-only health request and version comparison.
+  impact: An unauthenticated caller may alter a GraphQL filter and read data outside the intended result set.
+  remediation: Upgrade Dgraph to version 25.3.8 or later.
+  reference:
+    - https://github.com/dgraph-io/dgraph/security/advisories/GHSA-33p8-wc97-5qcj
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-63637
+  classification:
+    cve-id: CVE-2026-63637
+    cwe-id: CWE-89
+    cvss-score: 8.6
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: dgraph
+    product: dgraph
+  tags: cve,cve2026,dgraph,graphql,injection
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/health"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"instance"'
+          - '"status":"healthy"'
+          - '"version"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '<= 25.3.7')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"v?([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The GraphQL regexp-injection request was replaced with Dgraph's read-only health endpoint.

- Official V/F images: `dgraph/standalone:v25.3.7` (`sha256:df0a645e374d898b851b31ae5a2c70eef36f2d6029c7177f93760f7349c13590`) and `v25.3.8` (`sha256:d13e00426b45ac637a17a0fe7d5445f4ba756b4e205f0fdeaaf3b5307740d674`)
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/health` is a public GET endpoint and returns a JSON `version` field.

No GraphQL query, injected filter, data disclosure attempt, mutation, or state-changing request is sent.