### PR TITLE
Create CVE-2026-1340.yaml - Ivanti EPMM < 12.8.0.0 - Remote Code Execution (PASSIVE)

### DIFF
--- a/http/cves/2026/CVE-2026-1340.yaml
+++ b/http/cves/2026/CVE-2026-1340.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-1340
+
+info:
+  name: Ivanti EPMM < 12.8.0.0 - Remote Code Execution
+  author: 0x_Akoko
+  severity: critical
+  description: |
+    Ivanti Endpoint Manager Mobile contains a code injection vulnerability allowing unauthenticated attackers to execute arbitrary code remotely, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can execute arbitrary code remotely, potentially leading to full system compromise.
+  remediation: |
+    Update to the latest version of Ivanti Endpoint Manager Mobile.
+  reference:
+    - https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-1340
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-1340
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ivanti
+    product: endpoint_manager_mobile
+    shodan-query: http.title:"Ivanti User Portal"
+    fofa-query: title="Ivanti User Portal" || body="ui.login.css"
+  tags: cve,cve2026,ivanti,epmm,mobileiron,rce,kev,passive,vkev
+
+http:
+  - raw:
+      - |
+        GET /mifs/user/login.jsp HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    max-redirects: 3
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Ivanti")'
+          - 'compare_versions(version, "< 12.8.0")'
+        condition: and
+
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - 'ui\.login\.css\?([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - 'ui\.login\.css\?([0-9]+\.[0-9]+(?:\.[0-9]+)?)'


### PR DESCRIPTION
### PR Information

Reason Cant Create Full POC :

```Not reproducible in the wild. The payload itself is fine, but nslookup isn't installed on most EPMM appliances, so nothing runs - swapping in curl fires where this stays silent. The /mifs/ gate also misses real hosts: it accepts intro.html, /mifs/#/login, /mifs/login, /mifs/admin/, but EPMM redirects to /mifs/user/login.jsp (the path Metasploit uses), which matches none of them.```

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

<!-- Include `nuclei -debug` output along with Shodan / Fofa / Google Query / Docker or screenshots if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
