### PR TITLE
Add CVE-2026-9103 template

### DIFF
--- a/http/cves/2026/CVE-2026-9103.yaml
+++ b/http/cves/2026/CVE-2026-9103.yaml
@@ -4,16 +4,18 @@ info:
   name: Langflow OSS - Unauthenticated Superuser Token Issuance
   author: str4k3r
   severity: critical
-  description: >
-    Langflow OSS deployments with the default AUTO_LOGIN behavior expose an
-    unauthenticated endpoint that issues an access token with superuser scope.
-    The detector makes one GET request and checks the token response shape; it
-    does not use the token against another endpoint or change application
-    state.
+  description: |
+    Langflow OSS with default AUTO_LOGIN exposes `/api/v1/auto_login`, which returns a superuser access token to any unauthenticated request.
+  impact: |
+    An unauthenticated attacker obtains a superuser access token, granting full control of the Langflow instance including flow creation and execution, which typically leads to remote code execution and access to connected credentials and data sources.
+  remediation: |
+    Disable AUTO_LOGIN by setting `LANGFLOW_AUTO_LOGIN=false`, configure strong superuser credentials, upgrade to a fixed Langflow release, and restrict network exposure of the management interface.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-9103
     - https://github.com/langflow-ai/langflow
   classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
     cve-id: CVE-2026-9103
     cwe-id: CWE-306
   metadata:
@@ -21,21 +23,33 @@ info:
     max-request: 1
     vendor: langflow-ai
     product: langflow
-    technology: python, fastapi
-  tags: cve,cve2026,langflow,auth-bypass,exposure,unauth
+    framework: fastapi
+    shodan-query: http.title:"Langflow"
+    fofa-query: title="Langflow"
+    google-query: intitle:"Langflow"
+  tags: cve,cve2026,langflow,langflow-ai,auth-bypass,unauth
 
 http:
   - method: GET
     path:
       - "{{BaseURL}}/api/v1/auto_login"
+
     matchers-condition: and
     matchers:
-      - type: status
-        status:
-          - 200
       - type: regex
         part: body
         regex:
           - '"access_token"\s*:\s*"[^"\r\n]+"'
           - '"refresh_token"\s*:\s*null'
         condition: and
+
+      - type: status
+        status:
+          - 200
+
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"access_token"\s*:\s*"([^"\r\n]+)"'

--- a/http/cves/2026/CVE-2026-9103.yaml
+++ b/http/cves/2026/CVE-2026-9103.yaml
@@ -1,0 +1,41 @@
+id: CVE-2026-9103
+
+info:
+  name: Langflow OSS - Unauthenticated Superuser Token Issuance
+  author: str4k3r
+  severity: critical
+  description: >
+    Langflow OSS deployments with the default AUTO_LOGIN behavior expose an
+    unauthenticated endpoint that issues an access token with superuser scope.
+    The detector makes one GET request and checks the token response shape; it
+    does not use the token against another endpoint or change application
+    state.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-9103
+    - https://github.com/langflow-ai/langflow
+  classification:
+    cve-id: CVE-2026-9103
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: langflow-ai
+    product: langflow
+    technology: python, fastapi
+  tags: cve,cve2026,langflow,auth-bypass,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/auto_login"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - '"access_token"\s*:\s*"[^"\r\n]+"'
+          - '"refresh_token"\s*:\s*null'
+        condition: and


### PR DESCRIPTION
## Verification

This template detects Langflow's public `auto_login` token-issuance behavior,
not a version string. It uses one unauthenticated GET and requires both a
non-empty access token and a null refresh token in the response. The issued
token is not replayed and no application state is changed.

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2026-9103