### PR TITLE
Add CVE-2026-72794 template

### DIFF
--- a/http/cves/2026/CVE-2026-72794.yaml
+++ b/http/cves/2026/CVE-2026-72794.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-72794
+
+info:
+  name: SiYuan - Unauthenticated Session Cookie Signing Key Disclosure
+  author: str4k3r
+  severity: high
+  description: |
+    SiYuan returns the session-cookie signing key in the configuration response
+    for /api/system/getConf. On a publish service with anonymous readers enabled,
+    the endpoint can be reached without authentication.
+  impact: |
+    An unauthenticated attacker may obtain the key used to sign SiYuan session
+    cookies and forge authenticated sessions, potentially gaining unauthorized
+    access to protected application functionality.
+  remediation: Upgrade SiYuan to a release containing commit 77421530be4a or later.
+  reference:
+    - https://github.com/siyuan-note/siyuan/security/advisories/GHSA-34fj-mwm6-fjfg
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-72794
+    - https://github.com/siyuan-note/siyuan/commit/77421530be4ab1f43310d0f50fbab05d16c38675
+    - https://hub.docker.com/r/b3log/siyuan/tags
+  classification:
+    cve-id: CVE-2026-72794
+    cwe-id: CWE-200
+    cvss-score: 8.6
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: b3log
+    product: siyuan
+    shodan-query: 'title:"SiYuan"'
+  tags: cve,cve2026,siyuan,info-disclosure,session,unauth
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/system/getConf"
+    headers:
+      Content-Type: application/json
+    body: "{}"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: regex
+        part: body
+        regex:
+          - '"cookieKey"\s*:\s*"[^"]{8,}"'


### PR DESCRIPTION
## Summary

Adds a safe detector for CVE-2026-72794, where SiYuan returns the session-cookie signing key from `POST /api/system/getConf` to anonymous readers of an exposed publish service.

The request is a single read-only JSON POST (`{}`), uses the product's generic configuration endpoint, and matches only a non-empty `cookieKey` field. The template does not extract, print, or store the key.

## References

- [GitHub Security Advisory GHSA-34fj-mwm6-fjfg](https://github.com/siyuan-note/siyuan/security/advisories/GHSA-34fj-mwm6-fjfg)
- [NVD CVE-2026-72794](https://nvd.nist.gov/vuln/detail/CVE-2026-72794)
- [Upstream fix commit 77421530be4ab1f43310d0f50fbab05d16c38675](https://github.com/siyuan-note/siyuan/commit/77421530be4ab1f43310d0f50fbab05d16c38675)

## Validation

- Vulnerable: official `b3log/siyuan:v3.7.3` Docker image with the product publish service and anonymous readers enabled — 3/3 detected.
- Fixed: official `b3log/siyuan:v3.8.3` Docker image with the same publish configuration — 3/3 not detected.
- Native Nuclei v3.11.0 validation passed.
- No credentials, session creation, state-changing methods, file reads, callbacks, or extractors are used.