### PR TITLE
Add CVE-2026-24880 for Apache Tomcat request smuggling

### DIFF
--- a/http/cves/2026/CVE-2026-24880.yaml
+++ b/http/cves/2026/CVE-2026-24880.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-24880
+
+info:
+  name: Apache Tomcat - HTTP Request Smuggling
+  author: Mys7ic
+  # Severity: NVD/CISA secondary rating is 7.5 HIGH (I:H), while Apache rates this issue
+  # low. Exploitation requires a vulnerable Tomcat behind an intermediary that interprets
+  # the invalid chunk extension differently, so real-world impact is rather low to medium.
+  # Set to medium as a deliberate middle ground - feel free to adjust to low or high.
+  severity: medium
+  description: |
+    Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling') vulnerability in Apache Tomcat via invalid chunk extension.
+    This issue affects Apache Tomcat: from 11.0.0-M1 through 11.0.18, from 10.1.0-M1 through 10.1.52, from 9.0.0.M1 through 9.0.115, from 8.5.0 through 8.5.100, from 7.0.0 through 7.0.109.
+  impact: |
+    An attacker can craft a request with an invalid chunk extension that is misinterpreted by Tomcat, enabling HTTP request smuggling. This may lead to cache poisoning, session hijacking, or bypassing access controls enforced by intermediaries such as reverse proxies and web application firewalls.
+  remediation: |
+    Users are recommended to upgrade to version 11.0.20, 10.1.53 or 9.0.116, which fix the issue.
+  reference:
+    - https://lists.apache.org/thread/2c682qnlg2tv4o5knlggqbl9yc2gb5sn
+    - http://www.openwall.com/lists/oss-security/2026/04/09/20
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-24880
+    - https://cve.org/CVERecord?id=CVE-2026-24880
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-24880
+    cwe-id: CWE-444
+    epss-score: 0.0052
+    epss-percentile: 0.42314
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: apache
+    product: tomcat
+    shodan-query: title:"Apache Tomcat"
+    fofa-query: app="APACHE-Tomcat"
+  tags: cve,cve2026,apache,tomcat,http-smuggling,passive
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{randstr}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 404'
+          - 'contains(body, "Apache Tomcat/")'
+          - 'regex("Apache Tomcat/(7\.0\.(0|[1-9]|[1-9][0-9]|10[0-9])|8\.5\.(0|[1-9]|[1-9][0-9]|100)|9\.0\.(0(\.M[0-9]+)?|[1-9]|[1-9][0-9]|1(0[0-9]|1[0-5]))|10\.1\.(0(-M[0-9]+)?|[1-9]|[1-4][0-9]|5[0-2])|11\.0\.(0(-M[0-9]+)?|[1-9]|1[0-8]))(?:[^0-9]|$)", body)'
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'Apache Tomcat/([0-9]+\.[0-9]+\.[0-9]+(?:[.\-]M[0-9]+)?)'


### PR DESCRIPTION
### PR Information

- Added CVE-2026-24880 (Apache Tomcat - HTTP Request Smuggling via invalid chunk extension)
- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2026-24880
  - https://lists.apache.org/thread/2c682qnlg2tv4o5knlggqbl9yc2gb5sn
  - http://www.openwall.com/lists/oss-security/2026/04/09/20

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

The template follows the version detection pattern used for the earlier Tomcat request smuggling CVE-2023-45648 (http/cves/2023/CVE-2023-45648.yaml). It requests a random non existing path and checks the version shown on the Tomcat 404 error page against the affected version ranges from the vendor advisory, including the milestone notations 9.0.0.M1, 10.1.0-M1 and 11.0.0-M1.

Validated locally against official Docker Hub images with nuclei v3.11.1:

| Instance | Result |
|---|---|
| tomcat:9.0.115-jre17-temurin-noble | MATCH ("9.0.115") |
| tomcat:9.0.116-jre17-temurin-noble | no match |
| tomcat:10.1.52-jre17-temurin-noble | MATCH ("10.1.52") |
| tomcat:10.1.53-jre17-temurin-noble | no match |
| tomcat:11.0.18-jre17-temurin-noble | MATCH ("11.0.18") |
| tomcat:11.0.20-jre17-temurin-noble | no match |
| tomcat:8.5.100-jre17-temurin-jammy | MATCH ("8.5.100") |
| nginx / httpd | no match (no false positives) |

The version range regex was additionally tested against 35 vulnerable versions (7.0.0 to 7.0.109, 8.5.0 to 8.5.100, 9.0.0.M1 to 9.0.115, 10.1.0-M1 to 10.1.52, 11.0.0-M1 to 11.0.18) and 17 patched or out of range versions (9.0.116, 10.1.53, 11.0.19, 11.0.20, 7.0.110 and later, 8.0.x, 6.x, 12.x) without false positives or false negatives.

Debug output (tomcat:9.0.115, localhost):

```
[CVE-2026-24880] [http] [medium] http://localhost:8092/3J0BMod9m0FDoearBMG0b46Qija ["9.0.115"]
[INF] Scan completed in 42.471445ms. 1 matches found.
```

Severity: The NVD/CISA secondary scoring gives 7.5 HIGH (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N) while the Apache announcement rates the issue low. Exploitation requires a vulnerable Tomcat behind an intermediary that parses the invalid chunk extension differently, so the practical impact is more in the low to medium range. The template uses medium as middle ground. If maintainers prefer low or high, it is a one line change. The same note is included as comment in the template.

The vendor announcement states "upgrade to 11.0.20, 10.1.52 or 9.0.116". 10.1.52 is a typo in the advisory since this version is itself listed as affected. The NVD CPE configuration (10.1.0 to <10.1.53) confirms 10.1.53 is the fixed version. The remediation in the template reflects that.

Reproduce locally:

```bash
docker run -d --rm -p 8080:8080 tomcat:9.0.115-jre17-temurin-noble
nuclei -t http/cves/2026/CVE-2026-24880.yaml -u http://localhost:8080 -debug
```