### PR TITLE
Add Penpot panel detection template

### DIFF
--- a/http/exposed-panels/penpot-panel.yaml
+++ b/http/exposed-panels/penpot-panel.yaml
@@ -1,0 +1,43 @@
+id: penpot-panel
+
+info:
+  name: Penpot - Login Panel
+  author: ashish-cybersec
+  severity: info
+  description: |
+    Penpot is an open-source design and prototyping platform. The web interface was detected.
+  reference:
+    - https://help.penpot.app/technical-guide/getting-started/
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: penpot
+    product: penpot
+    shodan-query: http.title:"Penpot"
+  tags: panel,penpot,design,oss
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Penpot | Full-stack design</title>"
+
+      - type: word
+        part: body
+        words:
+          - "globalThis.penpotVersion"
+          - '"./js/main-workspace.js"'
+        condition: and
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added `penpot-panel` - Penpot design platform detection
- References:
  - https://help.penpot.app/technical-guide/getting-started/

Penpot is an open-source design and prototyping platform that can be self-hosted via Docker. No existing template covers it.

Detection uses three matchers on a single unauthenticated request to `{{BaseURL}}`: the exact page title, two application-specific strings from the page's inline JavaScript, and status 200. The `globalThis.penpotVersion` global and the `./js/main-workspace.js` importmap key are structural and contain no version hashes, unlike the stylesheet and script `src` attributes on the same page, which carry per-release `?version=` query strings.

Note: the matcher checks for the presence of the `globalThis.penpotVersion` identifier only. It does not parse or compare the version value, so this is a presence check rather than version-based detection.

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Tested against the official image `penpotapp/frontend:latest` (Penpot 2.17.2).

True positive:

```
[penpot-panel] [http] [info] http://127.0.0.1:8092
[INF] Scan completed in 68.909737ms. 1 matches found.
```

Honeypot check against honey.scanme.sh:

```
[INF] Scan completed in 589.317575ms. No results found.
```

Penpot has no vulnerable/patched distinction as this is a technology detection template. The honeypot check against honey.scanme.sh served as the false-positive control.

`nuclei -validate` passes and the file lints clean against `.yamllint`.

Note: the Shodan query is derived from the page title observed on the running instance rather than tested against Shodan.