### PR TITLE
Create apache-skywalking-horizon-ui-detect.yaml, apache-skywalking-horizon-ui-default-login.yaml and apache-skywalking-horizon-ui-config.yaml

### DIFF
--- a/http/default-logins/apache/apache-skywalking-horizon-ui-default-login.yaml
+++ b/http/default-logins/apache/apache-skywalking-horizon-ui-default-login.yaml
@@ -1,0 +1,43 @@
+id: apache-skywalking-horizon-ui-default-login
+
+info:
+  name: Apache SkyWalking Horizon UI - Default Login
+  author: icarot
+  severity: high
+  description: |
+    Apache SkyWalking next-generation UI (Horizon). An attacker can execute unauthorized operations.
+  reference:
+    - https://github.com/apache/skywalking-horizon-ui
+  metadata:
+    max-request: 1
+    vendor: apache
+    product: skywalking
+    shodan-query: title:"SkyWalking Horizon UI"
+  tags: apache,skywalking-horizon-ui,default-login
+
+http:
+  - raw:
+      - |
+        POST /api/auth/login HTTP/1.1
+        Host: {{Hostname}}
+        content-type: application/json
+        
+        {"username":"{{username}}","password":"{{password}}"}
+    attack: pitchfork
+    payloads:
+      username:
+        - skywalking
+      password:
+        - skywalking
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"username":"skywalking"'
+          - '"authSource":'
+          - '"roles":'
+        condition: or
+      - type: status
+        status:
+          - 200

--- a/http/exposures/configs/apache-skywalking-horizon-ui-config.yaml
+++ b/http/exposures/configs/apache-skywalking-horizon-ui-config.yaml
@@ -1,0 +1,36 @@
+id: apache-skywalking-horizon-ui-config
+
+info:
+  name: Apache SkyWalking Horizon UI - Config Exposure
+  author: icarot
+  severity: medium
+  description: |
+    Detects if path /api/auth/oidc/providers and /api/auth/health of SkyWalking Horizon UI server is exposed, getting authentication information.
+  reference:
+    - https://github.com/apache/skywalking-horizon-ui
+  metadata:
+    max-request: 2
+    shodan-query: title:"SkyWalking Horizon UI"
+    vendor: apache
+    product: skywalking-horizon-ui
+  tags: apache,skywalking-horizon-ui,config,exposure
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/auth/oidc/providers"
+      - "{{BaseURL}}/api/auth/health"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - '"backend":'
+          - '"configured":'
+          - '"ldap":'
+          - '"breakGlass":'
+          - '"passwordLogin":'
+          - '"providers":'
+        condition: or
+      - type: status
+        status:
+          - 200

--- a/http/technologies/apache/apache-skywalking-horizon-ui-detect.yaml
+++ b/http/technologies/apache/apache-skywalking-horizon-ui-detect.yaml
@@ -1,0 +1,32 @@
+id: apache-skywalking-horizon-ui-detect
+
+info:
+  name: Apache SkyWalking Horizon UI - Detection
+  author: icarot
+  severity: info
+  description: |
+    Detects an SkyWalking Horizon UI server, using the next-generation UI (Horizon).
+  reference:
+    - https://github.com/apache/skywalking-horizon-ui
+  metadata:
+    max-request: 2
+    shodan-query: title:"SkyWalking Horizon UI"
+    vendor: apache
+    product: skywalking-horizon-ui
+  tags: apache,skywalking-horizon-ui,detect
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/login"
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'SkyWalking Horizon UI'
+          - 'Apache Software Foundation'
+        condition: and
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
These nuclei templates:

* Detects an SkyWalking Horizon UI server, using the next-generation UI (Horizon).
* Apache SkyWalking next-generation UI (Horizon). An attacker can execute unauthorized operations.
* Detects if path /api/auth/oidc/providers and /api/auth/health of SkyWalking Horizon UI server is exposed, getting authentication information.

- References:

https://github.com/apache/skywalking-horizon-ui

I've validated this template locally?
- [x] YES
- [ ] NO

**Steps to test:**

**Apache Skywalking Horizon UI Docker:**

1. Running container:

`$ bash <(curl -sSL https://skywalking.apache.org/quickstart-docker.sh)`

2. Acessing the Apache Skywalking Horizon UI service:

`$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ui`

Access the URL "http://<obteined_inspect_IP_Address>:8081/".

**Nuclei execution:**

`$ ~/go/bin/nuclei -t apache-skywalking-horizon-ui-detect.yaml -t apache-skywalking-horizon-ui-default-login.yaml -t apache-skywalking-horizon-ui-config.yaml -u "http://<obteined_inspect_IP_Address>:8081/" -H "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"`

<img width="1838" height="583" alt="image" src="https://github.com/user-attachments/assets/c162d747-9e1c-47ed-a7fb-de979921958f" />
