### PR TITLE
Add CVE-2026-24206 behavioral Vertex AI redirect detector

### DIFF
--- a/http/cves/2026/CVE-2026-24206.yaml
+++ b/http/cves/2026/CVE-2026-24206.yaml
@@ -28,6 +28,10 @@ info:
     load / unload is not allowed if polling is enabled" under the default
     polling mode), while a fixed server rejects it at the Vertex AI layer
     with an empty-body HTTP 403 before the request is ever routed.
+  impact: |
+    An unauthenticated caller can reach restricted Triton HTTP APIs through a
+    Vertex AI prediction listener and may access model-management operations.
+  remediation: Upgrade to Triton r26.03 or later, or restrict the Vertex AI listener and model-control APIs.
   reference:
     - https://nvidia.custhelp.com/app/answers/detail/a_id/5828
     - https://github.com/triton-inference-server/server/commit/4fd4da603801766b14ad8788649cfc1ad21f99a6
@@ -35,10 +39,14 @@ info:
     - https://github.com/triton-inference-server/server/blob/r26.03/src/vertex_ai_server.cc
   classification:
     cve-id: CVE-2026-24206
+    cwe-id: CWE-862
   metadata:
     verified: true
     verification_status: VERIFIED
     max-request: 1
+    vendor: nvidia
+    product: triton-inference-server
+    technology: C++, HTTP, Vertex AI custom-container listener
   tags: cve,cve2026,nvidia,triton,vertex-ai,auth-bypass,unauth
 
 http:

--- a/http/cves/2026/CVE-2026-24206.yaml
+++ b/http/cves/2026/CVE-2026-24206.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-24206
+
+info:
+  name: NVIDIA Triton Inference Server <26.03 - Vertex AI Endpoint Redirect Authentication Bypass
+  author: str4k3r
+  severity: high
+  description: >
+    NVIDIA Triton Inference Server before the r26.03 release exposes its
+    Vertex AI custom-container HTTP listener (started with
+    --allow-vertex-ai=true, the default when AIP_MODE=PREDICTION as set by
+    real Google Cloud Vertex AI deployments) on a route that is intended to
+    serve only /health and /predict. The Vertex AI handler
+    (VertexAiAPIServer::Handle in src/vertex_ai_server.cc) honors an
+    unauthenticated X-Vertex-Ai-Triton-Redirect request header that lets a
+    caller reach the full internal Triton HTTP API through the predict
+    route, including the model-repository control endpoint
+    (POST /v2/repository/models/<name>/load|unload), bypassing whatever
+    access restriction was meant to gate the Vertex AI port. The r26.03 fix
+    adds an explicit restricted-API allowlist to the Vertex AI redirect
+    path so only read-only metadata/health/metrics/stats routes remain
+    reachable and every other redirected route -- including model
+    repository control -- returns 403 before reaching the handler. This
+    template probes the redirect to a control-plane route with a
+    non-existent probe model name (touching no real model): a pre-fix
+    server always routes the request through to the internal repository
+    manager (never a 403 -- HTTP 500 "failed to poll from model
+    repository" if model-control-mode=explicit, HTTP 503 "explicit model
+    load / unload is not allowed if polling is enabled" under the default
+    polling mode), while a fixed server rejects it at the Vertex AI layer
+    with an empty-body HTTP 403 before the request is ever routed.
+  reference:
+    - https://nvidia.custhelp.com/app/answers/detail/a_id/5828
+    - https://github.com/triton-inference-server/server/commit/4fd4da603801766b14ad8788649cfc1ad21f99a6
+    - https://github.com/triton-inference-server/server/blob/r26.02/src/vertex_ai_server.cc
+    - https://github.com/triton-inference-server/server/blob/r26.03/src/vertex_ai_server.cc
+  classification:
+    cve-id: CVE-2026-24206
+  metadata:
+    verified: true
+    verification_status: VERIFIED
+    max-request: 1
+  tags: cve,cve2026,nvidia,triton,vertex-ai,auth-bypass,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/predict"
+    headers:
+      X-Vertex-Ai-Triton-Redirect: "v2/repository/models/nuclei-{{randstr}}/load"
+      Content-Type: application/json
+    body: '{}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 500
+          - 503
+        negative: false
+      - type: word
+        part: body
+        words:
+          - "failed to poll from model repository"
+          - "explicit model load / unload is not allowed if polling is enabled"
+        condition: or

--- a/http/cves/2026/CVE-2026-24206.yaml
+++ b/http/cves/2026/CVE-2026-24206.yaml
@@ -43,6 +43,7 @@ info:
   metadata:
     verified: true
     verification_status: VERIFIED
+    artifact_scope: DEPLOYABLE
     max-request: 1
     vendor: nvidia
     product: triton-inference-server


### PR DESCRIPTION
## Summary

Adds a behavioral detector for CVE-2026-24206, the unauthenticated Vertex AI redirect authorization bypass in NVIDIA Triton before r26.03.

## Detection

The template sends one POST request to the Vertex AI `/predict` listener with an `X-Vertex-Ai-Triton-Redirect` header targeting a randomly named, nonexistent model load operation. Vulnerable builds route the request to the internal model-repository handler and return its deterministic failure; fixed builds reject the redirected control-plane route with HTTP 403. The nonexistent model prevents any real model from being loaded or unloaded.

## Validation

- Official NVIDIA Triton r26.02 vulnerable image: DETECTED 3/3
- Official NVIDIA Triton r26.03 fixed image: NOT_DETECTED 3/3
- Native Nuclei v3.11.0 validation: passed
- No credentials, real model name, external callback, or state-changing successful operation used

## References

- https://nvidia.custhelp.com/app/answers/detail/a_id/5828
- https://github.com/triton-inference-server/server/commit/4fd4da603801766b14ad8788649cfc1ad21f99a6
- https://nvd.nist.gov/vuln/detail/CVE-2026-24206