### PR TITLE
Add CVE-2026-58191 template

### DIFF
--- a/http/cves/2026/CVE-2026-58191.yaml
+++ b/http/cves/2026/CVE-2026-58191.yaml
@@ -1,0 +1,48 @@
+id: CVE-2026-58191
+
+info:
+  name: Appium Base Driver <=10.6.0 - Reflected XSS in Guinea Pig Test Pages
+  author: str4k3r
+  severity: medium
+  description: |
+    Appium base-driver through 10.6.0 unconditionally exposes the built-in
+    guinea-pig test pages. The throwError query parameter is reflected into
+    an inline script without HTML or JavaScript escaping.
+  impact: |
+    An attacker can induce a victim to open a crafted URL and execute
+    arbitrary JavaScript in the Appium server origin. The script can then
+    access same-origin Appium APIs exposed by the server.
+  remediation: Upgrade @appium/base-driver to 10.7.0 or later and disable legacy test pages where supported.
+  reference:
+    - https://github.com/appium/appium/security/advisories/GHSA-3wgp-x9p5-c7cc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-58191
+    - https://github.com/appium/appium/pull/22394
+    - https://github.com/appium/appium/commit/d94a40af9f8040191ee7888571a1c9d5aec59f89
+  classification:
+    cve-id: CVE-2026-58191
+    cwe-id: CWE-79
+    cvss-score: 6.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: appium
+    product: base-driver
+    shodan-query: 'http.title:"I am a page title"'
+  tags: cve,cve2026,appium,xss,reflected-xss,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/test/guinea-pig?throwError=NUCLEI_CVE_2026_58191"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "NUCLEI_CVE_2026_58191"
+          - "This page is a Selenium sandbox"
+        condition: and


### PR DESCRIPTION
## Summary

Adds a safe detector for CVE-2026-58191 in Appium's `@appium/base-driver` test pages. Versions through 10.6.0 mount `/test/guinea-pig` without authentication and reflect `throwError` into an inline script without escaping.

The template sends one GET request with an inert alphanumeric marker. It checks that the marker is reflected together with the built-in Selenium sandbox page. It does not submit JavaScript, create a driver session, or call any mutating API.

## References

- [GitHub Security Advisory GHSA-3wgp-x9p5-c7cc](https://github.com/appium/appium/security/advisories/GHSA-3wgp-x9p5-c7cc)
- [NVD CVE-2026-58191](https://nvd.nist.gov/vuln/detail/CVE-2026-58191)
- [Upstream fix PR #22394](https://github.com/appium/appium/pull/22394)
- [Upstream fix commit d94a40af9f8040191ee7888571a1c9d5aec59f89](https://github.com/appium/appium/commit/d94a40af9f8040191ee7888571a1c9d5aec59f89)

## Validation

- Vulnerable: official `appium@3.5.0` package (bundling `@appium/base-driver@10.6.0`) — 3/3 detected.
- Fixed: official `appium@3.6.0` package (bundling `@appium/base-driver@10.7.2`) — 3/3 not detected.
- Native Nuclei v3.11.0 validation passed.
- No JavaScript payload is sent and no state-changing endpoint is called.