### PR TITLE
Add CVE-2026-0769 template

### DIFF
--- a/http/cves/2026/CVE-2026-0769.yaml
+++ b/http/cves/2026/CVE-2026-0769.yaml
@@ -1,0 +1,54 @@
+id: CVE-2026-0769
+
+info:
+  name: Langflow < 1.9.0 - Custom Component Code Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    Langflow versions before 1.9.0 permit unauthenticated custom-component
+    source submission in affected configurations. This template performs only
+    a read-only version request and does not submit source or execute code.
+  impact: An unauthenticated caller may submit custom component source for evaluation.
+  remediation: Upgrade Langflow to version 1.9.0 or later and require authentication for component operations.
+  reference:
+    - https://www.zerodayinitiative.com/advisories/ZDI-26-035/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0769
+    - https://github.com/langflow-ai/langflow/releases/tag/1.9.0
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-0769
+    cwe-id: CWE-95
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflowai
+    product: langflow
+  tags: cve,cve2026,langflow,code-injection,eval
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"package":"Langflow"'
+          - '"main_version"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.0.0', '< 1.9.0')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The custom-component submission was replaced with Langflow's read-only version endpoint.

- Official V/F images: `langflowai/langflow:1.8.4` and `1.9.0`
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/api/v1/version` is a public GET endpoint and returns the Langflow package and semantic version.

No component source, authentication token, code execution, flow, or state-changing request is sent.