### PR TITLE
Add CVE-2025-62593 template: Ray Dashboard browser-guard bypass to RCE

### DIFF
--- a/http/cves/2025/CVE-2025-62593.yaml
+++ b/http/cves/2025/CVE-2025-62593.yaml
@@ -1,0 +1,78 @@
+id: CVE-2025-62593
+
+info:
+  name: Ray Dashboard < 2.52.0 - Browser-Guard Bypass to Unauthenticated RCE
+  author: mohamed-bashir-dev,JLLeitschuh,avilum
+  severity: high
+  description: |
+    The Ray dashboard (default port 8265) ships without authentication. Prior
+    to 2.52.0, its only defense against browser-originated attacks was
+    rejecting requests whose User-Agent header starts with "Mozilla". Because
+    the fetch specification lets scripts alter that header, an attacker can
+    combine a modified User-Agent with a DNS rebinding attack to drive a
+    victim browser against the local dashboard and reach its unauthenticated
+    job-submission API, resulting in remote code execution on the developer's
+    machine. Ray 2.52.0 added a defense that rejects any POST/PUT request
+    carrying Sec-Fetch-* headers. This template detects the vulnerable
+    behavior with a single safe probe: it sends a POST carrying
+    Sec-Fetch-Site and a non-Mozilla User-Agent to the jobs API with an empty
+    JSON body. Vulnerable instances process the request and fail request
+    validation (HTTP 400 with a Ray jobs-specific error), while patched
+    instances reject it outright (HTTP 405 "Method Not Allowed for browser
+    traffic."). The empty body is rejected during request validation, so no
+    job is created, no command is executed and no state is changed. Known to
+    be exploited in the wild (CISA KEV).
+  impact: |
+    A malicious web page (or malvertisement) can, via DNS rebinding, execute
+    arbitrary commands on the machine of a developer running the Ray dashboard
+    by using the developer's own browser to reach the unauthenticated
+    /api/jobs/ endpoint with a forged User-Agent.
+  remediation: |
+    Upgrade Ray to 2.52.0 or later. Do not expose the dashboard (port 8265)
+    beyond the loopback interface of trusted machines.
+  reference:
+    - https://github.com/ray-project/ray/security/advisories/GHSA-q279-jhrf-cc6v
+    - https://github.com/ray-project/ray/commit/70e7c72780bdec075dba6cad1afe0832772bfe09
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-62593
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2025-62593
+    cwe-id: CWE-346
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ray-project
+    product: ray
+    shodan-query: http.title:"Ray Dashboard"
+  tags: cve,kev,ray,rce,detect
+
+http:
+  # Safe single-probe detection of the missing Sec-Fetch-* guard that 2.52.0
+  # added. The empty JSON body is rejected by JobSubmitRequest validation
+  # before any handler logic runs, so the probe never creates a job or
+  # executes anything. Vulnerable: 400 with the Ray jobs validation error.
+  # Patched: 405 "Method Not Allowed for browser traffic." (Sec-Fetch guard).
+  # A non-Mozilla User-Agent is required: vulnerable builds only blocked
+  # "Mozilla"-prefixed agents, which is the exact weakness of this CVE.
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/jobs/"
+    headers:
+      Sec-Fetch-Site: cross-site
+      Content-Type: application/json
+      User-Agent: Nuclei-CVE-2025-62593
+    body: '{}'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        words:
+          - "JobSubmitRequest"
+          - "entrypoint"
+        condition: and


### PR DESCRIPTION
## Summary
Adds a safe, single-request detection template for **CVE-2025-62593** (GHSA-q279-jhrf-cc6v, CVSS 8.8, CISA KEV since 2026-08-17): the Ray dashboard's only anti-browser defense prior to 2.52.0 was rejecting `User-Agent: Mozilla*` requests. Since browsers' fetch() can alter that header, an attacker combines a forged User-Agent with DNS rebinding to reach the unauthenticated `/api/jobs/` endpoint from a victim browser → unauthenticated RCE on the developer's machine. Ray 2.52.0 rejects any POST/PUT carrying `Sec-Fetch-*` headers.

## Template design (non-destructive behavioral probe)
- **One POST** to `/api/jobs/` with header `Sec-Fetch-Site: cross-site`, a non-Mozilla `User-Agent`, and an **empty JSON body `{}`**.
- **Vulnerable** (all versions < 2.52.0): the request passes the UA-only guard and fails `JobSubmitRequest` validation → **HTTP 400** with the Ray jobs-specific error (`JobSubmitRequest` / `entrypoint`).
- **Patched** (≥ 2.52.0): the new Sec-Fetch guard rejects it before routing → **HTTP 405** `Method Not Allowed for browser traffic.`
- The empty body is rejected during request validation — **no job is created, no command is executed, no state changes**. Matchers key on the Ray-specific validation text, so non-Ray aiohttp applications do not match.

## Validation evidence (localhost only)
- `ray[default]==2.51.1` dashboard: `nuclei -debug` → **1 match** (400 + Ray jobs validation error).
- `ray[default]==2.52.0` dashboard: `nuclei -debug` → **no results** (405 guard response).
- Control probes: same POST **without** `Sec-Fetch-*` returns 400 on both builds (proves the Sec-Fetch header is the discriminator); a plain non-Ray aiohttp app → no match.
- `nuclei -validate`: pass.

## Notes
- This is an alternative to #17171 for the same CVE. That template submits a real job running `id` and fetches its logs; this one proves the vulnerable/patched boundary with a single request that never reaches execution, keeping scans non-mutating on customer infrastructure.
- Credits: vulnerability reported by JLLeitschuh / avilum per the advisory; template by mohamed-bashir-dev.

References:
- https://github.com/ray-project/ray/security/advisories/GHSA-q279-jhrf-cc6v
- https://github.com/ray-project/ray/commit/70e7c72780bdec075dba6cad1afe0832772bfe09
- https://nvd.nist.gov/vuln/detail/CVE-2025-62593