### PR TITLE
Create modbus-detect.yaml

### DIFF
--- a/network/detection/modbus-detect.yaml
+++ b/network/detection/modbus-detect.yaml
@@ -1,0 +1,34 @@
+id: modbus-detect
+
+info:
+  name: Modbus TCP Service Detection
+  author: K3ysTr0K3R
+  severity: info
+  description: |
+    Detects Modbus TCP services by sending a read-only
+    Read Holding Registers request to TCP port 502.
+  metadata:
+    verified: true
+  tags: modbus,scada,ics,ot,network,tcp
+
+tcp:
+  - inputs:
+      - data: "000100000006010300000001"
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 502
+
+    read-size: 1024
+
+    matchers:
+      - type: binary
+        binary:
+          - "000100000005010302"
+        condition: and
+
+      - type: binary
+        binary:
+          - "000100"
+        condition: and


### PR DESCRIPTION
Adds a simple Modbus TCP detection template.

It sends a read only Read Holding Registers request to port 502 and checks the response for a Modbus TCP service.

Tested with a Modbus TCP service and validated with `nuclei -validate`.