### PR TITLE
Add RuoYi templates (detect + scheduled task unauth)

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1549,4 +1549,15 @@
             "website": "",
             "email": ""
         }
+    },
+    {
+        "author": "xiabai2008",
+        "links": {
+            "github": "https://github.com/xiabai2008",
+            "twitter": "",
+            "linkedin": "",
+            "website": "https://xiabai2008.github.io/ruoyi-scan/",
+            "email": ""
+        }
+    }
 ]

--- a/http/misconfiguration/ruoyi-job-unauth.yaml
+++ b/http/misconfiguration/ruoyi-job-unauth.yaml
@@ -1,0 +1,61 @@
+id: ruoyi-job-unauth
+
+info:
+  name: RuoYi - Scheduled Task Unauthenticated Access
+  author: xiabai2008
+  severity: high
+  description: |
+    RuoYi versions prior to 4.7 expose the Quartz scheduled task endpoint
+    (/monitor/job/edit) without enforcing authentication. An unauthenticated
+    attacker reaches the task management business layer, which is the
+    prerequisite for abusing the invokeTarget parameter to invoke arbitrary
+    methods and achieve remote code execution.
+
+    This template only verifies whether the endpoint is reachable without
+    authentication. It does not create, modify, or trigger any scheduled task.
+  reference:
+    - https://github.com/yangzongzhuan/RuoYi
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4564
+    - https://github.com/M0onc/RuoYi-Quartz-RCE
+    - https://github.com/xiabai2008/ruoyi-scan
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ruoyi
+    product: ruoyi
+    shodan-query: 'http.title:"RuoYi"'
+    fofa-query: 'title="若依"'
+  tags: ruoyi,unauth,quartz,misconfig
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/monitor/job/edit"
+
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+
+    body: "jobId=99999999&jobName=nuclei&jobGroup=DEFAULT&invokeTarget=nuclei&cronExpression=0/5+*+*+*+*%3F&misfirePolicy=1&concurrent=1&status=0"
+
+    matchers-condition: and
+    matchers:
+      # 1) 已进入业务层：任务不存在（而非鉴权拦截）
+      - type: word
+        part: body
+        words:
+          - "任务不存在"
+          - "定时任务不存在"
+
+      # 2) 明确排除鉴权拦截响应，避免把受保护实例判为未授权
+      - type: word
+        part: body
+        words:
+          - "请先登录"
+          - "认证失败"
+          - "无法访问系统资源"
+          - "未登录"
+        negative: true

--- a/http/technologies/ruoyi-detect.yaml
+++ b/http/technologies/ruoyi-detect.yaml
@@ -1,0 +1,73 @@
+id: ruoyi-detect
+
+info:
+  name: RuoYi - Detect
+  author: xiabai2008
+  severity: info
+  description: |
+    RuoYi is a Java-based rapid development framework widely deployed for
+    enterprise and government backend systems in China, with a large number of
+    secondary-development projects. This template detects RuoYi installations
+    across its major variants (Bootstrap, Vue, Vue3, Cloud) using the
+    application title and framework-specific response markers.
+  reference:
+    - https://github.com/yangzongzhuan/RuoYi
+    - https://github.com/yangzongzhuan/RuoYi-Vue
+    - https://github.com/yangzongzhuan/RuoYi-Cloud
+    - https://ruoyi.vip/
+    - https://github.com/xiabai2008/ruoyi-scan
+  classification:
+    cpe: cpe:2.3:a:ruoyi:ruoyi:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: ruoyi
+    product: ruoyi
+    shodan-query: 'http.title:"RuoYi"'
+    fofa-query: 'title="若依"'
+  tags: tech,ruoyi,detect
+
+http:
+  # 品牌指纹：登录页 / 首页标题
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+      - "{{BaseURL}}/"
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "若依管理系统"
+          - "若依管理"
+          - "RuoYi管理系统"
+          - "RuoYi"
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        name: variant
+        group: 1
+        regex:
+          - "(?i)(ruoyi-vue-plus|ruoyi-cloud-plus|ruoyi-vue3|ruoyi-vue|ruoyi-cloud|ruoyi-app|ruoyi)"
+
+  # Vue / Cloud 变体：/prod-api/ 前缀返回 RuoYi 专属鉴权 JSON
+  - method: GET
+    path:
+      - "{{BaseURL}}/prod-api/"
+
+    matchers:
+      - type: word
+        name: ruoyi-vue
+        part: body
+        words:
+          - "无法访问系统资源"
+          - "认证失败"
+        condition: or


### PR DESCRIPTION
## Templates

### 1. `http/technologies/ruoyi-detect.yaml`

RuoYi is a widely deployed Java backend framework in China with a large number of secondary-development projects. The existing `fingerprinthub-web-fingerprints.yaml` entry matches only `/ry-ui.css` and `/ry-ui.js`, which covers the Bootstrap distribution.

This template adds an application-title check plus the `/prod-api/` authentication-response marker, which is what identifies Vue / Vue3 / Cloud deployments whose frontend assets do not expose those two static paths.

Two independent matchers: brand word (body) + HTTP status 200.

### 2. `http/misconfiguration/ruoyi-job-unauth.yaml`

Detects unauthenticated access to the Quartz scheduled task endpoint (`POST /monitor/job/edit`) in RuoYi versions prior to 4.7. Reaching the task management business layer without authentication is the prerequisite for abusing the `invokeTarget` parameter to invoke arbitrary methods (see CVE-2026-4564 / GHSA-g23v-6jmr-rc3m).

**This template is non-destructive.** It posts a non-existent `jobId`, so no scheduled task is created, modified, or triggered. The second matcher is negative and explicitly excludes authentication-rejection responses (`请先登录` / `认证失败` / `无法访问系统资源`), so a hardened instance cannot be reported as unauthenticated.

## Verification

Tested against RuoYi signature labs (Flask-based, no Java runtime required) built for this purpose. Two modes: `vuln` (endpoint reachable without auth) and `safe` (endpoint returns 401).

**Template 1** — detected on both instances, which is the expected behaviour for a technology-detection template:

```
[ruoyi-detect:variant] [http] [info] http://127.0.0.1:8080/login ["RuoYi"]
```

**Template 2** — vulnerable instance:

```
[ruoyi-job-unauth] [http] [high] http://127.0.0.1:8080/monitor/job/edit
```

Hardened instance, which responds with `{"code":401,"msg":"请先登录"}`: **no match, no false positive.**

Both templates validate cleanly:

```
$ nuclei -validate -duc -t ruoyi-detect.yaml ruoyi-job-unauth.yaml
[INF] All templates validated successfully
```

The lab used for verification ships with the scanner these templates come from:
https://github.com/xiabai2008/ruoyi-scan

## Note on `contributors.json`

While appending my entry I found the file is currently **invalid JSON** — the last existing entry (`Th3l0newolf`) is missing its closing brace, so the array never closes the object:

```
            "email": ""
        }
]
```

This PR repairs that brace in addition to appending the new entry. The file now has 156 entries and parses cleanly.
