### PR TITLE
Add CVE-2026-13153 template

### DIFF
--- a/http/cves/2026/CVE-2026-13153.yaml
+++ b/http/cves/2026/CVE-2026-13153.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-13153
+
+info:
+  name: Essential Blocks < 6.4.0 - Unauthenticated WooCommerce Sales/Stock Data Disclosure
+  author: str4k3r
+  severity: medium
+  description: |
+    The Essential Blocks WordPress plugin before 6.4.0 does not restrict access
+    to its public REST route (essential-blocks/v1/products) and returns the
+    non-public WooCommerce per-product `sold_count` (lifetime total_sales) and
+    `stock_quantity` fields to unauthenticated callers. Fixed in 6.4.0 by
+    gating both fields behind current_user_can('manage_woocommerce').
+  impact: |
+    An unauthenticated visitor can learn private product sales and inventory
+    information from stores using Essential Blocks with WooCommerce.
+  remediation: |
+    Upgrade Essential Blocks to version 6.4.0 or later.
+  reference:
+    - https://wpscan.com/vulnerability/0401a229-9630-49ab-ae4b-53360cf5d109/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13153
+  classification:
+    cve-id: CVE-2026-13153
+    cwe-id: CWE-862
+  metadata:
+    vendor: wpdeveloper
+    product: essential-blocks
+    technology: WordPress plugin, WooCommerce, PHP
+    verified: true
+    max-request: 1
+  tags: cve,cve2026,wordpress,wp-plugin,essential-blocks,woocommerce,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-json/essential-blocks/v1/products?per_page=20"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"sold_count":'
+      - type: regex
+        part: body
+        regex:
+          - '"sold_count":\s*[0-9]'


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-13153, an unauthenticated WooCommerce sales and
stock disclosure in Essential Blocks before 6.4.0.

## Detection

The template performs one unauthenticated GET request to the plugin's generic
`/wp-json/essential-blocks/v1/products` endpoint. It reports only when the
response exposes a numeric `sold_count` field, which is the private
WooCommerce lifetime sales value returned by vulnerable versions. The request
is read-only and does not create, modify, or delete products or orders.

The detector is intended for installations with a WooCommerce product
catalog; an empty catalog correctly produces no finding. This avoids relying
on a hardcoded product ID or synthetic marker.

## Validation

- Vulnerable official Essential Blocks 6.3.0: `DETECTED` 3/3
- Fixed official Essential Blocks 6.4.0: `NOT_DETECTED` 3/3
- Native Nuclei v3.11.0 template validation: passed
- V/F validation used official WordPress.org plugin packages and a disposable
  WooCommerce product solely to exercise the disclosed field

## References

- https://wpscan.com/vulnerability/0401a229-9630-49ab-ae4b-53360cf5d109/
- https://nvd.nist.gov/vuln/detail/CVE-2026-13153