### PR TITLE
fix(caldera-c2): add detection for Caldera 5.x Magma UI

### DIFF
--- a/http/exposed-panels/c2/caldera-c2.yaml
+++ b/http/exposed-panels/c2/caldera-c2.yaml
@@ -2,7 +2,7 @@ id: caldera-c2
 
 info:
   name: Caldera C2 - Detect
-  author: pussycat0x
+  author: pussycat0x,s4e-io
   severity: info
   description: |
     MITRE Caldera™ is a cyber security platform designed to easily automate adversary emulation, assist manual red-teams, and automate incident response.
@@ -30,8 +30,9 @@ http:
         part: body
         words:
           - '<title>Login | CALDERA</title>'
+          - '<title>Magma | Caldera</title>'
+        condition: or
 
       - type: status
         status:
           - 200
-# digest: 4b0a004830460221008da5221352e32eaed83ec498b59ad29fb5e32613d6add3f70deaadb0f134aaf8022100ce31a6e69a949c1e8fcda5abf76965739ed6e1a9f58bc630132cfc0233e068c6:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

The `caldera-c2` template identifies exposed MITRE Caldera panels by matching `<title>Login | CALDERA</title>` in the response body. That title belongs to the 4.x line only, so Caldera 5.x instances are currently not detected.

**Root cause**

In Caldera 4.x, `GET /` is handled by the `landing` route. For an unauthenticated request it renders `templates/login.html` inline and returns HTTP 200, so the title is present in the response body and the matcher fires.

Caldera 5.0 replaced the server-rendered interface with the Vue-based [Magma](https://github.com/mitre/magma) plugin. `GET /` now returns the SPA shell, titled `<title>Magma | Caldera</title>`, and the login form is drawn client-side. The previous signature is therefore absent from the HTTP response and no match occurs.

`templates/login.html` still exists in the 5.x tree, but it is no longer served on any route, and its title was re-cased to `Login | Caldera`. Neither detail restores detection on its own.

**Change**

The 5.x title is added to the existing word matcher under `condition: or`. The status matcher, the request itself and `max-request` are unchanged, so this extends coverage without altering scan behaviour or affecting 4.x detection.

**Version coverage**

| Version | Response at `/` | Title | Detected |
| --- | --- | --- | --- |
| 4.0.0 – 4.2.0 | Server-rendered login page | `Login \| CALDERA` | Yes (unchanged) |
| 5.0.0 – 5.3.0 | Magma SPA shell | `Magma \| Caldera` | Yes (new) |

The Magma title is identical across 5.0.0, 5.1.0, 5.2.0 and 5.3.0, checked at the magma submodule commit pinned by each release tag. The 4.x `landing` rendering path is identical in 4.0.0, 4.1.0 and 4.2.0.

- References:
  - https://github.com/apache/caldera
  - https://github.com/mitre/magma

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Both releases were deployed locally from the official repository and scanned with nuclei v3.11.0.

| Template | Caldera 4.2.0 | Caldera 5.3.0 |
| --- | --- | --- |
| Current | Match | **No match** |
| This PR | Match | Match |

As this is a panel-detection template, the second checkbox above was covered by scanning unrelated web applications as negative controls. Neither produced a match, so the added title does not broaden the template beyond Caldera. `nuclei -validate` passes.

The `# digest` line was dropped because the template body changed and the existing signature no longer applies.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
