### PR TITLE
Add CVE-2026-55884 template

### DIFF
--- a/http/cves/2026/CVE-2026-55884.yaml
+++ b/http/cves/2026/CVE-2026-55884.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-55884
+
+info:
+  name: Tilt HUD <= 0.37.3 - Missing Authentication on Trigger API
+  author: str4k3r
+  severity: critical
+  description: |
+    Tilt HUD versions 0.20.8 through 0.37.3 expose the /api/trigger endpoint
+    without authentication when the HUD listens on a non-loopback address.
+    Tilt 0.37.4 adds token authentication for this endpoint.
+  impact: |
+    An unauthenticated network attacker can trigger developer-defined Tiltfile
+    resources and reach sensitive HUD state, potentially executing predefined
+    commands with the developer's privileges and exposing cluster credentials.
+  remediation: Upgrade Tilt to 0.37.4 or later, or keep the HUD bound to loopback.
+  reference:
+    - https://github.com/advisories/GHSA-c73q-8xxr-rgqm
+    - https://github.com/tilt-dev/tilt/commit/47393fba7f6ef5e305d5e814551feef8e4acbc0a
+    - https://github.com/tilt-dev/tilt/releases/tag/v0.37.4
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55884
+  classification:
+    cve-id: CVE-2026-55884
+    cwe-id: CWE-306
+    cvss-score: 9.2
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:N/SI:N/SA:N
+  metadata:
+    vendor: tilt-dev
+    product: tilt
+    technology: Go, Tilt CLI, HUD HTTP server
+    max-request: 1
+    verified: true
+  tags: cve,cve2026,tilt,go,hud,missing-authentication,unauthenticated
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/trigger"
+    headers:
+      Content-Type: application/json
+    body: '{"manifest_names":["__tilt_missing_manifest__"]}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 404
+      - type: word
+        part: body
+        words:
+          - 'resource "__tilt_missing_manifest__" does not exist'


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-55884, the missing authentication check on the
Tilt HUD `/api/trigger` endpoint through version 0.37.3. Tilt 0.37.4 requires a
session token before the endpoint can be reached.

## Detection

The template submits one nonexistent manifest name. On vulnerable builds the
request reaches the trigger handler and returns the handler's deterministic
`resource does not exist` response before any resource dispatch. On fixed
builds the authentication middleware rejects the request with `403` first.
No real resource name, command, callback, or credential is used.

## References

- https://github.com/advisories/GHSA-c73q-8xxr-rgqm
- https://github.com/tilt-dev/tilt/commit/47393fba7f6ef5e305d5e814551feef8e4acbc0a
- https://nvd.nist.gov/vuln/detail/CVE-2026-55884

## Validation

- Vulnerable official Linux/amd64 Tilt `v0.37.3`: detected 3/3
- Fixed official Linux/amd64 Tilt `v0.37.4`: not detected 3/3
- Native Nuclei v3.11.0: vulnerable `DETECTED` 3/3; fixed `NOT_DETECTED` 3/3
- Native template validation: passed with Nuclei v3.11.1

The differential was reproduced in disposable isolated containers with no host
ports. The request does not dispatch a resource or alter application state.