### PR TITLE
Add CVE-2026-59177 template

### DIFF
--- a/http/cves/2026/CVE-2026-59177.yaml
+++ b/http/cves/2026/CVE-2026-59177.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-59177
+
+info:
+  name: ESPHome Device Builder <1.0.10 - Unauthenticated Dashboard Access
+  author: str4k3r
+  severity: high
+  description: |
+    ESPHome Device Builder versions before 1.0.10 bind the trusted Home
+    Assistant ingress site to all interfaces. A client that can reach the
+    ingress port can therefore access the dashboard without the Supervisor's
+    authentication proxy.
+  impact: |
+    An unauthenticated network client may access the Device Builder dashboard
+    and its authenticated capabilities, which can lead to unauthorized access
+    to ESPHome projects and device-management operations.
+  remediation: Upgrade the ESPHome add-on to a release bundling Device Builder 1.0.10 or later.
+  reference:
+    - https://github.com/esphome/device-builder/security/advisories/GHSA-vv4j-m4vr-f3g6
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59177
+    - https://github.com/esphome/device-builder/pull/1565
+    - https://github.com/esphome/device-builder/commit/b6387db3f8bf1d3df5771f40e9856b959ae4f6a1
+  classification:
+    cve-id: CVE-2026-59177
+    cwe-id: CWE-306
+    cvss-score: 8.8
+    cvss-metrics: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: esphome
+    product: device-builder
+    shodan-query: 'http.title:"ESPHome Device Builder"'
+  tags: cve,cve2026,esphome,device-builder,auth-bypass,unauth,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<title>ESPHome Device Builder</title>"
+          - "<esphome-app"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a safe detector for CVE-2026-59177, where the ESPHome Device Builder trusted Home Assistant ingress site binds to all interfaces in versions before 1.0.10. A client that reaches the ingress port can therefore bypass the Supervisor authentication boundary.

The template sends one unauthenticated `GET /` request and matches the product's dashboard title and application element. It does not create projects, invoke build/device operations, use credentials, or access project data.

## References

- [GitHub Security Advisory GHSA-vv4j-m4vr-f3g6](https://github.com/esphome/device-builder/security/advisories/GHSA-vv4j-m4vr-f3g6)
- [NVD CVE-2026-59177](https://nvd.nist.gov/vuln/detail/CVE-2026-59177)
- [Upstream fix PR #1565](https://github.com/esphome/device-builder/pull/1565)
- [Upstream fix commit b6387db3f8bf1d3df5771f40e9856b959ae4f6a1](https://github.com/esphome/device-builder/commit/b6387db3f8bf1d3df5771f40e9856b959ae4f6a1)

## Validation

- Vulnerable: official PyPI `esphome-device-builder[esphome]==1.0.9` with `--ha-addon` — 3/3 detected.
- Fixed: official PyPI `esphome-device-builder[esphome]==1.0.10` with the fixed ingress bind — 3/3 not detected from the external interface.
- Native Nuclei v3.11.0 validation passed.
- The fixed build was also verified to reject an unavailable Supervisor gateway bind in the isolated harness; the test then used an explicit loopback bind to keep the fixed service alive and confirmed the published port was not externally reachable.