### PR TITLE
Add CVE-2026-55549 template

### DIFF
--- a/http/cves/2026/CVE-2026-55549.yaml
+++ b/http/cves/2026/CVE-2026-55549.yaml
@@ -1,0 +1,46 @@
+id: CVE-2026-55549
+
+info:
+  name: Yamcs <=5.8.6 - Reflected XSS in Authorization Endpoint
+  author: str4k3r
+  severity: medium
+  description: |
+    Yamcs versions through 5.8.6 reflect the OAuth authorization endpoint's
+    redirect_uri parameter into a hidden HTML input without escaping. An
+    attacker can therefore inject markup into the authorization page.
+  impact: |
+    An attacker can induce a Yamcs user to open a crafted authorization URL
+    and execute arbitrary JavaScript in the Yamcs origin, potentially
+    compromising the user's session and authorized actions.
+  remediation: Upgrade Yamcs to version 5.9.4 or later.
+  reference:
+    - https://github.com/yamcs/yamcs/security/advisories/GHSA-rxpg-wjf8-qv9c
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55549
+    - https://github.com/yamcs/yamcs/commit/4d47d5cdcf5d92c2c5bbbc19feada422923332e3
+    - https://github.com/yamcs/yamcs/releases/tag/yamcs-5.9.4
+  classification:
+    cve-id: CVE-2026-55549
+    cwe-id: CWE-79
+    cvss-score: 6.5
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: yamcs
+    product: yamcs
+    shodan-query: 'title:"Yamcs"'
+  tags: cve,cve2026,yamcs,xss,reflected-xss,unauth
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/authorize?client_id=yamcs-web&state=stable-state&response_mode=query&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fexample.com%2Fcbi0i7y%22%3E%3Cb%3ENUCLEI_CVE_2026_55549%3C%2Fb%3E"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - 'value="https://example.com/cbi0i7y"><b>NUCLEI_CVE_2026_55549</b>"'


### PR DESCRIPTION
## Summary

Adds a safe detector for CVE-2026-55549 in Yamcs through 5.8.6. The unauthenticated `/auth/authorize` page reflects `redirect_uri` into a hidden HTML input without escaping, allowing markup/script injection in a user's Yamcs origin.

The template sends one request with a URL-encoded, inert `<b>` marker and matches the raw markup form. It does not send JavaScript, log in, create a session, or invoke any Yamcs operation.

## References

- [GitHub Security Advisory GHSA-rxpg-wjf8-qv9c](https://github.com/yamcs/yamcs/security/advisories/GHSA-rxpg-wjf8-qv9c)
- [NVD CVE-2026-55549](https://nvd.nist.gov/vuln/detail/CVE-2026-55549)
- [Upstream fix commit 4d47d5cdcf5d92c2c5bbbc19feada422923332e3](https://github.com/yamcs/yamcs/commit/4d47d5cdcf5d92c2c5bbbc19feada422923332e3)
- [Yamcs 5.9.4 release](https://github.com/yamcs/yamcs/releases/tag/yamcs-5.9.4)

## Validation

- Vulnerable: official Yamcs 5.8.6 Linux x86_64 distribution — 3/3 detected.
- Fixed: official Yamcs 5.9.4 Linux x86_64 distribution — 3/3 not detected.
- Native Nuclei v3.11.0 validation passed.
- No JavaScript payload, authentication attempt, state-changing request, callback, or extractor is used.