### PR TITLE
Add cve-search CVE-2026-59509 template

### DIFF
--- a/http/cves/2026/CVE-2026-59509.yaml
+++ b/http/cves/2026/CVE-2026-59509.yaml
@@ -1,0 +1,49 @@
+id: CVE-2026-59509
+
+info:
+  name: cve-search 4.0-6.0.0 - Unauthenticated NoSQL Injection
+  author: str4k3r
+  severity: critical
+  description: |
+    cve-search versions 4.0 through 6.0.0 expose an unauthenticated DataTables
+    endpoint that accepts attacker-controlled MongoDB collection, projection,
+    filtering, and pagination parameters. This detector uses a harmless invalid
+    projection field against the intended cves collection; version 6.0.1
+    rejects that field.
+  impact: |
+    An unauthenticated network attacker can read unintended MongoDB data,
+    including administrative usernames and password hashes when local
+    authentication is enabled, by controlling DataTables query parameters.
+  reference:
+    - https://github.com/cve-search/cve-search/issues/1217
+    - https://github.com/cve-search/cve-search/pull/1218
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59509
+  remediation: |
+    Upgrade cve-search to v6.0.1 or later.
+  classification:
+    cvss-score: 9.2
+    cvss-metrics: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X
+    cve-id: CVE-2026-59509
+    cwe-id: CWE-20
+  metadata:
+    verified: true
+    product: cve-search
+    vendor: cve-search
+  tags: cve,cve2026,cve-search,mongodb,nosql-injection,unauthenticated
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/fetch_cve_data"
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: "draw=1&start=0&length=1&retrieve=cves&search%5Bvalue%5D=&search%5Bregex%5D=false&columns%5B0%5D%5Bdata%5D=password&columns%5B0%5D%5Bsearchable%5D=true&columns%5B0%5D%5Borderable%5D=false&columns%5B0%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B0%5D%5Bsearch%5D%5Bregex%5D=false"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - '"recordsTotal"'


### PR DESCRIPTION
Adds an HTTP template for the unauthenticated cve-search CVE-2026-59509 issue.

The request posts a single-row DataTables query to the intended `cves` collection with an invalid projection field. Source-pinned vulnerable v6.0.0 accepts it with HTTP 200 and a DataTables response; fixed v6.0.1 rejects the column with HTTP 400. The probe does not select the credentials collection or perform a state-changing action.

Validation: source-pinned V/F builds from commits `b0f06812afd0f2cb0a109971815be47a8e1d34fd` and `2e25b80902ae3dfe12c2671b249d69e7944d9748`; native Nuclei v3.11.1 detected V 3/3 and did not detect F 3/3. Submitted template passes native Nuclei v3.11.0 `-validate`.

References: https://github.com/cve-search/cve-search/issues/1217, https://github.com/cve-search/cve-search/pull/1218, https://nvd.nist.gov/vuln/detail/CVE-2026-59509