### PR TITLE
Add CVE-2026-26077 template

### DIFF
--- a/http/cves/2026/CVE-2026-26077.yaml
+++ b/http/cves/2026/CVE-2026-26077.yaml
@@ -1,0 +1,42 @@
+id: CVE-2026-26077
+
+info:
+  name: Discourse - Unauthenticated Mailpace Webhook Bounce-Score Forgery
+  author: str4k3r
+  severity: medium
+  description: |
+    Discourse's WebhooksController contains a missing-authentication flaw
+    caused by accepting requests to provider webhook endpoints (including
+    /webhooks/mailpace, SendGrid, Mailjet, Mandrill, Postmark, and
+    SparkPost) without validating a token when none is configured, which
+    is the default state, letting an unauthenticated attacker forge
+    webhook payloads.
+  impact: An unauthenticated attacker can forge bounce-status webhook events to artificially inflate a user's bounce score, causing that user's legitimate emails to be disabled.
+  remediation: Upgrade Discourse to the patched version, which rejects any provider webhook request with HTTP 406 when no authentication token is configured for that provider.
+  reference:
+    - https://github.com/discourse/discourse/security/advisories/GHSA-j67c-53j2-4hfw
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
+    cvss-score: 6.5
+    cve-id: CVE-2026-26077
+    cwe-id: CWE-306
+  metadata:
+    verified: true
+    max-request: 1
+    product: discourse
+    vendor: discourse
+  tags: cve,cve2026,discourse,authbypass,unauth
+
+http:
+  - raw:
+      - |
+        POST /webhooks/mailpace HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"event":"email.bounced","payload":{"message_id":"nuclei-check@example.local","status":"bounced"}}
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-26077.yaml
+++ b/http/cves/2026/CVE-2026-26077.yaml
@@ -40,3 +40,7 @@ http:
       - type: status
         status:
           - 200
+      - type: regex
+        part: body
+        regex:
+          - '^\s*$'


### PR DESCRIPTION
## Description

This template detects CVE-2026-26077, an unauthenticated Discourse webhook authentication bypass. Provider webhook endpoints accepted forged events when no provider token was configured, which is the default configuration.

## Detection logic

- Sends one JSON `email.bounced` event to `/webhooks/mailpace` without credentials.
- Reports the issue only when the endpoint returns the vulnerable `200` response with the empty body produced by Discourse's `success` response.
- The payload uses a deliberately nonexistent `message_id` and does not target a real message or user; the request is intended to exercise endpoint authentication only.

The request is limited to one harmless webhook probe. Fixed versions reject the unauthenticated request with `406 Not Acceptable`; the empty-body matcher also avoids generic honeypot `200` responses.

## References

- https://github.com/discourse/discourse/security/advisories/GHSA-j67c-53j2-4hfw

## Validation

- Native Nuclei validation: passed
- Vulnerable Discourse 2026.1.0: detected 3/3
- Fixed Discourse 2026.1.1: not detected 3/3