### PR TITLE
Add CVE-2026-8505 template

### DIFF
--- a/http/cves/2026/CVE-2026-8505.yaml
+++ b/http/cves/2026/CVE-2026-8505.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-8505
+
+info:
+  name: Langflow 1.0.0-1.10.0 - Webhook Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    Langflow OSS versions 1.0.0 through 1.10.0 can leave webhook
+    authentication disabled by default, allowing unauthenticated execution of
+    a known flow. This template performs only a read-only version request and
+    does not create, invoke, or modify a flow.
+  impact: An unauthenticated caller may execute a Langflow webhook as the flow owner.
+  remediation: Upgrade Langflow OSS to version 1.10.1 or later and enable webhook authentication.
+  reference:
+    - https://www.ibm.com/support/pages/node/7278921
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-8505
+  classification:
+    cve-id: CVE-2026-8505
+    cwe-id: CWE-306
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflow
+    product: langflow
+  tags: cve,cve2026,langflow,webhook,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"package":"Langflow"'
+          - '"main_version"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.0.0', '< 1.10.1')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The webhook creation and invocation sequence was replaced with Langflow's read-only version endpoint.

- Official V/F images: `langflowai/langflow:1.10.0` and `1.10.2`
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/api/v1/version` is a public GET endpoint and returns the Langflow package and semantic version.

No flow, webhook, API key, credential, execution, or state-changing request is sent.