### PR TITLE
Add CVE-2026-55255 template: Langflow cross-user flow IDOR

### DIFF
--- a/http/cves/2026/CVE-2026-55255.yaml
+++ b/http/cves/2026/CVE-2026-55255.yaml
@@ -1,0 +1,96 @@
+id: CVE-2026-55255
+
+info:
+  name: Langflow < 1.9.1 - IDOR in Flow Lookup Allowing Cross-User Flow Access
+  author: mohamed-bashir-dev,yzeirnials,LeftenantZero,Zwique
+  severity: high
+  description: |
+    Langflow is an open-source low-code framework for building agentic AI workflows.
+    In versions prior to 1.9.1, the flow-resolution helper get_flow_by_id_or_endpoint_name()
+    performs a UUID lookup with session.get(Flow, flow_id) without verifying that the
+    authenticated caller owns the flow. Any authenticated user can therefore resolve,
+    access, and execute any other user's flow by guessing or knowing its UUID
+    (CWE-639, authorization bypass through user-controlled key). The flaw is reachable
+    through the /api/v1/responses endpoint (the advisory PoC executes a victim's flow by
+    passing its UUID in the "model" field with the attacker's x-api-key) and through the
+    /api/v1/run* routes. The issue is fixed in 1.9.1, where flow lookups are scoped to
+    the authenticated user and cross-user lookups fail closed with 404.
+
+    This template is SAFE and non-executing: it sends POST /api/v1/run/{flow_id} with an
+    empty body, which stops before any flow execution on both patched and unpatched
+    servers. On vulnerable versions the cross-owner flow is still resolved by the flawed
+    helper and the request is then aborted by the in-handler permission check with
+    403 "You do not have permission to run this flow". On fixed versions the
+    owner-scoped lookup fails first with 404 "Flow identifier ... not found". A 403 with
+    that exact message can only occur when the server resolved a flow owned by a
+    different user, which proves the authorization bypass without running the flow.
+
+    Usage (an authenticated IDOR requires valid credentials of a low-privileged user and
+    the UUID of a flow owned by another user):
+      nuclei -t CVE-2026-55255.yaml -u https://target -var api_key=<attacker x-api-key> -var victim_flow_id=<other users flow UUID>
+
+    The placeholder defaults never match: a random key yields 403 "Invalid or missing
+    API key" and the nil UUID yields 404 on every version.
+  impact: |
+    An authenticated attacker with a valid API key of any regular user can read and
+    execute other users' (including administrators') flows. Because flows frequently
+    hold prompts, credentials, and integrations, this leads to disclosure of sensitive
+    flow configurations and unauthorized execution of victim workflows, up to full
+    server-side compromise depending on the components the victim flows use. The
+    vulnerability is listed in the CISA Known Exploited Vulnerabilities catalog.
+  remediation: |
+    Upgrade Langflow to version 1.9.1 or later.
+  reference:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-qrpv-q767-xqq2
+    - https://github.com/langflow-ai/langflow/commit/2c9f498d664a3c32698b57d7c5e752625291060e
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55255
+    - https://github.com/pypa/advisory-database/tree/main/vulns/langflow/PYSEC-2026-221.yaml
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:L
+    cvss-score: 8.4
+    cve-id: CVE-2026-55255
+    cwe-id: CWE-639
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflow
+    product: langflow
+    shodan-query: http.title:"Langflow"
+  tags: cve,cve2026,langflow,idor,auth,kev
+
+variables:
+  # Placeholder defaults; override both with -var for real targets.
+  # A random key returns 403 "Invalid or missing API key" (no match) and the
+  # nil UUID does not exist, so the defaults can never produce a finding.
+  api_key: "sk-{{rand_base(32)}}"
+  victim_flow_id: "00000000-0000-0000-0000-000000000000"
+
+http:
+  # Non-executing probe: POST /api/v1/run/{victim_flow_id} with an empty body.
+  # - Vulnerable (< 1.9.1): the flawed helper resolves the cross-owner flow,
+  #   then check_flow_user_permission aborts with 403 "You do not have
+  #   permission to run this flow" BEFORE body parsing or flow execution.
+  # - Fixed (>= 1.9.1): the owner-scoped dependency lookup aborts with 404
+  #   "Flow identifier ... not found" before the handler runs.
+  # - Bogus UUID: 404 on both versions; invalid key: 403 "Invalid or missing
+  #   API key" on both - neither can satisfy the matcher below.
+  - raw:
+      - |
+        POST /api/v1/run/{{victim_flow_id}} HTTP/1.1
+        Host: {{Hostname}}
+        x-api-key: {{api_key}}
+        Content-Type: application/json
+
+        {}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 403
+
+      - type: word
+        part: body
+        words:
+          - "You do not have permission to run this flow"


### PR DESCRIPTION
## Summary
Adds a safe detection template for **CVE-2026-55255** (GHSA-qrpv-q767-xqq2, CVSS 8.4 high, CWE-639, CISA KEV since 2026-07-07): in Langflow < 1.9.1, `get_flow_by_id_or_endpoint_name()` resolves UUID lookups without an owner check (`session.get(Flow, flow_id)`), so any authenticated user can resolve/access/execute any other user's flow by its UUID.

## Template design (non-executing behavioral probe)
- **One POST** to `/api/v1/run/{{victim_flow_id}}` with the attacker's `x-api-key` and an **empty JSON body**.
- **Vulnerable** (< 1.9.1): the flawed helper resolves the cross-owner flow, then the in-handler permission check aborts with **403** `You do not have permission to run this flow` — this 403 can only occur when the server resolved a flow owned by a different user, which proves the IDOR without running the flow.
- **Fixed** (≥ 1.9.1): the owner-scoped lookup fails closed first with **404** `Flow identifier ... not found`.
- Empty body is rejected before flow execution on vulnerable versions, so nothing is executed and no state changes. Controls verified: bogus UUID → identical 404 on both; invalid key → 403 `Invalid or missing API key` on both — neither satisfies the matcher.
- Authenticated IDOR by nature: template ships placeholder-only `api_key` / `victim_flow_id` variables (random key + nil UUID never match); real usage: `nuclei -t CVE-2026-55255.yaml -u https://target -var api_key=... -var victim_flow_id=...`.

## Validation evidence (localhost only)
- Seeded Langflow **1.9.0** (langflow-base 0.9.0 — pinning matters, bare resolution pulls a fixed base) with two users and a victim-owned flow: `nuclei -debug` → **match** (403 + permission-check body).
- Seeded Langflow **1.9.1** (langflow-base 0.9.1): same request → **no results** (404).
- `nuclei -validate`: pass.

## Credits
Reporters `yzeirnials`, `LeftenantZero`, `Zwique` (per advisory credits) + `mohamed-bashir-dev` (template).

References:
- https://github.com/langflow-ai/langflow/security/advisories/GHSA-qrpv-q767-xqq2
- https://github.com/langflow-ai/langflow/commit/2c9f498d664a3c32698b57d7c5e752625291060e
- https://nvd.nist.gov/vuln/detail/CVE-2026-55255
- https://github.com/pypa/advisory-database/tree/main/vulns/langflow/PYSEC-2026-221.yaml