### PR TITLE
Add CVE-2026-13446 template

### DIFF
--- a/http/cves/2026/CVE-2026-13446.yaml
+++ b/http/cves/2026/CVE-2026-13446.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-13446
+
+info:
+  name: Langflow 1.0.0-1.10.1 - Hard-Coded AUTO_LOGIN Credentials
+  author: str4k3r
+  severity: critical
+  description: |
+    Langflow versions 1.0.0 through 1.10.1 can bootstrap AUTO_LOGIN with a
+    hard-coded superuser credential when no password is configured. This
+    template performs only a read-only version request and does not attempt a
+    login or access protected data.
+  impact: An unauthenticated attacker may obtain superuser access using the shared bootstrap credential.
+  remediation: Upgrade Langflow to version 1.10.2 or later and configure a strong bootstrap password.
+  reference:
+    - https://www.ibm.com/support/pages/node/7279991
+    - https://github.com/langflow-ai/langflow/issues/13054
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13446
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-13446
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflowai
+    product: langflow
+  tags: cve,cve2026,langflow,default-credentials,auth-bypass
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/version"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"package":"Langflow"'
+          - '"main_version"'
+        condition: and
+      - type: dsl
+        dsl:
+          - "compare_versions(version, '>= 1.0.0', '< 1.10.2')"
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '"version"\s*:\s*"([0-9.]+)"'
+        internal: true


### PR DESCRIPTION
## Template validation

The hard-coded credential login attempt was replaced with Langflow's read-only version endpoint.

- Official V/F images: `langflowai/langflow:1.10.0` and `1.10.2`
- Native Nuclei v3.11.0: V detected 3/3; F not detected 3/3
- `/api/v1/version` is a public GET endpoint and returns the Langflow package and semantic version.

No credential, login, access token, protected resource, or state-changing request is sent.