### PR TITLE
Create apache-livy-detect.yaml and apache-livy-logs.yaml

### DIFF
--- a/http/exposures/logs/apache-livy-logs.yaml
+++ b/http/exposures/logs/apache-livy-logs.yaml
@@ -1,0 +1,31 @@
+id: apache-livy-logs
+
+info:
+  name: Apache Livy - Logs Exposed
+  author: icarot
+  severity: medium
+  description: |
+    Detects if the logs/metrics page of the Apache Livy server is exposed.
+  reference:
+    - https://github.com/apache/livy
+  metadata:
+    max-request: 3
+    vendor: apache
+    product: livy
+    shodan-query: title:"Livy - Sessions"
+  tags: apache,livy,logs,exposure
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/metrics/healthcheck"
+      - "{{BaseURL}}/metrics/metrics"
+      - "{{BaseURL}}/metrics/threads"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'livy.sessions'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/exposures/logs/apache-livy-logs.yaml
+++ b/http/exposures/logs/apache-livy-logs.yaml
@@ -14,18 +14,21 @@ info:
     product: livy
     shodan-query: title:"Livy - Sessions"
   tags: apache,livy,logs,exposure
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/metrics/healthcheck"
       - "{{BaseURL}}/metrics/metrics"
       - "{{BaseURL}}/metrics/threads"
+
     matchers-condition: and
     matchers:
       - type: word
         words:
           - 'livy.sessions'
         condition: and
+
       - type: status
         status:
           - 200

--- a/http/technologies/apache/apache-livy-detect.yaml
+++ b/http/technologies/apache/apache-livy-detect.yaml
@@ -1,0 +1,31 @@
+id: apache-livy-detect
+
+info:
+  name: Apache Livy - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects a Apache Livy, a open source REST interface for interacting with Apache Spark from anywhere.
+  reference:
+    - https://github.com/apache/livy
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: livy
+    shodan-query: title:"Livy - Sessions"
+  tags: apache,livy,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Livy'
+          - 'livy-'
+          - 'livy-ui'
+        condition: and
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-livy-detect.yaml
+++ b/http/technologies/apache/apache-livy-detect.yaml
@@ -1,7 +1,7 @@
 id: apache-livy-detect
 
 info:
-  name: Apache Livy - Detection
+  name: Apache Livy - Detect
   author: icarot
   severity: info
   description: |
@@ -14,10 +14,12 @@ info:
     product: livy
     shodan-query: title:"Livy - Sessions"
   tags: apache,livy,detect
+
 http:
   - method: GET
     path:
       - "{{BaseURL}}/ui"
+
     matchers-condition: and
     matchers:
       - type: word
@@ -26,6 +28,7 @@ http:
           - 'livy-'
           - 'livy-ui'
         condition: and
+
       - type: status
         status:
           - 200


### PR DESCRIPTION
These nuclei templates:

* Detects a Apache Livy, a open source REST interface for interacting with Apache Spark from anywhere.
* Detects if the logs/metrics page of the Apache Livy server is exposed.

- References:

https://github.com/apache/livy

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Livy Docker Container:**

1. Running the docker container:

```
$ git clone https://github.com/apache/livy.git
$ cd livy/dev/docker/
$ chmod +x build-images.sh
$ ./build-images.sh
$ cd dev/docker/livy-dev-cluster/
$ docker compose up -d
```

2. Acessing the Apache Livy service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' livy`

And the access URL will be http://<obteined_inspect_IP_Address>:8998/

**Nuclei execution:**

`~/go/bin/nuclei -t apache-livy-detect.yaml -t apache-livy-logs.yaml -u "http://<obteined_inspect_IP_Address>:8998/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1840" height="389" alt="image" src="https://github.com/user-attachments/assets/b4338943-5d6b-411b-8dfc-ceb70ea4b2c8" />
