### PR TITLE
fix(CVE-2024-42640): dsl matcher references out-of-scope body_3/body_4

### DIFF
--- a/http/cves/2024/CVE-2024-42640.yaml
+++ b/http/cves/2024/CVE-2024-42640.yaml
@@ -65,10 +65,11 @@ http:
         GET /bower_components/angular-base64-upload/demo/uploads/{{filename}}.php HTTP/1.1
         Host: {{Hostname}}
 
+    stop-at-first-match: true
+
     matchers:
       - type: dsl
         dsl:
-          - 'contains(body_3, "{{num}}") || contains(body_4, "{{num}}")'
-          - 'status_code_3 == 200 || status_code_4 == 200'
+          - 'contains(body_1, "{{num}}") || contains(body_2, "{{num}}")'
+          - 'status_code_1 == 200 || status_code_2 == 200'
         condition: and
-# digest: 4a0a00473045022100d1d9407aa118ce26ecd9a62dfe4c44de3bfcb0c7fd517109346a5655d52fe8a2022009899920a10a966cf750fd848a3c78a876c63b34278f118e6dbf78a27e9e54e2:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### PR Information

- Fixed CVE-2024-42640 (`http/cves/2024/CVE-2024-42640.yaml`)

The second `http` block has two requests, so only `body_1`, `body_2`, `status_code_1` and `status_code_2` exist inside it. Its `dsl` matcher reads `body_3`, `body_4`, `status_code_3` and `status_code_4`, which that block never defines, so neither expression resolves and `condition: and` can never be satisfied. Request-condition variables are scoped per block, which the first block's own matcher already relies on.

The template therefore runs the exploit end to end, uploads the PHP file, reads it back, and then reports nothing. It has not matched since #11000.

Renaming the four identifiers restores detection. I also added `stop-at-first-match` to the same block, because with both path variants ORed into one expression a host serving the `node_modules` variant reported twice, the second time against a URL that returned 404.

- References:
  - https://nvd.nist.gov/vuln/detail/CVE-2024-42640
  - https://github.com/adonespitogo/angular-base64-upload/blob/v0.1.20/demo/server.php
  - https://docs.projectdiscovery.io/templates/protocols/http/request-condition

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Lab:

```
git clone --depth 1 --branch v0.1.20 https://github.com/adonespitogo/angular-base64-upload
mkdir -p webroot/node_modules && cp -r angular-base64-upload webroot/node_modules/
mkdir -p webroot/node_modules/angular-base64-upload/demo/uploads
chmod -R 777 webroot/node_modules/angular-base64-upload/demo/uploads
docker run -d -p 8091:80 -v "$PWD/webroot:/var/www/html" php:7.4-apache
```

Same recipe at `bower_components/` for the other path variant, and at tag `v0.1.21` for the patched control, which deletes `demo/` entirely.

Before, template as merged, against the vulnerable host. Both stages succeed on the wire and the scan still ends at zero:

```
POST /node_modules/angular-base64-upload/demo/server.php
Content-Type: application/json

{"base64": "OTgxMzMyMw==", "filename": "zholvmayosxt.php"}

HTTP/1.1 200 OK
Content-Length: 24

uploads/zholvmayosxt.php
```

```
GET /node_modules/angular-base64-upload/demo/uploads/zholvmayosxt.php

HTTP/1.1 200 OK
Content-Length: 7

9813323
```

```
[INF] Scan completed in 4.149701ms. 0 matches found.
[0:00:00] | Templates: 1 | Hosts: 1 | Matched: 0 | Errors: 0 | Requests: 4/4 (100%)
```

After, same host and command:

```
[CVE-2024-42640] [http] [critical] http://127.0.0.1:8091/node_modules/angular-base64-upload/demo/uploads/mvyblmwzcujc.php
```

Test matrix, nuclei v3.8.0:

| Target | Result |
| -- | -- |
| v0.1.20 at `node_modules/` | match |
| v0.1.20 at `bower_components/` | match |
| v0.1.21, patched | no match |
| catch-all 200 host echoing URI and request body | no match |
| host echoing `uploads/<filename>.php` on the POST but storing nothing | no match |
| `http://honey.scanme.sh` | no match |

The last two are the useful ones. Stage 1 keys on `uploads/{{filename}}.php`, a prefix the client never sends, and stage 2 keys on `{{num}}`, which leaves the client only base64 encoded. A host that reflects the request cannot satisfy either.

`stop-at-first-match` takes the `node_modules` layout from four requests to three. The `bower_components` layout still uses four, so `max-request: 4` stays correct.

`nuclei -validate` passes and `yamllint -c .yamllint` is clean. Dropped the trailing `# digest:` line, as in #16739 and #16704.

I left the `classification` block alone, where the shipped `CWE-94` and CVSS 4.0 score of 10 disagree with NVD's `CWE-434` and 9.8. Happy to raise that separately.
