### PR TITLE
Add CVE-2026-61736 template

### DIFF
--- a/http/cves/2026/CVE-2026-61736.yaml
+++ b/http/cves/2026/CVE-2026-61736.yaml
@@ -1,24 +1,19 @@
 id: CVE-2026-61736
 
 info:
-  name: LightRAG - Credentialed CORS Wildcard
+  name: LightRAG <= 1.5.3 - Credentialed CORS Wildcard
   author: str4k3r
-  severity: critical
-  description: >
-    LightRAG before 1.5.4 configures a wildcard CORS policy together with
-    credential support. Its preflight response reflects an arbitrary Origin
-    and enables credentials, allowing a malicious origin to issue
-    credentialed cross-origin requests from a victim browser.
-  impact: >
-    An attacker-controlled origin may make authenticated API requests on
-    behalf of a LightRAG user and access or modify data available to that user.
-  remediation: >
-    Upgrade to LightRAG 1.5.4 or later, or configure an explicit trusted
-    origin allowlist and disable credentials for wildcard origins.
+  severity: high
+  description: |
+    LightRAG <= 1.5.4 contains a broken access control vulnerability caused by default CORS_ORIGINS=* with allow_credentials=True in lightrag_server.py, letting malicious websites perform authenticated API requests, exploit requires authenticated user.
+  impact: |
+    Malicious websites can perform authenticated API requests to exfiltrate or delete data, leading to data loss and information disclosure.
+  remediation: |
+    Update to version 1.5.4 or later.
   reference:
     - https://github.com/HKUDS/LightRAG/security/advisories/GHSA-6x6h-qqr7-855w
     - https://github.com/HKUDS/LightRAG/commit/09567a4c983f580050db63569dd477122c058c3d
-    - https://github.com/HKUDS/LightRAG/releases/tag/v1.5.4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-61736
   classification:
     cve-id: CVE-2026-61736
     cwe-id: CWE-942
@@ -26,28 +21,48 @@ info:
     cvss-score: 9.3
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: hkuds
     product: lightrag
-    technology: python, fastapi, starlette
-  tags: cve,cve2026,lightrag,cors,misconfiguration
+    shodan-query: http.html:"LightRAG"
+    fofa-query: body="LightRAG"
+  tags: cve,cve2026,lightrag,cors,misconfig
+
+flow: http(1) && http(2)
 
 http:
-  - method: OPTIONS
-    path:
-      - "{{BaseURL}}/query"
-    headers:
-      Origin: "https://evil.example.com"
-      Access-Control-Request-Method: "POST"
-      Access-Control-Request-Headers: "authorization,content-type"
-    matchers-condition: and
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    redirects: true
+    max-redirects: 3
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: regex
-        part: header
-        regex:
-          - "(?mi)^Access-Control-Allow-Origin:\\s*https://evil\\.example\\.com\\s*$"
-          - "(?mi)^Access-Control-Allow-Credentials:\\s*true\\s*$"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(tolower(body), "lightrag", "light-rag", "knowledge graph")'
+        condition: and
+        internal: true
+
+  - raw:
+      - |
+        OPTIONS /query HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{cors_origin}}
+        Access-Control-Request-Method: POST
+        Access-Control-Request-Headers: authorization,content-type
+
+    payloads:
+      cors_origin:
+        - "https://{{tolower(rand_base(5))}}.com"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(tolower(header), "access-control-allow-origin: {{cors_origin}}")'
+          - 'contains(tolower(header), "access-control-allow-credentials: true")'
         condition: and

--- a/http/cves/2026/CVE-2026-61736.yaml
+++ b/http/cves/2026/CVE-2026-61736.yaml
@@ -1,0 +1,53 @@
+id: CVE-2026-61736
+
+info:
+  name: LightRAG - Credentialed CORS Wildcard
+  author: str4k3r
+  severity: critical
+  description: >
+    LightRAG before 1.5.4 configures a wildcard CORS policy together with
+    credential support. Its preflight response reflects an arbitrary Origin
+    and enables credentials, allowing a malicious origin to issue
+    credentialed cross-origin requests from a victim browser.
+  impact: >
+    An attacker-controlled origin may make authenticated API requests on
+    behalf of a LightRAG user and access or modify data available to that user.
+  remediation: >
+    Upgrade to LightRAG 1.5.4 or later, or configure an explicit trusted
+    origin allowlist and disable credentials for wildcard origins.
+  reference:
+    - https://github.com/HKUDS/LightRAG/security/advisories/GHSA-6x6h-qqr7-855w
+    - https://github.com/HKUDS/LightRAG/commit/09567a4c983f580050db63569dd477122c058c3d
+    - https://github.com/HKUDS/LightRAG/releases/tag/v1.5.4
+  classification:
+    cve-id: CVE-2026-61736
+    cwe-id: CWE-942
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N
+    cvss-score: 9.3
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: hkuds
+    product: lightrag
+    technology: python, fastapi, starlette
+  tags: cve,cve2026,lightrag,cors,misconfiguration
+
+http:
+  - method: OPTIONS
+    path:
+      - "{{BaseURL}}/query"
+    headers:
+      Origin: "https://evil.example.com"
+      Access-Control-Request-Method: "POST"
+      Access-Control-Request-Headers: "authorization,content-type"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: header
+        regex:
+          - "(?mi)^Access-Control-Allow-Origin:\\s*https://evil\\.example\\.com\\s*$"
+          - "(?mi)^Access-Control-Allow-Credentials:\\s*true\\s*$"
+        condition: and


### PR DESCRIPTION
## Verification

This template detects the documented LightRAG CORS misconfiguration with one
credentialless `OPTIONS` preflight. It asserts both reflection of an arbitrary
Origin and `Access-Control-Allow-Credentials: true`, so it is behavioral rather
than version-only and does not read application data or mutate server state.

The public advisory documents the vulnerable defaults and the credentialed
cross-origin impact:
https://github.com/HKUDS/LightRAG/security/advisories/GHSA-6x6h-qqr7-855w